### PR TITLE
fix(runtime): bump Codex ACP to 1.10.0-agentconnect.2

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -111,7 +111,7 @@ FROM node:24-bookworm-slim AS runtime-sandbox
 
 # Exact pins keep the published runtime table truthful.
 ARG CLAUDE_ACP_VERSION=0.75.1
-ARG CODEX_ACP_VERSION=1.10.0-agentconnect.1
+ARG CODEX_ACP_VERSION=1.10.0-agentconnect.2
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.30
 ARG AGENT_BROWSER_VERSION=0.37.0
 


### PR DESCRIPTION
Update the runtime-sandbox image to `@agentconnect.md/codex-acp@1.10.0-agentconnect.2`, which fixes unannotated HTTP MCP calls being rejected in protected Full access (agentconnect-md/codex-acp#4).

Only the existing `CODEX_ACP_VERSION` pin changes. The package binary, permission mode IDs, and model definitions are unchanged; self-hosted runtimes already follow the `agentconnect` npm tag.

Validation: the adapter release workflow passed typecheck, tests, and build; confirmed the published npm version and dist-tag. `git diff --check` passed. No tests or CI files added.

Related to #1831. Cloud rollout requires rebuilding and deploying the runtime-sandbox image after this pin update lands.

Created by Codex . GPT-6
