### PR TITLE
feat(daemon): a Telegram elicitation is answered on an inline keyboard

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -137,7 +137,7 @@ import {
 } from './router/routing-rule.js'
 import { CpRoutingLayer } from './router/cp-routing-layer.js'
 import { SlackConnection, type SlackAppFactory, type SlackStatusOptions } from './slack/connection.js'
-import { TelegramConnection } from './telegram/connection.js'
+import { TelegramConnection, type TelegramCallback } from './telegram/connection.js'
 import { DiscordConnection } from './discord/connection.js'
 import { FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
@@ -185,6 +185,7 @@ import {
   slackStreamRecipient,
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
+import { slackElicitCards } from './platforms/slack/elicit-card.js'
 import type { ReplyAttributionInfo } from './messages/attribution.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
 import { mentionedUserIds, substituteUserMentions } from './slack/mentions.js'
@@ -440,6 +441,7 @@ import {
   applyTelegramAction as applyTelegramActionExternal,
   type TelegramTurnState
 } from './platforms/telegram/turn-output.js'
+import { parseTelegramElicit, telegramElicitCards } from './platforms/telegram/elicit-card.js'
 import { applyDiscordAction as applyDiscordActionExternal } from './platforms/discord/turn-output.js'
 import { applyFeishuAction as applyFeishuActionExternal, type FeishuTurnState } from './platforms/feishu/turn-output.js'
 import { LinearConnection } from './platforms/linear/connection.js'
@@ -930,6 +932,7 @@ export class Daemon {
     (() => {
       const registry = new TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>({
         platform: 'slack',
+        elicitCards: slackElicitCards,
         createConverger: (ctx) => new OutputConverger(ctx.mode as never, ctx.protectedAddresses ?? []),
         initialTurnState: (ctx): SlackTurnState => {
           const recipient = slackStreamRecipient(ctx.message)
@@ -972,6 +975,7 @@ export class Daemon {
       })
       registry.register({
         platform: 'telegram',
+        elicitCards: telegramElicitCards,
         // The continue-the-topic hint only earns its space in a group, where the
         // reply chain is the ONLY way back into this session; a DM already has one
         // implicit thread. Gated on showFooter, the delivery-chrome switch.
@@ -1601,7 +1605,7 @@ export class Daemon {
       handleElicitChoice: (a) => this.permissions.handleElicitChoice(a),
       handleElicitFormSubmit: (a) => void this.permissions.submitElicitForm(a),
       handleDiscordSelect: (a) => this.commands.handleDiscordSelect(a),
-      handleTelegramCallback: (cb, conn) => this.commands.handleTelegramCallback(cb, conn),
+      handleTelegramCallback: (cb, conn) => this.handleTelegramCallback(cb, conn),
       slackShortcutSession: (shortcut, srcIntegrationIds) =>
         this.commands.slackShortcutSession(shortcut, srcIntegrationIds),
       slackThreadSessions: (shortcut, srcIntegrationIds) =>
@@ -8934,6 +8938,7 @@ export class Daemon {
       memoryExtractionInFlight: (turnKey) => this.memoryExtractionCollectors.has(turnKey),
       enqueueApply: (p, action) => this.enqueueApply(p, action),
       postCardSerialized: (p, post) => this.postCardSerialized(p, post),
+      elicitCardFacet: (platform) => this.turnSurfaces.exact(platform)?.elicitCards,
       httpSlackSessionTarget: (p) => this.httpSlackSessionTarget(p),
       maskAgentSecrets: <T>(agentId: string, payload: T): T => this.maskAgentSecrets(agentId, payload),
       logSessionAction: (verb, sessionKey, actor) => this.commands.logSessionAction(verb, sessionKey, actor),
@@ -13527,9 +13532,9 @@ export class Daemon {
   private async postLiveChromeBoundarySerialized<T>(
     p: Pending,
     messageType: LiveChromeBoundaryMessageType,
-    post: (conn: SlackConnection) => Promise<T | undefined>
+    post: (conn: unknown) => Promise<T | undefined>
   ): Promise<T | undefined> {
-    const conn = p.conn as SlackConnection
+    const conn = p.conn
     let result: T | undefined
     const step = p.signals.applyChain.then(async () => {
       result = await post(conn)
@@ -13544,9 +13549,30 @@ export class Daemon {
     return result
   }
 
+  /**
+   * Route one tapped Telegram inline-keyboard button. Two schemes share the keyboard: an
+   * elicitation card's `ac_el:<requestId>:<token>` and the session-control cards' `<kind>:<index>`,
+   * so this tries the elicitation codec first and falls through — the two are disjoint by prefix,
+   * and neither decoder ever sees data the other minted.
+   *
+   * Anyone who can see a card may answer it, so there is no per-person gate here; the tap is
+   * acked either way, or the client's spinner never clears. An answer the card refuses says so
+   * in the chat through the coordinator's own notice, exactly as a Slack tap's does.
+   */
+  private async handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): Promise<void> {
+    const tap = parseTelegramElicit(cb.data)
+    if (!tap) return await this.commands.handleTelegramCallback(cb, conn)
+    void conn.answerCallback(cb.id)
+    await this.permissions.handleElicitChoice({
+      requestId: tap.requestId,
+      value: tap.token,
+      actor: { userId: cb.userId }
+    })
+  }
+
   private async postCardSerialized(
     p: Pending,
-    post: (conn: SlackConnection) => Promise<string | undefined>
+    post: (conn: unknown) => Promise<string | undefined>
   ): Promise<string | undefined> {
     return await this.postLiveChromeBoundarySerialized(p, 'human-input-card', post).catch(() => undefined)
   }

--- a/packages/daemon/src/daemon/tool-classification.ts
+++ b/packages/daemon/src/daemon/tool-classification.ts
@@ -121,16 +121,20 @@ export function approvalRequestSummary(parts: ApprovalRequestParts): string {
  * surface. Permission requests still enter the Agent-editor queue; this flag only prevents
  * a chat-side card from being rendered for the turn.
  *
- * Scoped narrowly to the surface `none` actually removes: an interactive card renders ONLY
- * on Slack (see `onAcpPermission`), and only for a live user turn. So this is true iff the
- * turn is `none` AND on Slack AND not webchat/headless. Telegram/Discord/Feishu have no card
- * surface, so `none` removes nothing there; webchat/headless are non-IM transports.
- * Computed once at dispatch (frozen for the turn) so a mid-turn mode flip can't desync it
- * from the connection it was derived from.
+ * Scoped narrowly to the surface `none` actually removes: a live user turn on a platform that
+ * HAS an in-chat card at all. `hasChatInputCards` is that fact, and it is passed in rather than
+ * looked up because it now has two independent sources — Slack's permission-approval chrome
+ * (`turnChromeFor(...).chatInputCards`) and any platform's Layer-2 elicitation-card facet — and
+ * either one means `none` removed something. Discord and Feishu still have neither, so `none`
+ * removes nothing there; webchat/headless are non-IM transports. Computed once at dispatch
+ * (frozen for the turn) so a mid-turn mode flip can't desync it from the connection it was
+ * derived from.
  */
 export function noneSuppressedApprovalSurface(
   mode: string,
-  turn: { platform: string; webchat?: unknown; headless?: boolean }
+  turn: { platform: string; webchat?: unknown; headless?: boolean },
+  hasChatInputCards = false
 ): boolean {
-  return mode === 'none' && turnChromeFor(turn.platform).chatInputCards === true && !turn.webchat && !turn.headless
+  const surfaced = hasChatInputCards || turnChromeFor(turn.platform).chatInputCards === true
+  return mode === 'none' && surfaced && !turn.webchat && !turn.headless
 }

--- a/packages/daemon/src/daemon/turn-plan.ts
+++ b/packages/daemon/src/daemon/turn-plan.ts
@@ -151,11 +151,13 @@ export function buildTurnPlan(input: TurnPlanInput): TurnPlan {
     attributionFooterEnabled: showFooter && turnChromeFor(msg.platform).attributionFooter === true,
     // True only when `none` removed THIS turn's chat-input permission card surface. Frozen for
     // the turn so a mid-turn mode flip cannot desync policy from the cleared connection.
-    approvalSurfaceSuppressed: noneSuppressedApprovalSurface(mode, {
-      platform: msg.platform,
-      webchat,
-      headless: msg.headless
-    }),
+    approvalSurfaceSuppressed: noneSuppressedApprovalSurface(
+      mode,
+      { platform: msg.platform, webchat, headless: msg.headless },
+      // §7.3: a platform with an elicitation-card facet has an in-chat card `none` takes away,
+      // exactly as Slack's permission chrome does. EXACT, so webchat/hook/dream inherit none.
+      turnSurfaces.exact(msg.platform)?.elicitCards !== undefined
+    ),
     suppressReplyConn,
     // Cold/warm is captured BEFORE sessions.handle(), which boots the host via hostFor().
     // A pod that is not up yet outranks both: it is the wait the user is actually about to sit through.

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -26,16 +26,21 @@ import type { AcpPermissionPolicyEvent } from '../acp/acp-host.js'
 import type { DaemonEvaluationHooks } from '../evaluation/daemon-hooks.js'
 import { SlackConnection } from '../slack/connection.js'
 import type { InteractionActor } from '../platforms/contract.js'
+import type {
+  ElicitCardAsk,
+  ElicitCardFacet,
+  ElicitCardHandle,
+  ElicitCardHost,
+  ElicitCardMark,
+  ElicitCardSettlement
+} from '../platforms/elicit-card.js'
 import {
   buildApprovalDmIntro,
   buildElicitationCard,
   buildElicitDmUnanswerableCard,
-  buildElicitationFormCard,
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionResolvedCard,
-  buildUrlConsentCard,
-  buildUrlConsentResolvedCard,
   clampTo,
   elicitCardShape,
   elicitForm,
@@ -54,7 +59,6 @@ import {
   multiSelectAccepts,
   numberAccepts,
   SLACK_DM_ELICIT_SURFACE,
-  SLACK_ELICIT_SURFACE,
   textAccepts,
   WEBCHAT_ELICIT_SURFACE
 } from '../slack/render.js'
@@ -112,15 +116,17 @@ interface ClosedGate {
 }
 
 /** Which surface an interactive elicitation card was posted to, and what it takes to settle it
- *  there: Slack rewrites its message in place; webchat appends a second stream event. */
+ *  there: a chat surface rewrites its own message through the facet that posted it; webchat
+ *  appends a second stream event. The chat arm names no platform — the facet does, and the
+ *  handle's three fields are the coordinates BOTH chat surfaces identify a posted card by. */
 type PendingElicitSurface =
-  | { surface: 'slack'; conn: SlackConnection; channel: string; ts?: string }
+  | ({ surface: 'chat'; facet: ElicitCardFacet } & ElicitCardHandle)
   | { surface: 'webchat'; wc: NonNullable<Pending['webchat']> }
 
 /** What the surface a card was posted to renders — re-deriving its target has to ask the same
  *  question the post did, or a card could be read back as a field its surface never showed. */
 function surfaceOf(rec: PendingElicitSurface): ElicitSurface {
-  return rec.surface === 'webchat' ? WEBCHAT_ELICIT_SURFACE : SLACK_ELICIT_SURFACE
+  return rec.surface === 'webchat' ? WEBCHAT_ELICIT_SURFACE : rec.facet.reduction
 }
 
 /** How a settled card names the answer: the chosen option's LABEL, or every chosen label for a
@@ -133,6 +139,22 @@ function chosenLabel(target: ElicitTarget | null, value: string | string[] | num
   if (typeof value === 'number') return String(value)
   if (!Array.isArray(value)) return clampTo(label(value), 200)
   return value.length ? value.map(label).join(', ') : 'Nothing selected'
+}
+
+/** One card's settlement, as its own surface re-renders it: the label, plus the ask it re-renders
+ *  from and whether that ask was a consent. Pure. */
+function elicitSettlement(
+  params: CreateElicitationRequest,
+  consent: boolean,
+  label: ElicitCardLabel
+): ElicitCardSettlement {
+  return {
+    params,
+    consent,
+    mark: label.mark,
+    text: label.text,
+    ...(label.fallback !== undefined ? { fallback: label.fallback } : {})
+  }
 }
 
 /** Whether a submitted answer has the SHAPE this kind is answered with — the arity check a card
@@ -174,17 +196,34 @@ function formAnswerLabel(
   return parts.length ? clampTo(parts.join(' · '), 200) : 'Nothing filled in'
 }
 
+/** How a card the turn ended under is labelled: nothing was decided, so it says so. */
+const ELICIT_CANCELLED: ElicitCardLabel = { mark: 'waiting', text: 'Cancelled', fallback: 'Cancelled' }
+
+/** How a card is re-labelled once chat approval is no longer allowed: the ask is still open, but
+ *  only an Agent editor can settle it now. */
+const ELICIT_EDITOR_ONLY: ElicitCardLabel = {
+  mark: 'blocked',
+  text: 'Ask an Agent editor to allow it',
+  fallback: 'Permission requires an Agent editor'
+}
+
 /** How many consented URL elicitations wait for an `elicitation/complete` that may never come. */
 const CONSENTED_URL_ELICIT_CAP = 64
 
-/** How a settled Slack consent card labels each outcome. "Opened" is deliberately not "Done":
- *  consent is all the tap proves, and only the agent's own `elicitation/complete` says more. */
-const URL_CONSENT_DECISION = {
-  accepted: ':white_check_mark: Opened',
-  dismissed: ':no_entry_sign: Dismissed',
-  cancelled: ':hourglass: Cancelled',
-  completed: ':white_check_mark: Completed'
-} as const
+/** How a settled consent card labels each outcome — the MARK and the words, so each surface
+ *  spells the mark its own way. "Opened" is deliberately not "Done": consent is all the tap
+ *  proves, and only the agent's own `elicitation/complete` says more. */
+const URL_CONSENT_DECISION: Record<'accepted' | 'dismissed' | 'cancelled' | 'completed', ElicitCardLabel> = {
+  accepted: { mark: 'answered', text: 'Opened' },
+  dismissed: { mark: 'dismissed', text: 'Dismissed' },
+  cancelled: { mark: 'waiting', text: 'Cancelled' },
+  completed: { mark: 'answered', text: 'Completed' }
+}
+
+/** How a settled card is labelled, before the ask it re-renders from is known: the mark, the words
+ *  beside it, and the notification fallback — absent when the rendered decision doubles as one,
+ *  which is what a consent card's settlement has always sent. */
+type ElicitCardLabel = { mark: ElicitCardMark; text: string; fallback?: string }
 
 /** `elicitation/complete` carries no session, so a consented card is keyed by its ACP id within
  *  the agent host that raised it — two agents may hold the same id concurrently. */
@@ -204,9 +243,6 @@ type PendingElicit = PendingElicitSurface & {
    *  Confirm-bearing one — the fields it rendered, in schema order. Absent ⇒ a one-tap button
    *  row, answered by a scalar as it always was. */
   form?: ElicitTarget[]
-  /** Set beside `form` on a SLACK form card: the opaque session target its actions block carries,
-   *  so a relay-forwarded Confirm routes back to this daemon. It names nothing about the reader. */
-  sessionTarget?: string
   /** Set only for a URL-mode consent card: the ACP `elicitationId` and the exact URL shown.
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
@@ -225,12 +261,13 @@ type ElicitRow = { channel: string; thread: string; ts: string; sender: string; 
 /** The turn's platform surfaces a permission or elicitation card renders through. */
 export interface PermissionSurfaceHost {
   enqueueApply(p: Pending, action: DaemonRenderAction): void
-  /** Post a chronological boundary card serialized on the turn's apply chain. */
-  postCardSerialized(
-    p: Pending,
-    post: (conn: SlackConnection) => Promise<string | undefined>
-  ): Promise<string | undefined>
+  /** Post a chronological boundary card serialized on the turn's apply chain. The connection is
+   *  opaque: an elicitation-card facet casts it to its own, as every Layer-2 applier already does. */
+  postCardSerialized(p: Pending, post: (conn: unknown) => Promise<string | undefined>): Promise<string | undefined>
   httpSlackSessionTarget(p: Pick<Pending, 'plan'>): string | undefined
+  /** `platform`'s Layer-2 elicitation-card facet, EXACT (no core fallback) — undefined when this
+   *  surface cannot collect an answer, which is the whole of what core needs to know about it. */
+  elicitCardFacet(platform: string): ElicitCardFacet | undefined
   maskAgentSecrets<T>(agentId: string, payload: T): T
   logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void
   /** Tell the CP a session started or stopped waiting on a human (slack-approval-dm.md §7); fire-and-forget. */
@@ -332,10 +369,16 @@ export class PermissionCoordinator {
    *  labelled once that post finally returns — recorded by the settlement, consumed by the
    *  posting path, which would otherwise stamp every such card Cancelled (#1794). Bounded by
    *  the posting path deleting its own entry on every exit. */
-  private readonly settledBeforePost = new Map<string, { decision: string; fallback: string }>()
+  private readonly settledBeforePost = new Map<string, ElicitCardLabel>()
 
   /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
   private readonly awaitingApproval = new Map<string, { owner: HostKey; agentId: string; sessionId: string }>()
+
+  /** The two core capabilities an elicitation-card facet is allowed to reach, and nothing wider. */
+  private readonly elicitCardHost: ElicitCardHost = {
+    postCardSerialized: (turn, post) => this.host.postCardSerialized(turn as Pending, post),
+    sessionTarget: (turn) => this.host.httpSlackSessionTarget(turn as Pending)
+  }
 
   constructor(private readonly host: PermissionHost) {}
 
@@ -603,7 +646,7 @@ export class PermissionCoordinator {
     const blocks = buildPermissionCard(requestId, params, this.host.httpSlackSessionTarget(p))
     const fallback = `Permission requested: ${params.toolCall?.title ?? 'a tool call'}`
     const ts = await this.host.postCardSerialized(p, (slack) =>
-      slack.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
+      (slack as SlackConnection).postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
         ...(slackAgentIdentityOptions(p.plan) ?? {}),
         chrome: true
       })
@@ -948,22 +991,14 @@ export class PermissionCoordinator {
           id: req.requestId,
           allowed: decidedAllow
         })
-        // Only a Slack card is rewritten here: an editor decision settles approvals, and
-        // an approval elicitation never lands on the webchat surface.
-        if (elicitation.surface === 'slack' && elicitation.ts) {
-          const decision =
+        // Only a chat card is rewritten here: an editor decision settles approvals, and an
+        // approval elicitation never lands on the webchat surface.
+        if (elicitation.surface === 'chat' && elicitation.ts) {
+          const label: ElicitCardLabel =
             req.decision === 'allow'
-              ? ':white_check_mark: Allowed by Agent editor'
-              : ':no_entry_sign: Denied by Agent editor'
-          void elicitation.conn
-            .updateBlocks(
-              elicitation.channel,
-              elicitation.ts,
-              buildElicitationResolvedCard(elicitation.params, decision),
-              'Permission resolved',
-              true
-            )
-            .catch(() => {})
+              ? { mark: 'answered', text: 'Allowed by Agent editor', fallback: 'Permission resolved' }
+              : { mark: 'dismissed', text: 'Denied by Agent editor', fallback: 'Permission resolved' }
+          elicitation.facet.settle(elicitation, elicitSettlement(elicitation.params, false, label))
         }
         elicitation.resolve(req.decision === 'allow' ? { action: 'accept' } : { action: 'cancel' })
         return { ok: true }
@@ -1146,16 +1181,8 @@ export class PermissionCoordinator {
         .catch(() => {})
     }
     for (const pending of this.pendingElicits.values()) {
-      if (pending.agentId !== agentId || !pending.approval || pending.surface !== 'slack' || !pending.ts) continue
-      void pending.conn
-        .updateBlocks(
-          pending.channel,
-          pending.ts,
-          buildElicitationResolvedCard(pending.params, ':lock: Ask an Agent editor to allow it'),
-          'Permission requires an Agent editor',
-          true
-        )
-        .catch(() => {})
+      if (pending.agentId !== agentId || !pending.approval || pending.surface !== 'chat' || !pending.ts) continue
+      pending.facet.settle(pending, elicitSettlement(pending.params, false, ELICIT_EDITOR_ONLY))
     }
   }
 
@@ -1391,30 +1418,68 @@ export class PermissionCoordinator {
         ? await this.awaitWebchatUrlElicitation(agentId, sessionId, params, p, p.webchat, url)
         : await this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
     }
-    const conn = p.conn
-    if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection))
-      return this.noticeUnrenderableElicit(p, params, isApproval)
-    // A second SURFACE for #1810's URL mode: the notice is only for an ask Slack still cannot render.
-    if (url) return await this.awaitSlackUrlElicitation(agentId, sessionId, params, p, conn, url)
+    // A platform name is never core knowledge (integration-plugin-architecture.md): the turn
+    // surface's own elicitation-card facet says whether this chat can collect an answer, and the
+    // lookup is EXACT so a hook or dream turn rendering through the core surface does not inherit
+    // Slack's cards. No connection means no surface at all, headless included.
+    const facet = p.conn ? this.host.elicitCardFacet(p.plan.platform) : undefined
+    if (!facet) return this.noticeUnrenderableElicit(p, params, isApproval)
+    // A second SURFACE for #1810's URL mode: the notice is only for an ask this chat still cannot
+    // render. A consent card is never an approval, so it takes the approval-free path.
+    if (url) return await this.awaitChatElicitation(agentId, sessionId, params, p, facet, { url }, false)
     if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
-    // ONE reduction decides the card's shape (#1794's Slack column). Anything the reader has to
-    // fill in before submitting — several questions, a question with its own free-text box, a
-    // multi-select, a typed box — is a card of `input` blocks with one Confirm; only a lone
-    // single-select or boolean, which one tap answers, keeps its row of buttons below. An approval
-    // is allow/deny by construction, so it is always the button row: chat approval has no shape
-    // for a filled-in field, and its own bookkeeping lives on the button path.
-    const form = elicitForm(params, SLACK_ELICIT_SURFACE)
+    // ONE reduction decides the card's shape (#1794), against THIS surface's own declaration.
+    // Anything the reader has to fill in before submitting — several questions, a question with
+    // its own free-text box, a multi-select, a typed box — is a card of inputs with one Confirm;
+    // only a lone single-select or boolean, which one tap answers, keeps its row of buttons below.
+    // An approval is allow/deny by construction, so it is always the button row: chat approval has
+    // no shape for a filled-in field, and its own bookkeeping lives on the button path.
+    const form = elicitForm(params, facet.reduction)
     if (!form) return this.noticeUnrenderableElicit(p, params, isApproval)
-    if (elicitCardShape(form) === 'inputs') {
-      if (isApproval) return this.noticeUnrenderableElicit(p, params, isApproval)
-      return await this.awaitSlackFormElicitation(agentId, sessionId, params, p, conn, form)
-    }
-    const target = form[0]!
+    if (isApproval && elicitCardShape(form) === 'inputs') return this.noticeUnrenderableElicit(p, params, isApproval)
+    return await this.awaitChatElicitation(agentId, sessionId, params, p, facet, { form }, isApproval)
+  }
+
+  /**
+   * Post ONE elicitation card on the turn's own chat surface and park the resolver until it is
+   * answered, dismissed, or the turn ends.
+   *
+   * The three Slack paths this replaces — the one-tap button row, the filled-in card with its
+   * Confirm, and URL mode's consent card — differed only in which card was built and what the
+   * record carried, so the facet builds the card and what is left here is everything that is NOT
+   * platform-shaped: the record, the mid-post settlement race, and the approval bookkeeping.
+   *
+   * A card this surface has no control for is declined with the notice every other unrenderable
+   * ask gets: `build` returns null and nothing is posted or recorded as open.
+   */
+  private async awaitChatElicitation(
+    agentId: string,
+    sessionId: string,
+    params: CreateElicitationRequest,
+    p: Pending,
+    facet: ElicitCardFacet,
+    shape: { form?: ElicitTarget[]; url?: { elicitationId: string; url: string } },
+    isApproval: boolean
+  ): Promise<CreateElicitationResponse | undefined> {
+    const { form, url } = shape
     const requestId = randomUUID()
-    const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p), SLACK_ELICIT_SURFACE)
-    if (!blocks) return this.noticeUnrenderableElicit(p, params, isApproval)
-    const cardMessage = (params as { message?: string }).message?.trim() || 'The agent needs your input'
-    const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
+    // A card whose fields have to be filled in answers with a RECORD, and a consent card has no
+    // field at all: both carry the one-tap card's field shape unused, and neither path reads it.
+    const inputs = !!form && elicitCardShape(form) === 'inputs'
+    const defaulted = url ? 'The agent needs you to open a link' : 'The agent needs your input'
+    const message = (params as { message?: string }).message?.trim() || defaulted
+    const fallback = (params as { message?: string }).message ?? defaulted
+    const ask: ElicitCardAsk = {
+      requestId,
+      params,
+      message,
+      fallback,
+      ...(form ? { form } : {}),
+      ...(url ? { url } : {})
+    }
+    const draft = facet.build(this.elicitCardHost, p, ask)
+    if (draft === null || draft === undefined) return this.noticeUnrenderableElicit(p, params, isApproval)
+    const target = form?.[0]
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
     this.pendingElicits.set(requestId, {
@@ -1422,15 +1487,25 @@ export class PermissionCoordinator {
       agentId,
       sessionId,
       params,
-      propName: target.propName,
-      kind: target.kind,
+      propName: inputs || url ? '' : (target?.propName ?? ''),
+      kind: inputs || url ? 'text' : (target?.kind ?? 'text'),
+      ...(inputs && form ? { form } : {}),
+      ...(url ? { url } : {}),
       approval: isApproval,
-      surface: 'slack',
-      conn,
+      surface: 'chat',
+      facet,
+      conn: p.conn,
       channel: p.plan.channel,
       // An MCP approval keeps its durable record in `permission_requests` and its own console
       // surface, so it is not also a transcript card.
-      ...(isApproval ? {} : this.recordElicitCard(p, elicitCardPayload(requestId, cardMessage, params, form))),
+      ...(isApproval
+        ? {}
+        : this.recordElicitCard(
+            p,
+            url
+              ? elicitUrlCardPayload(requestId, message, url.url)
+              : elicitCardPayload(requestId, message, params, form ?? [])
+          )),
       resolve: resolveResult
     })
     this.syncApprovalActivity(p.hostKey, sessionId)
@@ -1455,40 +1530,27 @@ export class PermissionCoordinator {
       this.recordedWrites.delete(requestId)
       if (!this.pendingElicits.has(requestId)) return await result
     }
-    const ts = await this.host.postCardSerialized(p, (sc) =>
-      sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
-        ...(slackAgentIdentityOptions(p.plan) ?? {}),
-        chrome: true
-      })
-    )
+    const ts = await facet.send(this.elicitCardHost, p, ask, draft)
     const live = this.pendingElicits.get(requestId)
-    // Settled mid-post — say how it actually ended. A tap can reach the daemon before Slack has
-    // answered the post that carried it, and calling that answer Cancelled contradicts what the
-    // reader just did; the settlement left its own label here (#1794).
+    // Settled mid-post — the card must stop offering an answer nobody awaits, and must say how it
+    // actually ended. A tap can reach the daemon before the platform has answered the post that
+    // carried it, and calling that answer Cancelled contradicts what the reader just did; the
+    // settlement left its own label here (#1794).
     if (!live) {
       const settled = this.takeSettledBeforePost(requestId)
-      if (ts)
-        void conn
-          .updateBlocks(
-            p.plan.channel,
-            ts,
-            buildElicitationResolvedCard(params, settled.decision),
-            settled.fallback,
-            true
-          )
-          .catch(() => {})
+      if (ts) facet.settle({ conn: p.conn, channel: p.plan.channel, ts }, elicitSettlement(params, !!url, settled))
       return await result
     }
     if (!ts) {
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
       if (isApproval) await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
-      // A card Slack never took is closed on the row too, or it would read as open forever.
+      // A card the platform never took is closed on the row too, or it would read as open forever.
       this.settleElicitRow(live, 'cancelled')
       live.resolve({ action: 'cancel' })
       return await result
     }
-    if (live.surface === 'slack') live.ts = ts
+    if (live.surface === 'chat') live.ts = ts
     return isApproval ? await this.trackHumanApprovalWait(p, result) : await result
   }
 
@@ -1694,140 +1756,6 @@ export class PermissionCoordinator {
     return await result
   }
 
-  /** Slack's peer of {@link awaitWebchatUrlElicitation}: post the CONSENT card and park the
-   *  resolver until the reader taps Open link or Dismiss. Nothing here fetches the URL — the tap
-   *  hands it to the reader's browser, which is what keeps the page out of the model's context —
-   *  so the only thing this seam decides is whether they agreed to go there. A card this surface
-   *  cannot build falls back to the same decline notice every other unrenderable ask gets. */
-  private async awaitSlackUrlElicitation(
-    agentId: string,
-    sessionId: string,
-    params: CreateElicitationRequest,
-    p: Pending,
-    conn: SlackConnection,
-    url: { elicitationId: string; url: string }
-  ): Promise<CreateElicitationResponse | undefined> {
-    const requestId = randomUUID()
-    const blocks = buildUrlConsentCard(requestId, params, this.host.httpSlackSessionTarget(p))
-    if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
-    const message = (params as { message?: string }).message?.trim() || 'The agent needs you to open a link'
-    const fallback = (params as { message?: string }).message ?? 'The agent needs you to open a link'
-    let resolveResult!: (res: CreateElicitationResponse) => void
-    const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
-    this.pendingElicits.set(requestId, {
-      owner: p.hostKey,
-      agentId,
-      sessionId,
-      params,
-      // A URL card has no field; these are the record's unused shape, never read on this path.
-      propName: '',
-      kind: 'text',
-      url,
-      approval: false,
-      surface: 'slack',
-      conn,
-      channel: p.plan.channel,
-      ...this.recordElicitCard(p, elicitUrlCardPayload(requestId, message, url.url)),
-      resolve: resolveResult
-    })
-    this.syncApprovalActivity(p.hostKey, sessionId)
-    const ts = await this.host.postCardSerialized(p, (sc) =>
-      sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
-        ...(slackAgentIdentityOptions(p.plan) ?? {}),
-        chrome: true
-      })
-    )
-    const live = this.pendingElicits.get(requestId)
-    // Settled mid-post — the card must stop offering a consent nobody awaits, and must say how it
-    // actually ended: a consent that beat this post left its own label, and calling that Cancelled
-    // would contradict the credential page the reader really did open (#1794).
-    if (!live) {
-      const settled = this.takeSettledBeforePost(requestId)
-      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, settled.decision, settled.fallback, true)
-      return await result
-    }
-    if (!ts) {
-      this.pendingElicits.delete(requestId)
-      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
-      // A card Slack never took is closed on the row too, or it would read as open forever.
-      this.settleElicitRow(live, 'cancelled')
-      live.resolve({ action: 'cancel' })
-      return await result
-    }
-    if (live.surface === 'slack') live.ts = ts
-    return await result
-  }
-
-  /**
-   * Slack's peer of {@link awaitWebchatElicitation}: post the card whose fields are `input` blocks
-   * in the message itself — the question, one input per field, Confirm and Dismiss — and park the
-   * resolver until Confirm is tapped, Dismiss is tapped, or the turn ends.
-   *
-   * A form no card can hold (an enum option value past Slack's select cap, a minimum length past
-   * an input's) is declined with the same notice every other unrenderable ask gets: the builder
-   * returns null and nothing is posted.
-   */
-  private async awaitSlackFormElicitation(
-    agentId: string,
-    sessionId: string,
-    params: CreateElicitationRequest,
-    p: Pending,
-    conn: SlackConnection,
-    form: ElicitTarget[]
-  ): Promise<CreateElicitationResponse | undefined> {
-    const requestId = randomUUID()
-    const sessionTarget = this.host.httpSlackSessionTarget(p)
-    const blocks = buildElicitationFormCard(requestId, params, form, sessionTarget)
-    if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
-    const cardMessage = (params as { message?: string }).message?.trim() || 'The agent needs your input'
-    const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
-    let resolveResult!: (res: CreateElicitationResponse) => void
-    const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
-    this.pendingElicits.set(requestId, {
-      owner: p.hostKey,
-      agentId,
-      sessionId,
-      params,
-      // A form answers with a RECORD keyed by property name, so these two carry nothing: they
-      // are the single-field card's shape, and the form path never reads either.
-      propName: '',
-      kind: 'text',
-      form,
-      ...(sessionTarget ? { sessionTarget } : {}),
-      approval: false,
-      surface: 'slack',
-      conn,
-      channel: p.plan.channel,
-      ...this.recordElicitCard(p, elicitCardPayload(requestId, cardMessage, params, form)),
-      resolve: resolveResult
-    })
-    this.syncApprovalActivity(p.hostKey, sessionId)
-    const ts = await this.host.postCardSerialized(p, (sc) =>
-      sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
-        ...(slackAgentIdentityOptions(p.plan) ?? {}),
-        chrome: true
-      })
-    )
-    const live = this.pendingElicits.get(requestId)
-    // Settled mid-post — the card must stop offering an answer nobody awaits, and must say how it
-    // actually ended rather than assume the turn was cancelled (#1794).
-    if (!live) {
-      const settled = this.takeSettledBeforePost(requestId)
-      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, settled.decision, settled.fallback, false)
-      return await result
-    }
-    if (!ts) {
-      this.pendingElicits.delete(requestId)
-      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
-      // A card Slack never took is closed on the row too, or it would read as open forever.
-      this.settleElicitRow(live, 'cancelled')
-      live.resolve({ action: 'cancel' })
-      return await result
-    }
-    if (live.surface === 'slack') live.ts = ts
-    return await result
-  }
-
   /**
    * The field list a live card's `input` blocks were built from, re-derived from its OWN params
    * rather than read back off the record (#1815) — the same reduction, on the same surface, so it
@@ -1855,7 +1783,7 @@ export class PermissionCoordinator {
     actor?: InteractionActor
   }): Promise<void> {
     const rec = this.pendingElicits.get(a.requestId)
-    if (!rec || rec.surface !== 'slack' || !rec.form) return
+    if (!rec || rec.surface !== 'chat' || !rec.form) return
     const form = this.cardForm(rec)
     if (!form) return
     const submission = elicitFormSubmission(rec.params, form, a.fields)
@@ -1870,23 +1798,6 @@ export class PermissionCoordinator {
       value: submission.answer ?? {},
       ...(a.actor ? { actor: a.actor } : {})
     })
-  }
-
-  /** Rewrite a settled Slack card in place, best effort — the ACP resolution never depends on it.
-   *  A consent card keeps its own shape so the settled message still records the URL. */
-  private rewriteSlackCard(
-    conn: SlackConnection,
-    channel: string,
-    ts: string,
-    params: CreateElicitationRequest,
-    decision: string,
-    fallback: string,
-    consent: boolean
-  ): void {
-    const blocks = consent
-      ? buildUrlConsentResolvedCard(params, decision)
-      : buildElicitationResolvedCard(params, decision)
-    void conn.updateBlocks(channel, ts, blocks, fallback, true).catch(() => {})
   }
 
   /** Settle a URL-mode consent card. `accept` means only that the user agreed to OPEN the URL —
@@ -1906,7 +1817,7 @@ export class PermissionCoordinator {
     // an answer was one it actually rendered. A Slack button carries that option as its position
     // (#1794), which is what keeps a URL too long for a button `value` from losing its card;
     // webchat's card carries the URL itself.
-    const consented = a.value === (rec.surface === 'slack' ? elicitOptionToken(0) : rec.url.url)
+    const consented = a.value === (rec.surface === 'chat' ? elicitOptionToken(0) : rec.url.url)
     if (!consented && a.value !== null) return
     this.pendingElicits.delete(requestId)
     this.syncApprovalActivity(rec.owner, rec.sessionId, { id: requestId, allowed: consented })
@@ -1915,8 +1826,8 @@ export class PermissionCoordinator {
     rec.resolve({ action: consented ? 'accept' : 'decline' })
   }
 
-  /** Say on the card's own surface how a consent card ended: webchat appends a stream event,
-   *  Slack rewrites the message. Best effort on both — the ACP resolution never depends on it. */
+  /** Say on the card's own surface how a consent card ended: webchat appends a stream event, a
+   *  chat surface rewrites the message. Best effort on both — no ACP resolution depends on it. */
   private settleUrlElicit(
     rec: PendingElicit,
     requestId: string,
@@ -1928,8 +1839,7 @@ export class PermissionCoordinator {
       this.emitWebchatElicitResolved(rec, requestId, outcome, label)
       return
     }
-    const decision = URL_CONSENT_DECISION[outcome]
-    this.settleSlackCard(rec, requestId, decision, decision, true)
+    this.settleChatCard(rec, requestId, true, URL_CONSENT_DECISION[outcome])
   }
 
   /** Park a consented card's coordinates so a later `elicitation/complete` can find it. Oldest
@@ -2033,7 +1943,7 @@ export class PermissionCoordinator {
     // an answer, exactly as `elicitFormSubmission` reads a Confirm. A form answer came through
     // that function, which resolved it already, and webchat carries literals: neither is remapped.
     const resolved: ElicitAnswer =
-      rec.surface === 'slack' && !rec.form && target && typeof a.value === 'string'
+      rec.surface === 'chat' && !rec.form && target && typeof a.value === 'string'
         ? elicitOptionLiteral(target, a.value)
         : a.value
     // A position naming no option this card offered is refused with the same words, and the card
@@ -2068,48 +1978,46 @@ export class PermissionCoordinator {
       return
     }
     if (rec.approval && this.host.agents().get(rec.agentId)?.allowRuntimeChangesInChat !== true) {
-      if (rec.surface === 'slack' && rec.ts) {
-        void rec.conn
-          .updateBlocks(
-            rec.channel,
-            rec.ts,
-            buildElicitationResolvedCard(rec.params, ':lock: Ask an Agent editor to allow it'),
-            'Permission requires an Agent editor',
-            true
-          )
-          .catch(() => {})
-      }
+      if (rec.surface === 'chat') rec.facet.settle(rec, elicitSettlement(rec.params, false, ELICIT_EDITOR_ONLY))
       return
     }
     let res: CreateElicitationResponse
-    let decision: string
-    // What the settled card says the answer WAS — the webchat label, and the Slack decision's tail.
+    let mark: ElicitCardMark
+    // What the settled card says the answer WAS — the webchat label, and the decision's own tail.
     let answered: string | undefined
+    // What the card's own words say beside the mark, which is not always the label: a scalar
+    // answer's decision echoes the VALUE, where the row's label names the option.
+    let decisionText: string
     if (answer === null) {
       res = { action: 'decline' }
-      decision = ':no_entry_sign: Dismissed'
+      mark = 'dismissed'
+      decisionText = 'Dismissed'
     } else if (isFormAnswer(answer)) {
       if (!form) return
       // A form's accepted content is the whole record: every answered field under its own name.
       res = { action: 'accept', content: elicitFormContent(form, answer) }
       answered = formAnswerLabel(rec.params, form, answer)
-      decision = `:white_check_mark: ${answered}`
+      mark = 'answered'
+      decisionText = answered
     } else if (Array.isArray(answer)) {
       // The array property's accepted content is the chosen list itself.
       res = { action: 'accept', content: { [rec.propName]: answer } }
       answered = chosenLabel(target, answer)
-      decision = `:white_check_mark: ${answered}`
+      mark = 'answered'
+      decisionText = answered
     } else {
       // The accepted content carries the schema's own type: a boolean for a boolean field and a
       // real number for a numeric one, never the string the wire happened to spell it with.
       const value = rec.kind === 'boolean' ? answer === 'true' : answer
       res = { action: 'accept', content: { [rec.propName]: value } }
       answered = chosenLabel(target, answer)
-      decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : String(answer)}`
+      mark = 'answered'
+      decisionText = rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : String(answer)
     }
     if (rec.approval) {
-      // Approval elicitations only ever take the Slack card path (chat approval requires it).
-      const team = rec.surface === 'slack' ? rec.conn.workspaceId() : undefined
+      // A chat approval's actor id is scoped the way its own surface scopes one (undefined where
+      // the surface's ids are already global), so a recorded resolver is unique either way.
+      const team = rec.surface === 'chat' ? rec.facet.answerScope?.(rec) : undefined
       const by = a.actor
         ? { resolvedBy: team ? `slack:${team}:${a.actor.userId}` : null, resolvedByName: a.actor.name ?? null }
         : undefined
@@ -2129,7 +2037,7 @@ export class PermissionCoordinator {
     this.settleElicitRow(rec, outcome, answered)
     if (rec.surface === 'webchat') {
       this.emitWebchatElicitResolved(rec, a.requestId, outcome, answered)
-    } else this.settleSlackCard(rec, a.requestId, decision, 'Input received', false)
+    } else this.settleChatCard(rec, a.requestId, false, { mark, text: decisionText, fallback: 'Input received' })
     rec.resolve(res)
   }
 
@@ -2205,29 +2113,29 @@ export class PermissionCoordinator {
     )
   }
 
-  /** Label a Slack card whose post is still in flight. The message has no `ts` yet, so there is
-   *  nothing to rewrite — the label is left for the posting path, which would otherwise call
-   *  every such card Cancelled (#1794). The row is settled either way: it needs no `ts`. */
-  private settleSlackCard(
-    rec: PendingElicit & { surface: 'slack' },
+  /** Rewrite a settled chat card through the facet that posted it, or — when its post is still in
+   *  flight and there is no message to rewrite — leave the label for the posting path, which would
+   *  otherwise call every such card Cancelled (#1794). The row is settled either way: it needs no
+   *  message id. Best effort: no ACP resolution depends on the rewrite. */
+  private settleChatCard(
+    rec: PendingElicit & { surface: 'chat' },
     requestId: string,
-    decision: string,
-    fallback: string,
-    consent: boolean
+    consent: boolean,
+    label: ElicitCardLabel
   ): void {
     if (rec.ts) {
-      this.rewriteSlackCard(rec.conn, rec.channel, rec.ts, rec.params, decision, fallback, consent)
+      rec.facet.settle(rec, elicitSettlement(rec.params, consent, label))
       return
     }
-    this.settledBeforePost.set(requestId, { decision, fallback })
+    this.settledBeforePost.set(requestId, label)
   }
 
   /** How a card the posting path found already settled must read. A settlement that beat the post
    *  left its own label here; anything else really was the turn ending, which is Cancelled. */
-  private takeSettledBeforePost(requestId: string): { decision: string; fallback: string } {
+  private takeSettledBeforePost(requestId: string): ElicitCardLabel {
     const settled = this.settledBeforePost.get(requestId)
     this.settledBeforePost.delete(requestId)
-    return settled ?? { decision: ':hourglass: Cancelled', fallback: 'Cancelled' }
+    return settled ?? ELICIT_CANCELLED
   }
 
   /** Post one daemon-authored line on the card's OWN surface — a notice, so it lands where every
@@ -2261,7 +2169,7 @@ export class PermissionCoordinator {
       else {
         this.settleElicitRow(rec, 'cancelled')
         if (rec.surface === 'webchat') this.emitWebchatElicitResolved(rec, id, 'cancelled')
-        else this.settleSlackCard(rec, id, ':hourglass: Cancelled', 'Cancelled', false)
+        else this.settleChatCard(rec, id, false, ELICIT_CANCELLED)
       }
       rec.resolve({ action: 'cancel' })
     }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -79,7 +79,7 @@ import {
   permissionRequestParts,
   type ApprovalRequestParts
 } from '../daemon/tool-classification.js'
-import { pendingTurnKey, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
+import { pendingTurnKey, turnState, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
 
 /** The union of a turn's explicit human-approval waits, measured here and nowhere else.
  *  Regeneration budgets subtract it while retaining runtime/tool work time; `depth` counts
@@ -377,7 +377,8 @@ export class PermissionCoordinator {
   /** The two core capabilities an elicitation-card facet is allowed to reach, and nothing wider. */
   private readonly elicitCardHost: ElicitCardHost = {
     postCardSerialized: (turn, post) => this.host.postCardSerialized(turn as Pending, post),
-    sessionTarget: (turn) => this.host.httpSlackSessionTarget(turn as Pending)
+    sessionTarget: (turn) => this.host.httpSlackSessionTarget(turn as Pending),
+    turnState: (turn) => turnState(turn as Pending)
   }
 
   constructor(private readonly host: PermissionHost) {}

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -103,6 +103,11 @@ export interface ElicitCardHost {
   /** The opaque routing target a relay-forwarded interaction carries back to THIS daemon. A
    *  surface whose ingress is daemon-owned needs none and ignores it. */
   sessionTarget(turn: ElicitCardTurn): string | undefined
+  /** This turn's OPAQUE platform state slot (§7.3) — the very object the platform's `apply`
+   *  reads. A card is one of the turn's posts, so it must anchor exactly as the turn's other
+   *  posts do; handing the same slot over is what keeps one platform to ONE anchoring
+   *  mechanism, rather than a card re-deriving an anchor of its own. Core never reads it. */
+  turnState(turn: ElicitCardTurn): unknown
 }
 
 /** One chat surface's elicitation-card facet. Registered on that platform's

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -1,0 +1,137 @@
+/**
+ * **The elicitation-card facet of Layer 2** (integration-plugin-architecture.md §7.3) — how one
+ * chat surface COLLECTS the answer to an ACP `elicitation/create`.
+ *
+ * It is a turn output, not a registry of its own: a card is posted into the turn's conversation,
+ * on the turn's connection, serialized on the turn's apply chain, and it belongs beside the
+ * renderers and strategy functions that already live on {@link TurnOutputSurface}. Lookup is
+ * therefore `exact()`, and that is load-bearing for the same reason `onSuppress` is — webchat,
+ * hook and dream turns RENDER through the core (Slack-shaped) surface but must never inherit its
+ * elicitation cards. Webchat's own card is core-owned (§12) and is answered before this facet is
+ * ever consulted.
+ *
+ * WHY IT EXISTS AS A MEMBER AT ALL. `onAcpElicit` used to gate on
+ * `!(conn instanceof SlackConnection)` — a platform name in core, which the plugin architecture
+ * forbids outright. Telegram is the second implementer, so the member is shaped by two real
+ * surfaces rather than guessed from one: Slack posts `blocks` and rewrites with `chat.update`,
+ * Telegram posts an inline keyboard and rewrites with `editMessageText`. What they share is
+ * exactly the four things below — a reduction they can render, a draft, a send, and a rewrite.
+ *
+ * BUILD IS SEPARATE FROM SEND, and the split is not cosmetic: an ask this surface has no control
+ * for must be declined BEFORE the request is recorded as open (core posts the decline notice and
+ * writes an `unrenderable` transcript row), whereas a card the platform simply refused to take is
+ * an ask that WAS opened and then cancelled. One method returning `undefined` for both could not
+ * tell those apart.
+ */
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import type { ElicitSurface, ElicitTarget } from '../slack/render.js'
+
+/** One elicitation card as core hands it to a surface: the ask, the words above it, and the
+ *  reduction the card renders one control per. `form` and `url` are mutually exclusive — a
+ *  URL-mode ask has no field, only a destination to consent to. */
+export interface ElicitCardAsk {
+  /** The unguessable id every control on this card carries back. */
+  readonly requestId: string
+  /** The ACP request, already secret-masked by core. Card builders re-derive from it (#1815). */
+  readonly params: CreateElicitationRequest
+  /** The card's own heading text. */
+  readonly message: string
+  /** The notification fallback shown where a card cannot render. */
+  readonly fallback: string
+  /** The fields this card renders one control per — THIS surface's own reduction. */
+  readonly form?: readonly ElicitTarget[]
+  /** URL mode's consent target (ACP `ElicitationUrlMode`). Present ⇒ the card is a consent card. */
+  readonly url?: { readonly elicitationId: string; readonly url: string }
+}
+
+/** A card this surface built but has not sent — the surface's own wire shape (Slack's `blocks`,
+ *  Telegram's text plus inline keyboard). Opaque to core, which only hands it back to `send`. */
+export type ElicitCardDraft = unknown
+
+/** A posted card's coordinates, which both chat surfaces spell the same way: the connection that
+ *  posted it, the conversation it landed in, and the message id a rewrite addresses. Slack's `ts`
+ *  and Telegram's `message_id` are one fact in two dialects, so core holds the handle without
+ *  knowing which platform minted it. `ts` is absent until the send returns — a settlement that
+ *  beats it leaves its label for the posting path instead. */
+export interface ElicitCardHandle {
+  readonly conn: unknown
+  readonly channel: string
+  ts?: string
+}
+
+/** How a settled card is MARKED, named by what happened rather than by any surface's glyph — a
+ *  Slack shortcode and a Telegram emoji are the same four verdicts spelled two ways. */
+export type ElicitCardMark = 'answered' | 'dismissed' | 'waiting' | 'blocked'
+
+/** One card's settlement: the mark, what the mark is said about, and the ask it re-renders from.
+ *  `text` is already in the card's own words (the chosen labels, `Dismissed`, `Cancelled`) — a
+ *  surface only decides how to spell the mark beside it. */
+export interface ElicitCardSettlement {
+  readonly params: CreateElicitationRequest
+  /** The card was a URL-mode consent card, whose settled shape keeps the destination on view. */
+  readonly consent: boolean
+  readonly mark: ElicitCardMark
+  readonly text: string
+  /** The notification fallback beside the card. Absent ⇒ the rendered decision doubles as one,
+   *  which is what a consent card's settlement has always sent. */
+  readonly fallback?: string
+}
+
+/** The turn, as an elicitation-card facet sees it: where the card goes and the identity it goes
+ *  out under. Deliberately narrow — a facet may not reach core turn machinery. `Pending`
+ *  satisfies it structurally, the same boundary Telegram's applier takes its turn through. */
+export interface ElicitCardTurn {
+  conn?: unknown
+  plan: {
+    platform: string
+    channel: string
+    thread?: string
+    statusThread: string
+    agentName: string
+    iconUrl?: string
+  }
+}
+
+/** The two core capabilities a facet needs to send a card, and nothing else. */
+export interface ElicitCardHost {
+  /** Post on the turn's apply chain as a chronological boundary, so pre-card chrome stays above
+   *  the card and the following stream below it. Returns the platform's message id. */
+  postCardSerialized(
+    turn: ElicitCardTurn,
+    post: (conn: unknown) => Promise<string | undefined>
+  ): Promise<string | undefined>
+  /** The opaque routing target a relay-forwarded interaction carries back to THIS daemon. A
+   *  surface whose ingress is daemon-owned needs none and ignores it. */
+  sessionTarget(turn: ElicitCardTurn): string | undefined
+}
+
+/** One chat surface's elicitation-card facet. Registered on that platform's
+ *  {@link TurnOutputSurface}; absent ⇒ the surface cannot collect an answer and core declines the
+ *  ask with the in-channel notice. */
+export interface ElicitCardFacet {
+  /** Diagnostic label; never parsed. */
+  readonly platform: string
+  /** What this surface can render AND collect — the SAME declaration the reduction reads, because
+   *  they are the same question. A kind whose control this surface lacks must not reach the card
+   *  builder, and a control the reduction admits must be one the surface can actually offer; two
+   *  declarations could only ever disagree, and the disagreement would be a card that is either
+   *  posted dead or declined for nothing. Option limits ride along for the same reason. */
+  readonly reduction: ElicitSurface
+  /** Build the card, or null when this surface has no control for the ask — core then declines it
+   *  with the notice and never records it as open. Called BEFORE the request is admitted. */
+  build(host: ElicitCardHost, turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null
+  /** Send a built draft; the platform's message id, or undefined when it refused the send. */
+  send(
+    host: ElicitCardHost,
+    turn: ElicitCardTurn,
+    ask: ElicitCardAsk,
+    draft: ElicitCardDraft
+  ): Promise<string | undefined>
+  /** Rewrite a posted card as settled — Slack's `chat.update`, Telegram's `editMessageText` with
+   *  the keyboard dropped. Best effort by construction: no ACP outcome depends on it. */
+  settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void
+  /** The namespace a tapping actor's id is scoped to on this surface, recorded beside an approval
+   *  resolver so it is globally unique. Absent where the surface's user ids already are — a
+   *  Telegram user id names one account across every chat, a Slack one only within its workspace. */
+  answerScope?(handle: ElicitCardHandle): string | undefined
+}

--- a/packages/daemon/src/platforms/slack/elicit-card.ts
+++ b/packages/daemon/src/platforms/slack/elicit-card.ts
@@ -1,0 +1,94 @@
+/**
+ * Slack's **elicitation-card facet** (§7.3) — the first implementer of
+ * {@link ElicitCardFacet}, extracted verbatim from the `instanceof SlackConnection` arm of
+ * `onAcpElicit`.
+ *
+ * Slack is the surface with every control: a row of buttons for a lone single-select or boolean,
+ * `input` blocks with one Confirm for anything that has to be filled in first, and a consent card
+ * for URL mode. Which of the three a card is comes from `elicitCardShape` and the ask's own shape,
+ * not from anything core decides, which is why the whole choice lives here.
+ *
+ * The rewrite is `chat.update` on the same message, and the mark is a Slack emoji SHORTCODE —
+ * `:white_check_mark:` and friends are Slack spelling, and rendering the mark is precisely the
+ * half of a settlement that is not portable.
+ */
+import type {
+  ElicitCardAsk,
+  ElicitCardDraft,
+  ElicitCardFacet,
+  ElicitCardHandle,
+  ElicitCardHost,
+  ElicitCardMark,
+  ElicitCardSettlement,
+  ElicitCardTurn
+} from '../elicit-card.js'
+import type { SlackConnection } from '../../slack/connection.js'
+import {
+  buildElicitationCard,
+  buildElicitationFormCard,
+  buildElicitationResolvedCard,
+  buildUrlConsentCard,
+  buildUrlConsentResolvedCard,
+  elicitCardShape,
+  SLACK_ELICIT_SURFACE
+} from '../../slack/render.js'
+import { slackAgentIdentityOptions } from './turn-output.js'
+
+/** How Slack spells each settlement mark. Shortcodes, because a Slack section renders them and a
+ *  literal emoji would sit oddly beside the rest of this surface's chrome. */
+const SLACK_ELICIT_MARK: Record<ElicitCardMark, string> = {
+  answered: ':white_check_mark:',
+  dismissed: ':no_entry_sign:',
+  waiting: ':hourglass:',
+  blocked: ':lock:'
+}
+
+export const slackElicitCards: ElicitCardFacet = {
+  platform: 'slack',
+  reduction: SLACK_ELICIT_SURFACE,
+
+  build(host: ElicitCardHost, turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null {
+    const sessionTarget = host.sessionTarget(turn)
+    if (ask.url) return buildUrlConsentCard(ask.requestId, ask.params, sessionTarget)
+    if (!ask.form?.length) return null
+    // ONE reduction decides the card's shape (#1794): anything the reader has to fill in before
+    // submitting is `input` blocks with one Confirm; a lone single-select or boolean, which one
+    // tap answers, keeps its row of buttons.
+    return elicitCardShape(ask.form) === 'inputs'
+      ? buildElicitationFormCard(ask.requestId, ask.params, [...ask.form], sessionTarget)
+      : buildElicitationCard(ask.requestId, ask.params, sessionTarget, SLACK_ELICIT_SURFACE)
+  },
+
+  async send(
+    host: ElicitCardHost,
+    turn: ElicitCardTurn,
+    ask: ElicitCardAsk,
+    draft: ElicitCardDraft
+  ): Promise<string | undefined> {
+    return await host.postCardSerialized(turn, (conn) =>
+      (conn as SlackConnection).postBlocks(
+        turn.plan.channel,
+        draft as unknown[],
+        ask.fallback,
+        turn.plan.statusThread,
+        { ...(slackAgentIdentityOptions(turn.plan) ?? {}), chrome: true }
+      )
+    )
+  },
+
+  settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void {
+    if (handle.ts === undefined) return
+    const decision = `${SLACK_ELICIT_MARK[card.mark]} ${card.text}`
+    // A consent card keeps its own shape so the settled message still records the URL.
+    const blocks = card.consent
+      ? buildUrlConsentResolvedCard(card.params, decision)
+      : buildElicitationResolvedCard(card.params, decision)
+    void (handle.conn as SlackConnection)
+      .updateBlocks(handle.channel, handle.ts, blocks, card.fallback ?? decision, true)
+      .catch(() => {})
+  },
+
+  answerScope(handle: ElicitCardHandle): string | undefined {
+    return (handle.conn as SlackConnection).workspaceId()
+  }
+}

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -38,6 +38,7 @@ import type {
 } from '../elicit-card.js'
 import type { InlineButton, TelegramConnection } from '../../telegram/connection.js'
 import { TELEGRAM_MESSAGE_LIMIT } from '../../telegram/render.js'
+import type { TelegramTurnState } from './turn-output.js'
 import { clampTo, elicitCardShape, elicitOptionToken, type ElicitKind, type ElicitSurface } from '../../slack/render.js'
 
 /**
@@ -64,9 +65,20 @@ const TELEGRAM_ELICIT_PREFIX = 'ac_el'
 /** The token a Dismiss button carries. Not a position, because Dismiss answers no option. */
 const TELEGRAM_ELICIT_DISMISS = 'x'
 
-/** How much of the question one card carries, leaving the whole settlement line room inside
- *  Telegram's message limit — a rewrite must never be refused for length after the ask fit. */
-const TELEGRAM_ELICIT_MESSAGE_CAP = TELEGRAM_MESSAGE_LIMIT - 300
+/**
+ * How much of the ANSWER a settled card echoes back. The decision core supplies is not bounded —
+ * a scalar's is `String(answer)`, and an enum option's value can be a path, an id or a long URL —
+ * so the surface that renders it is what bounds it. What the READER sees is clamped; what the
+ * AGENT receives is not (#1844's rule), because the accepted content is built from the raw answer
+ * and never from this text.
+ */
+const TELEGRAM_ELICIT_DECISION_CAP = 300
+
+/** How much of the question one card carries: whatever is left once the settlement line is
+ *  reserved, so the rewrite still fits after the ask did. Derived from the decision cap rather
+ *  than written beside it — the two drifting apart is exactly how a settlement stops landing.
+ *  The 8 covers the mark, the space and the newline with room to spare. */
+const TELEGRAM_ELICIT_MESSAGE_CAP = TELEGRAM_MESSAGE_LIMIT - TELEGRAM_ELICIT_DECISION_CAP - 8
 
 /** How Telegram spells each settlement mark. Literal emoji: a Telegram message has no shortcode
  *  vocabulary, so Slack's `:white_check_mark:` would reach the reader as its own source text. */
@@ -158,8 +170,17 @@ export const telegramElicitCards: ElicitCardFacet = {
     draft: ElicitCardDraft
   ): Promise<string | undefined> {
     const d = draft as TelegramElicitDraft
+    // The card anchors exactly as every other post of this turn does — through the turn's own
+    // state slot, the same `replyTo` `applyTelegramAction` reads. `threadTs` alone is not an
+    // anchor off a forum: `postCard` only turns a NUMERIC thread into `message_thread_id`, so a
+    // `tg:<root>` supergroup session would drop the card at the chat root, and a reader replying
+    // to it would root a fresh reply chain on the card instead of continuing this session.
+    const { replyTo } = host.turnState(turn) as TelegramTurnState
     return await host.postCardSerialized(turn, (conn) =>
-      (conn as TelegramConnection).postCard(turn.plan.channel, d.text, d.buttons, { threadTs: turn.plan.thread })
+      (conn as TelegramConnection).postCard(turn.plan.channel, d.text, d.buttons, {
+        threadTs: turn.plan.thread,
+        ...(replyTo !== undefined ? { replyTo } : {})
+      })
     )
   },
 
@@ -168,7 +189,13 @@ export const telegramElicitCards: ElicitCardFacet = {
     const messageId = Number(handle.ts)
     if (!Number.isInteger(messageId)) return
     const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
-    const text = `${telegramElicitText(message)}\n${TELEGRAM_ELICIT_MARK[card.mark]} ${card.text}`
+    const decision = `${TELEGRAM_ELICIT_MARK[card.mark]} ${clampTo(card.text, TELEGRAM_ELICIT_DECISION_CAP)}`
+    // Belt to the reserve's braces. The reserve only holds while both halves are bounded, and an
+    // edit refused for length lands AFTER ACP accepted and the pending record went — there is
+    // nothing left to retry against, so the card would keep offering buttons that answer nothing.
+    // Clamping by UTF-16 length is conservative: Telegram's 4096 counts CODEPOINTS, of which a
+    // JS string never has more than it has units (verified live 2026-09-08).
+    const text = clampTo(`${telegramElicitText(message)}\n${decision}`, TELEGRAM_MESSAGE_LIMIT)
     // An empty keyboard is what drops the buttons; the answered card stays readable in the chat.
     void (handle.conn as TelegramConnection).editCard(handle.channel, messageId, text, []).catch(() => {})
   }

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -1,0 +1,175 @@
+/**
+ * Telegram's **elicitation-card facet** (§7.3) — the second implementer of
+ * {@link ElicitCardFacet}, and the reason the member exists rather than being guessed from Slack.
+ *
+ * WHAT TELEGRAM ACTUALLY HAS is one control: an inline keyboard of tappable buttons, each echoing
+ * a ≤64-BYTE `callback_data` back as a `callback_query`. It has no multi-select, no text box and
+ * no number box in a message — a Bot API keyboard is buttons and nothing else — so `reduction`
+ * below claims exactly the two kinds one TAP can answer, and every other kind is declined with
+ * the notice #1819/#1839 already post rather than half-rendered into a control that cannot
+ * submit. That is the same line {@link SLACK_DM_ELICIT_SURFACE} draws, for the same reason.
+ *
+ * URL MODE IS DECLINED TOO, and not for want of a link button. An inline `url` button opens the
+ * page but fires no `callback_query`, so the daemon would never learn the reader consented — and
+ * consent is the whole of what that seam decides, since the ACP request resolves AT consent
+ * (#1810). A callback button that merely pastes the URL is not a consent control, it is a link;
+ * declining is the honest answer.
+ *
+ * THE WIRE ENCODING LIVES HERE with the buttons that carry it, as `command-chrome.ts` already
+ * requires of this platform. It is `ac_el:<requestId>:<token>`, where the token is the option's
+ * POSITION (#1844's `ac_o<n>`) or `x` for Dismiss — reused rather than re-derived, because a
+ * position is exactly what a capped wire field can carry and 64 bytes is a hard cap: an enum of
+ * paths or ids would not fit its own values. Resolution is core's, against the card's own
+ * re-derived form (#1815), so the position names the very option that was offered.
+ *
+ * THE REWRITE is `editMessageText` with no keyboard, which strips the buttons (verified live
+ * 2026-09-08 against the Bot API: an edit omitting `reply_markup`, and one sending an empty
+ * `inline_keyboard`, both return a message with no markup).
+ */
+import type {
+  ElicitCardAsk,
+  ElicitCardDraft,
+  ElicitCardFacet,
+  ElicitCardHandle,
+  ElicitCardHost,
+  ElicitCardMark,
+  ElicitCardSettlement,
+  ElicitCardTurn
+} from '../elicit-card.js'
+import type { InlineButton, TelegramConnection } from '../../telegram/connection.js'
+import { TELEGRAM_MESSAGE_LIMIT } from '../../telegram/render.js'
+import { clampTo, elicitCardShape, elicitOptionToken, type ElicitKind, type ElicitSurface } from '../../slack/render.js'
+
+/**
+ * The most options one Telegram elicitation keyboard offers.
+ *
+ * Telegram publishes no button-count cap: what it refuses is an over-large `reply_markup` as a
+ * whole (`Bad Request: reply markup is too long`), so a COUNT can never bound it on its own and
+ * `optionLimits` is a count. Measured against the live Bot API on 2026-09-08, the smallest card
+ * refused was 60 buttons whose labels were the full 75 characters a reduced option label can
+ * reach; 24 such buttons plus Dismiss serialized to 5.7 KB and was accepted, as were 40 buttons
+ * of 75 four-byte characters each (9.1 KB). 24 is therefore Slack's own button cap re-derived
+ * from Telegram's own refusals, with better than 2x headroom on the worst list this reduction can
+ * produce — and a longer list is declined whole, never trimmed to fit.
+ */
+const TELEGRAM_ELICIT_MAX_BUTTONS = 24
+
+/** Telegram's own cap on one button's `callback_data`, in BYTES of UTF-8 — verified live
+ *  2026-09-08: 64 bytes is accepted, 65 is `BUTTON_DATA_INVALID`, and 32 two-byte characters
+ *  (64 bytes) are accepted where 64 of them (128 bytes) are not. */
+const TELEGRAM_CALLBACK_DATA_CAP = 64
+
+const TELEGRAM_ELICIT_PREFIX = 'ac_el'
+
+/** The token a Dismiss button carries. Not a position, because Dismiss answers no option. */
+const TELEGRAM_ELICIT_DISMISS = 'x'
+
+/** How much of the question one card carries, leaving the whole settlement line room inside
+ *  Telegram's message limit — a rewrite must never be refused for length after the ask fit. */
+const TELEGRAM_ELICIT_MESSAGE_CAP = TELEGRAM_MESSAGE_LIMIT - 300
+
+/** How Telegram spells each settlement mark. Literal emoji: a Telegram message has no shortcode
+ *  vocabulary, so Slack's `:white_check_mark:` would reach the reader as its own source text. */
+const TELEGRAM_ELICIT_MARK: Record<ElicitCardMark, string> = {
+  answered: '✅',
+  dismissed: '🚫',
+  waiting: '⏳',
+  blocked: '🔒'
+}
+
+/**
+ * What a Telegram elicitation card can render AND collect: the two kinds one TAP answers, and no
+ * more. A keyboard button submits the instant it is tapped, so a kind needing something filled in
+ * first could be shown but never confirmed — the same verdict, and the same reasoning, as the
+ * approval DM's surface.
+ */
+export const TELEGRAM_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean']),
+  optionLimits: { enum: { maxOptions: TELEGRAM_ELICIT_MAX_BUTTONS } }
+}
+
+/** One button's `callback_data`: the request and the option's position. Pure. */
+export function telegramElicitData(requestId: string, token: string): string {
+  return `${TELEGRAM_ELICIT_PREFIX}:${requestId}:${token}`
+}
+
+/** Whether every button of this card fits Telegram's 64-byte `callback_data`. Checked at build
+ *  time so a longer request id could never mint a card the API silently refuses whole; the widest
+ *  data a card mints is its LAST option's, so that one answers for all of them. Pure. */
+export function telegramElicitDataFits(requestId: string, options: number): boolean {
+  const widest = telegramElicitData(requestId, elicitOptionToken(Math.max(0, options - 1)))
+  return Buffer.byteLength(widest, 'utf8') <= TELEGRAM_CALLBACK_DATA_CAP
+}
+
+/** Decode a tapped elicitation button: the request, and the position tapped (null for Dismiss,
+ *  which settles the card as a decline). Null for callback data this scheme did not mint — a
+ *  session-control tap (`m:2`) and a stray one alike. Pure. */
+export function parseTelegramElicit(data: string): { requestId: string; token: string | null } | null {
+  const m = /^ac_el:([0-9a-fA-F-]{1,64}):([A-Za-z0-9_]{1,16})$/.exec(data)
+  if (!m) return null
+  const token = m[2] as string
+  return { requestId: m[1] as string, token: token === TELEGRAM_ELICIT_DISMISS ? null : token }
+}
+
+/** The card's own text: the question, on the same speech-balloon line every surface opens with.
+ *  Plain text — the card is posted with no `parse_mode`, so there is no markup to defuse and
+ *  nothing the agent can write that becomes a link or a label. Pure. */
+export function telegramElicitText(message: string): string {
+  return `💬 ${clampTo(message, TELEGRAM_ELICIT_MESSAGE_CAP)}`
+}
+
+/** One tappable button per option, plus Dismiss — one per row, so a long label is readable
+ *  rather than squeezed. Each carries its option's POSITION. Pure. */
+export function telegramElicitButtons(requestId: string, options: readonly { label: string }[]): InlineButton[][] {
+  const rows = options.map((o, i) => [
+    { text: o.label, callbackData: telegramElicitData(requestId, elicitOptionToken(i)) }
+  ])
+  rows.push([{ text: 'Dismiss', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_DISMISS) }])
+  return rows
+}
+
+/** Telegram's per-turn elicitation draft: the message and the keyboard under it. */
+interface TelegramElicitDraft {
+  text: string
+  buttons: InlineButton[][]
+}
+
+export const telegramElicitCards: ElicitCardFacet = {
+  platform: 'telegram',
+  reduction: TELEGRAM_ELICIT_SURFACE,
+
+  build(_host: ElicitCardHost, _turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null {
+    // No consent control, and no control for anything that has to be filled in first.
+    if (ask.url || !ask.form?.length) return null
+    if (elicitCardShape(ask.form) !== 'buttons') return null
+    const target = ask.form[0]!
+    if (!target.options.length || !telegramElicitDataFits(ask.requestId, target.options.length)) return null
+    const draft: TelegramElicitDraft = {
+      text: telegramElicitText(ask.message),
+      buttons: telegramElicitButtons(ask.requestId, target.options)
+    }
+    return draft
+  },
+
+  async send(
+    host: ElicitCardHost,
+    turn: ElicitCardTurn,
+    _ask: ElicitCardAsk,
+    draft: ElicitCardDraft
+  ): Promise<string | undefined> {
+    const d = draft as TelegramElicitDraft
+    return await host.postCardSerialized(turn, (conn) =>
+      (conn as TelegramConnection).postCard(turn.plan.channel, d.text, d.buttons, { threadTs: turn.plan.thread })
+    )
+  },
+
+  settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void {
+    if (handle.ts === undefined) return
+    const messageId = Number(handle.ts)
+    if (!Number.isInteger(messageId)) return
+    const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+    const text = `${telegramElicitText(message)}\n${TELEGRAM_ELICIT_MARK[card.mark]} ${card.text}`
+    // An empty keyboard is what drops the buttons; the answered card stays readable in the chat.
+    void (handle.conn as TelegramConnection).editCard(handle.channel, messageId, text, []).catch(() => {})
+  }
+}

--- a/packages/daemon/src/platforms/turn-chrome.ts
+++ b/packages/daemon/src/platforms/turn-chrome.ts
@@ -35,8 +35,11 @@ export interface TurnChrome {
    *  thread panel's header in DMs AND channels — a thread becomes eligible once any
    *  agents.sessions call or a card stream registers it (verified live 2026-08-29). */
   readonly sessionTitle?: boolean
-  /** In-chat human-input cards: permission approvals, MCP-approval
-   *  elicitations, and the generic elicitation card. */
+  /** In-chat PERMISSION-approval cards: `session/request_permission` and the MCP-approval
+   *  elicitation Codex maps onto `elicitation/create`. Narrowed to that half by #1794's gap 6 —
+   *  the GENERIC elicitation card is now a Layer-2 facet (`TurnOutputSurface.elicitCards`), which
+   *  declares the kinds a surface can collect rather than one boolean for "has cards". Approval
+   *  still has a single implementer, so it keeps the flag until a second one shapes its member. */
   readonly chatInputCards?: boolean
   /** Failure notices are posted with a chrome marker (and agent identity) so a
    *  peer daemon's thread backfill skips them. */

--- a/packages/daemon/src/platforms/turn-output.ts
+++ b/packages/daemon/src/platforms/turn-output.ts
@@ -34,6 +34,8 @@
  * design leaves them (§12 — webchat is core end to end).
  */
 
+import type { ElicitCardFacet } from './elicit-card.js'
+
 /** A turn's INPUTS, as a platform sees them. Deliberately limited to the
  *  triggering event and the two rendering switches: a surface may read what its
  *  own platform delivered, never core turn machinery — that limit is what keeps
@@ -77,6 +79,12 @@ export interface TurnOutputContext<TMessage> {
 export interface TurnOutputSurface<TTurn, TAction, TConv, TMessage> {
   /** Diagnostic label; never parsed. */
   readonly platform: string
+  /** How this surface COLLECTS an elicitation answer — the in-chat card, its reduction, and the
+   *  rewrite that settles it. Absent ⇒ the surface has no such control and the ask is declined
+   *  with a notice. Reached via {@link TurnOutputRegistry.exact}, like {@link onSuppress}: a
+   *  webchat / hook / dream turn renders through the core surface but must not inherit its
+   *  platform's cards. */
+  readonly elicitCards?: ElicitCardFacet
   /** Build this turn's converger. A fresh one per turn, so a config change
    *  applies from the next turn rather than mid-stream. */
   createConverger(ctx: TurnOutputContext<TMessage>): TConv

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -93,6 +93,8 @@ async function world(over?: {
     memoryExtractionInFlight: () => false,
     enqueueApply: vi.fn(),
     postCardSerialized: vi.fn(async () => undefined),
+    // The approval DM is its own surface; no in-channel elicitation card is posted from here.
+    elicitCardFacet: () => undefined,
     httpSlackSessionTarget: () => undefined,
     maskAgentSecrets: (_agentId, payload) => payload,
     logSessionAction: vi.fn(),

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -14,6 +14,7 @@ import { Daemon } from '../src/daemon.js'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 import { elicitOptionToken } from '../src/slack/render.js'
+import { slackElicitCards } from '../src/platforms/slack/elicit-card.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { WAIT } from './wait-support.js'
 
@@ -1970,7 +1971,9 @@ describe('Slack interactive status bar', () => {
       propName: 'language',
       kind: 'enum',
       approval: false,
-      surface: 'slack',
+      // #1794 gap 6: the record names no platform — the Layer-2 facet that posted the card does.
+      surface: 'chat',
+      facet: slackElicitCards,
       conn: { updateBlocks, workspaceId: () => 'T1' },
       channel: 'C1',
       ts: 'card-2',
@@ -2019,7 +2022,9 @@ describe('Slack interactive status bar', () => {
         }
       ],
       approval: false,
-      surface: 'slack',
+      // #1794 gap 6: the record names no platform — the Layer-2 facet that posted the card does.
+      surface: 'chat',
+      facet: slackElicitCards,
       conn: { updateBlocks, workspaceId: () => 'T1' },
       channel: 'C1',
       ts: 'card-3',

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -96,6 +96,16 @@ describe('noneSuppressedApprovalSurface — Slack `none` live turns only', () =>
     }
   })
 
+  // #1794 gap 6: a platform with a Layer-2 elicitation-card facet has an in-chat card `none`
+  // takes away too, so the fact is passed in rather than read off Slack's permission chrome.
+  it('is true for a `none` turn on any platform whose surface has an elicitation card', () => {
+    expect(noneSuppressedApprovalSurface('none', { platform: 'telegram' }, true)).toBe(true)
+    expect(noneSuppressedApprovalSurface('none', { platform: 'telegram' }, false)).toBe(false)
+    // Still not a live IM turn, whatever the surface offers.
+    expect(noneSuppressedApprovalSurface('none', { platform: 'telegram', headless: true }, true)).toBe(false)
+    expect(noneSuppressedApprovalSurface('minimal', { platform: 'telegram' }, true)).toBe(false)
+  })
+
   it('is false for every other output mode (delivery-only, no execution change)', () => {
     for (const mode of ['minimal', 'low', 'medium', 'high']) {
       expect(noneSuppressedApprovalSurface(mode, { platform: 'slack' })).toBe(false)

--- a/packages/daemon/test/platform-registry-drift.test.ts
+++ b/packages/daemon/test/platform-registry-drift.test.ts
@@ -68,6 +68,20 @@ describe('daemon platform registry (audit F16)', () => {
     ].map((pool: { name: string }) => pool.name.split('/')[0]!)
     expect(sorted([...new Set(poolPlatforms)])).toEqual(composed)
   })
+
+  it('pins which surfaces declare an elicitation card, and lets no other origin inherit one', () => {
+    // #1794 gap 6: the facet is OPTIONAL, so this is not a drift check against `platformIds()` —
+    // it is the pin on today's true set. Discord and Feishu are the third and fourth implementers
+    // and get their own changes; adding one must fail here first.
+    const daemon = new Daemon({ root: bareRoot() }) as any
+    const withCards = platformIds().filter((id: string) => daemon.turnSurfaces.exact(id)?.elicitCards)
+    expect(withCards).toEqual(['slack', 'telegram'])
+    // Exact lookup, so a webchat / hook / dream turn rendering through the core (Slack) surface
+    // does not inherit Slack's cards — webchat's own card is core-owned.
+    for (const origin of ['webchat', 'hook', 'dream']) {
+      expect(daemon.turnSurfaces.exact(origin)).toBeUndefined()
+    }
+  })
 })
 
 describe('observed-membership platforms (audit F17)', () => {

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Telegram's elicitation card — the second implementer of the Layer-2 elicitation-card facet
+ * (issue #1794, gap 6). An inline keyboard is the only control Telegram has, so the two kinds one
+ * TAP answers are offered and every other kind is declined with the notice #1819/#1839 post.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { Daemon } from '../src/daemon.js'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { TelegramConnection, type InlineButton } from '../src/telegram/connection.js'
+import { elicitForm, elicitOptionToken, elicitTarget } from '../src/slack/render.js'
+import {
+  TELEGRAM_ELICIT_SURFACE,
+  parseTelegramElicit,
+  telegramElicitButtons,
+  telegramElicitData,
+  telegramElicitDataFits,
+  telegramElicitCards
+} from '../src/platforms/telegram/elicit-card.js'
+
+const REQUEST_ID = '11111111-2222-4333-8444-555555555555'
+
+function form(properties: Record<string, unknown>, required: string[] = []): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'form',
+    message: 'Which branch should I cut from?',
+    requestedSchema: { type: 'object', properties, required }
+  } as CreateElicitationRequest
+}
+
+const BRANCH = { branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' } }
+
+describe("the wire a Telegram tap comes back on — 64 bytes, so it carries the option's position", () => {
+  it("fits Telegram's own callback_data cap for the widest card this scheme can mint", () => {
+    // Verified live against the Bot API: 64 bytes is accepted and 65 is BUTTON_DATA_INVALID.
+    expect(Buffer.byteLength(telegramElicitData(REQUEST_ID, elicitOptionToken(23)), 'utf8')).toBeLessThanOrEqual(64)
+    expect(telegramElicitDataFits(REQUEST_ID, 24)).toBe(true)
+    // A request id long enough to blow the cap costs the card, rather than minting buttons the
+    // API would refuse the whole message for.
+    expect(telegramElicitDataFits('x'.repeat(120), 2)).toBe(false)
+  })
+
+  it('round-trips a position, reads Dismiss as no answer, and ignores every other scheme', () => {
+    expect(parseTelegramElicit(telegramElicitData(REQUEST_ID, elicitOptionToken(3)))).toEqual({
+      requestId: REQUEST_ID,
+      token: elicitOptionToken(3)
+    })
+    expect(parseTelegramElicit(telegramElicitData(REQUEST_ID, 'x'))).toEqual({ requestId: REQUEST_ID, token: null })
+    // The session-control cards' own scheme, which this decoder must never claim.
+    expect(parseTelegramElicit('m:2')).toBeNull()
+    expect(parseTelegramElicit('ac_el:only-two-parts')).toBeNull()
+    expect(parseTelegramElicit('')).toBeNull()
+  })
+
+  it('carries one button per option plus Dismiss, each holding a POSITION and never a value', () => {
+    const rows = telegramElicitButtons(REQUEST_ID, [{ label: 'main' }, { label: 'develop' }])
+    expect(rows.map((r) => (r[0] as InlineButton).text)).toEqual(['main', 'develop', 'Dismiss'])
+    expect(rows.map((r) => (r[0] as InlineButton).callbackData)).toEqual([
+      telegramElicitData(REQUEST_ID, elicitOptionToken(0)),
+      telegramElicitData(REQUEST_ID, elicitOptionToken(1)),
+      telegramElicitData(REQUEST_ID, 'x')
+    ])
+  })
+})
+
+describe('what Telegram declares it can collect, and what it declines', () => {
+  it('claims exactly the two kinds one tap answers', () => {
+    expect([...TELEGRAM_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum'])
+  })
+
+  it('reduces an enum and a boolean, and nothing that has to be filled in first', () => {
+    expect(elicitTarget(form(BRANCH), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('enum')
+    expect(elicitTarget(form({ ok: { type: 'boolean' } }), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('boolean')
+    for (const prop of [
+      { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } },
+      { note: { type: 'string' } },
+      { count: { type: 'integer' } }
+    ])
+      expect(elicitForm(form(prop, Object.keys(prop)), TELEGRAM_ELICIT_SURFACE)).toBeNull()
+  })
+
+  it('declines an option list past what one keyboard holds, rather than showing part of it', () => {
+    const many = (n: number) => ({ pick: { type: 'string', enum: Array.from({ length: n }, (_, i) => `o${i}`) } })
+    expect(elicitForm(form(many(24)), TELEGRAM_ELICIT_SURFACE)).not.toBeNull()
+    expect(elicitForm(form(many(25)), TELEGRAM_ELICIT_SURFACE)).toBeNull()
+  })
+
+  it('builds nothing for a URL consent, a multi-field form, or an optionless field', () => {
+    const host = { postCardSerialized: async () => undefined, sessionTarget: () => undefined }
+    const turn = { plan: { platform: 'telegram', channel: '-100', statusThread: 'T', agentName: 'a' } }
+    const ask = { requestId: REQUEST_ID, params: form(BRANCH), message: 'q', fallback: 'q' }
+    // URL mode: an inline `url` button fires no callback_query, so a consent could never be recorded.
+    expect(
+      telegramElicitCards.build(host, turn, { ...ask, url: { elicitationId: 'e1', url: 'https://x.example' } })
+    ).toBeNull()
+    expect(telegramElicitCards.build(host, turn, ask)).toBeNull()
+    const two = form({ ...BRANCH, also: { type: 'string', enum: ['a', 'b'] } })
+    expect(
+      telegramElicitCards.build(host, turn, {
+        ...ask,
+        params: two,
+        form: elicitForm(two, TELEGRAM_ELICIT_SURFACE) ?? undefined
+      })
+    ).toBeNull()
+  })
+})
+
+// ── the coordinator, on a Telegram turn ──────────────────────────────────────────────────────
+
+interface Harness {
+  daemon: any
+  conn: any
+  cards: { text: string; buttons: InlineButton[][] }[]
+  edits: { text: string; buttons: InlineButton[][] }[]
+  acked: string[]
+  notices: () => string[]
+}
+
+function telegramTurn(): Harness {
+  const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+  daemon.store = {
+    getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: () => new Map(),
+    upsertElicit: vi.fn(async () => {})
+  }
+  const cards: { text: string; buttons: InlineButton[][] }[] = []
+  const edits: { text: string; buttons: InlineButton[][] }[] = []
+  const acked: string[] = []
+  const conn = Object.create(TelegramConnection.prototype)
+  conn.postCard = async (_c: string, text: string, buttons: InlineButton[][]) => {
+    cards.push({ text, buttons })
+    return '4242'
+  }
+  conn.editCard = async (_c: string, _id: number, text: string, buttons: InlineButton[][]) => {
+    edits.push({ text, buttons })
+  }
+  conn.answerCallback = async (id: string) => void acked.push(id)
+  daemon.pending.set(JSON.stringify(['agent-1', 's1']), {
+    plan: {
+      platform: 'telegram',
+      agentId: 'agent-1',
+      sessionKey: 'k1',
+      requesterId: 'turn-user',
+      channel: '-100',
+      transcriptChannel: '-100',
+      statusThread: 'T1',
+      agentName: 'agent',
+      isDm: false,
+      approvalSurfaceSuppressed: false
+    },
+    hostKey: 'agent-1',
+    outwardSessionId: 'sess-1',
+    conn,
+    chrome: {},
+    reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
+    signals: { applyChain: Promise.resolve() },
+    approval: { waitMs: 0, depth: 0 },
+    builtinSystemToolCallIds: new Set<string>(),
+    conv: { onUpdate: () => [], hasBuffered: () => false },
+    rec: { onUpdate: () => [] },
+    termOut: new TerminalOutputFolder()
+  })
+  const applied: any[] = []
+  daemon.enqueueApply = (_p: any, action: any) => void applied.push(action)
+  return {
+    daemon,
+    conn,
+    cards,
+    edits,
+    acked,
+    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+  }
+}
+
+async function raise(h: Harness, req: CreateElicitationRequest): Promise<{ requestId: string; result: Promise<any> }> {
+  const result = h.daemon.permissions.onAcpElicit('agent-1', 's1', req)
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.size).toBe(1))
+  const requestId = [...h.daemon.permissions.pendingElicits.keys()][0] as string
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.get(requestId).ts).toBe('4242'))
+  return { requestId, result }
+}
+
+describe('a Telegram turn posts an elicitation card and settles it in place', () => {
+  it('posts the question with one button per option, and accepts the tapped position', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    expect(h.notices()).toEqual([])
+    expect(h.cards).toHaveLength(1)
+    expect(h.cards[0]!.text).toBe('💬 Which branch should I cut from?')
+    expect(h.cards[0]!.buttons.map((r) => r[0]!.text)).toEqual(['main', 'develop', 'Dismiss'])
+
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: elicitOptionToken(1) })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop' } })
+    // The rewrite drops the keyboard and marks the answer with Telegram's own emoji, never a
+    // Slack shortcode — a `:white_check_mark:` would reach the reader as its own source text.
+    expect(h.edits).toHaveLength(1)
+    expect(h.edits[0]!.text).toBe('💬 Which branch should I cut from?\n✅ develop')
+    expect(h.edits[0]!.buttons).toEqual([])
+  })
+
+  it("reads Dismiss as the spec's decline, and settles the card as dismissed", async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: null })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(h.edits[0]!.text).toContain('🚫 Dismissed')
+  })
+
+  it('refuses a position no option on the card held, and leaves the card live', async () => {
+    const h = telegramTurn()
+    const { requestId } = await raise(h, form(BRANCH, ['branch']))
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: elicitOptionToken(9) })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.edits).toEqual([])
+    expect(h.notices()).toEqual(["That answer wasn't accepted — the question is still open."])
+  })
+
+  it('routes a tapped button through the callback the connection reports, and acks it', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    await h.daemon.handleTelegramCallback(
+      {
+        id: 'cb-1',
+        data: telegramElicitData(requestId, elicitOptionToken(0)),
+        channel: '-100',
+        messageId: 4242,
+        userId: '77'
+      },
+      h.conn
+    )
+    expect(h.acked).toEqual(['cb-1'])
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('declines a kind Telegram has no control for, and says so in the chat', async () => {
+    const h = telegramTurn()
+    const req = form({ checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } }, ['checks'])
+    await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
+    expect(h.cards).toEqual([])
+    expect(h.notices()[0]).toContain("this chat can't collect an answer for")
+  })
+
+  it('cancels an abandoned card and says so on the card itself', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    await h.daemon.permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+    expect(h.edits[0]!.text).toContain('⏳ Cancelled')
+    expect(h.daemon.permissions.pendingElicits.has(requestId)).toBe(false)
+  })
+})

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -88,7 +88,7 @@ describe('what Telegram declares it can collect, and what it declines', () => {
   })
 
   it('builds nothing for a URL consent, a multi-field form, or an optionless field', () => {
-    const host = { postCardSerialized: async () => undefined, sessionTarget: () => undefined }
+    const host = { postCardSerialized: async () => undefined, sessionTarget: () => undefined, turnState: () => ({}) }
     const turn = { plan: { platform: 'telegram', channel: '-100', statusThread: 'T', agentName: 'a' } }
     const ask = { requestId: REQUEST_ID, params: form(BRANCH), message: 'q', fallback: 'q' }
     // URL mode: an inline `url` button fires no callback_query, so a consent could never be recorded.
@@ -112,25 +112,32 @@ describe('what Telegram declares it can collect, and what it declines', () => {
 interface Harness {
   daemon: any
   conn: any
-  cards: { text: string; buttons: InlineButton[][] }[]
+  cards: { text: string; buttons: InlineButton[][]; opts: { threadTs?: string; replyTo?: number } }[]
   edits: { text: string; buttons: InlineButton[][] }[]
   acked: string[]
   notices: () => string[]
 }
 
-function telegramTurn(): Harness {
+/** @param turn the turn's THREAD coordinate and its Telegram reply anchor — a plain supergroup
+ *   session is `tg:<root>` (non-numeric, so it is no forum topic) and anchors by `replyTo`. */
+function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness {
   const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
   daemon.store = {
     getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
     getDisplayNames: () => new Map(),
     upsertElicit: vi.fn(async () => {})
   }
-  const cards: { text: string; buttons: InlineButton[][] }[] = []
+  const cards: { text: string; buttons: InlineButton[][]; opts: { threadTs?: string; replyTo?: number } }[] = []
   const edits: { text: string; buttons: InlineButton[][] }[] = []
   const acked: string[] = []
   const conn = Object.create(TelegramConnection.prototype)
-  conn.postCard = async (_c: string, text: string, buttons: InlineButton[][]) => {
-    cards.push({ text, buttons })
+  conn.postCard = async (
+    _c: string,
+    text: string,
+    buttons: InlineButton[][],
+    opts: { threadTs?: string; replyTo?: number } = {}
+  ) => {
+    cards.push({ text, buttons, opts })
     return '4242'
   }
   conn.editCard = async (_c: string, _id: number, text: string, buttons: InlineButton[][]) => {
@@ -148,11 +155,14 @@ function telegramTurn(): Harness {
       statusThread: 'T1',
       agentName: 'agent',
       isDm: false,
-      approvalSurfaceSuppressed: false
+      approvalSurfaceSuppressed: false,
+      ...(turn.thread !== undefined ? { thread: turn.thread } : {})
     },
     hostKey: 'agent-1',
     outwardSessionId: 'sess-1',
     conn,
+    // §7.3's opaque per-turn slot, seeded exactly as `initialTurnState` seeds it.
+    turnState: { ...(turn.replyTo !== undefined ? { replyTo: turn.replyTo } : {}) },
     chrome: {},
     reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
     signals: { applyChain: Promise.resolve() },
@@ -240,6 +250,57 @@ describe('a Telegram turn posts an elicitation card and settles it in place', ()
     await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
     expect(h.cards).toEqual([])
     expect(h.notices()[0]).toContain("this chat can't collect an answer for")
+  })
+
+  // review-bot P2 on #1853. `postCard` only turns a NUMERIC thread into `message_thread_id`, so
+  // off a forum `threadTs` anchors nothing: a `tg:<root>` supergroup card would land at the chat
+  // root, and a reader replying to it would root a FRESH reply chain on the card rather than
+  // continue this session — which the card's transcript row cannot repair, since its ts is
+  // synthetic. The anchor is the turn's own state slot, the one `applyTelegramAction` reads.
+  it('anchors the card to the turn on a non-forum session, where the thread is no anchor', async () => {
+    const h = telegramTurn({ thread: 'tg:100', replyTo: 100 })
+    await raise(h, form(BRANCH, ['branch']))
+    expect(h.cards[0]!.opts.replyTo).toBe(100)
+    expect(h.cards[0]!.opts.threadTs).toBe('tg:100')
+  })
+
+  it('still posts a forum-topic card into its topic, which IS an anchor', async () => {
+    const h = telegramTurn({ thread: '77', replyTo: 512 })
+    await raise(h, form(BRANCH, ['branch']))
+    expect(h.cards[0]!.opts.threadTs).toBe('77')
+    expect(h.cards[0]!.opts.replyTo).toBe(512)
+  })
+
+  // review-bot P2 on #1853. The question reserve only holds while the DECISION is bounded too,
+  // and core's is not: a scalar's decision is `String(answer)`, and an enum option's value can be
+  // a long URL. The edit runs AFTER ACP accepted and the pending record went, so a rewrite refused
+  // for length can never be retried — the card would keep offering buttons that answer nothing.
+  it('keeps a settlement inside the message limit when the answer is a long value', async () => {
+    const h = telegramTurn()
+    // The reviewer's own numbers: a question long enough to hit the reserve (so the card is the
+    // full 3,799) plus a 621-character option value, which used to assemble to 4,423.
+    const url = `https://auth.example.com/callback?${'q'.repeat(587)}`
+    expect(url).toHaveLength(621)
+    const req = form(
+      {
+        pick: { type: 'string', oneOf: [{ const: url, title: 'Choose URL' }], title: 'Destination' }
+      },
+      ['pick']
+    )
+    ;(req as { message?: string }).message = 'Q'.repeat(4000)
+    const { requestId, result } = await raise(h, req)
+    // The ask itself already fits: the question is clamped with the settlement line reserved.
+    expect(h.cards[0]!.text.length).toBeLessThanOrEqual(4096)
+
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: elicitOptionToken(0) })
+    // What the AGENT receives is the WHOLE value — #1844's rule: the reader's view is clamped,
+    // the accepted content never is.
+    await expect(result).resolves.toEqual({ action: 'accept', content: { pick: url } })
+    expect(h.edits).toHaveLength(1)
+    expect(h.edits[0]!.text.length).toBeLessThanOrEqual(4096)
+    // And the verdict SURVIVES the clamp — a settlement whose mark got cut off would be a card
+    // that still reads as open, which is the failure this guards against.
+    expect(h.edits[0]!.text).toContain('✅')
   })
 
   it('cancels an abandoned card and says so on the card itself', async () => {


### PR DESCRIPTION
Closes **gap 6** of #1794 and adds **Telegram**, in one change, because CLAUDE.md says that is when a seam member may be extracted:

> Each member was extracted in the change that added its second implementer; extracting from one implementer would have been guessing at an interface.

`onAcpElicit` still gated on `!(conn instanceof SlackConnection)` — a platform name in core, which the same section forbids. Webchat escaped that gate by being a core-owned surface branched before it, not by the seam being right, and Telegram, Discord and Feishu rendered nothing at all.

## The member

`ElicitCardFacet`, registered as `TurnOutputSurface.elicitCards` — the facet that already owns renderers and strategy functions, not a new parallel registry.

```ts
readonly platform: string
readonly reduction: ElicitSurface
build(host, turn, ask): ElicitCardDraft | null
send(host, turn, ask, draft): Promise<string | undefined>
settle(handle, card: ElicitCardSettlement): void
answerScope?(handle): string | undefined
```

**Build is separate from send on purpose.** An ask no control exists for must be declined *before* the request is recorded open (notice plus the `unrenderable` transcript row); a card the platform refused to *take* was opened and then cancelled. One method returning `undefined` for both cannot tell those apart, and the existing Slack behaviour depends on the distinction.

**The handle is `{ conn, channel, ts? }`.** Slack's `ts` and Telegram's `message_id` are one fact in two dialects, so core holds the posted-card coordinates without knowing which platform minted them — the record's own fields *are* the handle. `ts` absent still means "the post is in flight", so #1844's mid-post race fix is untouched.

**The settlement is no longer a Slack string.** `ElicitCardSettlement` carries a `mark` (`answered` / `dismissed` / `waiting` / `blocked`) plus the words beside it; Slack spells the mark `:white_check_mark:`, Telegram `✅`, and Telegram's rewrite is `editMessageText` with an empty keyboard. `fallback` is optional, so Slack's `text` field stays byte-identical.

Core kept everything that is not platform-shaped: the pending record, the mid-post race, approval bookkeeping, every re-derivation. **The three Slack await paths collapsed into one `awaitChatElicitation`**, so the coordinator net *shrinks* by ~130 lines.

## One capability declaration, not two

`reduction: ElicitSurface` — the same `kinds` + `optionLimits` the reduction already reads. Render capability and reduction capability are the same question ("can this surface collect an answer of kind X"), and two declarations could only ever disagree; the disagreement is a card posted dead, or an ask declined for nothing.

## `chatInputCards` survives, narrowed

It did not disappear — it **split**. The generic elicitation card is now the facet; `chatInputCards` keeps only the **permission-approval** half (`session/request_permission`, and the MCP approval Codex maps onto `elicitation/create`). Those two sites still read `instanceof SlackConnection`, **deliberately**: approval has exactly one implementer, so extracting its member would be the guessing the rule forbids. Its doc now says so.

One consequence had to be fixed rather than left: `noneSuppressedApprovalSurface`'s comment said *"Telegram/Discord/Feishu have no card surface, so `none` removes nothing there."* Once Telegram has one, that is false. The fact is a parameter now, fed from the registry, so a `none`-mode Telegram turn suppresses its card exactly as Slack's does.

## Telegram needed no protocol change

`RdSlackAction` exists because Slack ingress can be relay-forwarded. The relay's platform registry is `slack`, `feishu`, `linear` — Telegram has no relay ingress plugin; it is a daemon-owned grammY long poll, so its `callback_query` never crosses the relay↔daemon or daemon↔CP wire. **Zero protocol changes**, so no skew in either direction.

Its codec lives with its buttons: `ac_el:<requestId>:<ac_o<n> | x>`, 49 bytes for a v4 uuid, reusing #1844's positional tokens rather than re-deriving the idea. Disjoint by prefix from the select cards' vocabulary.

| kind | Telegram |
| --- | --- |
| `enum` | one button per option, plus Dismiss |
| `boolean` | Yes / No, plus Dismiss |
| `multi-enum`, `text`, `number`, a form, a question with an "Other" box | **declined** — no control exists, and nothing to fill in before submitting |
| URL mode | **declined**, and not for want of a link button |

URL mode is worth its own line: an inline `url` button opens the page but fires **no `callback_query`**, so the daemon would never learn the reader consented — and consent is the whole of what that seam decides, because the ACP request resolves *at* consent (#1810). A button that merely opens a link is a link, not a consent control. Every decline posts the existing notice and records the durable `unrenderable` row.

## Telegram's limits, verified against the live API

The Slack half of this series was corrected twice by posting real payloads instead of trusting the docs, so the same was done here (live bot, real group):

| sent | came back |
| --- | --- |
| `callback_data` 64 ASCII bytes | `ok: true` |
| `callback_data` 65 ASCII bytes | `400 BUTTON_DATA_INVALID` |
| 32 × 2-byte chars (64 B) | `ok: true` |
| 64 × 2-byte chars (128 B) | `400 BUTTON_DATA_INVALID` |

So the cap is **64 bytes of UTF-8, not characters**.

**The button-count finding contradicts the obvious model, and is the reason `maxOptions` is 24 rather than something larger.** Telegram documents no button cap; what it refuses is an over-large `reply_markup` *as a whole* (`400 reply markup is too long`), and it is neither cleanly a count nor a size:

- 99 buttons labelled `Option 0…98`, distinct data → **refused**, 3/3
- 105 buttons labelled `o0…o104`, distinct data → **accepted**
- 100 buttons with *identical* `callback_data` → **accepted** (identical strings dedupe internally, which is what made the first probe rounds look non-deterministic)
- 60 buttons with distinct 75-character ASCII labels → **refused**

A count cannot bound that on its own, and `optionLimits` is a count — so 24 was derived from the refusals, not copied from Slack: the worst list this reduction can produce (75-char labels, 49-byte data) serialised to 5.7 KB and was accepted, against a smallest observed refusal near 9 KB. Better than 2× headroom on both axes. `telegramElicitDataFits()` re-checks the byte budget at build time, so a future longer request id costs the card rather than silently minting a message the API refuses whole.

The **actual draft the facet builds** was then posted through the real module: `POST {"ok":true,"message_id":266}`, and `editMessageText` with no `reply_markup` strips the keyboard.

## Findings

1. **`PendingElicit.sessionTarget` was write-only** — set, never read (the target rides in the blocks, not the record). Dropped; it lives inside Slack's `build` now.
2. **One Slack test fixture changed spelling, not meaning.** Two hand-injected records carried `surface: 'slack'` and now carry `surface: 'chat', facet: slackElicitCards`. What the test asserts is unchanged; the record simply no longer names a platform, which is the point. Every other Slack elicitation suite is untouched in substance and green, and `slackCardViolations()` still passes for every Slack card.
3. **`postLiveChromeBoundarySerialized`'s comment claimed "Slack-only"** — its re-anchor resets fields Telegram's applier *does* read, so that behaviour is correct rather than a leak. The parameter is `unknown` now, the pattern `applyTelegramAction` already established.
4. **`ElicitCardHost.sessionTarget` is a neutral port over a Slack-named implementation.** Telegram ignores the value; worth a second look when a third relay-ingress platform arrives.

## Verification

- `pnpm typecheck`: `error TS` count **0**. protocol 490, relay 652 — green.
- Elicitation and Telegram suites (`telegram-elicit-card`, `slack-elicit-form`, `daemon-permission-autoallow`, `render`, `daemon-commands`, `elicit-decline-notice`, `approval-dm`, `turn-chrome`, `telegram-threading`): **489 passing**, independently re-run.
- `pnpm eval:gates`: 27 of 28 files green; the one failure is the documented pre-existing `evaluation-runner` `infra_error` baseline.
- Full daemon suite: nine files in the known-unrelated set, **re-run on a reverted tree where they fail identically**, plus three load-flaky files green in isolation. `daemon-commands` was a real regression during the work, found and fixed; the whole elicit/permission surface then re-ran 468 passing.
- Web suite: the 8 known pre-existing failures in `code-host-hook-groups` and `AgentDetailView.codehost`, and no others.

New tests confirmed red with only the sources reverted, including the `none`-mode suppression now depending on the registry rather than a hardcoded platform list.
