### PR TITLE
feat(daemon): an elicitation card is a transcript row, and no Slack cap loses one

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2985,7 +2985,7 @@ export const SessionMessageDto = z.object({
   toolCallId: z.string().optional(),
   toolStatus: z.string().optional(),
   toolKind: z.string().optional(),
-  body: z.string().optional(), // JSON.stringify(ToolBody); may be a truncated-but-valid-JSON preview
+  body: z.string().optional(), // JSON.stringify(ToolBody / PlanBody / ElicitBody); may be a truncated-but-valid-JSON preview
   bodyTruncated: z.boolean().optional(), // preview shrunk for the frame; full body via /sessions/:id/tool-body
   bodyBytes: z.number().optional() // full (untruncated) body byte length
 })

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -379,6 +379,12 @@ export function createSessionReader(
           if (Buffer.byteLength(r.body) <= PREVIEW_CAP) base.body = r.body
           return base
         }
+        // An elicitation card's body is the card itself and likewise has no full-body fetch behind
+        // it: it rides inline or not at all, leaving the row's question to stand alone.
+        if (r.kind === 'elicit') {
+          if (Buffer.byteLength(r.body) <= PREVIEW_CAP) base.body = r.body
+          return base
+        }
         if (r.kind !== 'tool') return base
         // Enrich a tool row: surface toolCallId/status/kind + an inline body (verbatim
         // when ≤ 32 KiB, else a valid-JSON preview with bodyTruncated + full byte length).

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -315,7 +315,13 @@ export class PermissionCoordinator {
   private readonly permissionEvaluationDetails = new WeakMap<RequestPermissionRequest, Record<string, unknown>>()
 
   // ── Interactive elicitations (ACP elicitation/create, form + url mode) ──────
-  private elicitSeq = 0
+  /** One outstanding card per id, and the id is a `randomUUID()` — never a process-local
+   *  sequence. A card lives in a Slack MESSAGE, which outlives the daemon that posted it, so a
+   *  restart minting `elicit-1` again would let a stale button answer whatever request now holds
+   *  that id: the card carries its option's POSITION (#1794), and a position resolves against the
+   *  NEW question's options, so the stale tap would accept an answer to a question its reader
+   *  never saw. A literal used to be rejected by the new option list by accident; nothing should
+   *  rest on that accident, and one id shape is also one less branch. */
   private pendingElicits = new Map<string, PendingElicit>()
   /** URL-mode cards already consented to, keyed by `<owner>\x00<elicitationId>` and awaiting
    *  an `elicitation/complete` that may never come — their ACP request resolved at consent, so
@@ -1404,7 +1410,7 @@ export class PermissionCoordinator {
       return await this.awaitSlackFormElicitation(agentId, sessionId, params, p, conn, form)
     }
     const target = form[0]!
-    const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
+    const requestId = randomUUID()
     const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p), SLACK_ELICIT_SURFACE)
     if (!blocks) return this.noticeUnrenderableElicit(p, params, isApproval)
     const cardMessage = (params as { message?: string }).message?.trim() || 'The agent needs your input'
@@ -1593,7 +1599,7 @@ export class PermissionCoordinator {
     const form = elicitForm(params, WEBCHAT_ELICIT_SURFACE)
     if (!form) return this.noticeUnrenderableWebchatElicit(p, wc, params)
     const target = form[0]!
-    const requestId = `elicit-${++this.elicitSeq}`
+    const requestId = randomUUID()
     const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
     const card = elicitCardPayload(requestId, message, params, form)
     let resolveResult!: (res: CreateElicitationResponse) => void
@@ -1648,7 +1654,7 @@ export class PermissionCoordinator {
     wc: NonNullable<Pending['webchat']>,
     url: { elicitationId: string; url: string }
   ): Promise<CreateElicitationResponse | undefined> {
-    const requestId = `elicit-${++this.elicitSeq}`
+    const requestId = randomUUID()
     const message = (params as { message?: string }).message?.trim() || 'The agent needs you to open a link'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
@@ -1701,7 +1707,7 @@ export class PermissionCoordinator {
     conn: SlackConnection,
     url: { elicitationId: string; url: string }
   ): Promise<CreateElicitationResponse | undefined> {
-    const requestId = `elicit-${++this.elicitSeq}`
+    const requestId = randomUUID()
     const blocks = buildUrlConsentCard(requestId, params, this.host.httpSlackSessionTarget(p))
     if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
     const message = (params as { message?: string }).message?.trim() || 'The agent needs you to open a link'
@@ -1769,7 +1775,7 @@ export class PermissionCoordinator {
     conn: SlackConnection,
     form: ElicitTarget[]
   ): Promise<CreateElicitationResponse | undefined> {
-    const requestId = `elicit-${++this.elicitSeq}`
+    const requestId = randomUUID()
     const sessionTarget = this.host.httpSlackSessionTarget(p)
     const blocks = buildElicitationFormCard(requestId, params, form, sessionTarget)
     if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
@@ -1982,10 +1988,10 @@ export class PermissionCoordinator {
     requestId: string
     value: ElicitAnswer
     actor?: InteractionActor
-    /** Set only by the webchat ingress: the answering browser's conversation. It confines
-     *  the answer to a card THIS conversation was shown — a webchat client can neither
-     *  answer a Slack card nor another conversation's, both of which the guessable
-     *  `elicit-<n>` id would otherwise allow. */
+    /** Set only by the webchat ingress: the answering browser's conversation. It confines the
+     *  answer to a card THIS conversation was shown — a webchat client may answer neither a Slack
+     *  card nor another conversation's. Kept alongside the unguessable request id rather than
+     *  replaced by it: an id is a secret, and a scope is a rule. */
     webchatConversationId?: string
   }): Promise<void> {
     // A DM elicitation card's request lives on the editor path (§2/§6.4).
@@ -2015,8 +2021,8 @@ export class PermissionCoordinator {
     // for a numeric field, a string for the rest. Dismiss (null) settles any of them.
     if (a.value !== null && !isFormAnswer(a.value) && !answerFitsKind(rec.kind, a.value)) return
     const target = elicitTarget(rec.params, surfaceOf(rec))
-    // A browser answers only a card ITS OWN conversation was shown: both surfaces share one
-    // `elicit-<n>` counter, so the guessable id would otherwise reach another conversation's.
+    // A browser answers only a card ITS OWN conversation was shown: both surfaces mint ids from
+    // one place, so the scope is what keeps one conversation's answer out of another's card.
     if (a.webchatConversationId !== undefined) {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
       // And a card settles only from its own surface, so a Slack tap never answers a webchat one.
@@ -2185,7 +2191,7 @@ export class PermissionCoordinator {
    *  decline notice could not tell them. */
   private recordUnrenderableElicit(p: Pending, params: CreateElicitationRequest): void {
     const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
-    const card = elicitUnrenderablePayload(`elicit-${++this.elicitSeq}`, message)
+    const card = elicitUnrenderablePayload(randomUUID(), message)
     // Written settled in one go: this ask was never open on any surface.
     this.writeElicitRow(
       {

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -15,7 +15,8 @@ import type {
   AgentApprovalRouted,
   AgentPermissionDecision,
   ApprovalRouteTarget,
-  ElicitField
+  ElicitCard,
+  ElicitOutcome
 } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from '../log.js'
@@ -37,7 +38,6 @@ import {
   buildUrlConsentResolvedCard,
   clampTo,
   elicitCardShape,
-  elicitFieldLabel,
   elicitForm,
   elicitFormFieldLabel,
   elicitFormAccepts,
@@ -45,6 +45,8 @@ import {
   elicitFormRefusalNotice,
   ELICIT_ANSWER_REFUSED,
   elicitFormSubmission,
+  elicitOptionLiteral,
+  elicitOptionToken,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
@@ -60,7 +62,9 @@ import type { ElicitKind, ElicitSurface, ElicitTarget } from '../slack/render.js
 import { slackThreadUrl } from '../platforms/slack/permalink.js'
 import { slackAgentIdentityOptions } from '../platforms/slack/turn-output.js'
 import { turnChromeFor } from '../platforms/turn-chrome.js'
+import { monotonicTs } from '../store/monotonic-ts.js'
 import { buildElicitDeclinedNotice } from './elicit-notice.js'
+import { elicitCardPayload, elicitRowBody, elicitUnrenderablePayload, elicitUrlCardPayload } from './elicit-record.js'
 import { formatErr } from '../daemon/text.js'
 import {
   approvalRequestSummary,
@@ -170,52 +174,6 @@ function formAnswerLabel(
   return parts.length ? clampTo(parts.join(' · '), 200) : 'Nothing filled in'
 }
 
-/** The card-side descriptors of ONE field — the wire's own shape, minus what only a form
- *  entry names (property, label, kind, requiredness). */
-type ElicitCardDescriptors = Pick<ElicitField, 'options' | 'multi' | 'text' | 'number' | 'defaultValue'>
-
-/** The per-kind descriptors a webchat elicitation card carries for one field: its options plus
- *  whichever constraint block its kind brings. Shared by the single-field card and each entry
- *  of a form, so a one-field form's payload stays exactly the single-field card's. */
-function elicitCardDescriptors(t: ElicitTarget): ElicitCardDescriptors {
-  return {
-    options: t.options,
-    // Present only for a multi-select: it is what tells the card to offer toggles and a
-    // confirm rather than one-tap buttons, and the bounds the confirm enforces.
-    ...(t.kind === 'multi-enum'
-      ? {
-          multi: {
-            ...(t.minItems !== undefined ? { minItems: t.minItems } : {}),
-            ...(t.maxItems !== undefined ? { maxItems: t.maxItems } : {})
-          }
-        }
-      : {}),
-    // Present only for a typed field, and likewise what makes the card an input rather than a
-    // row of options. The constraints ride along so the control can refuse an answer the
-    // daemon would reject anyway.
-    ...(t.kind === 'text'
-      ? {
-          text: {
-            ...(t.minLength !== undefined ? { minLength: t.minLength } : {}),
-            ...(t.maxLength !== undefined ? { maxLength: t.maxLength } : {}),
-            ...(t.pattern !== undefined ? { pattern: t.pattern } : {}),
-            ...(t.format !== undefined ? { format: t.format } : {})
-          }
-        }
-      : {}),
-    ...(t.kind === 'number'
-      ? {
-          number: {
-            ...(t.integer ? { integer: true } : {}),
-            ...(t.minimum !== undefined ? { minimum: t.minimum } : {}),
-            ...(t.maximum !== undefined ? { maximum: t.maximum } : {})
-          }
-        }
-      : {}),
-    ...(t.defaultValue !== undefined ? { defaultValue: t.defaultValue } : {})
-  }
-}
-
 /** How many consented URL elicitations wait for an `elicitation/complete` that may never come. */
 const CONSENTED_URL_ELICIT_CAP = 64
 
@@ -253,9 +211,16 @@ type PendingElicit = PendingElicitSurface & {
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
   url?: { elicitationId: string; url: string }
+  /** Where this card's transcript row lives (#1794), so the settlement rewrites the very row the
+   *  ask wrote rather than appending a second one below the reply that followed it. Absent on an
+   *  approval elicitation, whose durable record is `permission_requests`. */
+  row?: ElicitRow
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
+
+/** One card's `elicit` transcript row: its coordinates, and the card the ask recorded there. */
+type ElicitRow = { channel: string; thread: string; ts: string; sender: string; card: ElicitCard }
 
 /** The turn's platform surfaces a permission or elicitation card renders through. */
 export interface PermissionSurfaceHost {
@@ -357,6 +322,11 @@ export class PermissionCoordinator {
    *  these hold only the surface coordinates the "Completed" re-label is said on. Bounded:
    *  an agent that never completes its flows must not grow this without limit. */
   private readonly consentedUrlElicits = new Map<string, { requestId: string; rec: PendingElicit }>()
+  /** How a card that settled while its own `chat.postMessage` was still in flight must be
+   *  labelled once that post finally returns — recorded by the settlement, consumed by the
+   *  posting path, which would otherwise stamp every such card Cancelled (#1794). Bounded by
+   *  the posting path deleting its own entry on every exit. */
+  private readonly settledBeforePost = new Map<string, { decision: string; fallback: string }>()
 
   /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
   private readonly awaitingApproval = new Map<string, { owner: HostKey; agentId: string; sessionId: string }>()
@@ -912,10 +882,12 @@ export class PermissionCoordinator {
       // Same card builder, same re-derivation: the actor checks above say who tapped, not what
       // this card offered, so an unoffered value is dropped and the DM card stays live.
       const target = elicitTarget(rec.params, SLACK_DM_ELICIT_SURFACE)
-      if (!target || !fieldAccepts(target, value)) return
-      const chosen = notify.valueKind === 'boolean' ? value === 'true' : value
+      // The DM card is a Slack button row, so it carries positions too (#1794).
+      const picked = target ? elicitOptionLiteral(target, value) : null
+      if (!target || picked === null || !fieldAccepts(target, picked)) return
+      const chosen = notify.valueKind === 'boolean' ? picked === 'true' : picked
       res = { action: 'accept', content: { [notify.propName]: chosen } }
-      decision = `:white_check_mark: ${notify.valueKind === 'boolean' ? (chosen ? 'Yes' : 'No') : value}`
+      decision = `:white_check_mark: ${notify.valueKind === 'boolean' ? (chosen ? 'Yes' : 'No') : picked}`
     } else {
       return
     }
@@ -1435,6 +1407,7 @@ export class PermissionCoordinator {
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
     const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p), SLACK_ELICIT_SURFACE)
     if (!blocks) return this.noticeUnrenderableElicit(p, params, isApproval)
+    const cardMessage = (params as { message?: string }).message?.trim() || 'The agent needs your input'
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
@@ -1449,6 +1422,9 @@ export class PermissionCoordinator {
       surface: 'slack',
       conn,
       channel: p.plan.channel,
+      // An MCP approval keeps its durable record in `permission_requests` and its own console
+      // surface, so it is not also a transcript card.
+      ...(isApproval ? {} : this.recordElicitCard(p, elicitCardPayload(requestId, cardMessage, params, form))),
       resolve: resolveResult
     })
     this.syncApprovalActivity(p.hostKey, sessionId)
@@ -1480,14 +1456,18 @@ export class PermissionCoordinator {
       })
     )
     const live = this.pendingElicits.get(requestId)
+    // Settled mid-post — say how it actually ended. A tap can reach the daemon before Slack has
+    // answered the post that carried it, and calling that answer Cancelled contradicts what the
+    // reader just did; the settlement left its own label here (#1794).
     if (!live) {
+      const settled = this.takeSettledBeforePost(requestId)
       if (ts)
         void conn
           .updateBlocks(
             p.plan.channel,
             ts,
-            buildElicitationResolvedCard(params, ':hourglass: Cancelled'),
-            'Cancelled',
+            buildElicitationResolvedCard(params, settled.decision),
+            settled.fallback,
             true
           )
           .catch(() => {})
@@ -1497,6 +1477,8 @@ export class PermissionCoordinator {
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
       if (isApproval) await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
+      // A card Slack never took is closed on the row too, or it would read as open forever.
+      this.settleElicitRow(live, 'cancelled')
       live.resolve({ action: 'cancel' })
       return await result
     }
@@ -1555,6 +1537,10 @@ export class PermissionCoordinator {
     const seen = (p.declinedElicitNotices ??= new Set<string>())
     if (seen.has(key)) return null
     seen.add(key)
+    // The durable half of the same notice (#1794): one row per distinct declined question, on
+    // whichever surface declined it, so a reader loading the conversation later still sees that
+    // the agent asked something nothing here could show.
+    this.recordUnrenderableElicit(p, params)
     let sessionUrl: string | undefined
     // A console link this daemon cannot compute must not cost the reader the question itself.
     try {
@@ -1607,9 +1593,9 @@ export class PermissionCoordinator {
     const form = elicitForm(params, WEBCHAT_ELICIT_SURFACE)
     if (!form) return this.noticeUnrenderableWebchatElicit(p, wc, params)
     const target = form[0]!
-    const required = new Set(elicitRequiredProps(params))
     const requestId = `elicit-${++this.elicitSeq}`
     const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+    const card = elicitCardPayload(requestId, message, params, form)
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
     this.pendingElicits.set(requestId, {
@@ -1623,6 +1609,7 @@ export class PermissionCoordinator {
       approval: false,
       surface: 'webchat',
       wc,
+      ...this.recordElicitCard(p, card),
       resolve: resolveResult
     })
     this.syncApprovalActivity(p.hostKey, sessionId)
@@ -1631,36 +1618,18 @@ export class PermissionCoordinator {
         conversationId: wc.conversationId,
         turnId: wc.turnId,
         index: wc.index++,
-        event: {
-          kind: 'elicitation',
-          requestId,
-          message,
-          // A multi-field form carries its fields as a LIST and NONE of the single-field
-          // descriptors: an old reader then gets an optionless card it can only dismiss,
-          // rather than one it could half-fill with an answer the daemon would refuse.
-          ...(form.length > 1
-            ? {
-                options: [],
-                fields: form.map((t) => ({
-                  propName: t.propName,
-                  label: elicitFieldLabel(params, t.propName),
-                  kind: t.kind,
-                  ...(required.has(t.propName) ? { required: true } : {}),
-                  ...(t.description ? { description: t.description } : {}),
-                  ...(t.customAnswerFor ? { customAnswerFor: t.customAnswerFor } : {}),
-                  ...elicitCardDescriptors(t)
-                }))
-              }
-            : elicitCardDescriptors(target))
-        }
+        event: { kind: 'elicitation', ...card }
       })
     } catch (err) {
       // An undelivered card can never be answered — drop the resolver and decline now
       // rather than stall the runtime until the turn ends. No notice: this sink IS the only thing
       // that speaks to this reader, so a line saying the ask could not be shown would go out
       // through the very call that just threw, and a webchat turn has no second surface for it.
+      const stillPending = this.pendingElicits.get(requestId)
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      // A card nobody was shown is closed on the row too, or it would read as open forever.
+      if (stillPending) this.settleElicitRow(stillPending, 'cancelled')
       this.host.log().warn(`webchat elicitation card not delivered for "${p.plan.sessionKey}": ${formatErr(err)}`)
       return undefined
     }
@@ -1683,6 +1652,7 @@ export class PermissionCoordinator {
     const message = (params as { message?: string }).message?.trim() || 'The agent needs you to open a link'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
+    const card = elicitUrlCardPayload(requestId, message, url.url)
     this.pendingElicits.set(requestId, {
       owner: p.hostKey,
       agentId,
@@ -1695,6 +1665,7 @@ export class PermissionCoordinator {
       approval: false,
       surface: 'webchat',
       wc,
+      ...this.recordElicitCard(p, card),
       resolve: resolveResult
     })
     this.syncApprovalActivity(p.hostKey, sessionId)
@@ -1703,13 +1674,14 @@ export class PermissionCoordinator {
         conversationId: wc.conversationId,
         turnId: wc.turnId,
         index: wc.index++,
-        // No options and no field descriptors: a reader that does not know `url` gets a card it
-        // can only Dismiss, which is the spec's `decline` — never an accidental consent.
-        event: { kind: 'elicitation', requestId, message, options: [], url: url.url }
+        event: { kind: 'elicitation', ...card }
       })
     } catch (err) {
+      const stillPending = this.pendingElicits.get(requestId)
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      // A card nobody was shown is closed on the row too, or it would read as open forever.
+      if (stillPending) this.settleElicitRow(stillPending, 'cancelled')
       this.host.log().warn(`webchat consent card not delivered for "${p.plan.sessionKey}": ${formatErr(err)}`)
       return undefined
     }
@@ -1732,6 +1704,7 @@ export class PermissionCoordinator {
     const requestId = `elicit-${++this.elicitSeq}`
     const blocks = buildUrlConsentCard(requestId, params, this.host.httpSlackSessionTarget(p))
     if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
+    const message = (params as { message?: string }).message?.trim() || 'The agent needs you to open a link'
     const fallback = (params as { message?: string }).message ?? 'The agent needs you to open a link'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
@@ -1748,6 +1721,7 @@ export class PermissionCoordinator {
       surface: 'slack',
       conn,
       channel: p.plan.channel,
+      ...this.recordElicitCard(p, elicitUrlCardPayload(requestId, message, url.url)),
       resolve: resolveResult
     })
     this.syncApprovalActivity(p.hostKey, sessionId)
@@ -1758,14 +1732,19 @@ export class PermissionCoordinator {
       })
     )
     const live = this.pendingElicits.get(requestId)
-    // Settled mid-post (an ended turn, say) — the card must stop offering a consent nobody awaits.
+    // Settled mid-post — the card must stop offering a consent nobody awaits, and must say how it
+    // actually ended: a consent that beat this post left its own label, and calling that Cancelled
+    // would contradict the credential page the reader really did open (#1794).
     if (!live) {
-      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, ':hourglass: Cancelled', 'Cancelled', true)
+      const settled = this.takeSettledBeforePost(requestId)
+      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, settled.decision, settled.fallback, true)
       return await result
     }
     if (!ts) {
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      // A card Slack never took is closed on the row too, or it would read as open forever.
+      this.settleElicitRow(live, 'cancelled')
       live.resolve({ action: 'cancel' })
       return await result
     }
@@ -1794,6 +1773,7 @@ export class PermissionCoordinator {
     const sessionTarget = this.host.httpSlackSessionTarget(p)
     const blocks = buildElicitationFormCard(requestId, params, form, sessionTarget)
     if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
+    const cardMessage = (params as { message?: string }).message?.trim() || 'The agent needs your input'
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
@@ -1812,6 +1792,7 @@ export class PermissionCoordinator {
       surface: 'slack',
       conn,
       channel: p.plan.channel,
+      ...this.recordElicitCard(p, elicitCardPayload(requestId, cardMessage, params, form)),
       resolve: resolveResult
     })
     this.syncApprovalActivity(p.hostKey, sessionId)
@@ -1822,14 +1803,18 @@ export class PermissionCoordinator {
       })
     )
     const live = this.pendingElicits.get(requestId)
-    // Settled mid-post (an ended turn, say) — the card must stop offering an Answer nobody awaits.
+    // Settled mid-post — the card must stop offering an answer nobody awaits, and must say how it
+    // actually ended rather than assume the turn was cancelled (#1794).
     if (!live) {
-      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, ':hourglass: Cancelled', 'Cancelled', false)
+      const settled = this.takeSettledBeforePost(requestId)
+      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, settled.decision, settled.fallback, false)
       return await result
     }
     if (!ts) {
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      // A card Slack never took is closed on the row too, or it would read as open forever.
+      this.settleElicitRow(live, 'cancelled')
       live.resolve({ action: 'cancel' })
       return await result
     }
@@ -1911,9 +1896,11 @@ export class PermissionCoordinator {
     if (rec.surface === 'webchat') {
       if (a.webchatConversationId === undefined || rec.wc.conversationId !== a.webchatConversationId) return
     } else if (a.webchatConversationId !== undefined) return
-    // Consent echoes the card's own URL back: the only value this card offers, checked the way
-    // every other card checks that an answer was one it actually rendered.
-    const consented = a.value === rec.url.url
+    // Consent echoes the card's own ONE option back, checked the way every other card checks that
+    // an answer was one it actually rendered. A Slack button carries that option as its position
+    // (#1794), which is what keeps a URL too long for a button `value` from losing its card;
+    // webchat's card carries the URL itself.
+    const consented = a.value === (rec.surface === 'slack' ? elicitOptionToken(0) : rec.url.url)
     if (!consented && a.value !== null) return
     this.pendingElicits.delete(requestId)
     this.syncApprovalActivity(rec.owner, rec.sessionId, { id: requestId, allowed: consented })
@@ -1929,13 +1916,14 @@ export class PermissionCoordinator {
     requestId: string,
     outcome: 'accepted' | 'dismissed' | 'cancelled' | 'completed'
   ): void {
+    const label = outcome === 'accepted' ? 'Opened' : undefined
+    this.settleElicitRow(rec, outcome, label)
     if (rec.surface === 'webchat') {
-      this.emitWebchatElicitResolved(rec, requestId, outcome, outcome === 'accepted' ? 'Opened' : undefined)
+      this.emitWebchatElicitResolved(rec, requestId, outcome, label)
       return
     }
-    if (!rec.ts) return
     const decision = URL_CONSENT_DECISION[outcome]
-    this.rewriteSlackCard(rec.conn, rec.channel, rec.ts, rec.params, decision, decision, true)
+    this.settleSlackCard(rec, requestId, decision, decision, true)
   }
 
   /** Park a consented card's coordinates so a later `elicitation/complete` can find it. Oldest
@@ -2033,22 +2021,38 @@ export class PermissionCoordinator {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
       // And a card settles only from its own surface, so a Slack tap never answers a webchat one.
     } else if (rec.surface === 'webchat') return
+    // A Slack one-tap card carries each option's POSITION, not its value (#1794) — resolve it
+    // against the card THAT card rendered, so an option whose value is a path, an id or a URL can
+    // be tapped at all. ONE rule for the whole surface: what comes back is a position or it is not
+    // an answer, exactly as `elicitFormSubmission` reads a Confirm. A form answer came through
+    // that function, which resolved it already, and webchat carries literals: neither is remapped.
+    const resolved: ElicitAnswer =
+      rec.surface === 'slack' && !rec.form && target && typeof a.value === 'string'
+        ? elicitOptionLiteral(target, a.value)
+        : a.value
+    // A position naming no option this card offered is refused with the same words, and the card
+    // stays live — Dismiss is still the only `null` that settles anything.
+    if (resolved === null && a.value !== null) {
+      this.noticeInTurn(rec, ELICIT_ANSWER_REFUSED)
+      return
+    }
+    const answer: ElicitAnswer = resolved
     // Every surface's answer is re-derived against the card that offered it: a signed interaction
     // and a relay that checks the block target say who tapped, never what the card offered.
     // An unoffered value would inject content the agent never asked for, so it is dropped and the
     // card stays live — one bad field refusing a whole form answer, as on webchat all along.
     const offered =
-      a.value === null ||
-      (isFormAnswer(a.value)
-        ? !!form && elicitFormAccepts(form, elicitRequiredProps(rec.params), a.value)
+      answer === null ||
+      (isFormAnswer(answer)
+        ? !!form && elicitFormAccepts(form, elicitRequiredProps(rec.params), answer)
         : !!target &&
-          (Array.isArray(a.value)
-            ? multiSelectAccepts(target, a.value)
-            : typeof a.value === 'number'
-              ? numberAccepts(target, a.value)
+          (Array.isArray(answer)
+            ? multiSelectAccepts(target, answer)
+            : typeof answer === 'number'
+              ? numberAccepts(target, answer)
               : target.kind === 'text'
-                ? textAccepts(target, a.value)
-                : target.options.some((o) => o.value === a.value)))
+                ? textAccepts(target, answer)
+                : target.options.some((o) => o.value === answer)))
     // A refused answer is not a silent one (#1794): the reader just acted, the card is still
     // standing, so its own surface says the answer was not taken — the same words a refused
     // Confirm gets, on whichever transport that card was posted to. Nothing here changes WHAT is
@@ -2075,27 +2079,27 @@ export class PermissionCoordinator {
     let decision: string
     // What the settled card says the answer WAS — the webchat label, and the Slack decision's tail.
     let answered: string | undefined
-    if (a.value === null) {
+    if (answer === null) {
       res = { action: 'decline' }
       decision = ':no_entry_sign: Dismissed'
-    } else if (isFormAnswer(a.value)) {
+    } else if (isFormAnswer(answer)) {
       if (!form) return
       // A form's accepted content is the whole record: every answered field under its own name.
-      res = { action: 'accept', content: elicitFormContent(form, a.value) }
-      answered = formAnswerLabel(rec.params, form, a.value)
+      res = { action: 'accept', content: elicitFormContent(form, answer) }
+      answered = formAnswerLabel(rec.params, form, answer)
       decision = `:white_check_mark: ${answered}`
-    } else if (Array.isArray(a.value)) {
+    } else if (Array.isArray(answer)) {
       // The array property's accepted content is the chosen list itself.
-      res = { action: 'accept', content: { [rec.propName]: a.value } }
-      answered = chosenLabel(target, a.value)
+      res = { action: 'accept', content: { [rec.propName]: answer } }
+      answered = chosenLabel(target, answer)
       decision = `:white_check_mark: ${answered}`
     } else {
       // The accepted content carries the schema's own type: a boolean for a boolean field and a
       // real number for a numeric one, never the string the wire happened to spell it with.
-      const value = rec.kind === 'boolean' ? a.value === 'true' : a.value
+      const value = rec.kind === 'boolean' ? answer === 'true' : answer
       res = { action: 'accept', content: { [rec.propName]: value } }
-      answered = chosenLabel(target, a.value)
-      decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : String(a.value)}`
+      answered = chosenLabel(target, answer)
+      decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : String(answer)}`
     }
     if (rec.approval) {
       // Approval elicitations only ever take the Slack card path (chat approval requires it).
@@ -2107,21 +2111,117 @@ export class PermissionCoordinator {
         !(await this.resolveStoredPermissionRequest(
           rec.agentId,
           a.requestId,
-          a.value === null ? 'denied' : 'allowed',
+          answer === null ? 'denied' : 'allowed',
           by
         ))
       )
         return
     }
     this.pendingElicits.delete(a.requestId)
-    this.syncApprovalActivity(rec.owner, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
+    this.syncApprovalActivity(rec.owner, rec.sessionId, { id: a.requestId, allowed: answer !== null })
+    const outcome = answer === null ? 'dismissed' : 'accepted'
+    this.settleElicitRow(rec, outcome, answered)
     if (rec.surface === 'webchat') {
-      this.emitWebchatElicitResolved(rec, a.requestId, a.value === null ? 'dismissed' : 'accepted', answered)
-    } else if (rec.ts)
-      void rec.conn
-        .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)
-        .catch(() => {})
+      this.emitWebchatElicitResolved(rec, a.requestId, outcome, answered)
+    } else this.settleSlackCard(rec, a.requestId, decision, 'Input received', false)
     rec.resolve(res)
+  }
+
+  /**
+   * Record one elicitation card as a transcript row (#1794) and hand back the handle its
+   * settlement rewrites. Losing the card on a page reload is real data loss — a reader who joins
+   * later never learns a question was asked at all — so the ask becomes durable history on both
+   * surfaces, Slack and webchat alike.
+   *
+   * The row can never be fed back to the runtime as fresh conversation: it already answered this
+   * request over ACP, and asking again would be the bug. Three independent things keep it out —
+   * its `kind` is not `text`, and `text` is the only kind any replay reader selects; it is
+   * authored by the agent itself, which every participant gap filters; and on Slack the card
+   * MESSAGE carries the `agentconnect_chrome` marker, so a peer daemon's thread backfill drops it
+   * before it can become a row of its own.
+   *
+   * Best effort by construction: the ACP request never waits on the write and never fails with it.
+   */
+  private recordElicitCard(p: Pending, card: ElicitCard): { row?: ElicitRow } {
+    const row: ElicitRow = {
+      channel: p.plan.transcriptChannel,
+      thread: p.plan.statusThread,
+      // The monotonic internal-event clock, as every other non-conversational row uses: it keeps
+      // the card in the position it was asked and cannot collide with a second card's row.
+      ts: monotonicTs(),
+      sender: p.plan.agentId,
+      card
+    }
+    this.writeElicitRow(row)
+    return { row }
+  }
+
+  /** Write (or rewrite) one card's row. */
+  private writeElicitRow(row: ElicitRow, settled?: { outcome: ElicitOutcome; answerLabel?: string }): void {
+    void this.host
+      .store()
+      .upsertElicit({
+        channel: row.channel,
+        thread: row.thread,
+        ts: row.ts,
+        sender: row.sender,
+        text: row.card.message,
+        body: elicitRowBody(row.card, settled)
+      })
+      .catch((err: unknown) => {
+        this.host.log().warn(`elicitation row not recorded for ${row.card.requestId}: ${formatErr(err)}`)
+      })
+  }
+
+  /** Say on the card's own row how it ended, so a reader loading the conversation later sees the
+   *  settled card rather than one that still looks open. */
+  private settleElicitRow(rec: PendingElicit, outcome: ElicitOutcome, answerLabel?: string): void {
+    if (!rec.row) return
+    this.writeElicitRow(rec.row, { outcome, ...(answerLabel !== undefined ? { answerLabel } : {}) })
+  }
+
+  /** Record an ask NO surface had a control for. It offers nothing because nothing was offered:
+   *  the row exists so a later reader still learns the question was asked, which #1839's live-only
+   *  decline notice could not tell them. */
+  private recordUnrenderableElicit(p: Pending, params: CreateElicitationRequest): void {
+    const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+    const card = elicitUnrenderablePayload(`elicit-${++this.elicitSeq}`, message)
+    // Written settled in one go: this ask was never open on any surface.
+    this.writeElicitRow(
+      {
+        channel: p.plan.transcriptChannel,
+        thread: p.plan.statusThread,
+        ts: monotonicTs(),
+        sender: p.plan.agentId,
+        card
+      },
+      { outcome: 'unrenderable' }
+    )
+  }
+
+  /** Label a Slack card whose post is still in flight. The message has no `ts` yet, so there is
+   *  nothing to rewrite — the label is left for the posting path, which would otherwise call
+   *  every such card Cancelled (#1794). The row is settled either way: it needs no `ts`. */
+  private settleSlackCard(
+    rec: PendingElicit & { surface: 'slack' },
+    requestId: string,
+    decision: string,
+    fallback: string,
+    consent: boolean
+  ): void {
+    if (rec.ts) {
+      this.rewriteSlackCard(rec.conn, rec.channel, rec.ts, rec.params, decision, fallback, consent)
+      return
+    }
+    this.settledBeforePost.set(requestId, { decision, fallback })
+  }
+
+  /** How a card the posting path found already settled must read. A settlement that beat the post
+   *  left its own label here; anything else really was the turn ending, which is Cancelled. */
+  private takeSettledBeforePost(requestId: string): { decision: string; fallback: string } {
+    const settled = this.settledBeforePost.get(requestId)
+    this.settledBeforePost.delete(requestId)
+    return settled ?? { decision: ':hourglass: Cancelled', fallback: 'Cancelled' }
   }
 
   /** Post one daemon-authored line on the card's OWN surface — a notice, so it lands where every
@@ -2152,9 +2252,11 @@ export class PermissionCoordinator {
       if (rec.approval) await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       // A consent card settles through its own shape, so the cancelled message still shows the URL.
       if (rec.url) this.settleUrlElicit(rec, id, 'cancelled')
-      else if (rec.surface === 'webchat') this.emitWebchatElicitResolved(rec, id, 'cancelled')
-      else if (rec.ts)
-        this.rewriteSlackCard(rec.conn, rec.channel, rec.ts, rec.params, ':hourglass: Cancelled', 'Cancelled', false)
+      else {
+        this.settleElicitRow(rec, 'cancelled')
+        if (rec.surface === 'webchat') this.emitWebchatElicitResolved(rec, id, 'cancelled')
+        else this.settleSlackCard(rec, id, ':hourglass: Cancelled', 'Cancelled', false)
+      }
       rec.resolve({ action: 'cancel' })
     }
   }

--- a/packages/daemon/src/permissions/elicit-record.ts
+++ b/packages/daemon/src/permissions/elicit-record.ts
@@ -1,0 +1,116 @@
+// One elicitation card's REDUCED payload — the shape the webchat stream sends live and the
+// transcript row persists (#1794), built once so the two can never describe one card differently.
+
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import type { ElicitBody, ElicitCard, ElicitField, ElicitOutcome } from '@agentconnect.md/protocol'
+import type { ElicitTarget } from '../slack/render.js'
+import { elicitFieldLabel, elicitRequiredProps } from '../slack/render.js'
+
+/** The card-side descriptors of ONE field — the wire's own shape, minus what only a form
+ *  entry names (property, label, kind, requiredness). */
+type ElicitCardDescriptors = Pick<ElicitField, 'options' | 'multi' | 'text' | 'number' | 'defaultValue'>
+
+/** The per-kind descriptors an elicitation card carries for one field: its options plus
+ *  whichever constraint block its kind brings. Shared by the single-field card and each entry
+ *  of a form, so a one-field form's payload stays exactly the single-field card's. Pure. */
+export function elicitCardDescriptors(t: ElicitTarget): ElicitCardDescriptors {
+  return {
+    options: t.options,
+    // Present only for a multi-select: it is what tells the card to offer toggles and a
+    // confirm rather than one-tap buttons, and the bounds the confirm enforces.
+    ...(t.kind === 'multi-enum'
+      ? {
+          multi: {
+            ...(t.minItems !== undefined ? { minItems: t.minItems } : {}),
+            ...(t.maxItems !== undefined ? { maxItems: t.maxItems } : {})
+          }
+        }
+      : {}),
+    // Present only for a typed field, and likewise what makes the card an input rather than a
+    // row of options. The constraints ride along so the control can refuse an answer the
+    // daemon would reject anyway.
+    ...(t.kind === 'text'
+      ? {
+          text: {
+            ...(t.minLength !== undefined ? { minLength: t.minLength } : {}),
+            ...(t.maxLength !== undefined ? { maxLength: t.maxLength } : {}),
+            ...(t.pattern !== undefined ? { pattern: t.pattern } : {}),
+            ...(t.format !== undefined ? { format: t.format } : {})
+          }
+        }
+      : {}),
+    ...(t.kind === 'number'
+      ? {
+          number: {
+            ...(t.integer ? { integer: true } : {}),
+            ...(t.minimum !== undefined ? { minimum: t.minimum } : {}),
+            ...(t.maximum !== undefined ? { maximum: t.maximum } : {})
+          }
+        }
+      : {}),
+    ...(t.defaultValue !== undefined ? { defaultValue: t.defaultValue } : {})
+  }
+}
+
+/**
+ * The payload for ONE form-mode card: its question plus what it offered. A multi-field form
+ * carries its fields as a LIST and none of the single-field descriptors, exactly as the live
+ * webchat event does — a reader that does not know `fields` then gets an optionless card it can
+ * only dismiss, rather than one it could half-fill with an answer the daemon would refuse.
+ *
+ * `form` is the surface's OWN reduction, so a persisted Slack card describes what Slack offered
+ * and a persisted webchat card what webchat did. Pure.
+ */
+export function elicitCardPayload(
+  requestId: string,
+  message: string,
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[]
+): ElicitCard {
+  const required = new Set(elicitRequiredProps(params))
+  const target = form[0]!
+  return {
+    requestId,
+    message,
+    ...(form.length > 1
+      ? {
+          options: [],
+          fields: form.map((t) => ({
+            propName: t.propName,
+            label: elicitFieldLabel(params, t.propName),
+            kind: t.kind,
+            ...(required.has(t.propName) ? { required: true } : {}),
+            ...(t.description ? { description: t.description } : {}),
+            ...(t.customAnswerFor ? { customAnswerFor: t.customAnswerFor } : {}),
+            ...elicitCardDescriptors(t)
+          }))
+        }
+      : elicitCardDescriptors(target))
+  }
+}
+
+/** The payload for a URL-mode CONSENT card. No options and no field descriptors: a reader that
+ *  does not know `url` gets a card it can only Dismiss, which is the spec's `decline` and never
+ *  an accidental consent. Pure. */
+export function elicitUrlCardPayload(requestId: string, message: string, url: string): ElicitCard {
+  return { requestId, message, options: [], url }
+}
+
+/** The payload for an ask no surface had a control for. It offers nothing, because nothing was
+ *  offered — the row exists so a later reader still learns the question was asked, which the
+ *  live-only decline notice (#1839) could not tell them. Pure. */
+export function elicitUnrenderablePayload(requestId: string, message: string): ElicitCard {
+  return { requestId, message, options: [] }
+}
+
+/** The card plus how it ended — what one `elicit` transcript row's `body` holds. The answer is
+ *  named by its LABEL and never by the accepted content: the values are already in the agent's
+ *  own context, and a label is what a reader coming back to the thread needs. Pure. */
+export function elicitRowBody(card: ElicitCard, settled?: { outcome: ElicitOutcome; answerLabel?: string }): string {
+  const body: ElicitBody = {
+    ...card,
+    ...(settled ? { outcome: settled.outcome } : {}),
+    ...(settled?.answerLabel !== undefined ? { answerLabel: settled.answerLabel } : {})
+  }
+  return JSON.stringify(body)
+}

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -617,14 +617,16 @@ export type ElicitKind = 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
  *  surface has not claimed on either count, so a kind (or an option list) reaches a surface only
  *  once that surface claims it, and a form it cannot show whole is declined rather than trimmed.
  *  Every surface limit belongs here: a limit left inside a card builder is one the reduction
- *  cannot see, which is exactly how an over-long option list used to be quietly cut to fit. */
+ *  cannot see, which is exactly how an over-long option list used to be quietly cut to fit. An
+ *  option's own LENGTH is not among them any more — a Slack card carries positions rather than
+ *  values ({@link elicitOptionToken}), so no surface refuses a long one (#1794). */
 export interface ElicitSurface {
   kinds: ReadonlySet<ElicitKind>
   /** Per-kind option limits, because one surface's controls do not all hold the same list: on
-   *  Slack a row of buttons and a select menu differ in BOTH how many options they take and how
-   *  long an option's wire value may be. A kind absent from the map is unlimited on both counts —
-   *  webchat renders them all. Widening one kind's limit never widens another's. */
-  optionLimits?: Partial<Record<ElicitKind, { maxOptions?: number; maxOptionValue?: number }>>
+   *  Slack a row of buttons and a select menu do not take the same number of options. A kind
+   *  absent from the map is unlimited — webchat renders them all. Widening one kind's limit
+   *  never widens another's. */
+  optionLimits?: Partial<Record<ElicitKind, { maxOptions?: number }>>
 }
 
 /** Slack allows 25 elements in one `actions` block and wraps them across lines, so the card can
@@ -632,11 +634,47 @@ export interface ElicitSurface {
  *  declined: no card is built from a slice of it, which is what made a pick a misreported answer. */
 const SLACK_ELICIT_MAX_BUTTONS = 24
 
-/** Slack's own cap on a select menu's `options`, and on one option's `value` — the second is why
- *  #1813 refused a `static_select` for single-select, where a button's 2000 fits any enum value.
- *  A multi-select has no button to fall back to, so an option value this long declines instead. */
+/** Slack's own cap on a select menu's `options`. */
 const SLACK_SELECT_MAX_OPTIONS = 100
-const SLACK_SELECT_VALUE_CAP = 75
+
+const ELICIT_OPTION_TOKEN_PREFIX = 'ac_o'
+
+/** The value one option carries ON A SLACK CARD: its POSITION in the field the card rendered,
+ *  never the option's own value. Slack caps an option object's `value` at 75 characters and a
+ *  button's at 2000, so an enum of paths, ids or a long URL could not carry its own answer and
+ *  was declined outright (#1794). A position always fits, and it resolves without a lookup table
+ *  to keep: the same trick {@link elicitFormBlockId} already uses for a field's block id, and
+ *  safe for the same reason — the daemon re-derives the field list from the card's own params
+ *  (#1815), so the position names the very option that was offered. Every Slack card carries
+ *  positions, so a token can never be mistaken for a literal one of its own options spells. */
+export function elicitOptionToken(index: number): string {
+  return `${ELICIT_OPTION_TOKEN_PREFIX}${index}`
+}
+
+/** The option one carried card value stands for, or null when it names none this field offered —
+ *  the server-side half of {@link elicitOptionToken}, and the only way a Slack answer becomes a
+ *  literal again. Pure. */
+export function elicitOptionLiteral(target: ElicitTarget, carried: string): string | null {
+  if (!carried.startsWith(ELICIT_OPTION_TOKEN_PREFIX)) return null
+  const digits = carried.slice(ELICIT_OPTION_TOKEN_PREFIX.length)
+  if (!/^\d+$/.test(digits)) return null
+  return target.options[Number(digits)]?.value ?? null
+}
+
+/** The literals a card's carried option value(s) stand for — `carried` unchanged for a field that
+ *  offers no options, and null when one of them names no option this field rendered, which is the
+ *  same verdict `fieldAccepts` reaches for an unoffered value. Pure. */
+export function elicitCardValues(target: ElicitTarget, carried: string | string[]): string | string[] | null {
+  if (!target.options.length) return carried
+  if (!Array.isArray(carried)) return elicitOptionLiteral(target, carried)
+  const out: string[] = []
+  for (const one of carried) {
+    const literal = elicitOptionLiteral(target, one)
+    if (literal === null) return null
+    out.push(literal)
+  }
+  return out
+}
 
 /** Slack renders a lone single-select or boolean as a row of buttons — one tap answers it — and
  *  every other shape as `input` blocks in the message with one Confirm, since a select, a
@@ -647,7 +685,7 @@ export const SLACK_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
   optionLimits: {
     enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS },
-    'multi-enum': { maxOptions: SLACK_SELECT_MAX_OPTIONS, maxOptionValue: SLACK_SELECT_VALUE_CAP }
+    'multi-enum': { maxOptions: SLACK_SELECT_MAX_OPTIONS }
   }
 }
 
@@ -958,8 +996,7 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
   // card built from part of it would report the reader's pick as their answer to the question.
   const fits = (kind: ElicitKind, options: readonly { value: string }[]) => {
     const limits = surface.optionLimits?.[kind]
-    if (limits?.maxOptions !== undefined && options.length > limits.maxOptions) return false
-    return limits?.maxOptionValue === undefined || options.every((o) => o.value.length <= limits.maxOptionValue!)
+    return limits?.maxOptions === undefined || options.length <= limits.maxOptions
   }
   const found: ElicitTarget[] = []
   for (const [name, prop] of Object.entries(p.requestedSchema?.properties ?? {})) {
@@ -1295,16 +1332,20 @@ const SLACK_MAX_SELECTED_ELEMENTS: ReadonlySet<string> = new Set([
   'multi_channels_select'
 ])
 
-/** Slack's own caps on one `actions` block's elements and on an option object's `value`. */
+/** Slack's own caps on one `actions` block's elements, on an option object's `value`, and on an
+ *  interactive element's own `value`. Every Slack card carries positions rather than agent-authored
+ *  strings ({@link elicitOptionToken}), so nothing we build should reach either value cap — which
+ *  is exactly why they are asserted rather than assumed. */
 const SLACK_ACTIONS_MAX_ELEMENTS = 25
 const SLACK_OPTION_VALUE_CAP = 75
+const SLACK_ACTION_VALUE_CAP = 2000
 
 /** Every Slack rule this file has paid for, checked over one card's blocks: the element types a
  *  block type refuses, the per-element option caps, `max_selected_items` only where it exists,
- *  an `input` block's mandatory element, an option value past Slack's cap, and block ids unique
- *  within the message. Returns the reasons Slack would reject the card, empty when it would take
- *  it. Exported and asserted over every card we build, because our own JSON looks valid to us
- *  right up until Slack sees it — which is the only reason #1825 shipped. Pure. */
+ *  an `input` block's mandatory element, an option value or an element `value` past Slack's own
+ *  cap, and block ids unique within the message. Returns the reasons Slack would reject the card,
+ *  empty when it would take it. Exported and asserted over every card we build, because our own
+ *  JSON looks valid to us right up until Slack sees it — the only reason #1825 shipped. Pure. */
 export function slackCardViolations(blocks: readonly unknown[]): string[] {
   const bad: string[] = []
   const seen = new Set<string>()
@@ -1331,6 +1372,7 @@ export function slackCardViolations(blocks: readonly unknown[]): string[] {
  *  everything-optional, since the point is to inspect JSON that may be wrong. */
 interface SlackElementShape {
   type?: string
+  value?: unknown
   options?: { value?: unknown }[]
   initial_options?: { value?: unknown }[]
   initial_option?: { value?: unknown }
@@ -1360,14 +1402,18 @@ function slackElementViolations(el: SlackElementShape, at: string): string[] {
   for (const o of values)
     if (typeof o?.value === 'string' && o.value.length > SLACK_OPTION_VALUE_CAP)
       bad.push(`${at}: an option value is ${o.value.length} characters, past ${SLACK_OPTION_VALUE_CAP}`)
+  // A button's own `value` — the cap that silently cost a long consent URL its whole card.
+  if (typeof el.value === 'string' && el.value.length > SLACK_ACTION_VALUE_CAP)
+    bad.push(`${at}: a value is ${el.value.length} characters, past ${SLACK_ACTION_VALUE_CAP}`)
   return bad
 }
 
 /**
  * Build the ONE-TAP elicitation card: the agent's `message` and one actions row carrying EVERY
  * {@link elicitTarget} option as a button, plus Dismiss. The choice rides each option's `value`
- * (`<requestId>|<optionValue>`). Only a single-select or a boolean is answered this way — one tap
- * IS the answer there, where every other kind needs something filled in first and takes the
+ * (`<requestId>|<optionToken>`, see {@link elicitOptionToken}). Only a single-select or a boolean
+ * is answered this way — one tap IS the answer there, where every other kind needs something
+ * filled in first and takes the
  * `input` blocks of {@link buildElicitationFormCard} ({@link elicitCardShape} decides). Returns
  * null when the form can't be rendered on `surface` (caller declines): a kind or an option list
  * it does not claim, which the reduction has already refused. Nothing here trims a list to fit.
@@ -1390,7 +1436,7 @@ export function buildElicitationCard(
     type: 'button',
     action_id: `${ELICIT_ACTION_PREFIX}:${i}`,
     text: { type: 'plain_text', text: o.label, emoji: true },
-    value: encodePermValue(requestId, o.value)
+    value: encodePermValue(requestId, elicitOptionToken(i))
   }))
   buttons.push(elicitDismissButton(requestId) as (typeof buttons)[number])
   return [
@@ -1439,9 +1485,10 @@ const SLACK_HINT_TEXT_CAP = 2000
  *  numbers, each carrying the schema's own bounds so Slack refuses on the card what the daemon
  *  would refuse anyway. A checkbox list gets no `max_selected_items` (Slack has no such property
  *  there): its bounds are said in the block's hint and enforced when the answer comes back, which
- *  is where they were always binding. Null ⇒ this field cannot BE an input block — an option value
- *  past Slack's 75-char cap, or a minimum length past what an input holds — and the whole card is
- *  then withheld rather than posted with a field the reader cannot answer honestly. Pure. */
+ *  is where they were always binding. Null ⇒ this field cannot BE an input block — no options at
+ *  all, or a minimum length past what an input holds — and the whole card is then withheld rather
+ *  than posted with a field the reader cannot answer honestly. An option's own length is no longer
+ *  such a reason: every option carries its POSITION ({@link elicitOptionToken}). Pure. */
 function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> | null {
   const action_id = ELICIT_FORM_INPUT_ACTION as string
   if (target.kind === 'text') {
@@ -1466,15 +1513,15 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
       ...(typeof target.defaultValue === 'number' ? { initial_value: String(target.defaultValue) } : {})
     }
   }
-  const options = target.options.map((o) => ({
+  const options = target.options.map((o, i) => ({
     text: { type: 'plain_text', text: o.label, emoji: true },
-    value: o.value
+    value: elicitOptionToken(i)
   }))
-  if (!options.length || options.some((o) => o.value.length > SLACK_SELECT_VALUE_CAP)) return null
+  if (!options.length) return null
   const short = options.length <= SLACK_CHOICE_MAX_OPTIONS
   if (target.kind === 'multi-enum') {
     const seeded = Array.isArray(target.defaultValue) ? new Set(target.defaultValue) : null
-    const initial = seeded ? options.filter((o) => seeded.has(o.value)) : []
+    const initial = seeded ? options.filter((_, i) => seeded.has(target.options[i]!.value)) : []
     if (short)
       return { type: 'checkboxes', action_id, options, ...(initial.length ? { initial_options: initial } : {}) }
     return {
@@ -1488,7 +1535,8 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
   }
   // A boolean's `default` is a real boolean, so its option value is the string the card spells it with.
   const seed = target.kind === 'boolean' ? String(target.defaultValue) : target.defaultValue
-  const initial = options.find((o) => o.value === seed)
+  const seedIndex = target.options.findIndex((o) => o.value === seed)
+  const initial = seedIndex < 0 ? undefined : options[seedIndex]
   if (short) return { type: 'radio_buttons', action_id, options, ...(initial ? { initial_option: initial } : {}) }
   return {
     type: 'static_select',
@@ -1604,8 +1652,9 @@ export interface ElicitFormSubmission {
 /**
  * Decode one Confirm's raw field state into the typed record a form card answers with, re-derived
  * against the FORM THAT WAS RENDERED rather than trusted from the wire (#1815): each value is read
- * under its field's own block id, given the schema's own type — a real number for `number`/
- * `integer`, a list for a multi-select — and checked by {@link fieldAccepts}. A blank optional
+ * under its field's own block id, resolved from the position the card carried it as, given the
+ * schema's own type — a real number for `number`/`integer`, a list for a multi-select — and
+ * checked by {@link fieldAccepts}. A blank optional
  * input is simply absent; a missing REQUIRED field, a value of the wrong shape, and a value the
  * field does not admit each come back as that field's error, so one bad field refuses the whole
  * answer instead of being silently dropped. Pure.
@@ -1630,18 +1679,27 @@ export function elicitFormSubmission(
       if (required.has(target.propName)) errors[blockId] = 'This field is required.'
       continue
     }
+    // A Slack card's options carry their POSITION, so the literals come back through the field
+    // the card rendered ({@link elicitCardValues}) before anything is checked — that is what lets
+    // an option's value be a path, an id or a URL at all (#1794). One carried value naming no
+    // option this field offered refuses the field, exactly as an unoffered literal would.
+    const carried = elicitCardValues(target, raw)
+    if (carried === null) {
+      errors[blockId] = elicitFormFieldError(target)
+      continue
+    }
     const shaped =
       target.kind === 'multi-enum'
-        ? Array.isArray(raw)
-          ? raw
+        ? Array.isArray(carried)
+          ? carried
           : undefined
-        : Array.isArray(raw)
+        : Array.isArray(carried)
           ? undefined
           : target.kind === 'number'
-            ? NUMERIC_REPLY_RE.test(raw.trim())
-              ? Number(raw.trim())
+            ? NUMERIC_REPLY_RE.test(carried.trim())
+              ? Number(carried.trim())
               : undefined
-            : raw
+            : carried
     if (shaped === undefined || !fieldAccepts(target, shaped)) errors[blockId] = elicitFormFieldError(target)
     else answer[target.propName] = shaped
   }
@@ -1670,10 +1728,6 @@ export function elicitFormRefusalNotice(
   }
   return clampTo(`${ELICIT_ANSWER_REFUSED} ${parts.join(' ')}`, ELICIT_MESSAGE_CAP)
 }
-
-/** Slack's own limit on an interactive element's `value`. A URL longer than this cannot ride a
- *  button, so its card is not built at all rather than posted with a truncated consent. */
-const SLACK_ACTION_VALUE_CAP = 2000
 
 /** What a consent card shows about its URL: the REAL host, so a lookalike or a userinfo prefix
  *  cannot pass itself off as one, and what to warn about. Both checks are on the host alone — a
@@ -1710,10 +1764,12 @@ function consentUrlParts(url: string): { host: string; warnings: string[] } | nu
  *  but deliberately NOT followable as text — Slack autolinks a bare URL, and a reader who left
  *  through that autolink would deliver no interaction, so the card would hang unanswered. The
  *  button's `url` field both opens the page and still sends Slack's interaction, which is what
- *  makes consent observable; its `value` carries the URL back so the answer is re-derived against
- *  the card that offered it. Returns null — the caller then declines with a notice — when this is
- *  not a URL-mode ask, when the URL is not one a card may offer, or when it will not fit a Slack
- *  button `value`. Pure; the daemon never fetches the URL. */
+ *  makes consent observable; its `value` carries the card's ONE option back ({@link
+ *  elicitOptionToken}), which the daemon resolves to this same URL, so the answer is re-derived
+ *  against the card that offered it. The URL itself never rides the button: Slack caps a `value`
+ *  at 2000 and `elicitUrl` admits 2048, so a long OAuth `state` used to lose the card entirely
+ *  (#1794). Returns null — the caller then declines with a notice — when this is not a URL-mode
+ *  ask or the URL is not one a card may offer. Pure; the daemon never fetches the URL. */
 export function buildUrlConsentCard(
   requestId: string,
   params: CreateElicitationRequest,
@@ -1722,8 +1778,7 @@ export function buildUrlConsentCard(
   const url = elicitUrl(params)
   const parts = url && consentUrlParts(url.url)
   if (!url || !parts) return null
-  const value = encodePermValue(requestId, url.url)
-  if (value.length > SLACK_ACTION_VALUE_CAP) return null
+  const value = encodePermValue(requestId, elicitOptionToken(0))
   const detail = [
     'Opens in your browser. This agent never sees that page or anything you type on it.',
     `Host: \`${escapeSlackMrkdwn(parts.host)}\``,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -365,11 +365,22 @@ export interface SessionListRow extends SessionRecord {
  *  - `tool`      — an agent tool invocation (label). Audit/UI only.
  *  - `reasoning` — an agent's coalesced thinking block. Audit/UI only.
  *  - `plan`      — the turn's task list (one upserted row, `Plan · n/m` label). Audit/UI only.
- * `tool`/`reasoning`/`plan` are recorded for EVERY turn regardless of the agent's Slack
- * output mode — output mode only gates what reaches the platform, never the transcript.
- * Only `text` and `tool` rows ever rebuild model context; the other two are read-only history.
+ *  - `elicit`    — the agent's structured question and how it ended (one upserted row, the
+ *                  `ElicitBody` in `body`). Audit/UI only, and deliberately so: the runtime
+ *                  already received the answer as the ACP response, so re-feeding the card as
+ *                  conversation on catch-up would ask it again (#1794).
+ * Every one of these is recorded for EVERY turn regardless of the agent's Slack output mode —
+ * output mode only gates what reaches the platform, never the transcript.
+ * Only `text` and `tool` rows ever rebuild model context; the rest are read-only history.
  */
-export type TranscriptKind = 'text' | 'tool' | 'reasoning' | 'plan'
+export type TranscriptKind = 'text' | 'tool' | 'reasoning' | 'plan' | 'elicit'
+
+/** One elicitation card's row identity in the shared `tool_call_id` column, namespaced so it
+ *  cannot be an ACP tool id. Keyed by the card's minted `ts`, not its request id: request ids
+ *  restart with the daemon, and a reused one would rewrite an older card's row. */
+function elicitRowId(ts: string): string {
+  return `elicit:${ts}`
+}
 
 export interface TranscriptEntry {
   channel: string
@@ -4120,6 +4131,69 @@ export class LocalStore {
         [e.sender, e.recipient, ...sharedRecipients],
         this.transcriptRevision
       )
+    }
+  }
+
+  /** Write one elicitation card's row (the question in `text`, the serialized `ElicitBody` in
+   *  `body`). An upsert on the card's own `ts`, which the caller mints once and keeps for the
+   *  life of the request: the ask claims the row and the settlement rewrites it in place, so the
+   *  card holds the position in the turn where it was actually asked rather than reappearing
+   *  below the reply that followed it. `ts` comes from the monotonic internal-event clock, so
+   *  two cards in one thread never share a row. Shares the tool row's `tool_call_id` column as
+   *  its identity, exactly as {@link upsertPlan} does — the value is namespaced and both
+   *  statements are fenced on kind, so a real tool id can never collide with one. */
+  upsertElicit(e: {
+    channel: string
+    thread: string
+    ts: string
+    sender: string
+    text: string
+    body: string
+  }): Promise<void> {
+    const orgId = this.orgFor(e.sender)
+    return this.transcriptMutex.run(() => this.upsertElicitLocked(e, orgId))
+  }
+
+  /** The upsert itself, under {@link transcriptMutex} — see {@link appendTranscriptLocked}. */
+  private async upsertElicitLocked(
+    e: { channel: string; thread: string; ts: string; sender: string; text: string; body: string },
+    orgId: string
+  ): Promise<void> {
+    const revision = this.transcriptRevision + 1
+    const written = await this.writeTranscriptRows(orgId, e.channel, e.thread, [
+      {
+        kind: 'run',
+        sql: `INSERT OR IGNORE INTO transcript
+           (orgId, channel, thread, ts, sender, kind, text, tool_call_id, body, eventTimeUs, revision)
+         VALUES (@orgId, @channel, @thread, @ts, @sender, 'elicit', @text, @cardId, @body, @eventTimeUs, @revision)`,
+        params: [
+          {
+            orgId,
+            channel: e.channel,
+            thread: e.thread,
+            ts: e.ts,
+            sender: e.sender,
+            text: e.text,
+            cardId: elicitRowId(e.ts),
+            body: e.body,
+            eventTimeUs: transcriptEventTimeUs(e.ts),
+            revision
+          }
+        ]
+      },
+      {
+        kind: 'run',
+        sql: `UPDATE transcript SET text = ?, body = ?, revision = ?
+         WHERE orgId = ? AND channel = ? AND thread = ? AND sender = ? AND tool_call_id = ? AND kind = 'elicit'
+           AND (text IS NOT ? OR body IS NOT ?)`,
+        params: [e.text, e.body, revision, orgId, e.channel, e.thread, e.sender, elicitRowId(e.ts), e.text, e.body]
+      }
+    ])
+    // An unchanged re-write changes neither statement and must not bump the revision a live
+    // console polls on — the same rule the plan upsert follows.
+    if (written.changes.some((changed) => changed > 0)) {
+      this.transcriptRevision = written.revision
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender], this.transcriptRevision)
     }
   }
 

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { CreateElicitationRequest, RequestPermissionRequest } from '@agentclientprotocol/sdk'
 import { PermissionCoordinator, type PermissionHost } from '../src/permissions/coordinator.js'
 import type { SlackConnection } from '../src/slack/connection.js'
+import { elicitOptionToken } from '../src/slack/render.js'
 import { LocalStore } from '../src/store/local-store.js'
 import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
 import { pendingTurnKey, type Pending } from '../src/daemon/turn-types.js'
@@ -194,11 +195,14 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
     const requestId = requestIdOf(w.route)
 
+    // A DM card is a Slack button row, so its taps carry each option's POSITION (#1794): a
+    // literal, and a position past the list, are both answers this card never offered.
     await w.coordinator.handleElicitChoice({ requestId, value: 'always', actor: { userId: 'U1' } })
+    await w.coordinator.handleElicitChoice({ requestId, value: elicitOptionToken(9), actor: { userId: 'U1' } })
     expect(w.conn.updateBlocks).not.toHaveBeenCalled()
     expect((await w.store.listPermissionRequests(AGENT))[0]!.status).toBe('pending')
 
-    await w.coordinator.handleElicitChoice({ requestId, value: 'session', actor: { userId: 'U1' } })
+    await w.coordinator.handleElicitChoice({ requestId, value: elicitOptionToken(1), actor: { userId: 'U1' } })
     await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'session' } })
     await w.store.close()
   })

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -13,6 +13,7 @@ import {
 import { Daemon } from '../src/daemon.js'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
+import { elicitOptionToken } from '../src/slack/render.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { WAIT } from './wait-support.js'
 
@@ -1979,7 +1980,8 @@ describe('Slack interactive status bar', () => {
       await (daemon as any).handleRelayMsg(
         action({
           msgId: 'action-elicit',
-          payload: { kind: 'elicitation-choice', requestId: 'elicit-1', value: 'TypeScript' }
+          // A Slack card carries the option's POSITION, never its value (#1794).
+          payload: { kind: 'elicitation-choice', requestId: 'elicit-1', value: elicitOptionToken(0) }
         }),
         () => {}
       )
@@ -2027,7 +2029,11 @@ describe('Slack interactive status bar', () => {
       await (daemon as any).handleRelayMsg(
         action({
           msgId: 'action-elicit-confirm',
-          payload: { kind: 'elicitation-confirm', requestId: 'elicit-2', fields: { ac_elicit_f0: ['lint', 'test'] } }
+          payload: {
+            kind: 'elicitation-confirm',
+            requestId: 'elicit-2',
+            fields: { ac_elicit_f0: [elicitOptionToken(0), elicitOptionToken(1)] }
+          }
         }),
         () => {}
       )

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -14,6 +14,7 @@ import {
   ELICIT_CONFIRM_ACTION,
   elicitForm,
   elicitFormBlockId,
+  elicitOptionToken,
   elicitTarget,
   SLACK_ELICIT_SURFACE,
   slackCardViolations,
@@ -126,7 +127,8 @@ function installPending(daemon: Daemon): {
     getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
     getDisplayNames: () => new Map([['turn-user', 'Turn User']]),
     createPermissionRequest: vi.fn(),
-    resolvePermissionRequest: vi.fn(() => true)
+    resolvePermissionRequest: vi.fn(() => true),
+    upsertElicit: vi.fn(async () => {})
   }
   const pending = {
     plan: {
@@ -691,6 +693,38 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     })
   })
 
+  // #1794: the card is a transcript row on THIS surface too. Without it a page reload lost the
+  // question and the answer, and a reader who joined later never saw either.
+  it('records the card in the transcript, and rewrites that row with the answer', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    installWebchat(pending)
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const rows = () => (daemon as any).store.upsertElicit.mock.calls.map(([r]: any[]) => r)
+    const bodies = () => rows().map((r: any) => JSON.parse(r.body))
+    // The row carries the reduced card — the same payload the live event streamed.
+    expect(bodies()[0]).toMatchObject({
+      message: 'Which checks should I run?',
+      options: [
+        { value: 'lint', label: 'lint' },
+        { value: 'test', label: 'test' },
+        { value: 'build', label: 'build' }
+      ],
+      multi: { minItems: 1 }
+    })
+
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: ['lint'],
+      webchatConversationId: 'conv-1'
+    })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint'] } })
+    expect(rows()[1].ts).toBe(rows()[0].ts)
+    expect(bodies()[1]).toMatchObject({ outcome: 'accepted', answerLabel: 'lint' })
+  })
+
   it('re-checks the browser’s list: bounds, repeats, unoffered values, and the wrong shape', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending: any = installPending(daemon)
@@ -818,7 +852,8 @@ describe('a Slack card offers every option or none', () => {
     const [requestId] = (daemon as any).permissions.pendingElicits.keys()
     const elements = posted[0]![1]!.elements as any[]
     expect(elements.map((e) => e.text.text)).toEqual([...seven, 'Dismiss'])
-    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'g' })
+    // The seventh button carries its POSITION, and the daemon resolves it back (#1794).
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(6) })
     await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'g' } })
   })
 
@@ -854,10 +889,14 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     await vi.waitFor(() => expect(daemon.permissions.pendingElicits.get(requestId).ts).toBe('ts-1'))
     return requestId
   }
+  /** The `checks` options in the order {@link multiElicitation} declares them — a Slack card
+   *  carries each option's POSITION rather than its value (#1794), so a Confirm sends these. */
+  const CHECKS = ['lint', 'test', 'build']
+  const carried = (values: string[]) => values.map((v) => elicitOptionToken(CHECKS.indexOf(v)))
   const confirm = (daemon: any, requestId: string, values: string[], actor?: { userId: string }) =>
     daemon.permissions.submitElicitForm({
       requestId,
-      fields: { [elicitFormBlockId(0)]: values },
+      fields: { [elicitFormBlockId(0)]: carried(values) },
       ...(actor ? { actor } : {})
     })
 
@@ -924,7 +963,11 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     await confirm(daemon, requestId, ['lint']) // below minItems
     await confirm(daemon, requestId, ['lint', 'test', 'build']) // above maxItems — Slack's own cap is not the gate
     await confirm(daemon, requestId, ['lint', 'lint']) // a repeat is not two picks
-    await confirm(daemon, requestId, ['lint', 'rm -rf /']) // a relayed value the card never offered
+    await (daemon as any).permissions.submitElicitForm({
+      requestId,
+      // A relayed value the card never offered — and it has no position either.
+      fields: { [elicitFormBlockId(0)]: [elicitOptionToken(0), 'rm -rf /'] }
+    })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(updated).toHaveLength(0)
 
@@ -944,7 +987,7 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
       multiElicitation({ minItems: 1, default: ['test'] })
     )
     const requestId = await liveCard(daemon)
-    expect(selectOf(posted).initial_options.map((o: any) => o.value)).toEqual(['test'])
+    expect(selectOf(posted).initial_options.map((o: any) => o.value)).toEqual([elicitOptionToken(1)])
     await confirm(daemon, requestId, ['test'])
     await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['test'] } })
   })
@@ -984,7 +1027,7 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     await confirm(daemon, requestId, ['a'])
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(updated).toHaveLength(0)
-    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'a' })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
     await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'a' } })
   })
 })
@@ -1004,17 +1047,20 @@ describe('a Slack answer is re-derived against the card that offered it', () => 
     await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
     const [requestId] = (daemon as any).permissions.pendingElicits.keys()
 
+    // Neither a value the card never offered nor a position past the list it did.
     await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'rm -rf /' })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(9) })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1) // still live — nothing settled it
     expect(updated).toHaveLength(0)
     // The refusal stands, and the thread hears it — the same words a refused Confirm gets, since
     // the reader cannot tell a rejected tap from a dead button either way (#1794).
     expect(applied.filter((a) => a.kind === 'notice').map((a) => a.text)).toEqual([
+      "That answer wasn't accepted — the question is still open.",
       "That answer wasn't accepted — the question is still open."
     ])
 
     // A Slack tap on a button the card actually carries still resolves, unchanged.
-    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'b' })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(1) })
     await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'b' } })
   })
 
@@ -1025,16 +1071,23 @@ describe('a Slack answer is re-derived against the card that offered it', () => 
     const approval = (daemon as any).permissions.onAcpElicit('agent-1', 's1', elicitation('call-1'))
     await vi.waitFor(() => expect(posted).toHaveLength(1))
     const [requestId] = (daemon as any).permissions.pendingElicits.keys()
-    // The approval's enum reaches Slack as one button per value, each carrying `<id>|<value>`.
+    // The approval's enum reaches Slack as one button per value, each carrying that option's
+    // POSITION rather than the value itself (#1794).
     const elements = posted[0]![1]!.elements as any[]
-    expect(elements.map((e) => e.value)).toEqual([`${requestId}|once`, `${requestId}|session`, requestId])
+    expect(elements.map((e) => e.value)).toEqual([
+      `${requestId}|${elicitOptionToken(0)}`,
+      `${requestId}|${elicitOptionToken(1)}`,
+      requestId
+    ])
 
-    // A `persist` the schema never enumerated is not an approval this card can report.
+    // A `persist` the schema never enumerated is not an approval this card can report — and
+    // neither is a position past the options it offered.
     await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'always' })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(9) })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(updated).toHaveLength(0)
 
-    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'session' })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(1) })
     await expect(approval).resolves.toEqual({ action: 'accept', content: { persist: 'session' } })
   })
 })
@@ -1654,12 +1707,18 @@ describe('Slack renders and settles a URL-mode consent card', () => {
     expect(text).toContain('Sign in to the billing provider to continue')
 
     const [open, dismiss] = cardButtons(posted[0]!)
-    // Slack's `url` field is what both opens the page and still delivers an interaction.
-    expect(open).toMatchObject({ text: { text: 'Open link' }, url, value: expect.stringContaining(url) })
+    // Slack's `url` field is what both opens the page and still delivers an interaction. The
+    // `value` carries the card's one OPTION rather than the URL, which is what keeps a URL too
+    // long for a Slack button value from losing its card (#1794).
+    expect(open).toMatchObject({
+      text: { text: 'Open link' },
+      url,
+      value: `${await liveSlackCard(daemon)}|${elicitOptionToken(0)}`
+    })
     expect(dismiss).toMatchObject({ text: { text: 'Dismiss' } })
 
     const requestId = await liveSlackCard(daemon)
-    await (daemon as any).permissions.handleElicitChoice({ requestId, value: url })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
     // Consent resolves the ACP request — with no `content`, since nothing was answered here.
     await expect(result).resolves.toEqual({ action: 'accept' })
     // "Opened" and not "Done": the tap proves consent, never that the flow behind it finished.
@@ -1761,10 +1820,7 @@ describe('Slack renders and settles a URL-mode consent card', () => {
     const { updated } = slackPending(daemon)
     void (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
     const requestId = await liveSlackCard(daemon)
-    await (daemon as any).permissions.handleElicitChoice({
-      requestId,
-      value: 'https://billing.example.com/oauth/authorize?state=xyz'
-    })
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
     await vi.waitFor(() => expect(updated).toHaveLength(1))
     ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-nope')
     ;(daemon as any).permissions.onAcpElicitComplete('agent-2', 'el-1')

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -83,7 +83,8 @@ function installPending(daemon: Daemon): any {
     getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
     getDisplayNames: () => new Map(),
     createPermissionRequest: vi.fn(),
-    resolvePermissionRequest: vi.fn(() => true)
+    resolvePermissionRequest: vi.fn(() => true),
+    upsertElicit: vi.fn(async () => {})
   }
   const pending = {
     plan: {

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -561,6 +561,42 @@ describe('LocalStore', () => {
     await s.close()
   })
 
+  it('an elicitation card is one upserted row the replay never returns', async () => {
+    const s = await store()
+    await s.appendTranscript({ channel: 'C1', thread: 'T', ts: '1', sender: 'U1', kind: 'text', text: 'ask' })
+    const card = { requestId: 'elicit-1', message: 'Which branch?', options: [{ value: 'main', label: 'main' }] }
+    await s.upsertElicit({
+      channel: 'C1',
+      thread: 'T',
+      ts: '2',
+      sender: 'bot',
+      text: card.message,
+      body: JSON.stringify(card)
+    })
+    // The settlement rewrites the SAME row rather than appending a second one below the reply.
+    await s.upsertElicit({
+      channel: 'C1',
+      thread: 'T',
+      ts: '2',
+      sender: 'bot',
+      text: card.message,
+      body: JSON.stringify({ ...card, outcome: 'accepted', answerLabel: 'main' })
+    })
+    await s.appendTranscript({ channel: 'C1', thread: 'T', ts: '3', sender: 'bot', kind: 'text', text: 'answer' })
+
+    // The card is read-only history: the runtime already had its answer over ACP, so re-feeding
+    // the row as conversation would ask the same question again.
+    expect((await s.transcriptSince('C1', 'T', null, 'bot-a')).map((e) => e.text)).toEqual(['ask', 'answer'])
+    const rows = (await s.threadTranscript('C1', 'T')) as { kind: string; text: string; body?: string | null }[]
+    expect(rows.map((r) => [r.kind, r.text])).toEqual([
+      ['text', 'ask'],
+      ['elicit', 'Which branch?'],
+      ['text', 'answer']
+    ])
+    expect(JSON.parse(rows[1]!.body!)).toEqual({ ...card, outcome: 'accepted', answerLabel: 'main' })
+    await s.close()
+  })
+
   it('replay returns only text rows; the full activity log returns all kinds in order', async () => {
     const s = await store()
     await s.appendTranscript({ channel: 'C1', thread: 'T', ts: '1', sender: 'U1', kind: 'text', text: 'ask' })

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -25,6 +25,7 @@ import {
   elicitCardShape,
   elicitFieldExpectation,
   elicitFormBlockId,
+  elicitOptionToken,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
@@ -1591,7 +1592,7 @@ describe('elicitation card', () => {
     expect(elicitTarget(inverted, WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
-  it('renders titled enum (oneOf) as buttons carrying requestId|const, plus Dismiss', () => {
+  it('renders titled enum (oneOf) as buttons carrying requestId|optionToken, plus Dismiss', () => {
     const req = form({
       lang: {
         type: 'string',
@@ -1607,7 +1608,12 @@ describe('elicitation card', () => {
     const btns = blocks[1].elements
     expect(btns.map((b: any) => b.text.text)).toEqual(['Python', 'TypeScript', 'Dismiss'])
     expect(btns[0].action_id).toBe(`${ELICIT_ACTION_PREFIX}:0`)
-    expect(btns.slice(0, 2).map((b: any) => b.value)).toEqual(['elicit-1|py', 'elicit-1|ts'])
+    // The POSITION, not the value: Slack caps a `value`, and the daemon re-derives the option
+    // from the card's own params anyway (#1794).
+    expect(btns.slice(0, 2).map((b: any) => b.value)).toEqual([
+      `elicit-1|${elicitOptionToken(0)}`,
+      `elicit-1|${elicitOptionToken(1)}`
+    ])
     expect(btns[2].action_id).toBe(ELICIT_DISMISS_ACTION)
     expect(btns[2].value).toBe('elicit-1')
   })
@@ -1619,7 +1625,7 @@ describe('elicitation card', () => {
     const blocks = buildElicitationCard('elicit-7', form({ pick: { type: 'string', enum: seven } })) as any[]
     const btns = blocks[1].elements
     expect(btns.map((b: any) => b.text.text)).toEqual([...seven, 'Dismiss'])
-    expect(btns.slice(0, 7).map((b: any) => b.value)).toEqual(seven.map((v) => `elicit-7|${v}`))
+    expect(btns.slice(0, 7).map((b: any) => b.value)).toEqual(seven.map((_, i) => `elicit-7|${elicitOptionToken(i)}`))
     expect(btns.map((b: any) => b.action_id)).toEqual([
       ...seven.map((_, i) => `${ELICIT_ACTION_PREFIX}:${i}`),
       ELICIT_DISMISS_ACTION
@@ -1835,13 +1841,14 @@ describe('elicitation card', () => {
     expect(select.type).toBe('checkboxes')
     expect(select.max_selected_items).toBeUndefined()
     expect(blocks[1].hint.text).toBe('Select 1 to 2.')
+    // The label is the reader's half; the value is the option's POSITION (#1794).
     expect(select.options.map((o: any) => [o.text.text, o.value])).toEqual([
-      ['Red', '#FF0000'],
-      ['Green', '#00FF00']
+      ['Red', elicitOptionToken(0)],
+      ['Green', elicitOptionToken(1)]
     ])
     // Seeded from the schema's `default`, so an untouched Confirm submits what the card shows.
     expect(select.initial_options).toEqual([
-      { text: { type: 'plain_text', text: 'Green', emoji: true }, value: '#00FF00' }
+      { text: { type: 'plain_text', text: 'Green', emoji: true }, value: elicitOptionToken(1) }
     ])
     expect([confirm.action_id, confirm.value]).toEqual([ELICIT_CONFIRM_ACTION, 'elicit-1'])
     expect([dismiss.action_id, dismiss.value]).toEqual([ELICIT_DISMISS_ACTION, 'elicit-1'])
@@ -1856,8 +1863,8 @@ describe('elicitation card', () => {
     expect(select.initial_options).toBeUndefined()
   })
 
-  // A select holds 100 options where an actions row of buttons holds 24, and caps one option's
-  // `value` at 75 chars where a button's is 2000 — so the limits are per kind, not per surface.
+  // A select holds 100 options where an actions row of buttons holds 24 — so the limits are per
+  // kind, not per surface. An option's own LENGTH is no longer one of them (#1794).
   it('declines a multi-select past Slack’s own select limits', () => {
     const items = (n: number) => ({ type: 'string', enum: Array.from({ length: n }, (_, i) => `o${i}`) })
     const at = form({ colors: { type: 'array', items: items(100) } })
@@ -1869,10 +1876,13 @@ describe('elicitation card', () => {
     // 25 buttons is past the actions row, but well inside the select — one kind's cap is its own.
     expect(elicitTarget(form({ pick: { type: 'string', enum: items(25).enum } }), SLACK_ELICIT_SURFACE)).toBeNull()
     expect(elicitTarget(form({ colors: { type: 'array', items: items(25) } }), SLACK_ELICIT_SURFACE)).not.toBeNull()
-    // A value Slack's select cannot carry: declined whole, never posted with the option cut.
+    // A value past what a Slack option object carries used to decline the whole form; it now
+    // rides its position, so the card renders and its option values are all short (#1794).
     const long = form({ colors: { type: 'array', items: { type: 'string', enum: ['ok', 'x'.repeat(76)] } } })
-    expect(elicitTarget(long, SLACK_ELICIT_SURFACE)).toBeNull()
-    expect(buildElicitationCard('elicit-long', long)).toBeNull()
+    expect(elicitTarget(long, SLACK_ELICIT_SURFACE)?.options).toHaveLength(2)
+    const longCard = buildElicitationCard('elicit-long', long) as any[]
+    expect(slackCardViolations(longCard)).toEqual([])
+    expect(longCard[1].element.options.map((o: any) => o.value)).toEqual([elicitOptionToken(0), elicitOptionToken(1)])
     // Webchat's own list is unlimited on both counts, exactly as before.
     expect(elicitTarget(over, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(101)
     expect(elicitTarget(long, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(2)
@@ -2486,13 +2496,17 @@ describe('buildUrlConsentCard', () => {
       .map((b: any) => b.text.text as string)
       .join('\n')
 
-  it('refuses a non-URL ask, a scheme no tab may take, and a URL too long for a Slack value', () => {
+  it('refuses a non-URL ask and a scheme no tab may take, but not a URL Slack could not carry', () => {
     expect(buildUrlConsentCard('r1', { mode: 'form', message: 'x' } as any)).toBeNull()
     expect(buildUrlConsentCard('r1', urlReq({ url: 'javascript:alert(1)' }))).toBeNull()
-    // Slack caps a button `value` at 2000; a URL that cannot ride one has no observable consent.
-    expect(buildUrlConsentCard('r1', urlReq({ url: `https://x.test/${'a'.repeat(1990)}` }))).toBeNull()
     // A backtick cannot sit inside the code span that keeps the URL unfollowable.
     expect(buildUrlConsentCard('r1', urlReq({ url: 'https://x.test/a`b' }))).toBeNull()
+    // Slack caps a button `value` at 2000 and `elicitUrl` admits 2048, so a long OAuth `state`
+    // used to lose its card and fall back to a notice. The button now carries the card's one
+    // option instead of the URL, so the card survives (#1794).
+    const long = buildUrlConsentCard('r1', urlReq({ url: `https://x.test/${'a'.repeat(1990)}` }))!
+    expect(slackCardViolations(long)).toEqual([])
+    expect((long[2] as any).elements[0].value).toBe(`r1|${elicitOptionToken(0)}`)
   })
 
   it('escapes the mrkdwn metacharacters a URL carries, so the reader sees its real bytes', () => {

--- a/packages/daemon/test/slack-elicit-form.test.ts
+++ b/packages/daemon/test/slack-elicit-form.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import type { ElicitTarget } from '../src/slack/render.js'
 import { Daemon } from '../src/daemon.js'
 import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
@@ -25,6 +26,7 @@ import {
   elicitForm,
   elicitFormBlockId,
   elicitFormSubmission,
+  elicitOptionToken,
   elicitTarget,
   slackCardViolations
 } from '../src/slack/render.js'
@@ -72,7 +74,9 @@ describe('the in-message card a filled-in answer is given on', () => {
       [elicitFormBlockId(3), 'number_input', true, 'count'],
       [elicitFormBlockId(4), 'radio_buttons', true, 'draft']
     ])
-    expect(inputs[0]!.element.options.map((o: any) => o.value)).toEqual(['main', 'develop'])
+    // The POSITION, not the value: an option value rides {@link elicitOptionToken} on every
+    // Slack card, which is what keeps a long one from costing the whole message (#1794).
+    expect(inputs[0]!.element.options.map((o: any) => o.value)).toEqual([elicitOptionToken(0), elicitOptionToken(1)])
     // `minItems` has no Slack attribute — and `checkboxes` has no `max_selected_items` at all —
     // so the bounds are said as a hint and enforced when the answer comes back.
     expect(inputs[1]!.hint.text).toBe('Select at least 1.')
@@ -81,7 +85,7 @@ describe('the in-message card a filled-in answer is given on', () => {
     expect(inputs[2]!.hint.text).toBe('Anything the reviewer should know')
     expect(inputs[3]!.element).toMatchObject({ is_decimal_allowed: false, min_value: '1', max_value: '9' })
     // A boolean's `default` seeds the control with the option that spells it.
-    expect(inputs[4]!.element.initial_option.value).toBe('true')
+    expect(inputs[4]!.element.initial_option.value).toBe(elicitOptionToken(0))
     // The question is a section, and the FIRST thing on the card.
     expect(card[0]).toMatchObject({ type: 'section' })
     expect(card[0].text.text).toContain('How should I cut the release?')
@@ -128,13 +132,8 @@ describe('the in-message card a filled-in answer is given on', () => {
   })
 
   it('is withheld when a field cannot BE an input block, so no card is ever posted dead', () => {
-    // Slack caps a select option's `value` at 75 characters and an input block has no button to
-    // fall back to (#1813's finding, one surface on).
-    const long = 'x'.repeat(80)
-    const req = form({ branch: { type: 'string', enum: [long, 'dev'] }, note: { type: 'string' } }, ['branch'])
-    expect(elicitForm(req, SLACK_ELICIT_SURFACE)).toHaveLength(2)
-    expect(cardFor(req)).toBeNull()
-    // And a minimum length no input can hold.
+    // A minimum length no input can hold. (An option value past Slack's 75 no longer withholds
+    // anything: the option carries its position instead — #1794.)
     expect(cardFor(form({ a: { type: 'string', minLength: 3500 }, b: { type: 'boolean' } }))).toBeNull()
   })
 })
@@ -192,27 +191,36 @@ describe('a card is a button row exactly when ONE TAP can answer it', () => {
   })
 })
 
+/** What a Slack card carries back for one of a field's options: its POSITION (#1794). A value the
+ *  field never offered has no position, and the token it yields resolves to nothing. */
+const pick = (targets: ElicitTarget[], index: number, value: string) =>
+  elicitOptionToken(targets[index]!.options.findIndex((o) => o.value === value))
+
 describe('a form submission is re-derived against the card that offered it', () => {
   const req = form(EVERY_KIND, ['branch', 'checks'])
   const fields = elicitForm(req, SLACK_ELICIT_SURFACE)!
+  const carried = (index: number, value: string) => pick(fields, index, value)
 
   it('answers with the typed record — real numbers, arrays, the boolean’s own wire value', () => {
     expect(
       elicitFormSubmission(req, fields, {
-        [elicitFormBlockId(0)]: 'main',
-        [elicitFormBlockId(1)]: ['lint', 'test'],
+        [elicitFormBlockId(0)]: carried(0, 'main'),
+        [elicitFormBlockId(1)]: [carried(1, 'lint'), carried(1, 'test')],
         [elicitFormBlockId(2)]: 'ship it',
         [elicitFormBlockId(3)]: '4',
-        [elicitFormBlockId(4)]: 'false'
+        [elicitFormBlockId(4)]: carried(4, 'false')
       })
     ).toEqual({ answer: { branch: 'main', checks: ['lint', 'test'], note: 'ship it', count: 4, draft: 'false' } })
   })
 
   it('accepts an omitted OPTIONAL field and refuses a missing REQUIRED one', () => {
     expect(
-      elicitFormSubmission(req, fields, { [elicitFormBlockId(0)]: 'main', [elicitFormBlockId(1)]: ['lint'] })
+      elicitFormSubmission(req, fields, {
+        [elicitFormBlockId(0)]: carried(0, 'main'),
+        [elicitFormBlockId(1)]: [carried(1, 'lint')]
+      })
     ).toEqual({ answer: { branch: 'main', checks: ['lint'] } })
-    expect(elicitFormSubmission(req, fields, { [elicitFormBlockId(0)]: 'main' })).toEqual({
+    expect(elicitFormSubmission(req, fields, { [elicitFormBlockId(0)]: carried(0, 'main') })).toEqual({
       errors: { [elicitFormBlockId(1)]: 'This field is required.' }
     })
   })
@@ -226,7 +234,10 @@ describe('a form submission is re-derived against the card that offered it', () 
     )
     const target = elicitForm(optional, SLACK_ELICIT_SURFACE)!
     expect(
-      elicitFormSubmission(optional, target, { [elicitFormBlockId(0)]: 'main', [elicitFormBlockId(1)]: [] })
+      elicitFormSubmission(optional, target, {
+        [elicitFormBlockId(0)]: pick(target, 0, 'main'),
+        [elicitFormBlockId(1)]: []
+      })
     ).toEqual({ answer: { branch: 'main' } })
     // A REQUIRED one keeps its own bounds: there an empty selection is a real answer to judge.
     const needed = form({ checks: { type: 'array', minItems: 1, items: EVERY_KIND.checks.items } }, ['checks'])
@@ -236,8 +247,8 @@ describe('a form submission is re-derived against the card that offered it', () 
 
   it('refuses ONE bad field with that field’s own error, rather than dropping it', () => {
     const bad = elicitFormSubmission(req, fields, {
-      [elicitFormBlockId(0)]: 'trunk', // never offered
-      [elicitFormBlockId(1)]: ['lint'],
+      [elicitFormBlockId(0)]: 'trunk', // never offered, so no position stands for it
+      [elicitFormBlockId(1)]: [carried(1, 'lint')],
       [elicitFormBlockId(2)]: 'x'.repeat(50), // past maxLength
       [elicitFormBlockId(3)]: '40' // past maximum
     })
@@ -252,14 +263,14 @@ describe('a form submission is re-derived against the card that offered it', () 
   it('refuses a value of the wrong SHAPE, and ignores a block the form never rendered', () => {
     expect(
       elicitFormSubmission(req, fields, {
-        [elicitFormBlockId(0)]: ['main'], // a list cannot answer a single select
-        [elicitFormBlockId(1)]: ['lint']
+        [elicitFormBlockId(0)]: [carried(0, 'main')], // a list cannot answer a single select
+        [elicitFormBlockId(1)]: [carried(1, 'lint')]
       }).errors
     ).toEqual({ [elicitFormBlockId(0)]: 'Choose one of the options offered.' })
     expect(
       elicitFormSubmission(req, fields, {
-        [elicitFormBlockId(0)]: 'main',
-        [elicitFormBlockId(1)]: ['lint'],
+        [elicitFormBlockId(0)]: carried(0, 'main'),
+        [elicitFormBlockId(1)]: [carried(1, 'lint')],
         [elicitFormBlockId(99)]: 'injected',
         not_ours: 'injected'
       })
@@ -300,7 +311,8 @@ function installPending(daemon: any): any {
     getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
     getDisplayNames: () => new Map(),
     createPermissionRequest: vi.fn(),
-    resolvePermissionRequest: vi.fn(() => true)
+    resolvePermissionRequest: vi.fn(() => true),
+    upsertElicit: vi.fn(async () => {})
   }
   const pending = {
     plan: {
@@ -377,8 +389,10 @@ async function raise(h: Harness, req: CreateElicitationRequest): Promise<{ reque
   return { requestId, result }
 }
 
-const submitFields = (branch: string, note?: string) => ({
-  [elicitFormBlockId(0)]: branch,
+/** What a Confirm on the TWO-field card carries: `branch` is an enum, so the card sends its
+ *  option's POSITION (#1794), never the value itself. */
+const submitFields = (branch: 'main' | 'develop', note?: string) => ({
+  [elicitFormBlockId(0)]: elicitOptionToken(branch === 'main' ? 0 : 1),
   ...(note !== undefined ? { [elicitFormBlockId(1)]: note } : {})
 })
 
@@ -453,8 +467,8 @@ describe('a Slack turn answers a form card from its own Confirm', () => {
 
   it('declines with a notice, and posts no card, when no card can hold the form', async () => {
     const h = slackTurn()
-    const long = 'x'.repeat(80)
-    const req = form({ branch: { type: 'string', enum: [long, 'dev'] }, note: { type: 'string' } }, ['branch'])
+    // A minimum length no Slack input holds — a field the card genuinely cannot render.
+    const req = form({ a: { type: 'string', minLength: 3500 }, note: { type: 'string' } }, ['a'])
     await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
     expect(h.daemon.permissions.pendingElicits.size).toBe(0)
     expect(h.posted).toEqual([])
@@ -494,5 +508,202 @@ describe('both Slack ingress paths settle a form card the same way', () => {
       accepted: true
     })
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+})
+
+// ── #1794: a value too long for Slack's own caps no longer costs a card ───────────────────────
+
+/** Three enum values that are paths, each past Slack's 75-character option-value cap. */
+const LONG_PATHS = [
+  `packages/daemon/src/${'a'.repeat(70)}.ts`,
+  `packages/daemon/src/${'b'.repeat(70)}.ts`,
+  `packages/daemon/src/${'c'.repeat(70)}.ts`
+]
+
+describe('an option value past what Slack carries', () => {
+  it('renders the multi-select anyway, and maps the picks back to the real values', async () => {
+    const req = form({ files: { type: 'array', items: { type: 'string', enum: LONG_PATHS } } }, ['files'])
+    // The reduction used to refuse the property outright, so the whole form declined on Slack
+    // while it rendered on webchat.
+    const targets = elicitForm(req, SLACK_ELICIT_SURFACE)
+    expect(targets).not.toBeNull()
+
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, req)
+    const card = h.posted[0] as any[]
+    expect(slackCardViolations(card)).toEqual([])
+    const values = inputsOf(card)[0]!.element.options.map((o: any) => o.value as string)
+    expect(values).toEqual([elicitOptionToken(0), elicitOptionToken(1), elicitOptionToken(2)])
+    // The labels are the reader's half of the card and still name the option, clamped to the 75
+    // characters a Slack label holds — it is only the WIRE value that stopped carrying it.
+    expect(inputsOf(card)[0]!.element.options[0].text.text).toBe(`${LONG_PATHS[0]!.slice(0, 74)}…`)
+
+    await h.daemon.permissions.submitElicitForm({
+      requestId,
+      fields: { [elicitFormBlockId(0)]: [elicitOptionToken(2), elicitOptionToken(0)] }
+    })
+    // #1815 intact: the answer is still re-derived against the card — just through the mapping.
+    await expect(result).resolves.toEqual({
+      action: 'accept',
+      content: { files: [LONG_PATHS[2], LONG_PATHS[0]] }
+    })
+  })
+
+  it('refuses a card value that names no option the field offered', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    let settled = false
+    void result.then(() => (settled = true))
+    // A literal where a position belongs, and a position past the list: neither is an answer.
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: { [elicitFormBlockId(0)]: 'develop' } })
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: { [elicitFormBlockId(0)]: elicitOptionToken(9) } })
+    expect(h.notices()).toHaveLength(2)
+    expect(h.notices()[0]).toContain('Base branch: Choose one of the options offered.')
+    expect(settled).toBe(false)
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    await h.daemon.permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+  })
+
+  it('keeps a one-tap card answerable when its enum value outruns a button value', async () => {
+    const huge = 'x'.repeat(2_100)
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form({ pick: { type: 'string', enum: [huge, 'no'] } }, ['pick']))
+    const buttons = (h.posted[0] as any[])[1].elements as any[]
+    expect(slackCardViolations(h.posted[0] as any[])).toEqual([])
+    // The whole message used to be rejected by Slack, so the card never appeared at all.
+    expect(buttons[0].value).toBe(`${requestId}|${elicitOptionToken(0)}`)
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { pick: huge } })
+  })
+})
+
+/** A URL that fits `elicitUrl`'s 2048 but not a Slack button's 2000 — a long OAuth `state`. */
+const LONG_URL = `https://auth.example.com/authorize?state=${'s'.repeat(1_960)}`
+
+const urlAsk = (url: string): CreateElicitationRequest =>
+  ({
+    sessionId: 's1',
+    mode: 'url',
+    message: 'Sign in to continue',
+    url,
+    elicitationId: 'e-1'
+  }) as unknown as CreateElicitationRequest
+
+describe('a consent URL past what a Slack button carries', () => {
+  it('still posts the card, and the tap is still consent for that exact URL', async () => {
+    expect(LONG_URL.length).toBeGreaterThan(1_989)
+    expect(LONG_URL.length).toBeLessThanOrEqual(2_048)
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, urlAsk(LONG_URL))
+    // It used to fall back to the decline notice with no card at all.
+    expect(h.notices()).toEqual([])
+    expect(slackCardViolations(h.posted[0] as any[])).toEqual([])
+    const open = (h.posted[0] as any[])[2].elements[0]
+    expect(open.url).toBe(LONG_URL)
+    expect(open.value).toBe(`${requestId}|${elicitOptionToken(0)}`)
+
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
+    await expect(result).resolves.toEqual({ action: 'accept' })
+    expect(JSON.stringify(h.updated[0])).toContain('Opened')
+  })
+
+  it("takes nothing but that card's own option as consent", async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, urlAsk(LONG_URL))
+    let settled = false
+    void result.then(() => (settled = true))
+    // The URL itself is no longer what comes back, so it is not consent either.
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: LONG_URL })
+    expect(settled).toBe(false)
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: null })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+  })
+})
+
+describe('a card settled while its own post is still in flight', () => {
+  it('says how it ended rather than calling an accepted consent cancelled', async () => {
+    const h = slackTurn()
+    let releasePost: () => void = () => {}
+    const held = new Promise<void>((resolve) => (releasePost = resolve))
+    h.conn.postBlocks = async (_c: string, blocks: unknown[]) => {
+      h.posted.push(blocks)
+      await held
+      return 'ts-1'
+    }
+    const result = h.daemon.permissions.onAcpElicit('agent-1', 's1', urlAsk('https://auth.example.com/go'))
+    await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.size).toBe(1))
+    const requestId = [...h.daemon.permissions.pendingElicits.keys()][0] as string
+    // Slack can deliver the tap before it has answered the post that carried it — the card has
+    // no `ts` yet, so nothing can be rewritten at settlement time.
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
+    expect(h.updated).toEqual([])
+
+    releasePost()
+    await expect(result).resolves.toEqual({ action: 'accept' })
+    await vi.waitFor(() => expect(h.updated).toHaveLength(1))
+    // The channel record has to agree with the credential page the reader really did open.
+    expect(JSON.stringify(h.updated[0])).toContain('Opened')
+    expect(JSON.stringify(h.updated[0])).not.toContain('Cancelled')
+  })
+})
+
+// ── #1794: the card survives a page reload, and is never re-fed to the runtime ────────────────
+
+describe('a card recorded in the transcript', () => {
+  const rows = (h: Harness) => h.daemon.store.upsertElicit.mock.calls.map((c: any[]) => c[0])
+  const bodies = (h: Harness) => rows(h).map((r: any) => JSON.parse(r.body))
+
+  it('records the ask, then rewrites the SAME row with how it ended', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    expect(bodies(h)[0]).toMatchObject({
+      requestId,
+      message: 'How should I cut the release?',
+      fields: [
+        { propName: 'branch', label: 'Base branch', kind: 'enum' },
+        { propName: 'note', kind: 'text' }
+      ]
+    })
+    // The reduced card only — the raw requestedSchema is absent here for the same reason it
+    // never reaches a wire.
+    expect(bodies(h)[0]).not.toHaveProperty('requestedSchema')
+    expect(bodies(h)[0].outcome).toBeUndefined()
+
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('develop') })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop' } })
+    // One row, rewritten: same coordinates, now carrying the outcome and what was answered.
+    expect(rows(h)[1].ts).toBe(rows(h)[0].ts)
+    expect(rows(h)[1].channel).toBe('C1')
+    expect(rows(h)[1].sender).toBe('agent-1')
+    expect(bodies(h)[1]).toMatchObject({ outcome: 'accepted', answerLabel: 'Base branch: develop' })
+  })
+
+  it('records a cancelled card as cancelled, and a dismissed one as dismissed', async () => {
+    const h = slackTurn()
+    const dismissed = await raise(h, form(TWO, ['branch']))
+    await h.daemon.permissions.handleElicitChoice({ requestId: dismissed.requestId, value: null })
+    await expect(dismissed.result).resolves.toEqual({ action: 'decline' })
+    expect(bodies(h).at(-1)).toMatchObject({ outcome: 'dismissed' })
+
+    const abandoned = await raise(h, form(TWO, ['branch']))
+    await h.daemon.permissions.releaseElicits('agent-1', 's1')
+    await expect(abandoned.result).resolves.toEqual({ action: 'cancel' })
+    expect(bodies(h).at(-1)).toMatchObject({ outcome: 'cancelled' })
+    // Two cards, two rows — the second never rewrote the first.
+    expect(new Set(rows(h).map((r: any) => r.ts)).size).toBe(2)
+  })
+
+  it('records an ask nothing could show, which was previously only a live notice', async () => {
+    const h = slackTurn()
+    const req = form({ when: { type: 'string', minLength: 3500 } }, ['when'])
+    await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
+    expect(h.notices()[0]).toContain("this chat can't collect an answer for")
+    expect(bodies(h)).toHaveLength(1)
+    expect(bodies(h)[0]).toMatchObject({
+      message: 'How should I cut the release?',
+      options: [],
+      outcome: 'unrenderable'
+    })
   })
 })

--- a/packages/daemon/test/slack-elicit-form.test.ts
+++ b/packages/daemon/test/slack-elicit-form.test.ts
@@ -24,6 +24,7 @@ import {
   buildElicitationFormCard,
   elicitCardShape,
   elicitForm,
+  decodePermValue,
   elicitFormBlockId,
   elicitFormSubmission,
   elicitOptionToken,
@@ -705,5 +706,52 @@ describe('a card recorded in the transcript', () => {
       options: [],
       outcome: 'unrenderable'
     })
+  })
+})
+
+// ── #1794 review: a card outlives the daemon that posted it ───────────────────────────────────
+
+describe('a stale card cannot answer the request that reused its id', () => {
+  it("a tap from one daemon's card settles nothing on the next daemon's", async () => {
+    const before = slackTurn()
+    const staging = await raise(before, form({ env: { type: 'string', enum: ['staging', 'canary'] } }, ['env']))
+    // The button's own wire value, exactly as Slack would hand it back — and Slack keeps that
+    // message, and its buttons, long after the daemon that posted it is gone.
+    const staleValue = (before.posted[0] as any[])[1].elements[0].value as string
+    const stale = decodePermValue(staleValue)!
+    expect(stale.requestId).toBe(staging.requestId)
+    expect(stale.optionId).toBe(elicitOptionToken(0))
+
+    // A restart, and a fresh daemon that asks a DIFFERENT question.
+    const after = slackTurn()
+    const production = await raise(after, form({ env: { type: 'string', enum: ['production', 'rollback'] } }, ['env']))
+    let settled = false
+    void production.result.then(() => (settled = true))
+
+    // Tapping the stale card must not answer the new request. A process-local sequence handed
+    // both requests the same id, and the card carries a POSITION, so this tap used to accept
+    // `production` — an answer to a question this reader never saw.
+    await after.daemon.permissions.handleElicitChoice({ requestId: stale.requestId, value: stale.optionId })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(settled).toBe(false)
+    expect(after.daemon.permissions.pendingElicits.size).toBe(1)
+    // Which is only true because an id is unique across daemon lifetimes.
+    expect(production.requestId).not.toBe(staging.requestId)
+
+    await after.daemon.permissions.handleElicitChoice({
+      requestId: production.requestId,
+      value: elicitOptionToken(0)
+    })
+    await expect(production.result).resolves.toEqual({ action: 'accept', content: { env: 'production' } })
+  })
+
+  it('mints an id no card can guess and no restart can repeat', async () => {
+    const h = slackTurn()
+    const first = await raise(h, form({ a: { type: 'string', enum: ['x', 'y'] } }, ['a']))
+    await h.daemon.permissions.handleElicitChoice({ requestId: first.requestId, value: null })
+    await expect(first.result).resolves.toEqual({ action: 'decline' })
+    const second = await raise(h, form({ a: { type: 'string', enum: ['x', 'y'] } }, ['a']))
+    for (const id of [first.requestId, second.requestId]) expect(id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(second.requestId).not.toBe(first.requestId)
   })
 })

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { SessionKey } from './route.js'
-import { PlanEntry, WebchatImageAttachment } from './webchat.js'
+import { ElicitCard, PlanEntry, WebchatImageAttachment } from './webchat.js'
 
 /**
  * Session read-back (C→D REQ → REP) — the console's on-demand pulls.
@@ -99,6 +99,30 @@ export type ToolBody = z.infer<typeof ToolBody>
 export const PlanBody = z.object({ entries: z.array(PlanEntry) })
 export type PlanBody = z.infer<typeof PlanBody>
 
+/** How a persisted elicitation card ended. The four the live stream also carries, plus
+ *  `unrenderable` — the ask no surface had a control for, which was only ever a live notice
+ *  (#1839) and so vanished on reload. Absent ⇒ the card was still open when it was recorded,
+ *  which after a daemon restart means nobody ever answered it. */
+export const ElicitOutcome = z.enum(['accepted', 'dismissed', 'cancelled', 'completed', 'unrenderable'])
+export type ElicitOutcome = z.infer<typeof ElicitOutcome>
+
+/**
+ * The agent's structured question, transported as a JSON STRING in `SessionMessage.body` on an
+ * `elicit` row: the card exactly as it was offered, plus how it ended. The row exists so a page
+ * reload — or a reader who joins later — still sees that the question was asked and what was
+ * answered, which the live-only card lost.
+ *
+ * `answerLabel` is the chosen option's LABEL (the labels joined, for a multi-select or a form),
+ * never the accepted content: what a reader needs is what was picked, and the values are already
+ * in the agent's own context. The raw `requestedSchema` is absent for the same reason it never
+ * reaches any wire — the card is the reduction, and the reduction is what was shown.
+ */
+export const ElicitBody = ElicitCard.extend({
+  outcome: ElicitOutcome.optional(),
+  answerLabel: z.string().optional()
+})
+export type ElicitBody = z.infer<typeof ElicitBody>
+
 // The user-turn body schemas live in a bundler-safe leaf (the console validates with them);
 // re-exported here so every wire consumer keeps finding them beside the tool and plan bodies.
 export { CodehostTurnFacts, LinearTurnFacts, UserTurnBody } from '../user-turn-body.js'
@@ -125,14 +149,14 @@ export const SessionMessage = z.object({
   // at origin and identical on every participant's copy, independent of a
   // collision-bumped `ts`. Absent on non-webchat rows and pre-upgrade rows.
   postId: z.string().uuid().optional(),
-  kind: z.string(), // "text" / tool / reasoning / plan / … (daemon transcript kind)
+  kind: z.string(), // "text" / tool / reasoning / plan / elicit / … (daemon transcript kind)
   text: z.string(),
   attachments: z.array(SessionImageAttachment).max(1).optional(),
   // ── body enrichment (optional ⇒ text/reasoning rows and old daemons omit these) ──
   toolCallId: z.string().optional(), // parsed from the ToolBody (tool rows only)
   toolStatus: z.string().optional(), // ACP ToolCallStatus, surfaced for the console badge
   toolKind: z.string().optional(), // ACP ToolKind, surfaced for the console icon
-  body: z.string().optional(), // JSON.stringify(ToolBody) on a tool row, PlanBody on a plan row; a tool body may be a truncated-but-VALID-JSON preview
+  body: z.string().optional(), // JSON.stringify(ToolBody) on a tool row, PlanBody on a plan row, ElicitBody on an elicit row; a tool body may be a truncated-but-VALID-JSON preview
   bodyTruncated: z.boolean().optional(), // preview was shrunk for the frame; full body via session/tool-body
   bodyBytes: z.number().int().optional() // full (untruncated) body byte length
 })

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -171,6 +171,55 @@ export const ElicitField = z.object({
 })
 export type ElicitField = z.infer<typeof ElicitField>
 
+/** ONE elicitation card, as the daemon reduced it. Both the live event below and the
+ *  transcript row that persists the card (`ElicitBody`) are this shape, so a reader who
+ *  loads the conversation later is shown the very card the reader in the moment answered.
+ *
+ *  The agent asked for a choice (ACP `elicitation/create`, form or url mode) — webchat's own
+ *  in-band card, the peer of the Slack Block Kit one. Deliberately NOT the raw
+ *  `requestedSchema`: the daemon has already reduced the form to its renderable field(s), and
+ *  its options are the only answers the browser may send back (as the `elicitation_choice` op
+ *  keyed by this `requestId`). `message` is agent-authored text, masked before it reaches here.
+ *  Options are UNCAPPED — the Slack button cap is a Slack surface limit and does not follow the
+ *  choice onto this surface. They are also EMPTY for a typed field (`text`/`number`), whose
+ *  card offers nothing to pick. */
+export const ElicitCard = z.object({
+  requestId: z.string().min(1).max(200),
+  message: z.string(),
+  options: ElicitOptions,
+  // Absent ⇒ pick exactly ONE option, the original card. Present ⇒ pick several of the same
+  // options and confirm, and the answer is a list. An added OPTIONAL field rather than a new
+  // event kind on purpose: a relay or browser predating it decodes the event unchanged
+  // (zod strips what it does not know) instead of dropping the frame the way an unknown
+  // kind would, and a daemon predating it simply never sets it.
+  multi: ElicitMulti.optional(),
+  // Present ⇒ the card is a free-text input carrying the schema's own constraints, which the
+  // daemon re-checks on the way back in. Same optional-field reasoning as `multi`, with one
+  // added skew note: an old reader keeps `options` (now empty) and shows a card with nothing
+  // but Dismiss — unanswerable, never wrongly answered. `pattern` reaches here only once the
+  // daemon has cleared it as safe to run.
+  text: ElicitText.optional(),
+  // Present ⇒ a numeric input; `integer` is the schema's `integer` type, not just a bound.
+  number: ElicitNumber.optional(),
+  // The schema's `default`, already checked against the constraints above: the card
+  // pre-populates its control with it (MCP `2025-11-25`), and the reader may answer otherwise.
+  defaultValue: ElicitDefault.optional(),
+  // Present ⇒ the card is a multi-field FORM: one control per field, one submit, and the
+  // answer is a record of value-per-field. The single-field descriptors above are then all
+  // absent — deliberately, and the same closed-failure trade `text` records: an old reader
+  // sees an optionless card it can only Dismiss, rather than a card it could half-fill with
+  // one field's answer that the daemon would then refuse.
+  fields: z.array(ElicitField).min(2).max(ELICIT_FORM_WIRE_FIELD_CAP).optional(),
+  // Present ⇒ the card is a URL-mode CONSENT card (ACP `ElicitationUrlMode`): the reader is
+  // shown this exact URL and opens it in their own browser, and nothing about the page ever
+  // returns here. `options` is then empty and every field descriptor above is absent, so the
+  // same closed skew `text` records holds — an old reader sees a card it can only Dismiss,
+  // which the daemon reads as the spec's `decline`, never as consent. Only http/https reach
+  // here; the daemon declines any other scheme rather than hand a browser an unopenable href.
+  url: z.string().min(1).max(2048).optional()
+})
+export type ElicitCard = z.infer<typeof ElicitCard>
+
 export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('message'), text: z.string() }), // from agent_message_chunk
   z.object({ kind: z.literal('thinking'), text: z.string() }), // from agent_thought_chunk
@@ -218,50 +267,7 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // only after the fact. There is no relay capability echo to gate on (`rd/hello/ok` carries
   // only `relayId`), so this is the tradeoff rather than an oversight.
   z.object({ kind: z.literal('plan'), entries: z.array(PlanEntry) }),
-  // The agent asked for a choice (ACP `elicitation/create`, form or url mode) — webchat's own
-  // in-band card, the peer of the Slack Block Kit one. Deliberately NOT the raw
-  // `requestedSchema`: the daemon has already reduced the form to its renderable
-  // field(s), and its options are the only answers the browser may send back (as the
-  // `elicitation_choice` op keyed by this `requestId`). `message` is agent-authored text,
-  // masked before it reaches here. Options are UNCAPPED — the Slack 5-button cap is a
-  // Slack surface limit and does not follow the choice onto this surface. They are also
-  // EMPTY for a typed field (`text`/`number`), whose card offers nothing to pick.
-  z.object({
-    kind: z.literal('elicitation'),
-    requestId: z.string().min(1).max(200),
-    message: z.string(),
-    options: ElicitOptions,
-    // Absent ⇒ pick exactly ONE option, the original card. Present ⇒ pick several of the same
-    // options and confirm, and the answer is a list. An added OPTIONAL field rather than a new
-    // event kind on purpose: a relay or browser predating it decodes the event unchanged
-    // (zod strips what it does not know) instead of dropping the frame the way an unknown
-    // kind would, and a daemon predating it simply never sets it.
-    multi: ElicitMulti.optional(),
-    // Present ⇒ the card is a free-text input carrying the schema's own constraints, which the
-    // daemon re-checks on the way back in. Same optional-field reasoning as `multi`, with one
-    // added skew note: an old reader keeps `options` (now empty) and shows a card with nothing
-    // but Dismiss — unanswerable, never wrongly answered. `pattern` reaches here only once the
-    // daemon has cleared it as safe to run.
-    text: ElicitText.optional(),
-    // Present ⇒ a numeric input; `integer` is the schema's `integer` type, not just a bound.
-    number: ElicitNumber.optional(),
-    // The schema's `default`, already checked against the constraints above: the card
-    // pre-populates its control with it (MCP `2025-11-25`), and the reader may answer otherwise.
-    defaultValue: ElicitDefault.optional(),
-    // Present ⇒ the card is a multi-field FORM: one control per field, one submit, and the
-    // answer is a record of value-per-field. The single-field descriptors above are then all
-    // absent — deliberately, and the same closed-failure trade `text` records: an old reader
-    // sees an optionless card it can only Dismiss, rather than a card it could half-fill with
-    // one field's answer that the daemon would then refuse.
-    fields: z.array(ElicitField).min(2).max(ELICIT_FORM_WIRE_FIELD_CAP).optional(),
-    // Present ⇒ the card is a URL-mode CONSENT card (ACP `ElicitationUrlMode`): the reader is
-    // shown this exact URL and opens it in their own browser, and nothing about the page ever
-    // returns here. `options` is then empty and every field descriptor above is absent, so the
-    // same closed skew `text` records holds — an old reader sees a card it can only Dismiss,
-    // which the daemon reads as the spec's `decline`, never as consent. Only http/https reach
-    // here; the daemon declines any other scheme rather than hand a browser an unopenable href.
-    url: z.string().min(1).max(2048).optional()
-  }),
+  ElicitCard.extend({ kind: z.literal('elicitation') }),
   // The same card, settled. Slack rewrites its message in place; this stream is
   // append-only, so the collapse is a second event keyed by the same `requestId`.
   // `label` is the chosen option's label — the chosen labels joined, for a multi-select —

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -72,6 +72,30 @@ export function elicitCard(body: string | undefined): ElicitBody | null {
   }
 }
 
+/** One elicitation card's identity across the two places it can be rendered from: the agent that
+ *  owns the request, and the request itself. A uuid request id could stand alone, but identity
+ *  here is (owner, request) and saying so keeps a future non-unique id from silently colliding. */
+export function elicitStepKey(agentId: string | undefined, requestId: string): string {
+  return `${agentId ?? ''}\u0000${requestId}`
+}
+
+/** Every card the LIVE stream is currently carrying. On a reload a pending webchat card arrives
+ *  twice — once as its transcript row (#1794) and once as the replayed `elicitation` event — and
+ *  the live copy is the one that can still be answered and the one `elicitation_resolved` settles,
+ *  so this is what the transcript's twin is dropped against. Empty for every surface that streams
+ *  no cards at all, which is the Slack-origin case. */
+export function liveElicitKeys(
+  live: readonly { lane?: string; agentId?: string; elicit?: { requestId: string } }[],
+  ownerAgentId?: string
+): Set<string> {
+  const keys = new Set<string>()
+  for (const step of live) {
+    if (!step.elicit?.requestId) continue
+    keys.add(elicitStepKey(step.agentId ?? ownerAgentId, step.elicit.requestId))
+  }
+  return keys
+}
+
 /** Split an agent turn's collapsed work steps into the counts the summary reports:
  *  reasoning STEPS (THINK/PLAN), tool-command STEPS (TOOL), and edited FILES — the
  *  DISTINCT file paths across all EDIT steps (a single EDIT row can touch several

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -1,4 +1,5 @@
 import type { PlanBody } from '@/lib/api'
+import type { ElicitBody } from '@/lib/data'
 
 // 2b chat style: an agent turn shows its spoken answer (MSG/DONE lanes) as plain
 // text and collapses its "work" — reasoning (THINK/PLAN), tool calls (TOOL), and
@@ -41,6 +42,33 @@ export function planEntries(body: string | undefined): PlanEntry[] {
     return (parsed.entries ?? []).filter((entry) => typeof entry?.content === 'string' && entry.content.trim() !== '')
   } catch {
     return []
+  }
+}
+
+/** Every outcome this console can READ off a persisted card. A newer daemon's unknown verdict is
+ *  dropped rather than rendered, which shows the card as unsettled — the one direction that is
+ *  never a wrong verdict. The question itself comes from the row's `text`, not the body. */
+const ELICIT_OUTCOMES = new Set(['accepted', 'dismissed', 'cancelled', 'completed', 'unrenderable'])
+
+/** Parse an `elicit` row's `body` into the card it recorded. Null for everything that is not a
+ *  readable card — no body at all (a daemon or control plane predating the row), malformed JSON,
+ *  a payload with no request id — and the caller then falls back to rendering the row's own text,
+ *  which is at least the question, rather than a card with nothing in it. */
+export function elicitCard(body: string | undefined): ElicitBody | null {
+  if (!body) return null
+  try {
+    const parsed = JSON.parse(body) as Partial<ElicitBody>
+    if (typeof parsed?.requestId !== 'string' || !parsed.requestId) return null
+    const outcome =
+      typeof parsed.outcome === 'string' && ELICIT_OUTCOMES.has(parsed.outcome) ? parsed.outcome : undefined
+    return {
+      ...parsed,
+      requestId: parsed.requestId,
+      options: Array.isArray(parsed.options) ? parsed.options : [],
+      ...(outcome ? { outcome } : { outcome: undefined })
+    }
+  } catch {
+    return null
   }
 }
 

--- a/packages/web/src/components/console/views/SessionDetailView.elicit-transcript.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicit-transcript.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment happy-dom
+
+// A PERSISTED elicitation card on the real session page (#1794). The card used to live only in
+// the moment: a page reload lost it, and a reader who joined later never learned the question was
+// asked at all. It is now a transcript row, and this is the reader who was not there — a Slack
+// session read back in the console, whose card is a record rather than something to answer.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, Session } from '@/lib/data'
+import type { SessionMessageDto } from '@/lib/api'
+
+const wire = vi.hoisted(() => ({ messages: [] as unknown[] }))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'session-1' }),
+  usePathname: () => '/acme/sessions/session-1',
+  useSearchParams: () => new URLSearchParams(''),
+  useRouter: () => ({
+    replace: () => {},
+    push: () => {},
+    prefetch: () => {},
+    back: () => {},
+    forward: () => {},
+    refresh: () => {}
+  })
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    fetchSessionMessages: vi.fn(() => Promise.resolve({ messages: wire.messages, nextCursor: null })),
+    fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
+    fetchMySessionIdentity: vi.fn(() => Promise.reject(new Error('no identity'))),
+    fetchConversationByKey: vi.fn(() => Promise.reject(new Error('no conversation'))),
+    fetchAgentTasks: vi.fn(() =>
+      Promise.resolve({ sessionId: 'session-1', tracked: true, tasks: [], truncated: false })
+    ),
+    fetchSessionPullRequest: vi.fn(() => Promise.reject(new actual.ApiError('pull request not found', 404))),
+    fetchWorkspaceFiles: vi.fn((_agentId: string, opts: { path: string }) =>
+      Promise.resolve({ path: opts.path, exists: true, entries: [], nextCursor: null })
+    ),
+    fetchWorkspaceGitStatus: vi.fn(() => Promise.resolve({ isRepo: false })),
+    fetchWorkspaceGitLog: vi.fn(() => Promise.resolve({ isRepo: false, commits: [], truncated: false, tracking: null }))
+  }
+})
+
+const agent = {
+  id: 'agent-1',
+  name: 'Ops bot',
+  runtime: 'claude',
+  model: 'sonnet',
+  status: 'online',
+  statusLabel: 'online',
+  icon: 'bot',
+  daemon: 'daemon-1',
+  workdir: './services/api',
+  workspace: { mode: 'scratch' },
+  canEdit: false
+} as unknown as Agent
+
+const session = {
+  id: 'session-1',
+  title: 'Upgrade the node',
+  status: 'idle',
+  statusLabel: 'completed',
+  platform: 'slack',
+  channel: '#ops',
+  user: 'sam',
+  agentId: 'agent-1',
+  agentName: 'Ops bot',
+  // Empty, which is what puts the page on the REAL transcript (`wantTranscript`) instead of
+  // the mock step list a list-only session carries.
+  steps: []
+} as unknown as Session
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [agent],
+    allSessions: [session],
+    getSessions: () => [session],
+    sessionsLoading: false,
+    crons: [],
+    daemons: [],
+    members: [],
+    sessionActivityVersionById: {},
+    sessionStreamGeneration: 0,
+    revalidateSessionLists: () => {}
+  })
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({
+    activeOrg: { id: 'org-1', slug: 'acme' },
+    myRole: 'collaborator',
+    orgPath: (p: string) => `/acme${p}`
+  })
+}))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { name: 'Sam' }, me: null }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+vi.mock('@/lib/stick-to-bottom', () => ({ useStickToBottom: () => () => {} }))
+vi.mock('@/lib/auth', () => ({ isAuthConfigured: () => false }))
+vi.mock('@/lib/use-session-list', () => ({
+  useSessionList: () => ({ sessions: [], total: 0, isLoading: false, nextCursor: null, loadingMore: false })
+}))
+
+vi.mock('@/components/console/Shell', () => ({
+  useCrumbSlot: () => ({ register: () => {} }),
+  useMobileActionSlot: () => ({ action: null, register: () => {} })
+}))
+
+// One frozen object, not a fresh one per render: the transcript effect keys on
+// `reconcileLiveSteps` by identity, so a new closure each render refetches, re-renders, and
+// spins forever. (The viewer suite never sees this — its session carries mock steps, which
+// turns the real transcript off.)
+vi.mock('@/components/console/PlaygroundProvider', () => {
+  const playground = {
+    getPgSession: () => undefined,
+    getLiveSteps: () => [],
+    getBusyLaneAgentIds: () => [],
+    reconcileLiveSteps: () => {},
+    getPgImage: () => null,
+    getPgWorktree: () => false,
+    isPgBusy: () => false,
+    setPgImage: () => {},
+    openPlayground: () => 'pg_new',
+    pgSend: () => {},
+    pgAttach: () => {},
+    getPgQueue: () => [],
+    pgCancelQueued: () => {},
+    pgAddAgent: () => {},
+    pgSetModel: () => {},
+    pgSetEffort: () => {},
+    pgSetPermissionPreset: () => {},
+    pgSetFast: () => {},
+    pgSetWorktree: () => {},
+    pgCancel: () => {},
+    setPgInput: () => {}
+  }
+  return { usePlayground: () => playground, usePgDraft: () => '', usePgDraftHasText: () => false }
+})
+
+import SessionDetailView from './SessionDetailView'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+
+const row = (m: Partial<SessionMessageDto> & { seq: number; sender: string; kind: string; text: string }) => ({
+  ts: String(1_700_000_000 + m.seq),
+  ...m
+})
+
+const CARD = {
+  requestId: 'elicit-1',
+  message: 'Which branch should I cut from?',
+  options: [
+    { value: 'main', label: 'main' },
+    { value: 'develop', label: 'develop' }
+  ]
+}
+
+const elicitRow = (body: Record<string, unknown>) =>
+  row({ seq: 2, sender: 'agent-1', kind: 'elicit', text: CARD.message, body: JSON.stringify(body) })
+
+async function render() {
+  await act(async () => {
+    root?.render(<SessionDetailView />)
+    await Promise.resolve()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+const buttonNamed = (label: string) =>
+  [...(container?.querySelectorAll('button') ?? [])].find((b) => b.textContent === label)
+
+beforeEach(() => {
+  wire.messages = []
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false
+  })) as unknown as typeof window.matchMedia
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+})
+
+describe('a recorded elicitation card on the session page', () => {
+  it('shows what was asked and what was answered, with nothing left to answer', async () => {
+    wire.messages = [
+      row({ seq: 1, sender: 'sam', kind: 'text', text: 'cut a release' }),
+      elicitRow({ ...CARD, outcome: 'accepted', answerLabel: 'release/1.2' }),
+      row({ seq: 3, sender: 'agent-1', kind: 'text', text: 'cut from develop' })
+    ]
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    // The recorded answer — a label the surrounding conversation does not repeat, so this can
+    // only come from the card's own row.
+    expect(text()).toContain('release/1.2')
+    // A settled card collapses to its outcome, so there is nothing here to tap.
+    expect(buttonNamed('main')).toBeUndefined()
+    expect(buttonNamed('Dismiss')).toBeUndefined()
+    // And the conversation around it is still the conversation.
+    expect(text()).toContain('cut a release')
+    expect(text()).toContain('cut from develop')
+  })
+
+  it('shows an unanswered card as a record, every control inert', async () => {
+    wire.messages = [elicitRow(CARD)]
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    // The options are still visible — what was OFFERED is part of the record — but this reader
+    // has no socket to answer over, so the card is read-only rather than missing its controls.
+    for (const label of ['main', 'develop', 'Dismiss']) expect(buttonNamed(label)?.disabled).toBe(true)
+  })
+
+  it('says an ask nothing could show was not answerable here', async () => {
+    wire.messages = [elicitRow({ ...CARD, options: [], outcome: 'unrenderable' })]
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    expect(text()).toContain("Couldn't be answered here")
+  })
+
+  it('falls back to the question alone when the recorded card cannot be read', async () => {
+    wire.messages = [row({ seq: 2, sender: 'agent-1', kind: 'elicit', text: CARD.message, body: 'not json' })]
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    expect(buttonNamed('main')).toBeUndefined()
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -181,8 +181,9 @@ async function render() {
 }
 
 const text = () => container?.textContent ?? ''
-const buttonNamed = (label: string) =>
-  [...(container?.querySelectorAll('button') ?? [])].find((b) => b.textContent === label)
+const buttonsNamed = (label: string) =>
+  [...(container?.querySelectorAll('button') ?? [])].filter((b) => b.textContent === label)
+const buttonNamed = (label: string) => buttonsNamed(label)[0]
 
 beforeEach(() => {
   wire.messages = []
@@ -909,5 +910,54 @@ describe('the agent’s URL-mode consent card', () => {
     expect(text()).toContain('https://billing.example.com/tokens')
     for (const a of container?.querySelectorAll('a') ?? [])
       expect(a.getAttribute('href') ?? '').not.toContain('billing.example.com')
+  })
+})
+
+// A reload while a card is pending is where #1794's two halves meet: the transcript row the
+// daemon recorded, and the `elicitation` event `pgAttach` replays for the same still-open
+// request. Rendered independently they were one question with two answerable cards, and a
+// settlement that reached only one of them.
+describe('a reload with a webchat card still pending', () => {
+  /** The card's own transcript row — the same request, recorded still open. */
+  const ROW = {
+    seq: 1,
+    sender: 'agent-1',
+    ts: '1700000001',
+    kind: 'elicit',
+    text: 'Which branch should I cut from?',
+    body: JSON.stringify({
+      requestId: 'elicit-1',
+      message: 'Which branch should I cut from?',
+      options: CARD.elicit.options
+    })
+  }
+
+  it('renders exactly ONE card, and it is the answerable one', async () => {
+    wire.messages = [ROW]
+    live.steps = [CARD]
+    await render()
+
+    expect(buttonsNamed('main')).toHaveLength(1)
+    expect(buttonsNamed('Dismiss')).toHaveLength(1)
+    expect(buttonNamed('main')?.disabled).toBe(false)
+
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // One card, so one answer — never the same question answered twice.
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', 'main', 'conv-1']])
+  })
+
+  it('collapses to the live settlement, leaving no unanswered twin behind it', async () => {
+    // The row is still the OPEN copy: `elicitation_resolved` settles the live step, and the
+    // transcript is not re-read while the turn is busy.
+    wire.messages = [ROW]
+    live.steps = [{ ...CARD, elicit: { ...CARD.elicit, outcome: 'accepted', answerLabel: 'main' } }]
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    expect(buttonsNamed('main')).toHaveLength(0)
+    expect(buttonsNamed('Dismiss')).toHaveLength(0)
+    expect(live.answered).toEqual([])
   })
 })

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -103,6 +103,8 @@ import type { AgentIcon } from '@/lib/agent-icon'
 import {
   elicitCard,
   ELICIT_LANE,
+  elicitStepKey,
+  liveElicitKeys,
   NOTICE_LANE,
   PLAN_LANE,
   WORK_LANES,
@@ -3851,10 +3853,24 @@ export default function SessionDetailView() {
     }
     return undefined
   }
+  // #1794's two halves meet on a reload: a pending webchat card is BOTH a transcript row and the
+  // `elicitation` event the cold attach replays, and the two render independently — one question,
+  // two answerable cards, and a settlement that only reaches the live one. A card carries no
+  // `postId`, so `reconcilePersistedLiveSteps`' exact-post arm cannot retire it; its identity is
+  // its OWNER plus its request. The LIVE copy wins while that replay stands: it is the one that
+  // can be answered, and the one `elicitation_resolved` collapses. Once the turn's live steps are
+  // retired the persisted row takes over, carrying the outcome it was rewritten with. Empty on a
+  // Slack-origin session, which streams no cards and so only ever has the persisted copy.
+  const liveCards = liveElicitKeys(liveSteps, session.agentId)
   if (wantTranscript) {
     // Real transcript: agent output carries `sender === agentId`; everything else
     // is a human/cron author. Group consecutive agent messages into one turn.
     for (const m of visibleMsgs ?? []) {
+      if (liveCards.size > 0 && (m.kind || '').toLowerCase() === 'elicit') {
+        const persisted = elicitCard(m.body)
+        const owner = conversationSourceAgentByMessageRef.current.get(m) ?? m.sender
+        if (persisted && liveCards.has(elicitStepKey(owner, persisted.requestId))) continue
+      }
       const toolSessionId = conversationSourceSessionByMessageRef.current.get(m)
       const sourceTurnKey = conversationSourceTurnByMessageRef.current.get(m)
       // A merged conversation stamps every row with the platform of the source

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -101,6 +101,7 @@ import { useCommandAutocomplete } from '@/components/console/useCommandAutocompl
 import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
 import type { AgentIcon } from '@/lib/agent-icon'
 import {
+  elicitCard,
   ELICIT_LANE,
   NOTICE_LANE,
   PLAN_LANE,
@@ -402,9 +403,31 @@ function ComposerSendButton({
 }
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
-// transcript kind (text | tool | reasoning | plan) onto the existing lane styling.
+// transcript kind (text | tool | reasoning | plan | elicit) onto the existing lane styling.
 function msgStep(m: SessionMessageDto, toolSessionId?: string, platform?: string): FmtStep {
   const k = (m.kind || 'text').toLowerCase()
+  // A recorded elicitation card (#1794). It renders through the SAME component a live card does,
+  // just without an `onAnswer` — a reader loading the conversation later sees the question, what
+  // was offered and what was answered, with every control inert. A row whose body cannot be read
+  // falls through to plain text, which is at least the question itself.
+  if (k === 'elicit') {
+    const card = elicitCard(m.body)
+    if (card)
+      return {
+        lane: ELICIT_LANE,
+        laneColor: 'var(--text-tertiary)',
+        dot: 'var(--text-disabled)',
+        weight: 400,
+        textColor: 'var(--text-primary)',
+        codeColor: 'var(--text-secondary)',
+        text: m.text,
+        code: '',
+        files: [],
+        elicit: card,
+        time: formatTranscriptRowTime(m),
+        ...(platform ? { platform } : {})
+      }
+  }
   if (k === 'plan') {
     return {
       lane: PLAN_LANE,
@@ -660,7 +683,14 @@ const ELICIT_OUTCOME: Record<
     label: () => 'Cancelled'
   },
   // URL mode's second settlement: the agent reported the flow behind an opened link finished.
-  completed: { icon: 'check', color: 'var(--green-500)', edge: 'border-l-(--green-500)', label: () => 'Completed' }
+  completed: { icon: 'check', color: 'var(--green-500)', edge: 'border-l-(--green-500)', label: () => 'Completed' },
+  // Persisted cards only: the ask no surface here had a control for, so nothing was ever offered.
+  unrenderable: {
+    icon: 'x',
+    color: 'var(--text-tertiary)',
+    edge: 'border-l-(--border-strong)',
+    label: () => "Couldn't be answered here"
+  }
 }
 
 /** How a consent card reads its URL: the three display parts, so the HOST can be emphasized

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -626,10 +626,10 @@ export interface PlanBody {
   entries: { content: string; status: string; priority?: string }[]
 }
 
-// One transcript message (`GET /sessions/:id/messages`, proxied live from the
-// owning daemon). `kind` is the daemon transcript kind: text | tool | reasoning | plan.
-// `body` carries a ToolBody on a tool row and a PlanBody on a plan row; it is absent
-// on text/reasoning rows, and on plan rows from a daemon or CP predating them.
+// One transcript message (`GET /sessions/:id/messages`, proxied live from the owning daemon).
+// `kind` is the daemon transcript kind: text | tool | reasoning | plan | elicit. `body` carries a
+// ToolBody on a tool row, a PlanBody on a plan row and an ElicitBody on an elicit row; it is
+// absent on text/reasoning rows, and on rows from a daemon or CP predating them.
 export interface SessionMessageDto {
   seq: number
   sender: string
@@ -649,7 +649,7 @@ export interface SessionMessageDto {
   toolCallId?: string // ties the row to its full body (session/tool-body key)
   toolStatus?: string // ACP ToolCallStatus — drives the console status badge
   toolKind?: string // ACP ToolKind — drives the console icon
-  body?: string // JSON.stringify(ToolBody) on a tool row, PlanBody on a plan row, UserTurnBody on a text row; may be a truncated-but-VALID-JSON preview
+  body?: string // JSON.stringify(ToolBody) on a tool row, PlanBody on a plan row, ElicitBody on an elicit row, UserTurnBody on a text row; may be a truncated-but-VALID-JSON preview
   bodyTruncated?: boolean // preview was shrunk for the frame; full body via fetchToolBody
   bodyBytes?: number // full (untruncated) body byte length
 }

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1175,10 +1175,20 @@ export interface SessionStep {
     /** Present ⇒ a URL-mode CONSENT card: the reader examines this exact URL and opens it in
      *  their own browser tab. Nothing here ever fetches it, and `options` is then empty. */
     url?: string
-    outcome?: 'accepted' | 'dismissed' | 'cancelled' | 'completed'
+    /** How the card ended. Absent while it is live — and, on a PERSISTED card, absent means
+     *  nothing ever settled it. `unrenderable` is persist-only: the ask no surface had a control
+     *  for, which was previously said once in a live notice and then lost. */
+    outcome?: 'accepted' | 'dismissed' | 'cancelled' | 'completed' | 'unrenderable'
+    /** The chosen option's LABEL (the labels joined, for a multi-select or a form) — never the
+     *  accepted content, which is already in the agent's own context. */
     answerLabel?: string
   }
 }
+
+/** The agent's structured question as the transcript PERSISTS it (protocol `ElicitBody`): the
+ *  card plus how it ended, carried as a JSON string in an `elicit` row's `body`. Deliberately the
+ *  same type a live step carries, so one component renders the live card and the recorded one. */
+export type ElicitBody = NonNullable<SessionStep['elicit']>
 
 // Per-session token accounting (protocol `SessionUsage`), metered by the daemon.
 // Token counts are session-cumulative; context/cost are the latest snapshot.


### PR DESCRIPTION
Two items from #1794, plus two defects found while building them.

## 1. A card is a transcript row now

Nothing recorded these: `TranscriptRecorder` is driven only by ACP `SessionUpdate`, and an elicitation is a client *request*. So the card, its settlement, and #1839's notices were live-only — reload the console and they were gone, and a viewer joining later never learned a question had been asked.

**One upserted row per request**, not two: the ask writes it, the settlement rewrites the same row. The card keeps the position in the turn where it was asked instead of reappearing under the reply that followed it.

| what | recorded |
| --- | --- |
| the card | `requestId`, `message`, the offered options, plus `multi`/`text`/`number`/`defaultValue`, or `fields[]` for a form, or `url` for a consent card — the **surface's own reduction**, so a persisted Slack card describes what Slack offered |
| the settlement | `accepted` / `dismissed` / `cancelled` / `completed`, plus the chosen labels |
| a declined ask (#1839) | the same row, settled `unrenderable` |

Deliberately out: the raw `requestedSchema` (the card *is* the reduction, which is why it never reaches the wire either), the accepted `content` (a label is what a reader needs; the values are already in the agent's context), #1839's *refused-answer* notice (feedback on a still-open card, superseded by the outcome the row eventually records), and approval elicitations, whose durable record is `permission_requests`.

**Backfill skips them through three mechanisms that already existed**, none invented here: `kind` is not `text` and `text` is the only kind a replay reader selects; `sender` is the agent, which every participant gap filters; and on Slack the card message already posts with `chrome: true`, so the provenance-gated filter drops it before thread backfill can turn it into a row — the `chromeMarkedNotices` mechanism, untouched.

Every transcript reader was enumerated and classified — replay/gap/dream/attachment/tool readers skip it, console and activity-log readers see it and should, and the agent-facing MCP `getThreadHistory` filters on the same chrome marker. One reader needed a change: `cp/session-reader.ts` dropped the `body` of any row that was not text/plan/tool, so the card would have arrived at the console empty.

No migration: the live `transcript` table has no `kind` CHECK, and the row rides the existing unique index under a namespaced `elicit:<ts>` id exactly as `plan` does.

**The console needs no new component.** #1799's read-only branch — written for this day and unreachable through the view ever since — is the *absence* of `onAnswer`, and every control already renders `disabled={!onAnswer}`. A persisted card renders as a record with inert controls. A bonus: on a live webchat conversation the persisted card is still *answerable* after a reload, so a reload no longer costs the reader their answer.

## 2. No Slack value cap loses a card any more — and the mechanism needed no state

The issue recorded the fix as "a per-request nonce with a server-side lookup". It turns out **no state is needed at all**. Both value caps are one bug: an agent-authored string in a capped Slack wire field. So every Slack elicitation card now carries an option's **position** (`ac_o<n>`) rather than its value, and the daemon resolves it against the field list it re-derives from the card's own params — which is the re-derivation #1815 already performs on every answer.

Nothing is stored, nothing expires, and **#1815's rule gets stronger**: what comes back is a position or it is not an answer, so the resolver can only ever return one of that card's own option values. It is the same trick `elicitFormBlockId` already used for a block id.

- the 75-char option-value cap is gone from `ElicitSurface` — a multi-select of paths, URLs or ids renders on Slack
- a ~1989–2048-char consent URL keeps its card
- **a previously unreported third case**: a single-select whose enum value passed 2000 chars made Slack reject the *whole message*, so the card never posted — the same failure shape as the bug that started this work, and `slackCardViolations()` did not know the rule. It does now.

## 3. A consent that arrived before its own post said "Cancelled"

The channel record contradicted a credential page the reader had actually opened. **The ordering cannot be fixed** — Slack can always deliver the interaction before we parse our own `chat.postMessage` reply, and buffering taps until `ts` is known would either drop a genuine consent or make the reader tap twice. The contradiction lives in the label, so that is where it is fixed: a settlement with no `ts` to rewrite records the label it wanted, and the posting path applies it instead of hardcoding Cancelled. Applied to all three Slack card paths.

## Two behaviour changes, stated rather than buried

- **Every** Slack card's wire value became a position, not only over-long ones. A predicate the builder and the decoder must compute identically is exactly the skew that produces a card nobody can answer; one rule removes it. Cost: 28 mechanical test-assertion updates.
- A Slack tap carrying a *literal* option value is now refused with the standard "that answer wasn't accepted" line. That path is only ever fed by our own cards, so nothing real regresses, but it is a behaviour change rather than pure addition.

Validation is otherwise byte-identical: #1795/#1807/#1815/#1836 unchanged, and "anyone who can see a card may answer it" untouched.

## Verification

- `pnpm typecheck`: `error TS` count **0**. protocol 490, relay 652 — green.
- Touched daemon suites (`local-store`, `slack-elicit-form`, `daemon-permission-autoallow`, `render`, `daemon-commands`, `approval-dm`, `elicit-decline-notice`): **547 passing**; the new console suite 4 passing — independently re-run.
- **Store tests against real Postgres** (`vitest.postgres.config.ts`, `postgres:16-alpine`): 137 passing — this touched store SQL, so the dialect rewrite is exercised for real rather than only on SQLite.
- `pnpm eval:gates`: 27 of 28 files green; the one failure is the documented pre-existing `evaluation-runner` `infra_error` baseline.
- Full daemon suite: 12 files failing, all in the known-unrelated set (`acp-matrix` live runtimes, five skills-CLI files, bwrap `sandbox`, `evaluation-runner`, `daemon-smoke`) plus three load-flaky files confirmed clean alone (96/96). **No failure sits in a file this touches.** An earlier run had one that *was* mine — a relayed Confirm still carrying literal values — found, fixed, and green here.
- Web suite: the 8 known pre-existing failures in `code-host-hook-groups` and `AgentDetailView.codehost`, in exactly those two files.

Every new test was confirmed red with only the sources reverted, including the race reproduced by forcing the pre-fix label. One of the four console tests passes either way by construction — it asserts an unreadable body still shows the question, which is pre-existing behaviour it exists to preserve, and I would rather name that than dress it up.
