### PR TITLE
fix(daemon): preserve writable mounts beneath read-only parents

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN printf 'fetch-retries=5\nfetch-retry-maxtimeout=600000\nfetch-retry-mintimeo
 # by the root `prepare` hook.
 FROM base AS manifests
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .pnpmfile.mjs ./
+COPY patches/ patches/
 COPY scripts/ scripts/
 COPY packages/activation-policy/package.json packages/activation-policy/
 COPY packages/message/package.json packages/message/

--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -36,6 +36,7 @@ RUN printf 'fetch-retries=5\nfetch-retry-maxtimeout=600000\nfetch-retry-mintimeo
 
 # .pnpmfile.mjs is checksummed INTO the lockfile, so a frozen install without it is refused.
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json .pnpmfile.mjs tsconfig.base.json ./
+COPY patches/ patches/
 COPY scripts/ scripts/
 COPY packages/protocol/package.json packages/protocol/
 COPY packages/connection/package.json packages/connection/

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -209,10 +209,62 @@ describe('sandboxBoundary', () => {
   })
 })
 
-// Behavioral regression for the /proc escape (#799): with a PID namespace the daemon's
-// own PID must NOT be visible inside the sandbox, so /proc/<daemon-pid>/root/... cannot
-// be used to reach the daemon's writable mount namespace. Runs only where bwrap exists
-// (Linux CI); skipped elsewhere.
+describe('bwrap mount permissions', () => {
+  it.skipIf(detectSandbox() !== 'bwrap').each([false, true])(
+    'preserves nested mount permissions with an explicit parent write deny: %s',
+    (denyParentWrite) => {
+      const root = mkdtempSync(join(tmpdir(), 'ac-sbx-mounts-'))
+      const workspace = join(root, 'workspace')
+      const home = join(root, 'home')
+      const parent = join(root, 'protected')
+      const hiddenRoot = join(parent, 'hidden')
+      const tools = join(hiddenRoot, 'tools')
+      const cache = join(tools, 'cache')
+      const hidden = join(hiddenRoot, 'unmounted')
+      try {
+        for (const path of [workspace, home, cache, hidden]) mkdirSync(path, { recursive: true })
+        writeFileSync(join(tools, 'read-marker'), 'readable')
+        writeFileSync(join(hidden, 'hidden-marker'), 'hidden')
+        writeFileSync(join(cache, 'write-marker'), 'initial')
+        const writable = [workspace, home, cache, ...(denyParentWrite ? [root] : [])]
+        const settingsPath = writeSandboxSettings(root, 'mounts', {
+          writable,
+          denyRead: [hiddenRoot],
+          denyWrite: denyParentWrite ? [parent] : [],
+          allowRead: [workspace, home, tools, cache],
+          gitSafeDirectories: [workspace]
+        })
+        const script = `
+        const fs = await import('node:fs');
+        const assert = (await import('node:assert/strict')).default;
+        const [tools, cache, hidden, denyParentWrite] = process.argv.slice(1);
+        assert.equal(fs.readFileSync(tools + '/read-marker', 'utf8'), 'readable');
+        assert.throws(() => fs.writeFileSync(tools + '/forbidden', 'no'));
+        const write = () => fs.writeFileSync(cache + '/write-marker', 'writable');
+        if (denyParentWrite === 'true') assert.throws(write);
+        else write();
+        assert.throws(() => fs.readFileSync(hidden + '/hidden-marker', 'utf8'));
+      `
+        const { cmd, args } = sandboxWrap(
+          process.execPath,
+          ['--input-type=module', '-e', script, tools, cache, hidden, String(denyParentWrite)],
+          {
+            mechanism: 'bwrap',
+            writable,
+            settingsPath,
+            cwd: workspace
+          }
+        )
+        execFileSync(cmd, args, { env: { ...process.env, HOME: home }, timeout: 30_000, stdio: 'pipe' })
+        expect(readFileSync(join(cache, 'write-marker'), 'utf8')).toBe(denyParentWrite ? 'initial' : 'writable')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+})
+
+// The PID namespace blocks /proc/<daemon-pid>/root escapes into the host mount namespace (#799).
 describe('bwrap PID isolation', () => {
   const hasBwrap = detectSandbox() === 'bwrap'
 

--- a/packages/memory-plugin-mem0/Dockerfile
+++ b/packages/memory-plugin-mem0/Dockerfile
@@ -3,6 +3,7 @@ FROM node:24-bookworm-slim AS build
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .npmrc .pnpmfile.mjs ./
+COPY patches/ patches/
 COPY packages/protocol/package.json packages/protocol/tsconfig.json ./packages/protocol/
 COPY packages/protocol/src ./packages/protocol/src
 COPY packages/memory-plugin-mem0/package.json packages/memory-plugin-mem0/tsconfig.json ./packages/memory-plugin-mem0/
@@ -15,6 +16,7 @@ ENV NODE_ENV=production HOST=0.0.0.0 PORT=8788 MEM0_DIALECT=cloud MCP_TRANSPORT=
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc .pnpmfile.mjs ./
+COPY patches/ patches/
 COPY packages/protocol/package.json ./packages/protocol/package.json
 COPY packages/memory-plugin-mem0/package.json ./packages/memory-plugin-mem0/package.json
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts --filter @agentconnect.md/memory-plugin-mem0...

--- a/patches/@anthropic-ai__sandbox-runtime@0.0.73.patch
+++ b/patches/@anthropic-ai__sandbox-runtime@0.0.73.patch
@@ -1,0 +1,65 @@
+diff --git a/dist/sandbox/linux-sandbox-utils.js b/dist/sandbox/linux-sandbox-utils.js
+index 4c521f62da435e7de02d1a69ceda617ea51cca08..07f0589d62b7e695cffea310834ef90cd792d179 100644
+--- a/dist/sandbox/linux-sandbox-utils.js
++++ b/dist/sandbox/linux-sandbox-utils.js
+@@ -636,26 +636,14 @@ function resolveSymlinkDenyDest(normalizedPath) {
+ function pushReadDenyDirMounts(args, normalizedPath, allowedWritePaths, readAllowPaths) {
+     const denySep = normalizedPath === '/' ? '/' : normalizedPath + '/';
+     args.push('--tmpfs', normalizedPath);
+-    // tmpfs wiped any earlier write binds under this path — restore them.
+-    for (const writePath of allowedWritePaths) {
+-        if (writePath.startsWith(denySep) || writePath === normalizedPath) {
+-            args.push('--bind', writePath, writePath);
+-            logForDebugging(`[Sandbox Linux] Re-bound write path wiped by denyRead tmpfs: ${writePath}`);
+-        }
+-    }
+-    // Re-allow specific paths within the denied directory (allowRead overrides denyRead).
+-    // After mounting tmpfs over the denied dir, bind back the allowed subdirectories
+-    // so they are readable again.
++    // Restore read paths first so a read-only parent cannot cover a writable child.
+     for (const allowPath of readAllowPaths) {
+         if (allowPath.startsWith(denySep) || allowPath === normalizedPath) {
+             if (!fs.existsSync(allowPath)) {
+                 logForDebugging(`[Sandbox Linux] Skipping non-existent read allow path: ${allowPath}`);
+                 continue;
+             }
+-            // Skip only if a write path was re-bound just above AND covers
+-            // allowPath. A write path that's an ancestor of the deny dir isn't
+-            // re-bound (it wasn't wiped), so allowPath under it still needs
+-            // its own ro-bind here.
++            // Skip paths covered by a write bind restored below, excluding ancestors of the denied directory.
+             if (allowedWritePaths.some(w => (w.startsWith(denySep) || w === normalizedPath) &&
+                 (allowPath === w || allowPath.startsWith(w + '/')))) {
+                 continue;
+@@ -665,6 +653,13 @@ function pushReadDenyDirMounts(args, normalizedPath, allowedWritePaths, readAllo
+             logForDebugging(`[Sandbox Linux] Re-allowed read access within denied region: ${allowPath}`);
+         }
+     }
++    // Restore write paths last so explicit write access survives read-only parent mounts.
++    for (const writePath of allowedWritePaths) {
++        if (writePath.startsWith(denySep) || writePath === normalizedPath) {
++            args.push('--bind', writePath, writePath);
++            logForDebugging(`[Sandbox Linux] Re-bound write path wiped by denyRead tmpfs: ${writePath}`);
++        }
++    }
+ }
+ /**
+  * Generate filesystem bind mount arguments for bwrap
+@@ -1249,14 +1244,12 @@ async function generateFilesystemArgs(readConfig, writeConfig, maskedFileBinds,
+         if (rawDest !== dest)
+             emittedDenyWriteDests.push(rawDest);
+     }
+-    // The inverse stacking problem: a denyWrite ro-bind whose dest strictly
+-    // contains a read-denied dir re-exposes that dir's real contents (the bind
+-    // landed after the tmpfs). Re-apply the tmpfs on top, with the same write
+-    // and allowRead re-binds the denyRead loop emitted.
++    // A late write deny can expose a read-denied directory; restore its mask without reopening denied writes.
++    const restorableWritePaths = allowedWritePaths.filter(writePath => !emittedDenyWriteDests.some(dest => writePath === dest || writePath.startsWith(dest + '/')));
+     for (const tmpfsDir of tmpfsDirs) {
+         if (emittedDenyWriteDests.some(dest => tmpfsDir.startsWith(dest + '/'))) {
+             logForDebugging(`[Sandbox Linux] Re-applying denyRead tmpfs re-exposed by denyWrite bind: ${tmpfsDir}`);
+-            pushReadDenyDirMounts(args, tmpfsDir, allowedWritePaths, readAllowPaths);
++            pushReadDenyDirMounts(args, tmpfsDir, restorableWritePaths, readAllowPaths);
+         }
+     }
+     // Same problem for masked files: the mask landed before the denyWrite

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
 
 pnpmfileChecksum: sha256-yhrtow4uYXdBwgBbzJFJ4wA8s3O9UECr9QpwYpWeDfE=
 
+patchedDependencies:
+  '@anthropic-ai/sandbox-runtime@0.0.73': 8d318761e3fbe2013d84060bb87cb50dfdb7132b08996f61207239173f20ccc6
+
 importers:
 
   .:
@@ -290,7 +293,7 @@ importers:
         version: link:../protocol
       '@anthropic-ai/sandbox-runtime':
         specifier: 0.0.73
-        version: 0.0.73
+        version: 0.0.73(patch_hash=8d318761e3fbe2013d84060bb87cb50dfdb7132b08996f61207239173f20ccc6)
       '@larksuiteoapi/node-sdk':
         specifier: ^1.71.1
         version: 1.73.0
@@ -9027,7 +9030,7 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.201
     optional: true
 
-  '@anthropic-ai/sandbox-runtime@0.0.73':
+  '@anthropic-ai/sandbox-runtime@0.0.73(patch_hash=8d318761e3fbe2013d84060bb87cb50dfdb7132b08996f61207239173f20ccc6)':
     dependencies:
       '@pondwader/socks5-server': 1.0.10
       commander: 12.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,3 +27,6 @@ minimumReleaseAge: 60
 overrides:
   vite: 8.1.3
   rolldown: 1.1.4
+
+patchedDependencies:
+  '@anthropic-ai/sandbox-runtime@0.0.73': patches/@anthropic-ai__sandbox-runtime@0.0.73.patch


### PR DESCRIPTION
A writable cache inside a read-only tool directory became read-only when SRT restored paths beneath a hidden host directory. Restore read-only paths before writable paths so explicit write access survives the parent mount, while retaining the existing permission precedence and deny rules.

Pin this small fix as a patch to SRT 0.0.73, include the patch in every Docker dependency-install stage, and add a real Linux sandbox regression covering the writable child, read-only parent, and hidden sibling. This completes the nested mount behavior introduced in #1849.

Validation:
- Daemon build and typecheck passed.
- 163 focused daemon tests passed locally (6 Linux-only cases skipped on macOS).
- The packaged build passed real Linux SRT checks for read-only parents, writable children, explicit parent write denial, and hidden siblings.
- Frozen-lockfile installation, Prettier, and git diff checks passed.

Created by Codex . GPT-6
