### PR TITLE
fix(daemon): tunnel the git credential socket to a scratch agent's sandbox pod

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1909,15 +1909,14 @@ export class Daemon {
           orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
           // Which sockets this agent's pod needs, and where this daemon serves them — both are on
           // the daemon's own filesystem, so without a tunnel they exist nowhere the pod can reach.
-          // `mcp` is served for every pod agent because any session may carry tools and the
-          // listener belongs to the pod's lifetime, while the spec that dials it is decided per
-          // session; a managed-credential workspace — github-app or gitlab — adds the helper socket.
-          // An id this daemon holds no agent for gets neither: the member's own runtime probe is
-          // the case, and its channel is granted `probe` alone, so asking would only be refused.
+          // `mcp` for every pod agent: any session may carry tools and the listener lives as long as the pod.
+          // `gitcred` follows the credential marker, the predicate the pod gitconfig and the local carve use,
+          // so a scratch agent gets it; tunnels open once per pod, so the repo list would strand a late grant.
+          // An unknown id gets neither: the member's own runtime probe is granted `probe` alone.
           tunnelsFor: (agentId) => {
             const agent = this.agents.get(agentId)
             if (!agent) return []
-            return this.workspaces.usesManagedCredential(agent) ? ['mcp', 'gitcred'] : ['mcp']
+            return this.workspaces.helperBackedCredential(agent) ? ['mcp', 'gitcred'] : ['mcp']
           },
           tunnelSocketPath: (tunnel) => (tunnel === 'gitcred' ? gitcredSocketPath(root) : mcpSocketPath(root)),
           // A bound sandbox is a reachable memory tree: drain any managed capture that waited for it.

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -352,6 +352,11 @@ export class WorkspaceManager {
     return this.managedCredentialProvider(agent) !== undefined
   }
 
+  // Mode-agnostic, unlike usesManagedCredential: scratch carries `github-app` so git/gh/glab can name authorized repos.
+  helperBackedCredential(agent: Agent): boolean {
+    return agent.workspace.gitCredential !== undefined
+  }
+
   /**
    * Whether the spec carries a REPO-BEARING GitLab consumer (§24.4): a gitlab workspace, or an
    * authorized gitlab additional repository. A hook is deliberately not one — it authorizes a turn,

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -1016,6 +1016,34 @@ describe('daemon --k8s mode', () => {
       // A managed GitLab pod needs the same socket: its clone/pull and the agent's git/glab ask for one.
       ;(k8sDaemon as any).agents.set('gl', { id: 'gl', workspace: { mode: 'git-repo', gitCredential: 'gitlab' } })
       expect(planeOptions.tunnelsFor('gl')).toEqual(['mcp', 'gitcred'])
+      // Scratch carries the marker so git/gh/glab can name authorized repos, and its pod gitconfig
+      // already points at the helper — the socket has to be there whichever host the repo lives on.
+      const scratch = (additionalRepos: unknown[]) => ({
+        mode: 'from-scratch',
+        gitCredential: 'github-app',
+        additionalRepos
+      })
+      ;(k8sDaemon as any).agents.set('scratch-gh', {
+        id: 'scratch-gh',
+        workspace: scratch([{ repoFullName: 'acme/shared', repoId: '1' }])
+      })
+      expect(planeOptions.tunnelsFor('scratch-gh')).toEqual(['mcp', 'gitcred'])
+      ;(k8sDaemon as any).agents.set('scratch-gl', {
+        id: 'scratch-gl',
+        workspace: scratch([{ provider: 'gitlab', repoFullName: 'acme/shared', repoId: '7' }])
+      })
+      expect(planeOptions.tunnelsFor('scratch-gl')).toEqual(['mcp', 'gitcred'])
+      // Tunnels open once per pod, so a pod bound before its first grant gets the socket too; the
+      // helper refuses a repository-less request, so nothing is minted for it.
+      ;(k8sDaemon as any).agents.set('scratch-none', { id: 'scratch-none', workspace: scratch([]) })
+      expect(planeOptions.tunnelsFor('scratch-none')).toEqual(['mcp', 'gitcred'])
+      // An anonymous checkout has no marker even with a row: that row authorizes control-plane-owned
+      // review of its own repo, not agent credentials, so the row count alone must not decide.
+      ;(k8sDaemon as any).agents.set('anon', {
+        id: 'anon',
+        workspace: { mode: 'git-repo', additionalRepos: [{ repoFullName: 'acme/own', repoId: '2' }] }
+      })
+      expect(planeOptions.tunnelsFor('anon')).toEqual(['mcp'])
       // And nothing for the member's own runtime probe, whose channel is granted `probe` alone —
       // asking it to serve a socket would be refused, and the refusal logged, on every boot.
       expect(planeOptions.tunnelsFor('ac-runtime-probe-0f0f0f0f')).toEqual([])


### PR DESCRIPTION
Closes #1845

## Problem

A scratch agent authorized for an additional repository (GitHub or GitLab) ran in a sandbox pod that received only `mcp.sock`. Its session gitconfig already named the in-pod credential helper at the tunnelled `gitcred` socket path, so every authorized fetch failed at the helper instead of degrading to anonymous.

## Cause

The Kubernetes tunnel predicate keyed on `usesManagedCredential`, which is gated on a git-backed primary workspace. A scratch workspace carries the `github-app` credential marker precisely so `git`/`gh`/`glab` can name explicitly authorized repositories (`agent-multi-repo-authorization.md`), and both the local sandbox carve and the session gitconfig already key on that mode-agnostic marker. The tunnel was the one consumer using a different predicate.

## Fix

- `WorkspaceManager.helperBackedCredential(agent)`: the mode-agnostic marker check.
- `tunnelsFor` keys on it, so a scratch pod gets `gitcred.sock` alongside `mcp.sock`.

The issue suggested keying on the additional-repository count instead. Tunnels open once per pod incarnation, so that would strand a pod bound before its first authorization until the next launch, and it would also serve a socket to an anonymous checkout whose only row authorizes control-plane-owned review of its own repository, not agent credentials. Keying on the marker keeps the pod aligned with the gitconfig written into it.

## Tests

`daemon-k8s-mode.test.ts` now covers scratch + GitHub row, scratch + GitLab row, scratch with no rows (socket present, helper refuses repository-less requests), and an anonymous git checkout with a row (no socket), alongside the existing git-backed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
