### PR TITLE
feat(daemon): unify sandbox mount configuration

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -135,8 +135,8 @@ The daemon does not implement these, but interacts with them through the section
 | `--agent <name>`                 | Selector                       | Select by `agent.id`: single-agent `run` ignoring status, or disambiguate `chat`.                                                                  |
 | `--max-agents <n>`               | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
 | `--require-sandbox`              | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
-| n/a (config only)                | `security.sandboxReadRoots`    | Host toolchain dirs carved read-only into every sandbox; see the config example below.                                                             |
-| n/a (config only)                | `security.sandboxWriteRoots`   | Host package-manager stores carved writable into every sandbox, shared by every session; see the config example below.                             |
+| n/a (config only)                | `sandbox.backend`              | Select the local sandbox backend; defaults to `srt`, currently the only supported value.                                                           |
+| n/a (config only)                | `sandbox.mounts`               | Operator-owned host path mappings; `readOnly` defaults to true. SRT requires equal normalized source and target paths.                             |
 | `--k8s`                          | n/a (mode switch)              | Run runtimes in cluster sandbox pods instead of on this host; see section 2.6 for what that changes.                                               |
 | `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only service for session-scoped model credentials, http or https as the deployment chooses; see [key-server.md](key-server.md).              |
 | `--key-server-token-path <path>` | `KEY_SERVER_TOKEN_PATH`        | File re-read as the key-server bearer token on every request.                                                                                      |
@@ -322,29 +322,19 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
     // Linux SRT/bwrap sandbox. macOS and Windows are not supported in this rollout.
     "requireSandbox": false,
 
-    // Host directories carved read-only into EVERY sandbox, for toolchains the
-    // agent needs but the runtime-scoped read set would otherwise hide (nvm's
-    // node, a rustup toolchain, ...). `~/` expands against the daemon's HOME;
-    // each entry must exist or startup fails. Caches still land in the
-    // per-session private HOME. Name the toolchain dir itself, never a parent
-    // that also holds credentials (~/.cargo/credentials.toml, ~/.npmrc).
-    "sandboxReadRoots": [],
-
-    // Host directories carved WRITABLE into EVERY sandbox, so sessions share one
-    // package-manager store instead of each downloading its own (pnpm's store,
-    // corepack's cache; point the runtime at them with the agent's env: pnpm 11
-    // reads pnpm_config_store_dir and ignores the npm_config_ prefix, pnpm 10 the
-    // reverse; corepack reads COREPACK_HOME). Same expansion and existence rule as
-    // sandboxReadRoots. This is a deliberate hole in per-session isolation: what one
-    // session's install writes, the next session runs. Name the store itself, never
-    // HOME or a parent holding credentials.
-    "sandboxWriteRoots": [],
-
     // Origins that daemon-managed workspace clone/pull may target. Default ["*"]
     // admits any valid https/ssh origin; exact entries (scheme and non-default
     // port are part of the match, no partial wildcards or paths) tighten it, and
     // [] disables remote Git workspaces entirely.
     "workspaceGitAllowedOrigins": ["https://github.com", "ssh://github.com"]
+  },
+
+  // ---------- Local sandbox backend and shared host directories ----------
+  "sandbox": {
+    "backend": "srt", // Default and currently the only supported backend.
+    // Entries: { source, target, readOnly }; readOnly defaults to true.
+    // SRT requires existing paths and equal normalized source/target paths.
+    "mounts": []
   },
 
   // Daemon-local config.json / agent.json are secret-bearing files: CP API keys and
@@ -381,10 +371,11 @@ agent directories and higher custom parents are left unchanged.
 
 ### Linux ACP runtime sandbox
 
-The proposed [sandbox backend extension](daemon-sandbox-backends.md) adds
-configurable microsandbox execution and a shared mounts configuration while
-preserving SRT as the default. The behavior below describes the current SRT
-implementation.
+`sandbox.backend` defaults to `srt`, currently the only supported backend.
+Operator-owned filesystem access is configured through `sandbox.mounts`.
+The [sandbox backend design](daemon-sandbox-backends.md) documents this
+configuration and the proposed microsandbox extension. The behavior below
+describes the current SRT implementation.
 
 AgentConnect currently enables runtime sandboxing on Linux only. The daemon uses
 the exact-pinned `@anthropic-ai/sandbox-runtime` package, backed by `bubblewrap`,
@@ -402,13 +393,12 @@ An enabled sandbox gives the runtime a private HOME, hides daemon-owned agent
 metadata and the host source from which that runtime state was seeded, and
 re-allows reads only for the workspace, private HOME, managed memory,
 `run/config-files`, `.agentconnect/runtime-policy`, trusted runtime installation
-roots, any operator-declared `security.sandboxReadRoots` (host toolchains such as
-nvm's node or a rustup toolchain, carved read-only into every sandbox regardless
+roots, any operator-declared `sandbox.mounts` (host toolchains such as
+nvm's node or a rustup toolchain, made readable in every sandbox regardless
 of runtime), and the runtime's selected host credential path. Writes are limited to
 the workspace, private HOME, managed memory, SRT temporary storage, that
-credential path, and any operator-declared `security.sandboxWriteRoots` (a shared
-package-manager store, reopened by the same exception rule as a read root). Outbound
-domains are approved by a provider callback and Unix sockets remain
+credential path, and mounts with `readOnly: false` (such as a shared
+package-manager store). Outbound domains are approved by a provider callback and Unix sockets remain
 compatibility-open during this rollout. Proxy-aware HTTP(S) clients retain web
 egress, and the provider sets `NODE_USE_ENV_PROXY=1` so Node's built-in `fetch`
 and `http` clients (corepack downloading a pinned package manager, for one) join
@@ -417,6 +407,16 @@ agent-started local server and other clients that ignore the proxy environment
 are not yet compatibility guarantees; issue #312 tracks those boundaries. SRT's
 temporary directory is redirected below the private HOME and its shared
 `/tmp/claude` fallback is hidden.
+
+Mounts default to read-only. SRT expands host `~` and normalizes both paths;
+`source` and `target` must resolve to the same existing host path. Remapping a
+host path to a different target is rejected. Writable mounts also extend the
+runtime-native tool sandbox's write permissions, so the actual package-manager
+process can use them. Configure the package manager to use the target path;
+mounts do not change its settings. These paths are shared across sessions,
+and their host contents survive session cleanup. Replace the removed
+`security.sandboxReadRoots` and `security.sandboxWriteRoots` fields manually as
+shown in [the conversion table](daemon-sandbox-backends.md#shared-mounts-and-manual-conversion).
 
 The Claude ACP parent is trusted to manage the host Claude login. By default,
 AgentConnect resolves the host config directory from `CLAUDE_CONFIG_DIR`, falling

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -1,12 +1,12 @@
 # Daemon Sandbox Backends
 
-**Status: Proposed.** This document defines configurable self-hosted sandbox
-backends; it does not describe shipped configuration.
+**Status: Partially implemented.** `sandbox.backend: "srt"` and `sandbox.mounts`
+are implemented. SRT is currently the only accepted backend. The microsandbox
+backend, image selection, Docker, networking, and VM lifecycle remain proposed.
 
-The daemon continues to default to SRT. Operators can select microsandbox and
-configure its image, resources, mounts, and networking. The initial priority is a
-usable development environment: independent sessions, ordinary network access,
-Docker and Compose, and predictable stop/start behavior.
+The daemon continues to default to SRT. The proposed microsandbox backend adds
+image, resource, and networking configuration for independent session development
+environments with Docker, Compose, and predictable stop/start behavior.
 
 This extends [daemon configuration and lifecycle](daemon-detailed-design.md) and
 uses the existing [execution-driver seam](cluster-spawn-and-shim.md#1-why-a-seam-at-all).
@@ -15,8 +15,8 @@ Control Plane does not carry ACP or provider request traffic.
 
 ## 1. Configuration and ownership
 
-Add a daemon-owned `sandbox` object to `~/.agentconnect/config.json`. The minimal
-configuration preserves today's backend:
+The daemon-owned `sandbox` object in `~/.agentconnect/config.json` defaults to
+`{ "backend": "srt", "mounts": [] }`. The minimal configuration is:
 
 ```json
 {
@@ -26,7 +26,8 @@ configuration preserves today's backend:
 }
 ```
 
-An illustrative microsandbox configuration is:
+The following microsandbox configuration is proposed and is not accepted by the
+current schema:
 
 ```json
 {
@@ -61,54 +62,53 @@ An illustrative microsandbox configuration is:
 }
 ```
 
-Values above are example resource allocations, not measured minimums. New fields
-are strictly validated; they are not an untyped pass-through to a vendor SDK.
+Values above are example resource allocations, not measured minimums. Future VM
+fields will be strictly validated rather than passed untyped to a vendor SDK.
 
-| Setting                        | Proposed meaning                                                                                                                                                                                                                                                                                                            |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sandbox.backend`              | `srt` by default; `microsandbox` selects the VM implementation for sandboxed launches.                                                                                                                                                                                                                                      |
-| `security.requireSandbox`      | Keeps its current role: require sandboxed execution for every agent. It checks the selected backend rather than hardcoding SRT.                                                                                                                                                                                             |
-| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                            |
-| `sandbox.microsandbox.image`   | Optional OCI reference. Omitted uses the runtime image reference in new release-generated metadata bundled with the daemon. An explicit image wins; a development build without metadata requires one. Record the resolved digest.                                                                                          |
-| `cpus`, `memoryMiB`, `diskGiB` | Per-session CPU allocation, memory limit, and disk capacity. Validate against backend support and daemon capacity.                                                                                                                                                                                                          |
-| `docker`                       | Start an independent Docker daemon inside each VM. Requires Docker tools in the selected image; never means mounting the host Docker socket. Default false until the Docker-enabled shared image and workload checks are delivered.                                                                                         |
-| `sandbox.mounts`               | Shared operator-owned filesystem mappings for both backends; defaults to `[]`. Each entry has `source`, `target`, and `readOnly` (default `true`). SRT requires the same host path on both sides; microsandbox supports a different guest target. Session workspace, HOME, and runtime state are provisioned automatically. |
-| `network.access`               | `development` allows public, private-network, and host connectivity subject to mandatory control/admin exclusions; `public` allows public egress and required daemon endpoints; `none` disables external egress. Default `development`. Remote model use requires connectivity.                                             |
-| `network.ports`                | Guest service ports exposed through daemon-assigned host ports. `host: 0` requests an available port. The backend binds and verifies the mapping; retry allocation conflicts and release mappings on teardown.                                                                                                              |
-| `network.outboundProxy`        | Optional host-side SOCKS URL for microsandbox's outbound transport.                                                                                                                                                                                                                                                         |
+| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                                                       |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sandbox.backend`              | Implemented: `srt` is the default and only accepted value. Proposed: `microsandbox` selects the VM implementation for sandboxed launches.                                                                                                                                                                         |
+| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent. SRT is currently the only supported backend.                                                                                                                                                                                                      |
+| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                  |
+| `sandbox.microsandbox.image`   | Proposed: optional OCI reference. Omitted uses the runtime image reference in new release-generated metadata bundled with the daemon. An explicit image wins; a development build without metadata requires one. Record the resolved digest.                                                                      |
+| `cpus`, `memoryMiB`, `diskGiB` | Proposed: per-session CPU allocation, memory limit, and disk capacity. Validate against backend support and daemon capacity.                                                                                                                                                                                      |
+| `docker`                       | Proposed: start an independent Docker daemon inside each VM. Requires Docker tools in the selected image; never means mounting the host Docker socket. Default false until the Docker-enabled shared image and workload checks are delivered.                                                                     |
+| `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths. Proposed: microsandbox consumes the same list with guest targets. Session workspace, HOME, and runtime state remain automatically provisioned. |
+| `network.access`               | Proposed: `development` allows public, private-network, and host connectivity subject to mandatory control/admin exclusions; `public` allows public egress and required daemon endpoints; `none` disables external egress. Default `development`. Remote model use requires connectivity.                         |
+| `network.ports`                | Proposed: guest service ports exposed through daemon-assigned host ports. `host: 0` requests an available port. The backend binds and verifies the mapping; retry allocation conflicts and release mappings on teardown.                                                                                          |
+| `network.outboundProxy`        | Proposed: optional host-side SOCKS URL for microsandbox's outbound transport.                                                                                                                                                                                                                                     |
 
-### Shared mounts and configuration migration
+### Shared mounts and manual conversion
 
-Move operator-owned paths out of `security.sandboxReadRoots` and
-`security.sandboxWriteRoots` into `sandbox.mounts`. Both backend adapters consume
-this one normalized list; mounts are not nested under `sandbox.microsandbox`.
+`sandbox.mounts` replaces `security.sandboxReadRoots` and
+`security.sandboxWriteRoots`. The old fields are removed; the daemon does not
+automatically migrate or retain a compatibility path for them. Convert existing
+configuration manually using this table, then remove the old fields:
 
-| Previous entry                                          | Migrated entry                                                                                |
+| Previous entry                                          | Entry to add to `sandbox.mounts`                                                              |
 | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `security.sandboxReadRoots: ["/opt/toolchain"]`         | `{ "source": "/opt/toolchain", "target": "/opt/toolchain", "readOnly": true }`                |
 | `security.sandboxWriteRoots: ["/srv/agent-cache/pnpm"]` | `{ "source": "/srv/agent-cache/pnpm", "target": "/srv/agent-cache/pnpm", "readOnly": false }` |
 
-Convert existing configuration to the new list and remove the two legacy fields
-when migration succeeds. Expand host `~`, require existing absolute sources,
-and resolve symlinks using the current root normalization. Coalesce duplicate
-legacy paths; a path previously declared writable remains writable. Runtime
-launch preparation consumes only the migrated list, not two parallel policies.
-Existing protected-path checks remain in effect.
+Keep a previously writable path writable when converting duplicate legacy
+entries. Launch preparation consumes only `sandbox.mounts`. Normalization expands
+host `~`, requires existing absolute sources, and resolves symlinks using the
+current root normalization. Existing protected-path checks remain in effect.
 After normalization, reject different sources mapped to the same target; merge
 permissions only for entries with the same source and target.
 
 Access remains additive: a read-only entry adds read access; it does not revoke
-write access already granted by a workspace or writable mount. Normalize overlaps
-to the same effective access for both backends, and retain writable children of
-read-only parents rather than collapsing all nested paths into one entry.
+write access already granted by a workspace or writable mount. Retain writable
+children of read-only parents rather than collapsing all nested paths into one entry.
+The proposed VM backend must preserve the same effective access.
 
 SRT uses the configured paths at their host locations: its filesystem rules do
 not rename a host path inside the sandbox. Normalize `source` and `target` as
 host paths and require them to be equal. A mapping such as
 `/srv/agent-cache/pnpm` to `/cache/pnpm` fails validation for SRT. The same mapping
-is valid for microsandbox, where `target` is an absolute guest path. Migrated
-same-path entries therefore work with either backend; operators can choose new
-guest targets when switching to microsandbox.
+will be supported by microsandbox, where `target` is an absolute guest path.
+The shared configuration list is kept outside the future
+`sandbox.microsandbox` object.
 
 For example, SRT uses the same common configuration shape:
 
@@ -136,11 +136,14 @@ operator-owned mounts without deleting their host contents.
 
 Configuration is machine-local desired state. Agent configuration can select a
 runtime and request sandboxing, but cannot supply backend executables, images,
-or mounts. Future backends add a typed
-configuration member and an implementation at the existing execution-plane
+or mounts. Future backends add a typed configuration member and an implementation at the existing execution-plane
 composition point. Do not add speculative backend branches throughout ACP.
 
-### Availability and changes
+### Proposed VM availability and changes
+
+The following availability and lifecycle requirements belong to the future VM
+backend. Current configuration accepts only SRT and preserves its existing
+availability checks and optional/required sandbox behavior.
 
 Probe the selected backend with an actual launch/command, not only binary
 detection. On Linux, microsandbox requires usable KVM; checking `/dev/kvm` alone
@@ -150,7 +153,7 @@ but a requested microsandbox launch must fail explicitly. It must not silently
 fall back to SRT or an ordinary host process. Existing optional-SRT fallback
 semantics are unchanged by this proposal.
 
-This release adds no new backend for Linux hosts without usable KVM. They can
+The proposed VM release adds no new backend for Linux hosts without usable KVM. They can
 keep SRT, including fail-closed startup with `security.requireSandbox=true`. The
 new VM boundary requires bare metal or a VM exposing nested virtualization;
 Podman/runsc with systrap remains a future no-KVM option, not a hidden fallback.
@@ -320,30 +323,32 @@ Lifecycle and configuration-reuse rules are documented
 
 ## 4. Delivery and acceptance
 
-This is a design-only change. Implement in independently reviewable steps:
+Delivery is split into independently reviewable steps:
 
-1. **Configuration and capability reporting:** retain SRT defaults; add the typed
-   backend choice, shared mounts and legacy-root migration, real availability
-   checks, release image metadata, and explicit no-KVM behavior. Preserve the pool
-   and unsandboxed-agent paths.
-2. **microsandbox execution:** integrate the image, disk, ACP streams, workspace
-   and Git/file operations, declared ports with admin exclusions, and stop/start.
+1. **Implemented — SRT configuration and mounts:** add `sandbox.backend: "srt"`
+   and `sandbox.mounts`, remove legacy security roots, and apply mount permissions
+   to SRT and native tools. Existing configuration is converted manually. Preserve
+   the pool and unsandboxed-agent paths.
+2. **Proposed — microsandbox execution:** add the VM backend choice, availability
+   checks, release image metadata, and explicit no-KVM behavior. Integrate disk,
+   ACP streams, workspace and Git/file operations, declared ports with admin exclusions, and stop/start.
    Add the shared image's optional Docker/Compose support.
-3. **Developer experience and measurement:** run real projects and add dynamic
-   preview forwarding separately. Change the default only after compatibility
+3. **Proposed — developer experience and measurement:** run real projects and add
+   dynamic preview forwarding separately. Change the default only after compatibility
    and resource measurements support it.
 
-Use a small integration matrix:
+The SRT configuration/mount checks apply to the implemented slice; VM, image,
+Docker, networking, lifecycle, and performance evidence remain future gates:
 
-| Area                       | Required evidence                                                                                                                                                                                                                                                                                 |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Existing behavior          | Default SRT, required/optional sandbox policy, and Kubernetes execution remain usable. No-KVM behavior is explicit.                                                                                                                                                                               |
-| Mounts                     | Legacy roots migrate to the shared list with equivalent access. SRT accepts identical paths and rejects remapping; microsandbox maps guest targets. Verify read-only and writable paths from native tools, nested/duplicate entries, package-cache use, and host-data preservation on retirement. |
-| Image and complete session | Bundled release image selection and explicit overrides work; image preparation, ACP initialize/new/load, output, cancellation, cleanup, and a real native-tool turn succeed.                                                                                                                      |
-| Docker                     | Compose and Testcontainers work, including DNS, random ports, bind mounts, build cache, and cleanup helpers. Two sessions use the same internal ports.                                                                                                                                            |
-| Networking                 | Git/npm, an allowed host database, web preview and WebSockets work. Registered control/admin endpoints are unreachable through gateway and host address aliases, including when SOCKS is configured.                                                                                              |
-| Lifecycle                  | Idle stop preserves work/cache; start re-establishes ACP; daemon restart fences old hosts; dirty/unpushed work prevents destructive retirement.                                                                                                                                                   |
-| Performance                | Measure cold image preparation, warm disk clone, stopped-session restart, ACP-ready latency, and Git/install/build duration. At 1/10/20 sessions, record whole-environment memory, peaks, disk growth, CPU limits, and cleanup. Record reflink versus sparse-copy behavior.                       |
+| Area                       | Required evidence                                                                                                                                                                                                                                                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Existing behavior          | Default SRT, required/optional sandbox policy, and Kubernetes execution remain usable. No-KVM behavior is explicit.                                                                                                                                                                                           |
+| Mounts                     | Manually converted roots preserve access. SRT accepts equal normalized paths and rejects remapping; read-only is the default and writable mounts reach native tools. Verify nested/duplicate entries and package-cache access. Future VM checks cover guest targets and host-data preservation on retirement. |
+| Image and complete session | Bundled release image selection and explicit overrides work; image preparation, ACP initialize/new/load, output, cancellation, cleanup, and a real native-tool turn succeed.                                                                                                                                  |
+| Docker                     | Compose and Testcontainers work, including DNS, random ports, bind mounts, build cache, and cleanup helpers. Two sessions use the same internal ports.                                                                                                                                                        |
+| Networking                 | Git/npm, an allowed host database, web preview and WebSockets work. Registered control/admin endpoints are unreachable through gateway and host address aliases, including when SOCKS is configured.                                                                                                          |
+| Lifecycle                  | Idle stop preserves work/cache; start re-establishes ACP; daemon restart fences old hosts; dirty/unpushed work prevents destructive retirement.                                                                                                                                                               |
+| Performance                | Measure cold image preparation, warm disk clone, stopped-session restart, ACP-ready latency, and Git/install/build duration. At 1/10/20 sessions, record whole-environment memory, peaks, disk growth, CPU limits, and cleanup. Record reflink versus sparse-copy behavior.                                   |
 
 Keep plain Podman/crun and Docker Sandboxes as labeled comparison arms where
 useful. Compare actual agent sessions before deciding latency or density targets.

--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -21,7 +21,7 @@ export interface CodexPermissionProfileOptions {
   sessionGitMetadataRoots?: readonly string[]
   /** A confined session's private HOME (§11) — a SIBLING of the cwd, so `:workspace` never reaches it. */
   sessionHomeRoot?: string
-  /** Operator-declared `security.sandboxWriteRoots` the outer boundary already opened: a shared package store, outside the cwd. */
+  /** Operator-declared writable `sandbox.mounts` the outer boundary already opened: a shared package store, outside the cwd. */
   sharedWriteRoots?: readonly string[]
   allowModelToolUnixSockets?: boolean
   disableUnifiedExec?: boolean

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -28,7 +28,7 @@ export interface AcpSandboxLaunch {
   /** SDK flag settings that pin protected parent-only profile selection after
    * Claude merges workspace-controlled settings. */
   claudeProtectedSettings?: ClaudeProtectedSettings
-  /** Operator-declared `security.sandboxWriteRoots`, reopened in the runtime-native tool sandbox as well. */
+  /** Operator-declared writable `sandbox.mounts`, reopened in the runtime-native tool sandbox as well. */
   sharedWriteRoots?: string[]
 }
 

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -15,7 +15,7 @@ import { detectSandbox } from '../acp/sandbox.js'
 import { agentHostKey } from '../acp/host-key.js'
 import { resolveRoot } from '../paths.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
-import { sandboxReadRoots, sandboxWriteRoots } from '../runtimes/read-roots.js'
+import { normalizeSandboxMounts } from '../runtimes/read-roots.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { ArchiveStore, parseArchiveLaunch, storedArchiveRuntimeDef } from '../runtimes/archive-store.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
@@ -62,9 +62,10 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     overrides: { agentsDir: opts.agentsDir }
   })
   configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
-  // Same fail-fast the daemon applies at boot: a missing operator read root is a config error, not a turn error.
-  const operatorReadRoots = sandboxReadRoots(cfg.security.sandboxReadRoots)
-  const operatorWriteRoots = sandboxWriteRoots(cfg.security.sandboxWriteRoots)
+  // Validate operator mounts before selecting or probing a runtime.
+  const mounts = normalizeSandboxMounts(cfg.sandbox.mounts)
+  const operatorReadRoots = mounts.map((mount) => mount.source)
+  const operatorWriteRoots = mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source)
   const agent = selectAgent(cfg.agentsDir!, opts.agentName)
   await persistSkillSandboxRequirement(root)
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -125,6 +125,15 @@ export const StdioMemoryPluginDefSchema = z
   })
 export type StdioMemoryPluginDef = z.infer<typeof StdioMemoryPluginDefSchema>
 
+const SandboxMountSchema = z
+  .object({
+    source: z.string().min(1),
+    target: z.string().min(1),
+    readOnly: z.boolean().default(true)
+  })
+  .strict()
+export type SandboxMount = z.infer<typeof SandboxMountSchema>
+
 export const ConfigSchema = z.object({
   version: z.literal(1),
   daemonId: z.string().optional(),
@@ -159,6 +168,13 @@ export const ConfigSchema = z.object({
   // Agent/tenant configuration can reference a key but can never supply a
   // command, path, args, or secret environment target.
   memoryPlugins: z.record(MemoryPluginCommandRef, StdioMemoryPluginDefSchema).optional(),
+  sandbox: z
+    .object({
+      backend: z.literal('srt').default('srt'),
+      mounts: z.array(SandboxMountSchema).default([])
+    })
+    .strict()
+    .default({ backend: 'srt', mounts: [] }),
   security: z
     .object({
       // Prevent ACP runtimes from implicitly inheriting apps/connectors attached
@@ -169,20 +185,15 @@ export const ConfigSchema = z.object({
       // Linux SRT/bwrap is available and every agent runs sandboxed; the
       // console locks the per-agent option on. false leaves it agent-selectable.
       requireSandbox: z.boolean().default(false),
-      // Operator-owned host dirs (toolchains such as nvm's node or a rustup toolchain) carved read-only into every sandbox.
-      sandboxReadRoots: z.array(z.string()).default([]),
-      // Operator-owned host dirs carved WRITABLE into every sandbox: package-manager stores (pnpm's store, corepack's cache) every session shares, so a PR's install lands in one place. Nothing here is verified by the daemon — whatever a sandboxed turn writes, the next session reads.
-      sandboxWriteRoots: z.array(z.string()).default([]),
       // Operator-owned remote-origin policy for daemon-managed workspace clone/pull. Default
       // ['*'] admits any https/ssh origin; exact scheme+host+port entries tighten it, and []
       // disables remote Git workspaces entirely.
       workspaceGitAllowedOrigins: z.array(WorkspaceGitOrigin).default([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
     })
+    .strict()
     .default({
       isolateAccountApps: true,
       requireSandbox: false,
-      sandboxReadRoots: [],
-      sandboxWriteRoots: [],
       workspaceGitAllowedOrigins: [...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]
     }),
   // Relay roster the CP last published (shared-bot-relay.md §5). Persisted whole so

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -306,12 +306,7 @@ import { internalSessionKey, ModelSessionHostPool, type ModelSessionHostPoolHost
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
 import { RuntimeFactsRegistry, PROBE_TTL_MS, type RuntimeFactsHost } from './runtimes/facts-registry.js'
 import { assembleRuntimeLaunch } from './launch/assemble.js'
-import {
-  resolveTrustedExecutable,
-  sandboxReadRoots,
-  sandboxWriteRoots,
-  trustedRuntimeReadRoots
-} from './runtimes/read-roots.js'
+import { resolveTrustedExecutable, normalizeSandboxMounts, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
 import { CpClient } from './cp/client.js'
@@ -1848,9 +1843,8 @@ export class Daemon {
       autoCreate: true
     })
     this.cfg = cfg
-    // Fail the boot, not the first sandboxed turn, on a mistyped or missing operator read or write root.
-    sandboxReadRoots(cfg.security.sandboxReadRoots)
-    sandboxWriteRoots(cfg.security.sandboxWriteRoots)
+    // Validate operator mounts before startup can create any runtime hosts.
+    cfg.sandbox.mounts = normalizeSandboxMounts(cfg.sandbox.mounts)
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     // §24.4: an excluded origin is named at SPEC admission. All this knows is the operator list —
     // whether a spec names an instance of its own, which stays cloneable either way, is per-agent.
@@ -3609,7 +3603,7 @@ export class Daemon {
       executableCommands,
       moduleEntries: [cliEntry, ...nodeExecArgvModuleEntries()],
       paths,
-      readRoots: this.cfg.security.sandboxReadRoots
+      readRoots: this.cfg.sandbox.mounts.map((mount) => mount.source)
     })
   }
 
@@ -4454,7 +4448,9 @@ export class Daemon {
                 gitlabCredentials
               )
           : undefined,
-        runtimeWriteRoots: runInSandbox ? sandboxWriteRoots(this.cfg.security.sandboxWriteRoots) : undefined,
+        runtimeWriteRoots: runInSandbox
+          ? this.cfg.sandbox.mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source)
+          : undefined,
         // A session host with its own clones (§11) writes its session directory alone; the launch derives its Git grants from it.
         trustedWorkspaceWriteRoots: runInSandbox
           ? this.workspaces.trustedWorkspaceWriteRoots(agent, hostKeySessionKey(opts.hostKey))

--- a/packages/daemon/src/launch/assemble.ts
+++ b/packages/daemon/src/launch/assemble.ts
@@ -41,7 +41,7 @@ export interface AssembleRuntimeLaunchOptions {
   finalizeLaunchEnv?: (launchEnv: Record<string, string>) => void
   /** Daemon-owned code/socket/config carve-backs; a function receives the final launch env. */
   runtimeReadRoots?: string[] | ((launchEnv: Record<string, string>) => string[] | undefined)
-  /** Operator-declared `security.sandboxWriteRoots`, already normalized. */
+  /** Operator-declared writable `sandbox.mounts`, already normalized. */
   runtimeWriteRoots?: string[]
   trustedWorkspaceWriteRoots?: string[]
   trustedPrimaryCheckout?: string

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -158,7 +158,7 @@ export function composeRuntimeLaunch(opts: {
   /** Additional daemon-owned code/socket/config paths required by trusted
    * descendants such as the AgentConnect MCP bridge. */
   runtimeReadRoots?: string[]
-  /** Operator-declared `security.sandboxWriteRoots`, already normalized. */
+  /** Operator-declared writable `sandbox.mounts`, already normalized. */
   runtimeWriteRoots?: string[]
   trustedWorkspaceWriteRoots?: string[]
   trustedPrimaryCheckout?: string

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -195,7 +195,7 @@ export interface PreparedRuntimeLaunch {
     /** Highest-precedence Claude settings that keep project/local settings from
      * redirecting the trusted parent to an attacker-selected credential profile. */
     claudeProtectedSettings?: ClaudeProtectedSettings
-    /** Operator-declared `security.sandboxWriteRoots`, canonical: the runtime-native tool sandboxes reopen them too. */
+    /** Operator-declared writable `sandbox.mounts`, canonical: the runtime-native tool sandboxes reopen them too. */
     sharedWriteRoots?: string[]
   }
 }
@@ -245,7 +245,7 @@ export function prepareRuntimeLaunch(opts: {
    * Every entry is revalidated as a strict descendant of scopeDir. */
   trustedWorkspaceWriteRoots?: string[]
   trustedPrimaryCheckout?: string
-  /** Operator-declared host dirs (`security.sandboxWriteRoots`) reopened writable: a shared package store, never the daemon's own. */
+  /** Operator-declared host dirs (writable `sandbox.mounts`) reopened writable: a shared package store, never the daemon's own. */
   trustedOperatorWriteRoots?: string[]
   /** Test seam. Shared login remains Linux-only with the sandbox rollout. */
   credentialPlatform?: NodeJS.Platform
@@ -458,7 +458,7 @@ export function prepareRuntimeLaunch(opts: {
   )
   // An operator write root follows the exception rule: it may sit below the hidden host HOME (a pnpm store does), never equal or contain HOME, daemon state, an agent root, or shared temp.
   const operatorWriteRoots = compactReadRoots(
-    (opts.trustedOperatorWriteRoots ?? []).map((path) => validateException(path, 'security.sandboxWriteRoots entry'))
+    (opts.trustedOperatorWriteRoots ?? []).map((path) => validateException(path, 'writable sandbox.mounts source'))
   )
   const agentRoot = safeRoot(opts.scopeDir, 'agent root')
   const trustedWorkspaceWriteRoots = compactReadRoots(

--- a/packages/daemon/src/runtime-defs/claude-runtime.ts
+++ b/packages/daemon/src/runtime-defs/claude-runtime.ts
@@ -114,7 +114,7 @@ export interface ClaudeInnerSandboxSettings {
     allowAllUnixSockets: boolean
   }
   filesystem: {
-    /** Operator-declared `security.sandboxWriteRoots`; absent when there are none, so the policy stays byte-identical. */
+    /** Operator-declared writable `sandbox.mounts`; absent when there are none, so the policy stays byte-identical. */
     allowWrite?: string[]
     denyRead: string[]
     denyWrite: string[]

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -2,7 +2,7 @@ import { closeSync, existsSync, openSync, readFileSync, readSync, realpathSync, 
 import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
-import type { McpServerDef, RuntimeDef } from '../config/config-schema.js'
+import type { McpServerDef, RuntimeDef, SandboxMount } from '../config/config-schema.js'
 import { resolveCommandPath } from './probe.js'
 
 /**
@@ -23,7 +23,7 @@ export interface TrustedRuntimeReadRootsOptions {
   moduleEntries?: readonly string[]
   /** Exact daemon-owned files, sockets, or already-reviewed directories. */
   paths?: readonly string[]
-  /** Operator-owned daemon-wide read-only host dirs (`security.sandboxReadRoots`), shared by every runtime. */
+  /** Normalized operator mount sources, shared by every runtime. */
   readRoots?: readonly string[]
 }
 
@@ -47,14 +47,20 @@ function existingRoot(path: string, env: NodeJS.ProcessEnv, label = 'trusted run
   return realpathSync(expanded)
 }
 
-/** Normalize `security.sandboxReadRoots` (`~/` against the host HOME, must exist, realpath'd); throws so a boot fails fast. */
-export function sandboxReadRoots(paths: readonly string[], env: NodeJS.ProcessEnv = process.env): string[] {
-  return paths.map((path) => existingRoot(path, env, 'security.sandboxReadRoots entry'))
-}
-
-/** `security.sandboxWriteRoots`, normalized exactly like the read roots; the launch decides whether each may be reopened writable. */
-export function sandboxWriteRoots(paths: readonly string[], env: NodeJS.ProcessEnv = process.env): string[] {
-  return paths.map((path) => existingRoot(path, env, 'security.sandboxWriteRoots entry'))
+/** SRT exposes canonical host paths in place; duplicate writable grants take precedence. */
+export function normalizeSandboxMounts(
+  mounts: readonly SandboxMount[],
+  env: NodeJS.ProcessEnv = process.env
+): SandboxMount[] {
+  const normalized = new Map<string, SandboxMount>()
+  for (const mount of mounts) {
+    const source = existingRoot(mount.source, env, 'sandbox.mounts source')
+    const target = existingRoot(mount.target, env, 'sandbox.mounts target')
+    if (source !== target) throw new Error(`sandbox.mounts requires source and target to be the same path for srt`)
+    const previous = normalized.get(source)
+    normalized.set(source, { source, target, readOnly: mount.readOnly && (previous?.readOnly ?? true) })
+  }
+  return [...normalized.values()]
 }
 
 /** Resolve the existing prefix too, so a missing socket/file below a symlink is
@@ -250,7 +256,7 @@ export function trustedRuntimeReadRoots(opts: TrustedRuntimeReadRootsOptions): s
 
   addExecutable(opts.runtime.command, runtimeEnv, out, executables)
   for (const path of opts.runtime.readRoots ?? []) out.add(existingRoot(path, runtimeEnv))
-  for (const path of sandboxReadRoots(opts.readRoots ?? [], hostEnv)) out.add(path)
+  for (const path of opts.readRoots ?? []) out.add(existingRoot(path, hostEnv, 'sandbox.mounts source'))
 
   for (const server of opts.mcpServers ?? []) {
     if (server.transport !== 'stdio' || !server.command) continue

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -267,40 +267,22 @@ describe('runChat', () => {
     expect(hostFactory).not.toHaveBeenCalled()
   })
 
-  it('rejects a missing security.sandboxReadRoots entry before creating any host', async () => {
+  it.each([true, false])('rejects a missing mount before creating any host (readOnly=%s)', async (readOnly) => {
     const files = scaffold()
+    const source = join(files.root, 'no-such-mount')
     writeFileSync(
       files.configPath,
       JSON.stringify({
         version: 1,
         controlPlane: { enabled: false },
         runtimes: { fake: { command: process.execPath, args: [fakeAgent], env: [] } },
-        security: { sandboxReadRoots: [join(files.root, 'no-such-toolchain')] }
+        sandbox: { mounts: [{ source, target: source, readOnly }] }
       })
     )
     const hostFactory = vi.fn()
 
     await expect(runChat({ ...files, message: 'hi', out: capture().stream, hostFactory })).rejects.toThrow(
-      /security\.sandboxReadRoots entry does not exist/
-    )
-    expect(hostFactory).not.toHaveBeenCalled()
-  })
-
-  it('rejects a missing security.sandboxWriteRoots entry before creating any host', async () => {
-    const files = scaffold()
-    writeFileSync(
-      files.configPath,
-      JSON.stringify({
-        version: 1,
-        controlPlane: { enabled: false },
-        runtimes: { fake: { command: process.execPath, args: [fakeAgent], env: [] } },
-        security: { sandboxWriteRoots: [join(files.root, 'no-such-store')] }
-      })
-    )
-    const hostFactory = vi.fn()
-
-    await expect(runChat({ ...files, message: 'hi', out: capture().stream, hostFactory })).rejects.toThrow(
-      /security\.sandboxWriteRoots entry does not exist/
+      /sandbox\.mounts source does not exist/
     )
     expect(hostFactory).not.toHaveBeenCalled()
   })

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileS
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { loadConfig } from '../src/config/load-config.js'
-import { McpServerDefSchema, RuntimeDefSchema, sessionRetentionMs } from '../src/config/config-schema.js'
+import { ConfigSchema, McpServerDefSchema, RuntimeDefSchema, sessionRetentionMs } from '../src/config/config-schema.js'
 import { CP_URL_ENV, WORKSPACE_GIT_ORIGINS_ENV } from '@agentconnect.md/protocol'
 
 function tmpRoot(config: unknown): string {
@@ -77,10 +77,30 @@ describe('loadConfig', () => {
     expect(cfg.runtimes!.claude!.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
     expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['*'])
+    expect(cfg.sandbox).toEqual({ backend: 'srt', mounts: [] })
     expect(cfg.features.turnFinalContextRefresh).toBe(true)
     expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')
     expect(cfg.sessions.retention).toBe('7d') // #485 session retention defaults on
+  })
+
+  it('defaults explicit mounts to read-only without selecting another backend', () => {
+    const cfg = ConfigSchema.parse({
+      version: 1,
+      sandbox: { mounts: [{ source: '/opt/toolchain', target: '/opt/toolchain' }] }
+    })
+    expect(cfg.sandbox).toEqual({
+      backend: 'srt',
+      mounts: [{ source: '/opt/toolchain', target: '/opt/toolchain', readOnly: true }]
+    })
+  })
+
+  it('rejects an unimplemented sandbox backend', () => {
+    expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox' } })).toThrow()
+  })
+
+  it.each(['sandboxReadRoots', 'sandboxWriteRoots'])('rejects removed security.%s rather than ignoring it', (field) => {
+    expect(() => ConfigSchema.parse({ version: 1, security: { [field]: [] } })).toThrow(field)
   })
 
   // An in-cluster daemon is born with no config file and no key: the deployment injects the

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -52,6 +52,17 @@ function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', ico
 describe('Daemon (no Slack, injected ACP host)', () => {
   it('sandboxes a host only when the agent opts in — skills are not force-sandboxed (#36)', async () => {
     const root = scaffold()
+    const toolchain = join(root, 'shared-toolchain')
+    const cache = join(toolchain, 'cache')
+    mkdirSync(cache, { recursive: true })
+    const config = JSON.parse(readFileSync(join(root, 'config.json'), 'utf8'))
+    config.sandbox = {
+      mounts: [
+        { source: toolchain, target: toolchain },
+        { source: cache, target: cache, readOnly: false }
+      ]
+    }
+    writeFileSync(join(root, 'config.json'), JSON.stringify(config))
     const daemon = new Daemon({
       slackAppFactory: fakeSlackAppFactory(),
       root,
@@ -72,6 +83,11 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       expect((daemon as any).agentRunsInSandbox(agent)).toBe(true)
       const sandboxed = (daemon as any).ensureHost('bot-a', (daemon as any).cfg)
       expect((sandboxed as any).opts.sandbox).toMatchObject({ mechanism: 'bwrap' })
+      const sandbox = (sandboxed as any).opts.sandbox
+      expect(sandbox.allowReadRoots).toContain(realpathSync(toolchain))
+      expect(sandbox.writable).toContain(realpathSync(cache))
+      expect(sandbox.writable).not.toContain(realpathSync(toolchain))
+      expect(sandbox.sharedWriteRoots).toEqual([realpathSync(cache)])
     } finally {
       await daemon.stop().catch(() => undefined)
       const repoRoot = realpathSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../..'))
@@ -92,36 +108,21 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     ).rejects.toThrow(/daemon startup refused.*requireSandbox.*no supported Linux SRT\/bwrap/)
   })
 
-  it('refuses daemon startup when security.sandboxReadRoots names a directory that does not exist', async () => {
+  it.each([true, false])('refuses daemon startup for a missing mount (readOnly=%s)', async (readOnly) => {
     const root = scaffold()
+    const source = join(root, 'no-such-mount')
     writeFileSync(
       join(root, 'config.json'),
       JSON.stringify({
         version: 1,
         controlPlane: { enabled: false },
-        security: { sandboxReadRoots: [join(root, 'no-such-toolchain')] }
+        sandbox: { mounts: [{ source, target: source, readOnly }] }
       })
     )
 
     await expect(
       new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null }).start()
-    ).rejects.toThrow(/security\.sandboxReadRoots entry does not exist/)
-  })
-
-  it('refuses daemon startup when security.sandboxWriteRoots names a directory that does not exist', async () => {
-    const root = scaffold()
-    writeFileSync(
-      join(root, 'config.json'),
-      JSON.stringify({
-        version: 1,
-        controlPlane: { enabled: false },
-        security: { sandboxWriteRoots: [join(root, 'no-such-store')] }
-      })
-    )
-
-    await expect(
-      new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null }).start()
-    ).rejects.toThrow(/security\.sandboxWriteRoots entry does not exist/)
+    ).rejects.toThrow(/sandbox\.mounts source does not exist/)
   })
 
   it('does not force the skill sandbox or fail closed when the host has no sandbox mechanism (#36)', async () => {

--- a/packages/daemon/test/read-roots.test.ts
+++ b/packages/daemon/test/read-roots.test.ts
@@ -4,8 +4,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
   resolveTrustedExecutable,
-  sandboxReadRoots,
-  sandboxWriteRoots,
+  normalizeSandboxMounts,
   trustedRuntimeReadRoots
 } from '../src/runtimes/read-roots.js'
 
@@ -46,7 +45,7 @@ describe('trusted runtime read roots', () => {
     expect(resolveTrustedExecutable('runtime', { PATH: bin })).toBe(realpathSync(cli))
   })
 
-  it('carves daemon-wide security.sandboxReadRoots into every runtime, expanding ~ against the host HOME', () => {
+  it('exposes normalized operator mount sources to every runtime', () => {
     const root = mkdtempSync(join(tmpdir(), 'ac-daemon-roots-'))
     temporaryRoots.push(root)
     const home = join(root, 'host-home')
@@ -55,10 +54,17 @@ describe('trusted runtime read roots', () => {
     mkdirSync(toolchain, { recursive: true })
     mkdirSync(nodeInstall, { recursive: true })
 
+    const mounts = normalizeSandboxMounts(
+      [
+        { source: '~/.rustup/toolchains/stable/bin', target: toolchain, readOnly: true },
+        { source: nodeInstall, target: nodeInstall, readOnly: true }
+      ],
+      { HOME: home }
+    )
     const roots = trustedRuntimeReadRoots({
       runtime: { command: process.execPath, args: [], env: [] },
       hostEnv: { PATH: dirname(process.execPath), HOME: home },
-      readRoots: ['~/.rustup/toolchains/stable/bin', nodeInstall]
+      readRoots: mounts.map((mount) => mount.source)
     })
 
     expect(roots).toContain(realpathSync(toolchain))
@@ -72,26 +78,54 @@ describe('trusted runtime read roots', () => {
         hostEnv: { PATH: dirname(process.execPath) },
         readRoots: [join(tmpdir(), 'ac-missing-daemon-root-does-not-exist')]
       })
-    ).toThrow(/security\.sandboxReadRoots entry does not exist/)
-    expect(() => sandboxReadRoots(['relative/toolchain'], { HOME: tmpdir() })).toThrow(
-      /security\.sandboxReadRoots entry must be absolute/
-    )
+    ).toThrow(/sandbox\.mounts source does not exist/)
   })
 
-  it('normalizes security.sandboxWriteRoots like the read roots, and rejects a missing or relative one', () => {
+  it('coalesces canonical mounts with write access winning while preserving nested paths', () => {
     const root = mkdtempSync(join(tmpdir(), 'ac-daemon-write-roots-'))
     temporaryRoots.push(root)
     const home = join(root, 'host-home')
-    const store = join(home, '.local', 'share', 'pnpm', 'store')
+    const toolchain = join(home, 'toolchain')
+    const store = join(toolchain, 'cache')
+    const alias = join(root, 'cache-link')
     mkdirSync(store, { recursive: true })
+    symlinkSync(store, alias, 'junction')
 
-    expect(sandboxWriteRoots(['~/.local/share/pnpm/store'], { HOME: home })).toEqual([realpathSync(store)])
-    expect(() => sandboxWriteRoots([join(root, 'no-such-store')], { HOME: home })).toThrow(
-      /security\.sandboxWriteRoots entry does not exist/
+    const mounts = [
+      { source: '~/toolchain', target: toolchain, readOnly: true },
+      { source: alias, target: store, readOnly: true },
+      { source: store, target: alias, readOnly: false }
+    ]
+    const expected = [
+      { source: realpathSync(toolchain), target: realpathSync(toolchain), readOnly: true },
+      { source: realpathSync(store), target: realpathSync(store), readOnly: false }
+    ]
+    for (const entries of [mounts, [...mounts].reverse()]) {
+      const normalized = normalizeSandboxMounts(entries, { HOME: home })
+      expect(normalized).toHaveLength(2)
+      expect(normalized).toEqual(expect.arrayContaining(expected))
+    }
+  })
+
+  it('accepts an existing file mount and rejects missing, relative, or remapped paths', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-daemon-mount-paths-'))
+    temporaryRoots.push(root)
+    const file = join(root, 'toolchain.conf')
+    writeFileSync(file, 'test configuration')
+    const mount = { source: file, target: file, readOnly: true }
+    expect(normalizeSandboxMounts([mount])).toEqual([
+      { source: realpathSync(file), target: realpathSync(file), readOnly: true }
+    ])
+    expect(() => normalizeSandboxMounts([{ ...mount, source: join(root, 'missing') }])).toThrow(
+      /sandbox\.mounts source does not exist/
     )
-    expect(() => sandboxWriteRoots(['relative/store'], { HOME: home })).toThrow(
-      /security\.sandboxWriteRoots entry must be absolute/
+    expect(() => normalizeSandboxMounts([{ ...mount, source: 'relative/toolchain' }])).toThrow(
+      /sandbox\.mounts source must be absolute/
     )
+    expect(() => normalizeSandboxMounts([{ ...mount, target: 'relative/toolchain' }])).toThrow(
+      /sandbox\.mounts target must be absolute/
+    )
+    expect(() => normalizeSandboxMounts([{ ...mount, target: root }])).toThrow(/same|equal|remap/i)
   })
 
   it('rejects relative operator read roots', () => {

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -23,6 +23,7 @@ import { sandboxTempDirFor, SANDBOX_TEMP_DIR_ENV } from '../src/acp/sandbox-temp
 import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
 import { runtimeMemoryCapabilities } from '../src/memory/runtime/capabilities.js'
 import { MemoryProviderUnavailableError } from '../src/memory/provider.js'
+import { normalizeSandboxMounts } from '../src/runtimes/read-roots.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
 
 function fixture(): { scopeDir: string; cwd: string; hostHome: string } {
@@ -387,7 +388,7 @@ describe('prepareRuntimeLaunch', () => {
 
     // The same rule as every other exception: a root that IS a protected boundary reopens it wholesale.
     expect(() => prepareRuntimeLaunch({ ...base, trustedOperatorWriteRoots: [hostHome] })).toThrow(
-      /security\.sandboxWriteRoots entry .* would reopen protected path/
+      /sandbox\.mounts .* would reopen protected path/
     )
     expect(() => prepareRuntimeLaunch({ ...base, trustedOperatorWriteRoots: [dirname(scopeDir)] })).toThrow(
       /would reopen protected path/
@@ -494,6 +495,10 @@ describe('prepareRuntimeLaunch', () => {
     const { scopeDir, hostHome, key, sessionDir, cwd, primaryGit, cloneGit, secondaryGit } = sessionCloneFixture()
     const store = join(hostHome, '.local', 'share', 'pnpm', 'store')
     mkdirSync(store, { recursive: true })
+    const mounts = normalizeSandboxMounts([
+      { source: dirname(store), target: dirname(store), readOnly: true },
+      { source: store, target: store, readOnly: false }
+    ])
 
     const launch = prepareRuntimeLaunch({
       runtimeId: 'codex-acp',
@@ -507,7 +512,8 @@ describe('prepareRuntimeLaunch', () => {
       credentialPlatform: 'linux',
       // What the daemon hands a session host: the session directory alone (workspace-manager.ts).
       trustedWorkspaceWriteRoots: [sessionDir],
-      trustedOperatorWriteRoots: [store],
+      trustedRuntimeReadRoots: mounts.map((mount) => mount.source),
+      trustedOperatorWriteRoots: mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source),
       trustedPrimaryCheckout: join(scopeDir, 'workspace'),
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
@@ -534,7 +540,9 @@ describe('prepareRuntimeLaunch', () => {
     expect(table).not.toContain(realpathSync(primaryGit))
     // An operator-declared shared store is reopened at both layers: the outer boundary and the inner Codex profile.
     expect(coveredBy(policy.filesystem.allowWrite, realpathSync(store))).toBe(true)
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(dirname(store)))).toBe(false)
     expect(table).toContain(`"${realpathSync(store)}" = "write"`)
+    expect(table).not.toContain(`"${realpathSync(dirname(store))}" = "write"`)
   })
 
   // §11: the session's HOME lives under its leaf, so runtime state, temp and package caches are the session's alone and go with it.


### PR DESCRIPTION
Replace the separate sandbox read/write root settings with `sandbox.mounts`, shared by daemon and chat launches. Entries declare `source`, `target`, and `readOnly` (default true); SRT remains the default and only implemented backend.

SRT normalizes existing host paths, rejects path remapping, combines duplicate grants with writable access taking precedence, and preserves nested paths and runtime-native tool permissions. Removed security fields are rejected instead of silently ignored; existing installations use the documented one-time configuration conversion. No VM backend or automatic legacy compatibility layer is added.

Validation:
- Daemon build and typecheck passed.
- 141 targeted tests passed, including daemon configuration through outer and native tool permissions.
- Full local daemon suite: 6,022 passed, 87 skipped, 14 failed. The 13 macOS shim failures also reproduce on unchanged main; the remaining live runtime matrix requires a successful real provider turn and did not complete one in this environment.
- Prettier and `git diff --check` passed.

Created by Codex . GPT-6
