### PR TITLE
feat(daemon): add an opt-in microsandbox backend

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -135,7 +135,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--agent <name>`                 | Selector                       | Select by `agent.id`: single-agent `run` ignoring status, or disambiguate `chat`.                                                                  |
 | `--max-agents <n>`               | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
 | `--require-sandbox`              | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
-| n/a (config only)                | `sandbox.backend`              | Select the local sandbox backend; defaults to `srt`, currently the only supported value.                                                           |
+| n/a (config only)                | `sandbox.backend`              | Select the local sandbox backend; defaults to `srt`; `microsandbox` selects Linux VMs with an explicit image.                                      |
 | n/a (config only)                | `sandbox.mounts`               | Operator-owned host path mappings; `readOnly` defaults to true. SRT requires equal normalized source and target paths.                             |
 | `--k8s`                          | n/a (mode switch)              | Run runtimes in cluster sandbox pods instead of on this host; see section 2.6 for what that changes.                                               |
 | `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only service for session-scoped model credentials, http or https as the deployment chooses; see [key-server.md](key-server.md).              |
@@ -371,10 +371,10 @@ agent directories and higher custom parents are left unchanged.
 
 ### Linux ACP runtime sandbox
 
-`sandbox.backend` defaults to `srt`, currently the only supported backend.
+`sandbox.backend` defaults to `srt`; Linux hosts with KVM can select `microsandbox`.
 Operator-owned filesystem access is configured through `sandbox.mounts`.
-The [sandbox backend design](daemon-sandbox-backends.md) documents this
-configuration and the proposed microsandbox extension. The behavior below
+The [sandbox backend design](daemon-sandbox-backends.md) documents configuration,
+the implemented VM backend, and its remaining image/networking extensions. The behavior below
 describes the current SRT implementation.
 
 AgentConnect currently enables runtime sandboxing on Linux only. The daemon uses

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -1,12 +1,14 @@
 # Daemon Sandbox Backends
 
-**Status: Partially implemented.** `sandbox.backend: "srt"` and `sandbox.mounts`
-are implemented. SRT is currently the only accepted backend. The microsandbox
-backend, image selection, Docker, networking, and VM lifecycle remain proposed.
+**Status: Partially implemented.** SRT remains the default. The opt-in Linux
+microsandbox backend implements explicit image selection, resource configuration,
+guest execution, host mounts, and retained-disk stop/start. A complete real-daemon
+workload remains an acceptance gate. Default release image selection, Docker,
+network configuration, and port publication remain **Proposed**.
 
-The daemon continues to default to SRT. The proposed microsandbox backend adds
-image, resource, and networking configuration for independent session development
-environments with Docker, Compose, and predictable stop/start behavior.
+The first VM implementation uses the existing workspace modes and lifecycle.
+Docker, Compose, and development networking are subsequent additions to that
+execution path.
 
 This extends [daemon configuration and lifecycle](daemon-detailed-design.md) and
 uses the existing [execution-driver seam](cluster-spawn-and-shim.md#1-why-a-seam-at-all).
@@ -26,8 +28,8 @@ The daemon-owned `sandbox` object in `~/.agentconnect/config.json` defaults to
 }
 ```
 
-The following microsandbox configuration is proposed and is not accepted by the
-current schema:
+The current microsandbox configuration requires an explicit image. Replace the
+example reference with a compatible runtime image:
 
 ```json
 {
@@ -44,39 +46,32 @@ current schema:
       }
     ],
     "microsandbox": {
-      "cpus": 4,
-      "memoryMiB": 4096,
-      "diskGiB": 32,
-      "docker": true,
-      "network": {
-        "access": "development",
-        "ports": [
-          {
-            "guest": 3000,
-            "host": 0
-          }
-        ]
-      }
+      "image": "registry.example.com/agentconnect/runtime-sandbox:build-tag",
+      "cpus": 2,
+      "memoryMiB": 2048,
+      "diskGiB": 10
     }
   }
 }
 ```
 
-Values above are example resource allocations, not measured minimums. Future VM
-fields will be strictly validated rather than passed untyped to a vendor SDK.
+The resource values shown are the defaults, not measured minimums or capacity
+recommendations. All three are positive integers bounded by the SDK's supported
+numeric ranges. The VM configuration is strict: `docker` and `network` fields
+are not accepted yet.
 
-| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                                                       |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sandbox.backend`              | Implemented: `srt` is the default and only accepted value. Proposed: `microsandbox` selects the VM implementation for sandboxed launches.                                                                                                                                                                         |
-| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent. SRT is currently the only supported backend.                                                                                                                                                                                                      |
-| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                  |
-| `sandbox.microsandbox.image`   | Proposed: optional OCI reference. Omitted uses the runtime image reference in new release-generated metadata bundled with the daemon. An explicit image wins; a development build without metadata requires one. Record the resolved digest.                                                                      |
-| `cpus`, `memoryMiB`, `diskGiB` | Proposed: per-session CPU allocation, memory limit, and disk capacity. Validate against backend support and daemon capacity.                                                                                                                                                                                      |
-| `docker`                       | Proposed: start an independent Docker daemon inside each VM. Requires Docker tools in the selected image; never means mounting the host Docker socket. Default false until the Docker-enabled shared image and workload checks are delivered.                                                                     |
-| `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths. Proposed: microsandbox consumes the same list with guest targets. Session workspace, HOME, and runtime state remain automatically provisioned. |
-| `network.access`               | Proposed: `development` allows public, private-network, and host connectivity subject to mandatory control/admin exclusions; `public` allows public egress and required daemon endpoints; `none` disables external egress. Default `development`. Remote model use requires connectivity.                         |
-| `network.ports`                | Proposed: guest service ports exposed through daemon-assigned host ports. `host: 0` requests an available port. The backend binds and verifies the mapping; retry allocation conflicts and release mappings on teardown.                                                                                          |
-| `network.outboundProxy`        | Proposed: optional host-side SOCKS URL for microsandbox's outbound transport.                                                                                                                                                                                                                                     |
+| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sandbox.backend`              | Implemented: `srt` is the default; `microsandbox` selects the Linux VM implementation for sandboxed launches.                                                                                                                                                                                                                         |
+| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                                                                           |
+| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                                      |
+| `sandbox.microsandbox.image`   | Implemented: required, non-empty OCI reference when selecting microsandbox. No bundled release default or Kubernetes image lookup is used.                                                                                                                                                                                            |
+| `cpus`, `memoryMiB`, `diskGiB` | Implemented: per-VM CPU allocation, memory limit, and disk capacity; defaults are `2`, `2048`, and `10`. Host capacity planning remains the operator's responsibility.                                                                                                                                                                |
+| `docker`                       | Proposed: start an independent Docker daemon inside each VM. Requires Docker tools in the selected image; never means mounting the host Docker socket. Default false until the Docker-enabled shared image and workload checks are delivered.                                                                                         |
+| `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths; microsandbox accepts absolute guest targets. Workspace, HOME, and runtime state remain automatically provisioned.                                                  |
+| `network.access`               | Proposed: `development` allows public, private-network, and host connectivity subject to mandatory control/admin exclusions; `public` allows public egress and required daemon endpoints; `none` disables external egress. The proposed default is `development`; the current implementation retains upstream public-only networking. |
+| `network.ports`                | Proposed: guest service ports exposed through daemon-assigned host ports. `host: 0` requests an available port. The backend binds and verifies the mapping; retry allocation conflicts and release mappings on teardown.                                                                                                              |
+| `network.outboundProxy`        | Proposed: optional host-side SOCKS URL for microsandbox's outbound transport.                                                                                                                                                                                                                                                         |
 
 ### Shared mounts and manual conversion
 
@@ -97,17 +92,20 @@ current root normalization. Existing protected-path checks remain in effect.
 After normalization, reject different sources mapped to the same target; merge
 permissions only for entries with the same source and target.
 
-Access remains additive: a read-only entry adds read access; it does not revoke
-write access already granted by a workspace or writable mount. Retain writable
-children of read-only parents rather than collapsing all nested paths into one entry.
-The proposed VM backend must preserve the same effective access.
+For SRT, access remains additive: a read-only entry adds read access; it does not
+revoke write access already granted by a workspace or writable mount. Retain
+writable children of read-only parents rather than collapsing nested paths.
+microsandbox applies actual guest mount flags: a nested read-only mount restricts
+that subtree even inside a writable parent, and a writable child remains writable
+inside a read-only parent. Keep these nested mappings. User mappings that overlap
+the VM's automatically provisioned paths are rejected in either direction.
 
 SRT uses the configured paths at their host locations: its filesystem rules do
 not rename a host path inside the sandbox. Normalize `source` and `target` as
 host paths and require them to be equal. A mapping such as
 `/srv/agent-cache/pnpm` to `/cache/pnpm` fails validation for SRT. The same mapping
-will be supported by microsandbox, where `target` is an absolute guest path.
-The shared configuration list is kept outside the future
+is supported by microsandbox, where `target` is an absolute guest path.
+The shared configuration list is kept outside the
 `sandbox.microsandbox` object.
 
 For example, SRT uses the same common configuration shape:
@@ -139,33 +137,33 @@ runtime and request sandboxing, but cannot supply backend executables, images,
 or mounts. Future backends add a typed configuration member and an implementation at the existing execution-plane
 composition point. Do not add speculative backend branches throughout ACP.
 
-### Proposed VM availability and changes
+### VM availability and configuration changes
 
-The following availability and lifecycle requirements belong to the future VM
-backend. Current configuration accepts only SRT and preserves its existing
-availability checks and optional/required sandbox behavior.
+The current microsandbox integration supports Linux with usable KVM. Startup
+installs the pinned `microsandbox@0.6.17` package through the daemon's RuntimeStore,
+preserving its native platform package, and gives it a daemon-owned state home.
+It prepares the image, boots a temporary VM, validates the runtime table, and
+checks stop/start before admitting VM launches. Checking `/dev/kvm` alone would
+not establish availability. With `requireSandbox=true`, an unavailable backend
+refuses startup. Otherwise the daemon can still serve unsandboxed agents, but a
+requested microsandbox launch fails explicitly, with no fallback to SRT or a host
+process. Existing optional-SRT fallback semantics are unchanged. The standalone
+`chat` command currently refuses microsandbox configuration; use daemon sessions.
+The upstream SDK requires its derived Unix socket paths to fit Linux's 108-byte
+limit, so an unusually long daemon root can fail preflight.
 
-Probe the selected backend with an actual launch/command, not only binary
-detection. On Linux, microsandbox requires usable KVM; checking `/dev/kvm` alone
-does not prove a VM can start. With `requireSandbox=true`, an unavailable backend
-refuses startup. Otherwise the daemon can still serve trusted unsandboxed agents,
-but a requested microsandbox launch must fail explicitly. It must not silently
-fall back to SRT or an ordinary host process. Existing optional-SRT fallback
-semantics are unchanged by this proposal.
-
-The proposed VM release adds no new backend for Linux hosts without usable KVM. They can
+This implementation adds no new backend for Linux hosts without usable KVM. They can
 keep SRT, including fail-closed startup with `security.requireSandbox=true`. The
 new VM boundary requires bare metal or a VM exposing nested virtualization;
 Podman/runsc with systrap remains a future no-KVM option, not a hidden fallback.
 
-Record backend, runtime version, image digest, effective configuration hash, and
-sandbox generation with the daemon-local session execution record. Settings apply
-to newly created environments. A retained VM keeps its original configuration;
-`connectOrCreate` is not an upgrade operation. Restarting the daemon can reload
-configuration, but must not destroy an existing session to apply it. Backend or
-image changes require a new environment or a separately implemented, explicit
-migration of retained data. Publish only the capability/status facts needed by
-the existing daemon catalog, not host paths.
+The manager persists each environment ID, sandbox ID, requested image/resources/
+mount specification, and a hash of the SDK's saved configuration. Reuse rejects
+missing or changed bindings and configuration rather than silently recreating the
+VM. A retained VM keeps its original configuration. Restarting the daemon does
+not upgrade it or migrate its disk; configuration changes require an explicit
+retirement/recreation or a future data-migration operation. Resolved-image metadata
+and upgrade tooling remain proposed.
 
 Kubernetes mode retains `K8sDriver`, its resource configuration, and image rollout.
 An explicitly configured local microsandbox backend
@@ -211,38 +209,71 @@ and measure there; do not extrapolate bare-metal or desktop boot numbers.
 
 ## 3. Session environment and image contract
 
-Implement a `MicrosandboxDriver` behind `SpawnDriver`. Keep ACP's bidirectional
-byte streams and stop/exit contract. Use the SDK's streaming execution channel
-with persistent stdin; tools run inside the already-running harness and VM,
-rather than paying a VM creation or external CLI round trip for each tool call.
+`MicrosandboxManager` supplies the existing `SpawnDriver` contract. ACP uses the
+SDK's bidirectional byte streams with persistent stdin and process exit/signals;
+stop sends a termination signal and escalates to a kill when needed. Native tools
+run inside the existing harness and VM. There is no external CLI invocation for
+each tool call.
 
-The driver is only part of the integration. Compose the guest implementations of
-`GitRunner`, `WorkspaceFs`/workspace placement, session retirement, and artifact
-access at the same execution-plane boundary. Reuse the existing shim's operation
-handlers where useful, without importing Kubernetes service-account binding into
-local VM control. Command lookup, generated files, and executable hints resolve
-in the guest. Merely replacing ACP spawn would leave file and Git operations
-incorrectly targeting the host filesystem.
+Daemon-owned Git operations for mounted workspaces use the existing shim Git
+handler through SDK execution. Canonical clone preparation outside an exposed
+workspace remains host-side. Workspace reads and attachment access use host-backed
+directories mounted at the same guest paths. Once a VM exists, workspace mutations
+use the existing guest filesystem handler: renaming a staged clone on the host
+can leave the VM's cached directory view stale, while a guest rename is immediately
+visible to guest Git. Initial directory preparation remains local before VM boot.
+This does not require a second filesystem copy or a Kubernetes tunnel. Command
+lookup and generated launch files use the guest execution/file APIs. Small
+daemon tool channels use the guest helper and vsock; the image's Kubernetes
+entrypoint and control connection are not started.
 
-Each microsandbox session gets a distinct environment, writable runtime HOME,
-disk, and network namespace. Existing shared-workspace versus session-workspace
-choices still govern repository data; separate VMs do not magically make a
-deliberately shared host mount private. Linked-worktree Git metadata, secondary
-repositories, file attachments, and Docker bind mounts need consistent guest
-paths. Do not redesign the Git storage model in this change.
+VM identity follows workspace placement. Shared mode reuses the agent's
+`agent/agent` environment. An isolated session uses its own `agent/session-…`
+environment, writable runtime HOME, disk, and guest network namespace. Existing
+shared-workspace versus session-workspace choices still govern repository data;
+separate VMs do not make a deliberately shared host mount private. Linked-worktree
+Git metadata, secondary repositories, and file attachments keep consistent guest
+paths. This change does not redesign Git storage.
 
-### Image and Docker
+### Current image contract and flat disks
+
+An explicit OCI image is required. The runtime image must contain Node at
+`/usr/local/bin/node`, Python 3 for the guest helper, the declared runtime tools,
+and `/opt/agentconnect/runtime/k8s-runtimes.json`. The existing pool image contains
+these components. Startup reads and validates that table in a real VM; individual
+runtime execution and full-session compatibility still need workload checks.
+
+The SDK's `create()` does not execute OCI ENTRYPOINT/CMD automatically. The manager
+explicitly starts the bundled local guest helper and requested runtime commands.
+The pool's Kubernetes security context, volumes, and resource limits do not
+travel inside its OCI image. In particular, the pool's shim startup and UID/HOME
+configuration are not a substitute for the local VM's launch settings. See the
+upstream [execution semantics](https://docs.microsandbox.dev/sandboxes/commands).
+
+The first implementation uses private flat ext4 root disks and explicit
+host-bound workspace/cache mounts. The clone strategy is `auto`: preparation can
+reuse a base image, while each private disk clone can fall back from reflink to
+sparse copying on the host filesystem. Measure both image preparation and cloning.
+Flat disks do not provide native snapshots or rootfs patches; generated launch
+files are written after boot through the guest file API.
+
+In pinned version `0.6.17`, starting a retained flat-disk VM still validates the
+OCI image's VMDK cache. The manager therefore runs the official
+`msb pull <image> --materialize all --quiet` before its VM probe, preparing both
+image forms, and tests stop/start. The VM continues to use its flat disk. This
+uses the upstream CLI and package without an upstream source patch; cold image
+preparation includes the extra materialization cost.
+
+### Proposed release image selection and Docker
 
 Add release-generated metadata bundled with the daemon containing the published
 `runtimeSandboxImage` OCI reference. Generate it from the release workflow's
 component-version output, so local daemons use the same artifact as the pool
 without querying a cluster. This is new metadata: today's `poolRuntimeImage()`
 resolves the Kubernetes SandboxTemplate, and is not a local default resolver.
-An explicit daemon image overrides the metadata; builds without metadata require
-an explicit image. The current image contains runtimes and a shim, runs as UID
-10001 with `HOME=/agent`, and is not yet a Docker-daemon image. Its Kubernetes
-security context, volumes, and resource limits do not travel inside the OCI
-image. The microsandbox backend supplies its own launch settings.
+An explicit daemon image would override this metadata; builds without metadata
+would still require an explicit image. This default resolver is not implemented.
+The current shared image does not include a configured Docker daemon.
 
 For `docker=true`, extend that shared image with Docker Engine and the Compose
 plugin, and explicitly start dockerd inside the VM with guest privileges before
@@ -251,29 +282,25 @@ socket. Keep Docker opt-in for sessions that do not need its resource cost. A
 custom image must satisfy the same runtime/tool contract or fail its admission
 probe; do not silently install missing tools on every session start.
 
-Use flat ext4 root disks for the first microsandbox integration, including Docker
-data and build caches. Host-bound workspace/cache mounts remain explicit. A
-prepared base image can be reused, but the private disk clone may fall back from
-reflink to sparse copying on the host filesystem. Measure both preparation and
-per-session cloning. Current flat-disk support rejects rootfs patches and native
-snapshots: provision generated files through the execution/file channel after
-boot, and do not promise snapshot-based warm pools.
+Docker data and build caches would use the retained flat disk. Docker Engine,
+Compose, and Testcontainers compatibility remain separate acceptance work; the
+current backend neither starts dockerd nor exposes a `docker` setting.
 
-The SDK's `create()` does not execute OCI ENTRYPOINT/CMD automatically. The driver
-must explicitly launch the expected shim/harness and optional dockerd. These
-details follow the inspected microsandbox
-[command reference](https://docs.microsandbox.dev/cli/sandbox-commands) and
-[execution semantics](https://docs.microsandbox.dev/sandboxes/commands).
+### Current network and proposed development/preview experience
 
-### Network and preview experience
+The current implementation selects upstream's `single-tenant` deployment profile
+and leaves its default public-only network policy unchanged: public egress and
+gateway DNS are available; private, host, loopback, link-local, and metadata
+destinations are denied. There are no published ports and no daemon network or
+outbound-proxy settings yet. The following development and preview behavior is
+**Proposed**, not enabled by selecting microsandbox today.
 
 Development networking should let package managers, Git, databases, and web
-servers behave normally. The default local profile admits the connectivity
-described in section 1; it does not present users with per-domain approval prompts.
-microsandbox's default public-only rules must therefore be translated deliberately,
-not mistaken for our development profile. Its stricter multi-tenant profile is
-not selected here: it disables host access and port publication needed by this
-local workflow.
+servers behave normally. The proposed profile admits the connectivity described
+in section 1 without per-domain approval prompts. Translate upstream's public-only
+rules deliberately; they are not the proposed development profile. The stricter
+multi-tenant profile is not selected here: it disables host access and port
+publication needed by this future local workflow.
 
 Before broad development rules, deny the daemon's registered control/admin
 listeners and deployment-configured management endpoints, including the local
@@ -289,10 +316,10 @@ network rules for that route. SRT retains its existing network integration. See
 [microsandbox networking](https://docs.microsandbox.dev/networking/overview) and
 [its outbound proxy](https://docs.microsandbox.dev/networking/outbound-proxy).
 
-Two sessions can both use guest ports 3000 and 5432. The daemon allocates separate
-host listeners and reports their effective mappings; the browser gets an address
+Two sessions could both use guest ports 3000 and 5432. The daemon would allocate separate
+host listeners and report their effective mappings; the browser would get an address
 for the selected session. Remote-daemon preview needs a separately provided
-authorized tunnel or preview route: returning that machine's localhost URL is not
+tunnel or preview route: returning that machine's localhost URL is not
 a working remote preview. Live preview bytes must not be added to the CP control
 WebSocket.
 
@@ -306,16 +333,20 @@ already supplies that experience.
 ### Stop, restart, and retirement
 
 - A completed turn keeps its environment available for the existing idle policy.
-- Idle reclaim waits for turns, background jobs, and active execution leases to
-  finish, then stops processes/VM while retaining workspace, HOME, and Docker data.
+- The existing ACP host idle/max-lifetime policy stops the host. The VM manager
+  refuses suspend/removal while executions remain active, and the idle sweep also
+  stops VMs left idle after workspace preparation. Stopping retains mounted
+  workspace/HOME data and the private disk. Detached guest background processes
+  are not independently leased and end when the VM stops.
 - Start boots a new guest process environment from retained disk and re-establishes
   ACP; use runtime `session/load` when supported. It does not resume process memory,
-  an old TCP connection, or an interrupted Docker build.
-- Daemon restart reconciles its recorded sandbox IDs and generations, adopts only
-  owned retained environments, and replaces the old ACP process before
-  admitting new turns. Read-only console visits do not wake a stopped VM.
+  an old TCP connection, or an interrupted guest process.
+- Before admitting new VM launches, daemon restart stops recorded owned VMs that
+  are still running. It retains their disks and replaces the guest helper and ACP
+  processes on the next start; it does not adopt the old running processes.
 - Retirement uses existing dirty/unpushed-work protection before deleting a
-  session's retained storage. VM removal also removes its private Docker cache.
+  session's retained storage. VM removal deletes its private disk and binding;
+  operator-owned host mount contents are not deleted by VM removal.
 
 The inspected SDK does not provide general pause/resume of running process state.
 Lifecycle and configuration-reuse rules are documented
@@ -329,26 +360,30 @@ Delivery is split into independently reviewable steps:
    and `sandbox.mounts`, remove legacy security roots, and apply mount permissions
    to SRT and native tools. Existing configuration is converted manually. Preserve
    the pool and unsandboxed-agent paths.
-2. **Proposed — microsandbox execution:** add the VM backend choice, availability
-   checks, release image metadata, and explicit no-KVM behavior. Integrate disk,
-   ACP streams, workspace and Git/file operations, declared ports with admin exclusions, and stop/start.
-   Add the shared image's optional Docker/Compose support.
-3. **Proposed — developer experience and measurement:** run real projects and add
+2. **Implemented, workload validation pending — minimal microsandbox execution:**
+   explicit image and resources, Linux VM boot/runtime-table/stop-start checks,
+   SDK-backed ACP streams and guest Git, shared host filesystem paths, and retained
+   environment lifecycle. Keep upstream public-only networking and SRT as default.
+3. **Proposed — image and development features:** add release image metadata,
+   Docker/Compose support, and configured networking/declared ports with admin
+   exclusions. These configuration fields are not part of the current schema.
+4. **Proposed — developer experience and measurement:** run real projects and add
    dynamic preview forwarding separately. Change the default only after compatibility
    and resource measurements support it.
 
-The SRT configuration/mount checks apply to the implemented slice; VM, image,
-Docker, networking, lifecycle, and performance evidence remain future gates:
+Implementation status above does not establish successful end-to-end daemon
+execution. The current VM slice still needs complete-session and lifecycle
+evidence; proposed features have their own subsequent acceptance gates:
 
-| Area                       | Required evidence                                                                                                                                                                                                                                                                                             |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Existing behavior          | Default SRT, required/optional sandbox policy, and Kubernetes execution remain usable. No-KVM behavior is explicit.                                                                                                                                                                                           |
-| Mounts                     | Manually converted roots preserve access. SRT accepts equal normalized paths and rejects remapping; read-only is the default and writable mounts reach native tools. Verify nested/duplicate entries and package-cache access. Future VM checks cover guest targets and host-data preservation on retirement. |
-| Image and complete session | Bundled release image selection and explicit overrides work; image preparation, ACP initialize/new/load, output, cancellation, cleanup, and a real native-tool turn succeed.                                                                                                                                  |
-| Docker                     | Compose and Testcontainers work, including DNS, random ports, bind mounts, build cache, and cleanup helpers. Two sessions use the same internal ports.                                                                                                                                                        |
-| Networking                 | Git/npm, an allowed host database, web preview and WebSockets work. Registered control/admin endpoints are unreachable through gateway and host address aliases, including when SOCKS is configured.                                                                                                          |
-| Lifecycle                  | Idle stop preserves work/cache; start re-establishes ACP; daemon restart fences old hosts; dirty/unpushed work prevents destructive retirement.                                                                                                                                                               |
-| Performance                | Measure cold image preparation, warm disk clone, stopped-session restart, ACP-ready latency, and Git/install/build duration. At 1/10/20 sessions, record whole-environment memory, peaks, disk growth, CPU limits, and cleanup. Record reflink versus sparse-copy behavior.                                   |
+| Area                       | Required evidence                                                                                                                                                                                                                                                           |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Existing behavior          | Default SRT, required/optional sandbox policy, and Kubernetes execution remain usable. No-KVM behavior is explicit.                                                                                                                                                         |
+| Mounts                     | SRT accepts equal normalized paths and rejects remapping; read-only is the default and writable mounts reach native tools. Verify nested/duplicate entries, VM guest targets and mount flags, package-cache access, and host-data preservation on retirement.               |
+| Image and complete session | Explicit image preparation, ACP initialize/new/load, output, cancellation, cleanup, and a real native-tool turn succeed. Proposed release image defaults need separate verification when implemented.                                                                       |
+| Docker — Proposed          | Compose and Testcontainers work, including DNS, random ports, bind mounts, build cache, and cleanup helpers. Two sessions use the same internal ports.                                                                                                                      |
+| Networking                 | Verify current public Git/npm egress and denied host/private destinations. Proposed profiles additionally need an allowed host database, preview/WebSockets, and control/admin exclusions across gateway/address aliases, including with SOCKS.                             |
+| Lifecycle                  | Idle stop preserves work/cache; start re-establishes ACP; daemon restart fences old hosts; dirty/unpushed work prevents destructive retirement.                                                                                                                             |
+| Performance                | Measure cold image preparation, warm disk clone, stopped-session restart, ACP-ready latency, and Git/install/build duration. At 1/10/20 sessions, record whole-environment memory, peaks, disk growth, CPU limits, and cleanup. Record reflink versus sparse-copy behavior. |
 
 Keep plain Podman/crun and Docker Sandboxes as labeled comparison arms where
 useful. Compare actual agent sessions before deciding latency or density targets.

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "agent:chat": "tsx src/index.ts --agents-dir ./test/fixtures/sample-agent chat",
     "agent:run": "tsx src/index.ts --agents-dir ./test/fixtures/sample-agent run",
-    "build": "pnpm --filter '{.}^...' build && tsdown && pnpm run build:shim && node scripts/prepare-bundled-skills.mjs && node scripts/assert-self-contained.mjs",
+    "build": "pnpm --filter '{.}^...' build && tsdown && pnpm run build:shim && tsdown --config tsdown.microsandbox.config.ts && node scripts/prepare-bundled-skills.mjs && node scripts/assert-self-contained.mjs",
     "build:shim": "tsdown --config tsdown.shim.config.ts && node scripts/prepare-shim-skills.mjs && node scripts/emit-shim-gh-wrapper.mjs",
     "clean": "rm -rf dist",
     "dev": "tsx watch src/index.ts run",
@@ -82,6 +82,7 @@
     "@types/pg": "^8.20.0",
     "@types/ws": "^8.18.1",
     "json": "^11.0.0",
+    "microsandbox": "0.6.17",
     "tsdown": "^0.22.14",
     "tsx": "^4.23.1",
     "typescript": "^6.0.3",

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -61,6 +61,9 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     optional: true,
     overrides: { agentsDir: opts.agentsDir }
   })
+  if (cfg.sandbox.backend === 'microsandbox') {
+    throw new Error('chat does not support microsandbox yet; use a daemon session with this sandbox backend')
+  }
   configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
   // Validate operator mounts before selecting or probing a runtime.
   const mounts = normalizeSandboxMounts(cfg.sandbox.mounts)

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -134,6 +134,9 @@ const SandboxMountSchema = z
   .strict()
 export type SandboxMount = z.infer<typeof SandboxMountSchema>
 
+const SandboxBackendSchema = z.enum(['srt', 'microsandbox'])
+export type SandboxBackend = z.infer<typeof SandboxBackendSchema>
+
 export const ConfigSchema = z.object({
   version: z.literal(1),
   daemonId: z.string().optional(),
@@ -170,10 +173,34 @@ export const ConfigSchema = z.object({
   memoryPlugins: z.record(MemoryPluginCommandRef, StdioMemoryPluginDefSchema).optional(),
   sandbox: z
     .object({
-      backend: z.literal('srt').default('srt'),
-      mounts: z.array(SandboxMountSchema).default([])
+      backend: SandboxBackendSchema.default('srt'),
+      mounts: z.array(SandboxMountSchema).default([]),
+      microsandbox: z
+        .object({
+          image: z.string().trim().min(1),
+          // The backend accepts u8 CPUs and u32 MiB resource sizes.
+          cpus: z.number().int().positive().max(255).default(2),
+          memoryMiB: z.number().int().positive().max(0xffffffff).default(2048),
+          diskGiB: z
+            .number()
+            .int()
+            .positive()
+            .max(Math.floor(0xffffffff / 1024))
+            .default(10)
+        })
+        .strict()
+        .optional()
     })
     .strict()
+    .superRefine((sandbox, ctx) => {
+      if (sandbox.backend === 'microsandbox' && !sandbox.microsandbox) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['microsandbox', 'image'],
+          message: 'sandbox.microsandbox.image is required for the microsandbox backend'
+        })
+      }
+    })
     .default({ backend: 'srt', mounts: [] }),
   security: z
     .object({

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,5 +1,12 @@
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, join, relative, sep } from 'node:path'
+import { installMicrosandbox, microsandboxGuestEntry } from './microsandbox/install.js'
+import { prepareMicrosandboxLaunch } from './microsandbox/launch.js'
+import type { MicrosandboxManager, MicrosandboxEnvironment } from './microsandbox/driver.js'
+import { microsandboxGitRunner, microsandboxWorkspaceFs } from './microsandbox/guest.js'
+import { MicrosandboxWorkspaceFs } from './microsandbox/workspace-fs.js'
+import { microsandboxSupportMounts } from './microsandbox/support.js'
+import { GITCRED_SOCKET_ENV } from './gitcred/env.js'
 import { tmpdir } from 'node:os'
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
@@ -264,7 +271,12 @@ import {
 } from './runtimes/runtime-commands.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
-import { declaredRuntimeCatalog, loadK8sRuntimeTable, type K8sRuntimeAcpSnapshot } from './runtimes/k8s-runtimes.js'
+import {
+  declaredRuntimeCatalog,
+  loadK8sRuntimeTable,
+  type K8sRuntimeAcpSnapshot,
+  type K8sRuntimeTable
+} from './runtimes/k8s-runtimes.js'
 import {
   K8S_PROBE_CLAIM_TTL_MS,
   K8S_PROBE_FRESH_MS,
@@ -1137,6 +1149,11 @@ export class Daemon {
   private readonly clusterIdentityToken?: () => string | undefined
   // The k8s execution plane: shim dialer + driver + workspace seam. Undefined outside --k8s.
   private k8sPlane?: K8sRuntimePlane
+  private microsandbox?: MicrosandboxManager
+  private microsandboxTable?: K8sRuntimeTable
+  private microsandboxFailure?: string
+  private microsandboxCatalog?: ResolvedRuntimeCatalog
+  private localRuntimeCatalog?: ResolvedRuntimeCatalog
   // The resolved catalog the probed table is projected onto; it supplies command/args, which the
   // table never does — the table only says which ids this image provides.
   private k8sResolvedCatalog?: ResolvedRuntimeCatalog
@@ -1777,7 +1794,7 @@ export class Daemon {
   async start(): Promise<void> {
     await this.bootReadinessGate()
     const { root, cfg } = this.resolvePathAndConfig()
-    this.sandboxPreflight(cfg)
+    await this.sandboxPreflight(cfg, root)
     await this.startClusterPlanes(root, cfg)
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
     // A skill runs sandboxed only when its agent does (agentRunsInSandbox), so the
@@ -1848,7 +1865,7 @@ export class Daemon {
     })
     this.cfg = cfg
     // Validate operator mounts before startup can create any runtime hosts.
-    cfg.sandbox.mounts = normalizeSandboxMounts(cfg.sandbox.mounts)
+    cfg.sandbox.mounts = normalizeSandboxMounts(cfg.sandbox.mounts, process.env, cfg.sandbox.backend)
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     // §24.4: an excluded origin is named at SPEC admission. All this knows is the operator list —
     // whether a spec names an instance of its own, which stays cloneable either way, is per-agent.
@@ -1861,7 +1878,65 @@ export class Daemon {
   }
 
   /** Phase 3 — report the host sandbox mechanism and refuse a boot that cannot honor requireSandbox. */
-  private sandboxPreflight(cfg: Config): void {
+  private async sandboxPreflight(cfg: Config, root: string): Promise<void> {
+    if (cfg.sandbox.backend === 'microsandbox') {
+      if (this.k8s) throw new Error('sandbox.backend=microsandbox cannot be combined with --k8s')
+      this.workspaces.setGitRunnerResolver((agentId, cwd, abort) => this.microsandboxGit(agentId, cwd, abort))
+      this.workspaces.setFsResolver((agentId) => {
+        const agent = this.agents.get(agentId)
+        if (!agent || !this.usesMicrosandbox(agent)) return undefined
+        return {
+          fs: new MicrosandboxWorkspaceFs(
+            (path) => {
+              const manager = this.microsandbox
+              const environment = manager?.environment(this.microsandboxPlacement(agent, path).id)
+              const mounted = environment?.mounts.some(
+                (mount) =>
+                  !mount.readOnly &&
+                  mount.source === mount.target &&
+                  (path === mount.target || path.startsWith(`${mount.target}${sep}`))
+              )
+              return manager && environment && mounted
+                ? microsandboxWorkspaceFs({
+                    workspaceRoot: environment.workspaceRoot,
+                    execute: (command, args, options) => manager.exec(environment, command, args, options)
+                  })
+                : undefined
+            },
+            async (path) => {
+              const manager = this.microsandbox
+              const environment = manager?.environment(this.microsandboxPlacement(agent, path).id)
+              if (
+                !manager ||
+                !environment?.mounts.some((mount) => !mount.readOnly && mount.source === path && mount.target === path)
+              ) {
+                return false
+              }
+              await manager.suspend(environment.id)
+              return true
+            }
+          )
+        }
+      })
+      this.workspaces.setSessionsDiscarder((agentId, exceptLeaf) => this.discardSessionSandboxes(agentId, exceptLeaf))
+      try {
+        this.microsandbox = await installMicrosandbox({
+          root,
+          config: cfg.sandbox.microsandbox!,
+          sockets: { mcp: mcpSocketPath(root), gitcred: gitcredSocketPath(root) },
+          log: this.log
+        })
+        this.microsandboxTable = await this.microsandbox.prepare()
+        this.log.info('sandbox: microsandbox image and VM startup verified')
+      } catch (error) {
+        await this.microsandbox?.stopAll().catch((stopError: unknown) => this.log.warn(formatErr(stopError)))
+        this.microsandbox = undefined
+        this.microsandboxFailure = formatErr(error)
+        if (cfg.security.requireSandbox) throw new Error(`microsandbox startup refused: ${formatErr(error)}`)
+        this.log.warn(`microsandbox unavailable: ${formatErr(error)}; requested VM launches will be refused`)
+      }
+      return
+    }
     this.logSandboxPreflight()
     if (cfg.security.requireSandbox && !this.sandboxMechanism) {
       throw new Error(
@@ -2234,12 +2309,23 @@ export class Daemon {
     // first host start instead, so a host with six logged-in harnesses does not fetch all six here.
     const storedCatalog = await this.installManagedRuntimePackages(
       installedCatalog,
-      discoveredAgents.map((agent) => agent.runtime)
+      discoveredAgents.filter((agent) => !this.usesMicrosandbox(agent)).map((agent) => agent.runtime)
     )
     const { runtimes: installed, entries: installedEntries } = storedCatalog
-    this.runtimeCatalog = storedCatalog
+    this.localRuntimeCatalog = cfg.sandbox.backend === 'microsandbox' ? storedCatalog : undefined
+    if (this.microsandboxTable) {
+      const declared = declaredRuntimeCatalog(resolvedCatalog, this.microsandboxTable)
+      this.microsandboxCatalog = declared.catalog
+      this.k8sDeclaredModels = declared.models
+      this.k8sDeclaredAcp = declared.acp
+      this.runtimeCatalog = {
+        entries: { ...storedCatalog.entries, ...declared.catalog.entries },
+        runtimes: { ...storedCatalog.runtimes, ...declared.catalog.runtimes }
+      }
+    } else this.runtimeCatalog = storedCatalog
     this.refreshAdmittedRuntimes()
     this.runtimeFacts.setInstalled(installedEntries)
+    if (this.microsandboxCatalog) this.runtimeFacts.noteImageCatalog(this.microsandboxCatalog.entries)
     this.log.info(`runtimes ready: ${Object.keys(this.runtimes).join(', ') || '(none)'}`)
     const pendingCurated = Object.keys(installed).filter((id) => installedEntries[id]?.source === 'curated')
     if (pendingCurated.length) this.log.info(`runtimes pending ACP admission: ${pendingCurated.join(', ')}`)
@@ -2320,7 +2406,11 @@ export class Daemon {
 
   /** Install the adapter for a runtime the start-time sweep did not cover — an agent the CP assigned
    *  after boot. The store memoizes, so this resolves once for the runtime and never once per spawn. */
-  private async ensureRuntimeInstalled(runtimeId: string): Promise<void> {
+  private async ensureRuntimeInstalled(runtimeId: string, local = false): Promise<void> {
+    if (local && this.localRuntimeCatalog) {
+      this.localRuntimeCatalog = await this.installManagedRuntimePackages(this.localRuntimeCatalog, [runtimeId])
+      return
+    }
     const entry = this.runtimeCatalog.entries[runtimeId]
     if (!entry || !Daemon.STORE_MANAGED_SOURCES.has(entry.source)) return
     if (!parseNpxLaunch(entry.runtime) && !parseArchiveLaunch(runtimeId, entry)) return
@@ -2421,7 +2511,8 @@ export class Daemon {
     // Model-catalog cache: synchronous last-good hydrate BEFORE the CP client
     // starts, so the register-time facts snapshot already carries models + the
     // capability matrix instead of blanking the CP until the sweep completes.
-    await this.runtimeFacts.hydrateFromCache()
+    // Image runtimes must not inherit model catalogs cached by a previous host execution.
+    await this.runtimeFacts.hydrateFromCache(new Set(Object.keys(this.microsandboxCatalog?.entries ?? {})))
     // The image's declared models are the fresher truth than any cached row, and stay
     // `cached` provenance: no live probe confirmed them, so model gates remain permissive.
     this.runtimeFacts.applyDeclaredFacts(this.k8sDeclaredModels, this.k8sDeclaredAcp)
@@ -3042,7 +3133,7 @@ export class Daemon {
             agentName: agent.displayName?.trim() || agent.name,
             ...(agent.iconUrl ? { iconUrl: agent.iconUrl } : {})
           })
-          servers.push(...this.mcpToolServerSpec(token))
+          servers.push(...this.mcpToolServerSpec(token, agent))
         }
         servers.push(
           ...resolveAgentMcpServers({
@@ -3606,7 +3697,94 @@ export class Daemon {
       executableCommands,
       moduleEntries: [cliEntry, ...nodeExecArgvModuleEntries()],
       paths,
-      readRoots: this.cfg.sandbox.mounts.map((mount) => mount.source)
+      readRoots: this.cfg.sandbox.backend === 'srt' ? this.cfg.sandbox.mounts.map((mount) => mount.source) : []
+    })
+  }
+
+  private usesMicrosandbox(agent: Agent): boolean {
+    return this.cfg.sandbox.backend === 'microsandbox' && this.agentRunsInSandbox(agent)
+  }
+
+  private microsandboxPlacement(
+    agent: LoadedAgent,
+    cwd: string,
+    key?: HostKey
+  ): { id: string; trustedSessionDir?: string } {
+    const parts = relative(agent.dir, cwd).split(sep)
+    if (parts[0] === 'sessions' && /^session-[a-f0-9]{24}$/.test(parts[1] ?? '')) {
+      return { id: `${agent.id}/${parts[1]}`, trustedSessionDir: join(agent.dir, 'sessions', parts[1]!) }
+    }
+    return { id: `${agent.id}/${hostKeyDirName(key)}` }
+  }
+
+  private microsandboxContext(
+    agent: LoadedAgent,
+    cwd: string,
+    key?: HostKey,
+    excludeAgentToolCredentials = false
+  ): {
+    environment: MicrosandboxEnvironment
+    launch: ReturnType<typeof prepareMicrosandboxLaunch>
+  } {
+    if (!this.microsandbox)
+      throw new Error(`microsandbox unavailable: ${this.microsandboxFailure ?? 'not initialized'}`)
+    const runtime = this.microsandboxCatalog?.runtimes[agent.runtime]
+    if (!runtime) throw new Error(`runtime "${agent.runtime}" is not provided by the microsandbox image`)
+    const placement = this.microsandboxPlacement(agent, cwd, key)
+    const github = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
+    const gitlab = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'gitlab'
+    const scope = managedCredentialScope(
+      gitlab ? 'gitlab' : github ? 'github' : undefined,
+      agent.gitlabHost,
+      !excludeAgentToolCredentials && this.workspaces.gitlabRepoBearing(agent)
+    )
+    const git =
+      github || gitlab || agent.workspace.mode === 'git-repo'
+        ? sessionGitEnv(
+            agent.id,
+            github || gitlab ? this.gitCommitIdentity : undefined,
+            github || gitlab ? scope : null
+          )
+        : undefined
+    const launch = prepareMicrosandboxLaunch({
+      runtimeId: agent.runtime,
+      runtime,
+      scopeDir: agent.dir,
+      cwd: placement.trustedSessionDir ?? (key && hostKeySessionKey(key) ? cwd : agent.workspace.path),
+      hostKey: key,
+      ...placement,
+      trustedWorkspaceWriteRoots: placement.trustedSessionDir
+        ? [placement.trustedSessionDir]
+        : this.workspaces.trustedWorkspaceWriteRoots(agent),
+      trustedMounts: microsandboxSupportMounts(this.root, git?.GIT_CONFIG_GLOBAL),
+      mounts: this.cfg.sandbox.mounts,
+      guestEntry: microsandboxGuestEntry(this.root)
+    })
+    return { environment: { id: placement.id, ...launch.microsandbox }, launch }
+  }
+
+  private microsandboxGit(agentId: string, cwd?: string, abort?: AbortSignal) {
+    const agent = this.agents.get(agentId)
+    if (!agent || !cwd || !this.usesMicrosandbox(agent)) return undefined
+    if (!this.microsandbox)
+      throw new Error(`microsandbox unavailable: ${this.microsandboxFailure ?? 'not initialized'}`)
+    // The daemon's own parent directory is used to prepare canonical clones before exposing a checkout.
+    if (cwd === agent.dir) return undefined
+    const { environment, launch } = this.microsandboxContext(agent, cwd)
+    return microsandboxGitRunner({
+      workspaceRoot: environment.workspaceRoot,
+      cwd,
+      env: launch.env,
+      abort,
+      execute: (command, args, options) => this.microsandbox!.exec(environment, command, args, options),
+      mapEnv: (env) => ({
+        ...env,
+        ...Object.fromEntries(
+          Object.entries(launch.env).filter(
+            ([name]) => name === 'HOME' || name === 'PATH' || name.startsWith('XDG_') || name === GITCRED_SOCKET_ENV
+          )
+        )
+      })
     })
   }
 
@@ -3623,6 +3801,9 @@ export class Daemon {
    * cache, trusted installer state, and runtime CLI identity together prevents
    * a non-session warmup from spawning with a weaker preparation path. */
   private agentRunsInSandbox(agent: Agent): boolean {
+    if (this.cfg.sandbox.backend === 'microsandbox') {
+      return this.cfg.security.requireSandbox || agent.runInSandbox
+    }
     // Sandbox-optional principle (#36): skills follow the agent's OWN sandbox
     // decision, never a forced fleet-wide requirement. Only the explicit operator
     // `security.requireSandbox` still forces confinement; a trusted/unsandboxed
@@ -3807,7 +3988,12 @@ export class Daemon {
   }
 
   /** That tool server's `session/new` spec, in the coordinates of wherever the runtime runs. */
-  private mcpToolServerSpec(token: string): McpStdioServer[] {
+  private mcpToolServerSpec(token: string, agent?: Agent): McpStdioServer[] {
+    if (agent && this.usesMicrosandbox(agent)) {
+      const bridge = this.microsandboxTable?.mcpBridge
+      if (!bridge) throw new Error('microsandbox image does not provide the AgentConnect MCP bridge')
+      return buildSandboxMcpServers({ bridge, token })
+    }
     if (!this.k8sPlane) {
       return buildMcpServers({
         socketPath: mcpSocketPath(this.root),
@@ -4261,7 +4447,9 @@ export class Daemon {
   } {
     const agentId = agent.id
     const onUpdate = (sid: string, u: any) => this.enqueueAcpUpdate(opts.hostKey, sid, u)
-    const runtimeEntry = this.runtimeCatalog.entries[agent.runtime]
+    const micro = opts.runInSandbox && this.cfg.sandbox.backend === 'microsandbox'
+    const catalog = micro ? this.microsandboxCatalog : (this.localRuntimeCatalog ?? this.runtimeCatalog)
+    const runtimeEntry = catalog?.entries[agent.runtime]
     if (runtimeEntry?.source === 'curated') {
       this.curatedRuntimeAdmission.assertLaunch(agent.runtime, runtimeEntry.source)
     }
@@ -4285,8 +4473,11 @@ export class Daemon {
     if (this.opts.hostFactory) {
       return { host: this.opts.hostFactory(agent, onUpdate), configFileState }
     }
-    const runtime = this.runtimes[agent.runtime]
+    const runtime = catalog?.runtimes[agent.runtime]
     if (!runtime) throw new Error(this.runtimeUnavailableMessage(agent.runtime))
+    const microContext = micro
+      ? this.microsandboxContext(agent, opts.cwd, opts.hostKey, opts.excludeAgentToolCredentials === true)
+      : undefined
     // A dream reads only its materialized inputs to produce a memory proposal, so
     // it never needs the agent's TOOL credentials (github-app git helper, gh
     // wrapper, or materialized `*_DATA` config-file secrets like KUBECONFIG /
@@ -4323,7 +4514,7 @@ export class Daemon {
     // Native memory is redirected under the HOME this host actually launches with — a confined session's own (§11).
     const memoryAgent =
       memoryKindOf(agent) === 'native' && runInSandbox
-        ? { ...agent, dir: privateRuntimeHomeFor(agent.dir, opts.hostKey) }
+        ? { ...agent, dir: microContext?.launch.runtimeHome ?? privateRuntimeHomeFor(agent.dir, opts.hostKey) }
         : agent
     const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
     // On --k8s the runtime runs in the agent's pod, so the session gitconfig has to be COMPUTED in
@@ -4382,11 +4573,11 @@ export class Daemon {
       }
     }
     // The cluster driver routes every pod launch by AC_AGENT_ID, credentials or not.
-    if (this.k8sPlane) env.AC_AGENT_ID = agent.id
+    if (this.k8sPlane || micro) env.AC_AGENT_ID = agent.id
     const shimDirs = new Set<string>()
     // The gh wrapper is a DAEMON path: prepending it to a pod launch would name a dir the pod
     // never had, and the pod image ships no wrapper (gh there degrades to unauthenticated).
-    if (githubAppCredentials && this.ghBinDir && !this.k8sPlane) {
+    if (githubAppCredentials && this.ghBinDir && !this.k8sPlane && !micro) {
       // gh wrapper (multi-repo #457): PATH prepend + the agent identity the
       // wrapper hands to the hidden token helper. sessionGitEnv supplies the
       // matching runtime-only capability; a user PATH override must not
@@ -4394,7 +4585,7 @@ export class Daemon {
       env.AC_AGENT_ID = agent.id
       shimDirs.add(this.ghBinDir)
     }
-    if (gitlabCredentials && this.glabBinDir && !this.k8sPlane) {
+    if (gitlabCredentials && this.glabBinDir && !this.k8sPlane && !micro) {
       // glab wrapper (§13.3): read-only project tokens for the managed workspace.
       env.AC_AGENT_ID = agent.id
       // §24.4: point the real CLI at the deployment's instance, prefix and port included.
@@ -4402,7 +4593,7 @@ export class Daemon {
       shimDirs.add(this.glabBinDir)
     }
     if (shimDirs.size > 0) {
-      env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? process.env.PATH ?? ''}`
+      env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? microContext?.launch.env.PATH ?? process.env.PATH ?? ''}`
     }
     const target = opts.modelCredential?.target ?? modelProviderTarget(agent, runtime)
     // OS sandbox decision (issue #312). security.requireSandbox forces every agent
@@ -4417,6 +4608,16 @@ export class Daemon {
     let launchRuntime = runtime
     try {
       const assembled = assembleRuntimeLaunch({
+        ...(microContext
+          ? {
+              microsandbox: {
+                mounts: this.cfg.sandbox.mounts,
+                guestEntry: microsandboxGuestEntry(this.root),
+                trustedMounts: microsandboxSupportMounts(this.root, sessionGitInjection?.GIT_CONFIG_GLOBAL),
+                ...this.microsandboxPlacement(agent, opts.cwd, opts.hostKey)
+              }
+            }
+          : {}),
         runtimeId: agent.runtime,
         runtime,
         provider: memoryKindOf(agent),
@@ -4441,16 +4642,17 @@ export class Daemon {
           if (this.codexSessionFloor) applyCodexSessionFloor(target, launchEnv, this.codexSessionFloor)
           if (this.claudeModelAliases) applyClaudeModelAliases(target, launchEnv, this.claudeModelAliases)
         },
-        runtimeReadRoots: runInSandbox
-          ? () =>
-              this.sandboxRuntimeReadRoots(
-                agent,
-                runtime,
-                sessionGitInjection?.GIT_CONFIG_GLOBAL,
-                githubAppCredentials,
-                gitlabCredentials
-              )
-          : undefined,
+        runtimeReadRoots:
+          runInSandbox && !micro
+            ? () =>
+                this.sandboxRuntimeReadRoots(
+                  agent,
+                  runtime,
+                  sessionGitInjection?.GIT_CONFIG_GLOBAL,
+                  githubAppCredentials,
+                  gitlabCredentials
+                )
+            : undefined,
         runtimeWriteRoots: runInSandbox
           ? this.cfg.sandbox.mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source)
           : undefined,
@@ -4497,6 +4699,12 @@ export class Daemon {
     const constructed: { host?: AcpHost } = {}
     const podSubject = this.k8sPlane ? this.podSubjectFor(agent, opts.hostKey) : undefined
     const host = new AcpHost(launchRuntime, {
+      ...(microContext
+        ? {
+            driver: this.microsandbox!.driverFor({ ...microContext.environment, ...launch.microsandbox }),
+            hostKey: opts.hostKey
+          }
+        : {}),
       // In --k8s the runtime runs in a Sandbox pod — the agent's own, or the session's own for an isolated
       // session's host (§11); everywhere else AcpHost falls back to its LocalDriver, which is what a
       // self-hosted daemon wants.
@@ -4599,7 +4807,7 @@ export class Daemon {
       WORKSPACE_GIT_MESSAGE_FEATURE,
       WORKSPACE_GIT_REVIEW_FEATURE,
       WORKSPACE_GIT_WRITE_FEATURE,
-      ...(this.sandboxMechanism ? ['sandbox'] : []),
+      ...((this.cfg.sandbox.backend === 'microsandbox' ? this.microsandbox : this.sandboxMechanism) ? ['sandbox'] : []),
       ...(this.cfg.security.requireSandbox ? ['sandbox-required'] : []),
       'memory-dreaming-v1',
       ORGANIZATION_KNOWLEDGE_FEATURE,
@@ -4968,7 +5176,7 @@ export class Daemon {
         })
         this.releaseMemoryExtractionToken(cacheKey)
         this.memoryExtractionTokens.set(cacheKey, mcpToken)
-        const mcpServers = this.mcpToolServerSpec(mcpToken)
+        const mcpServers = this.mcpToolServerSpec(mcpToken, this.agents.get(agentId))
         sessionId = trusted
           ? await host.newSession(
               cwd,
@@ -5267,6 +5475,12 @@ export class Daemon {
     try {
       host = await this.buildDreamHost(agent, context.inputDir, dreamHostKey, issued)
     } catch (error) {
+      await this.microsandbox
+        ?.discard(`${agent.id}/${hostKeyDirName(dreamHostKey)}`)
+        .then(() => rm(join(agent.dir, 'sessions', hostKeyDirName(dreamHostKey)), { recursive: true, force: true }))
+        .catch((error: unknown) => {
+          this.log.warn(`microsandbox: could not discard extraction VM (${formatErr(error)})`)
+        })
       removeHostSandboxState(agent.dir, dreamHostKey)
       if (issued) await this.modelSessions.revokeKeyQuietly(issued.grant.keyId)
       throw error
@@ -5279,6 +5493,12 @@ export class Daemon {
       // attacker-influenced context never lingers (dreams are rare). Stopping the
       // child also kills a runtime that ignored `session/cancel`.
       await host.stop().catch(() => {})
+      await this.microsandbox
+        ?.discard(`${agent.id}/${hostKeyDirName(dreamHostKey)}`)
+        .then(() => rm(join(agent.dir, 'sessions', hostKeyDirName(dreamHostKey)), { recursive: true, force: true }))
+        .catch((error: unknown) => {
+          this.log.warn(`microsandbox: could not discard extraction VM (${formatErr(error)})`)
+        })
       removeHostSandboxState(agent.dir, dreamHostKey)
       if (issued) {
         await this.modelSessions.revokeKey(issued.grant.keyId)
@@ -5426,7 +5646,7 @@ export class Daemon {
         maxTopics: MAX_DREAM_FILES
       }
     })
-    const mcpServers = this.mcpToolServerSpec(mcpToken)
+    const mcpServers = this.mcpToolServerSpec(mcpToken, this.agents.get(agentId))
     try {
       const sessionId = trusted
         ? await host.newSession(
@@ -14145,7 +14365,7 @@ export class Daemon {
         bound && bound.cwd === undefined ? bound.workspace : undefined,
         allowAgentDrain
       )
-      await this.ensureRuntimeInstalled(agent.runtime)
+      if (!this.usesMicrosandbox(agent)) await this.ensureRuntimeInstalled(agent.runtime, true)
       if (this.hostStartGeneration.get(key) !== generation) {
         throw new Error(`host start superseded for ${label}`)
       }
@@ -15139,8 +15359,12 @@ export class Daemon {
     // reconcile must not release admission while clone/pull/install still runs.
     const hostStop = host ? Promise.resolve().then(() => host.stop(deadlineMs)) : Promise.resolve()
     const stop = Promise.allSettled([hostStop, ...supersededStarts])
-      .then(([hostResult]) => {
+      .then(async ([hostResult]) => {
         if (hostResult?.status === 'rejected') throw hostResult.reason
+        if (launch && this.microsandbox) {
+          const agent = this.agents.get(agentId)
+          if (agent) await this.microsandbox.suspend(this.microsandboxPlacement(agent, launch.cwd, key).id)
+        }
       })
       .finally(() => {
         if (this.hostStopping.get(key) === stop) this.hostStopping.delete(key)
@@ -15956,26 +16180,39 @@ export class Daemon {
         this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
         continue
       }
-      // Re-check synchronously after the git awaits: a message admitted mid-cleanup
-      // owns the serial gate now, and deleting the row underneath its turn would
-      // orphan the state the turn is about to write. The worktree (if any) is
-      // already gone, but prepareSessionWorkspace recreates it on that same turn.
-      if (await this.sessionRetentionActive(rec)) {
-        active += 1
-        continue
+      const purge = async () => {
+        // Recheck inside the admission fence before destroying a VM or deleting its last session record.
+        if (await this.sessionRetentionActive(rec)) {
+          active += 1
+          return
+        }
+        const sessionHost = this.sessionHostFence(rec.agentId, rec.key)
+        if (this.microsandbox) {
+          try {
+            await this.stopSessionHost(rec.agentId, rec.key, { ...sessionHost, row: rec })
+            await this.discardSessionSandbox(rec.agentId, rec.key)
+          } catch (err) {
+            failed += 1
+            this.log.warn(`retention: keeping session ${rec.key} — VM cleanup failed (${(err as Error).message})`)
+            return
+          }
+        }
+        // Deleting the row also writes the durable purge receipt for the Control Plane.
+        if (
+          await this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })
+        ) {
+          removed += 1
+          if (rec.acpSessionId)
+            this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
+          await this.modelSessions.release(rec.key)
+          if (!this.microsandbox) {
+            await this.stopSessionHost(rec.agentId, rec.key, { ...sessionHost, row: rec })
+            await this.discardSessionSandbox(rec.agentId, rec.key)
+          }
+        }
       }
-      const sessionHost = this.sessionHostFence(rec.agentId, rec.key)
-      // The purge receipt is written in deleteSession's transaction: the CP holds
-      // the only surviving record of this session, and it must be told that the
-      // content behind it is gone (drained below, durably, on ACK).
-      if (await this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })) {
-        removed += 1
-        if (rec.acpSessionId)
-          this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
-        await this.modelSessions.release(rec.key)
-        await this.stopSessionHost(rec.agentId, rec.key, { ...sessionHost, row: rec })
-        await this.discardSessionSandbox(rec.agentId, rec.key)
-      }
+      if (this.microsandbox) await this.withWorkspaceAdmissionFence(rec.agentId, purge)
+      else await purge()
     }
     this.log.info(
       `retention: session GC removed ${removed}/${expired.length} expired session(s)` +
@@ -16364,6 +16601,7 @@ export class Daemon {
    * failed. The cost is at most one sweep interval of delay after the host goes.
    */
   private async sweepIdleSandboxes(now: number, ttl: number): Promise<void> {
+    await this.microsandbox?.suspendIdle(now - ttl)
     const plane = this.k8sPlane
     if (!plane) return
     for (const { subject, agentId, since } of plane.launched()) {
@@ -16449,6 +16687,11 @@ export class Daemon {
    * the agent exists. One delete, logged on failure; the orphan reconciler collects what is left.
    */
   private async discardClusterSandbox(agentId: string): Promise<void> {
+    if (this.microsandbox) {
+      for (const id of await this.microsandbox.environmentIds()) {
+        if (id.startsWith(`${agentId}/`)) await this.microsandbox.discard(id)
+      }
+    }
     const plane = this.k8sPlane
     if (!plane) return
     try {
@@ -16463,6 +16706,7 @@ export class Daemon {
 
   /** Cluster only: a retired session's pod goes with its row — the claim, and the clones and HOME on its volume (§11). Best effort like the agent's; the orphan reconciler collects a leftover. */
   private async discardSessionSandbox(agentId: string, sessionKey: string): Promise<void> {
+    await this.microsandbox?.discard(`${agentId}/${hostKeyDirName(sessionHostKey(agentId, sessionKey))}`)
     const plane = this.k8sPlane
     if (!plane) return
     const leaf = hostKeyDirName(sessionHostKey(agentId, sessionKey))
@@ -16478,6 +16722,13 @@ export class Daemon {
 
   /** Cluster only: retire every session pod of the agent but the leaf named — a replaced workspace leaves them holding the old repository (§11). */
   private async discardSessionSandboxes(agentId: string, exceptLeaf?: string): Promise<void> {
+    if (this.microsandbox) {
+      for (const id of await this.microsandbox.environmentIds()) {
+        if (id.startsWith(`${agentId}/session-`) && id !== `${agentId}/${exceptLeaf}`) {
+          await this.microsandbox.discard(id)
+        }
+      }
+    }
     const plane = this.k8sPlane
     if (!plane) return
     for (const subject of await plane.driver.sessionClaimSubjects(agentId)) {
@@ -17858,6 +18109,9 @@ export class Daemon {
       store: () => this.store,
       draining: () => this.draining,
       catalog: () => this.runtimeCatalog,
+      localProbeCatalog: () => this.localRuntimeCatalog ?? this.runtimeCatalog,
+      executionLocation: (runtimeId) =>
+        this.k8s || this.microsandboxCatalog?.entries[runtimeId] !== undefined ? 'sandbox' : 'host',
       admittedRuntimes: () => this.runtimes,
       refreshAdmitted: () => this.refreshAdmittedRuntimes(),
       reportedRuntimeIds: () => this.reportedRuntimeIds(),
@@ -17866,7 +18120,20 @@ export class Daemon {
       updateCapabilities: () => this.cpClient?.updateCapabilities?.(),
       mcpServerFacts: () => this.mcpServerFactsFromDefs(),
       noteCatalogProbe: (input) => void this.modelCatalogSvc?.noteProbe(input),
-      localizeRuntime: (runtimeId) => this.ensureRuntimeInstalled(runtimeId),
+      localizeRuntime: async (runtimeId) => {
+        await this.ensureRuntimeInstalled(runtimeId)
+        // Host-only installs must stay current in the separate local launch catalog.
+        if (this.localRuntimeCatalog && !this.microsandboxCatalog?.entries[runtimeId]) {
+          const entry = this.runtimeCatalog.entries[runtimeId]
+          if (entry) {
+            this.localRuntimeCatalog.entries[runtimeId] = entry
+            this.localRuntimeCatalog.runtimes[runtimeId] = entry.runtime
+          } else {
+            delete this.localRuntimeCatalog.entries[runtimeId]
+            delete this.localRuntimeCatalog.runtimes[runtimeId]
+          }
+        }
+      },
       launch: () => ({
         k8s: this.k8s,
         fakeHosts: this.opts.hostFactory !== undefined,
@@ -18406,6 +18673,8 @@ export class Daemon {
     // Only now: the shim channel IS the runtimes' transport, so closing it before the drain
     // would cut in-flight turns and closing it before host teardown would leave `AcpHost.stop()`
     // unable to send its ACP close — a sandbox process still running, and reconnecting.
+    await this.microsandbox?.stopAll().catch((error: unknown) => errors.push(error))
+    this.microsandbox = undefined
     await this.k8sPlane?.stop().catch(() => undefined)
     await this.readiness?.stop().catch(() => undefined)
     this.readiness = undefined

--- a/packages/daemon/src/launch/assemble.ts
+++ b/packages/daemon/src/launch/assemble.ts
@@ -3,7 +3,7 @@ import { composeRuntimeLaunch, type ComposedRuntimeLaunch } from './compose.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
 import type { HostKey } from '../acp/host-key.js'
 import type { MemoryProviderKind } from '../memory/provider.js'
-import type { RuntimeDef } from '../config/config-schema.js'
+import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
 
 /** Config-file materialization result plus the pre-strip env it was planned from
  * (the daemon snapshots that env so an idle sweep can re-write the files later). */
@@ -53,6 +53,12 @@ export interface AssembleRuntimeLaunchOptions {
   hostEnv?: NodeJS.ProcessEnv
   k8s?: boolean
   hostPackageCache?: boolean
+  microsandbox?: {
+    mounts: SandboxMount[]
+    guestEntry: string
+    trustedSessionDir?: string
+    trustedMounts?: SandboxMount[]
+  }
 }
 
 /**
@@ -84,6 +90,7 @@ export function assembleRuntimeLaunch(opts: AssembleRuntimeLaunchOptions): Assem
     typeof opts.runtimeReadRoots === 'function' ? opts.runtimeReadRoots(launchEnv) : opts.runtimeReadRoots
 
   const composed = composeRuntimeLaunch({
+    ...(opts.microsandbox ? { microsandbox: opts.microsandbox } : {}),
     runtimeId: opts.runtimeId,
     runtime: opts.runtime,
     provider: opts.provider,

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -21,7 +21,7 @@ import {
   runtimeMemoryPolicyId
 } from '../memory/runtime/capabilities.js'
 import { MemoryProviderUnavailableError, type MemoryProviderKind } from '../memory/provider.js'
-import type { RuntimeDef } from '../config/config-schema.js'
+import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
 import { CLAUDE_PROFILE_ENV, isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
 import { resolveCommandPath } from '../runtimes/probe.js'
@@ -169,6 +169,12 @@ export function composeRuntimeLaunch(opts: {
   k8s?: boolean
   /** Probe launches only — keep npx/uvx on the host package cache. */
   hostPackageCache?: boolean
+  microsandbox?: {
+    mounts: SandboxMount[]
+    guestEntry: string
+    trustedSessionDir?: string
+    trustedMounts?: SandboxMount[]
+  }
 }): ComposedRuntimeLaunch {
   const policyId = runtimeMemoryPolicyId(opts.runtime, opts.runtimeId)
   const capabilities = runtimeMemoryCapabilities(opts.runtime, opts.runtimeId)
@@ -185,10 +191,11 @@ export function composeRuntimeLaunch(opts: {
   // externalExecution can never launch sandboxed — skip executable resolution so
   // prepareRuntimeLaunch reports the refusal instead of a resolution failure.
   const sandboxAccess =
-    opts.runInSandbox && opts.runtime.externalExecution !== true
+    opts.runInSandbox && !opts.microsandbox && opts.runtime.externalExecution !== true
       ? runtimeSandboxReadRoots(opts.runtime, stateSourceEnv)
       : undefined
   const launch = prepareRuntimeLaunch({
+    ...(opts.microsandbox ? { microsandbox: opts.microsandbox } : {}),
     ...(opts.k8s === true ? { k8s: true } : {}),
     runtimeId: opts.runtimeId,
     runtime: opts.runtime,

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -4,7 +4,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep 
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from '../acp/sandbox.js'
 import { prepareSandboxTempDir, SANDBOX_TEMP_DIR_ENV } from '../acp/sandbox-temp.js'
 import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key.js'
-import type { RuntimeDef } from '../config/config-schema.js'
+import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
+import { prepareMicrosandboxLaunch } from '../microsandbox/launch.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
 import {
@@ -179,6 +180,7 @@ export interface PreparedRuntimeLaunch {
    *  was confined or nothing was found. Logged at spawn so a stale grant is visible after the fact. */
   gitMetadataWriteRoots: string[]
   runtimeHome?: string
+  microsandbox?: { mounts: SandboxMount[]; workspaceRoot: string }
   sandbox?: {
     mechanism: SandboxMechanism
     writable: string[]
@@ -258,7 +260,16 @@ export function prepareRuntimeLaunch(opts: {
    * hostPackageCacheEnv). A probe never runs a model turn; an agent launch must not
    * get this, so its confined tool use cannot write another runtime's install tree. */
   hostPackageCache?: boolean
+  microsandbox?: {
+    mounts: SandboxMount[]
+    guestEntry: string
+    trustedSessionDir?: string
+    trustedMounts?: SandboxMount[]
+  }
 }): PreparedRuntimeLaunch {
+  if (opts.runInSandbox && opts.microsandbox) {
+    return prepareMicrosandboxLaunch({ ...opts, ...opts.microsandbox })
+  }
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   // A confined session's own directory (§11), read before anything branches: the tier is the session's and
   // does not follow the boundary, so an unsandboxed launch of one still runs against its clones, not the agent's.

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -1,0 +1,774 @@
+import { execFile } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join, posix } from 'node:path'
+import { promisify } from 'node:util'
+import type { ExecHandle, ExecSink, Sandbox, SandboxHandle } from 'microsandbox'
+import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-driver.js'
+import type { SandboxMount } from '../config/config-schema.js'
+import type { Logger } from '../log.js'
+import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
+import { SinkRelPathSchema } from '../shim/file-sink.js'
+import { SANDBOX_MCP_BRIDGE_ENTRY } from '../shim/sandbox-paths.js'
+import { MICROSANDBOX_GUEST_ENTRY, MICROSANDBOX_NODE } from './guest.js'
+
+const runFile = promisify(execFile)
+const STOP_TIMEOUT_MS = 10_000
+const RUNTIME_TABLE_PATH = '/opt/agentconnect/runtime/k8s-runtimes.json'
+const IMAGE_PROBE_SCRIPT = `
+const { existsSync, readFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+execFileSync('/usr/bin/python3', ['-c', 'import socket; socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM).close()'], { timeout: 10000 });
+const table = JSON.parse(readFileSync(process.argv[1], 'utf8'));
+const bridge = process.argv[2];
+if (existsSync(bridge)) table.mcpBridge = { command: process.execPath, args: [bridge] };
+process.stdout.write(JSON.stringify(table));
+`
+
+export interface MicrosandboxEnvironment {
+  id: string
+  mounts: SandboxMount[]
+  workspaceRoot: string
+}
+
+export interface MicrosandboxExecOptions {
+  env?: Record<string, string>
+  cwd?: string
+  abort?: AbortSignal
+  timeoutMs?: number
+  maxBytes?: number
+}
+
+export interface MicrosandboxExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+export interface MicrosandboxManagerOptions {
+  root: string
+  config: { image: string; cpus: number; memoryMiB: number; diskGiB: number }
+  sdk: Pick<typeof import('microsandbox'), 'Sandbox' | 'SandboxNotFoundError'>
+  msbCommand: { command: string; args: string[] }
+  log?: Logger
+  sockets: { mcp: string; gitcred: string }
+}
+
+interface EnvironmentState {
+  environment: MicrosandboxEnvironment
+  spec: string
+  sandbox: Promise<Sandbox>
+  active: number
+  closing?: Promise<void>
+  bridgeFailed?: boolean
+  processes: Set<MicrosandboxProcess>
+  pending: Set<Promise<void>>
+  lastUsed: number
+}
+
+interface Binding {
+  version: 1
+  spec: string
+  sandboxId: string
+  configHash: string
+  environmentId: string
+}
+
+/** Owns VM lifecycle while exposing the existing ACP process-stream contract. */
+export class MicrosandboxManager {
+  private readonly environments = new Map<string, EnvironmentState>()
+  private readonly bridges = new Map<string, MicrosandboxProcess>()
+  private preparation?: Promise<K8sRuntimeTable>
+  private closed = false
+
+  constructor(private readonly options: MicrosandboxManagerOptions) {}
+
+  prepare(): Promise<K8sRuntimeTable> {
+    return (this.preparation ??= this.probe())
+  }
+
+  driverFor(environment: MicrosandboxEnvironment): SpawnDriver {
+    return { launch: (request) => this.launch(environment, request) }
+  }
+
+  async exec(
+    environment: MicrosandboxEnvironment,
+    command: string,
+    args: string[],
+    options: MicrosandboxExecOptions = {}
+  ): Promise<MicrosandboxExecResult> {
+    options.abort?.throwIfAborted()
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let bytes = 0
+    const append = (chunks: Buffer[], chunk: Uint8Array) => {
+      bytes += chunk.byteLength
+      if (bytes > (options.maxBytes ?? 16 * 1024 * 1024)) throw new Error('microsandbox exec output limit exceeded')
+      chunks.push(Buffer.from(chunk))
+    }
+    const runtime = await this.startProcess(environment, command, args, options, (chunk) => append(stderr, chunk))
+    let failure: unknown
+    const abort = () => {
+      failure ??= options.abort?.reason ?? new Error('microsandbox exec aborted')
+      void runtime.stop(STOP_TIMEOUT_MS).catch((error: unknown) => runtime.fail(error))
+    }
+    options.abort?.addEventListener('abort', abort, { once: true })
+    const timer =
+      options.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            failure ??= new Error('microsandbox exec timed out')
+            void runtime.stop(STOP_TIMEOUT_MS).catch((error: unknown) => runtime.fail(error))
+          }, options.timeoutMs)
+    if (options.abort?.aborted) abort()
+    try {
+      await runtime.closeStdin()
+      for await (const chunk of runtime.fromAgent) append(stdout, chunk)
+      const exitCode = await runtime.exited
+      if (failure !== undefined) throw failure
+      return {
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+        exitCode
+      }
+    } catch (error) {
+      await runtime.stop(STOP_TIMEOUT_MS)
+      throw error
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+      options.abort?.removeEventListener('abort', abort)
+    }
+  }
+
+  async suspend(id: string): Promise<void> {
+    await this.closeEnvironment(id, false)
+  }
+
+  async discard(id: string): Promise<void> {
+    await this.closeEnvironment(id, true)
+  }
+
+  environment(id: string): MicrosandboxEnvironment | undefined {
+    return this.environments.get(id)?.environment
+  }
+
+  async environmentIds(): Promise<string[]> {
+    return [...new Set([...this.environments.keys(), ...(await this.persistedIds())])]
+  }
+
+  async suspendIdle(idleBefore: number): Promise<void> {
+    for (const [id, state] of this.environments) {
+      if (!state.closing && state.active === 0 && state.lastUsed <= idleBefore) await this.suspend(id)
+    }
+  }
+
+  async stopAll(): Promise<void> {
+    this.closed = true
+    const results = await Promise.allSettled(
+      [...this.environments.entries()].map(async ([id, state]) => {
+        await Promise.all([...state.pending])
+        await Promise.all([...state.processes].map((process) => process.stop(STOP_TIMEOUT_MS)))
+        await this.suspend(id)
+      })
+    )
+    const errors = results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []))
+    if (errors.length) throw new AggregateError(errors, 'microsandbox shutdown failed')
+  }
+
+  private name(id: string): string {
+    return `agentconnect-${hash(this.options.root).slice(0, 12)}-${hash(id).slice(0, 24)}`
+  }
+
+  private bindingPath(id: string): string {
+    return join(this.options.root, 'microsandbox', 'bindings', `${this.name(id)}.json`)
+  }
+
+  private spec(environment: MicrosandboxEnvironment): string {
+    return stableJson({
+      version: 1,
+      config: this.options.config,
+      environment: { ...environment, mounts: [...environment.mounts].sort((a, b) => a.target.localeCompare(b.target)) },
+      sockets: this.options.sockets
+    })
+  }
+
+  private builder(name: string, mounts: SandboxMount[]) {
+    const builder = this.options.sdk.Sandbox.builder(name)
+      .image(this.options.config.image)
+      .rootDisk((disk) =>
+        disk
+          .flat()
+          .size(this.options.config.diskGiB * 1024)
+          .cloneStrategy('auto')
+      )
+      .cpus(this.options.config.cpus)
+      .memory(this.options.config.memoryMiB)
+      .deploymentProfile('single-tenant')
+      .detached(true)
+      .ephemeral(false)
+      .quietLogs()
+    for (const mount of mounts) {
+      builder.volume(mount.target, (volume) => {
+        volume.bind(mount.source)
+        return mount.readOnly ? volume.readonly() : volume
+      })
+    }
+    return builder
+  }
+
+  private async probe(): Promise<K8sRuntimeTable> {
+    const bindings = join(this.options.root, 'microsandbox', 'bindings')
+    await mkdir(bindings, { recursive: true, mode: 0o700 })
+    for (const id of await this.persistedIds()) {
+      const binding = await this.readBinding(id)
+      const handle = await this.find(this.name(id))
+      if (handle) {
+        if (handle.id !== binding?.sandboxId) throw new Error('microsandbox persisted environment identity changed')
+        if (handle.status === 'running' || handle.status === 'starting' || handle.status === 'draining') {
+          await handle.stopWithTimeout(STOP_TIMEOUT_MS)
+        }
+      }
+    }
+    const { command, args } = this.options.msbCommand
+    await runFile(command, [...args, 'pull', this.options.config.image, '--materialize', 'all', '--quiet'], {
+      env: { ...process.env, MSB_HOME: join(this.options.root, 'microsandbox'), MSB_BACKEND: 'local' },
+      timeout: 5 * 60_000,
+      maxBuffer: 1024 * 1024
+    })
+    const sandbox = await this.builder(`${this.name('probe')}-${randomUUID().slice(0, 8)}`, []).create()
+    try {
+      const output = await sandbox.exec(MICROSANDBOX_NODE, [
+        '-e',
+        IMAGE_PROBE_SCRIPT,
+        RUNTIME_TABLE_PATH,
+        SANDBOX_MCP_BRIDGE_ENTRY
+      ])
+      if (!output.success)
+        throw new Error(`microsandbox image preflight failed (exit ${output.code}): ${output.stderr().trim()}`)
+      const table = K8sRuntimeTableSchema.parse(JSON.parse(output.stdout()))
+      await sandbox.stopWithTimeout(STOP_TIMEOUT_MS)
+      const resumed = await (await this.options.sdk.Sandbox.get(sandbox.name)).startDetached()
+      await resumed.ping()
+      this.options.log?.info('microsandbox: image, Node, Python/vsock, runtime table and disk resume verified')
+      return table
+    } finally {
+      await sandbox.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+    }
+  }
+
+  private async persistedIds(): Promise<string[]> {
+    const directory = join(this.options.root, 'microsandbox', 'bindings')
+    let files: string[]
+    try {
+      files = await readdir(directory)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+    const ids: string[] = []
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue
+      const value = JSON.parse(await readFile(join(directory, file), 'utf8')) as Partial<Binding>
+      if (typeof value.environmentId !== 'string' || file !== `${this.name(value.environmentId)}.json`) {
+        throw new Error('microsandbox has an invalid persisted environment binding')
+      }
+      await this.readBinding(value.environmentId)
+      ids.push(value.environmentId)
+    }
+    return ids
+  }
+
+  private async find(name: string): Promise<SandboxHandle | undefined> {
+    try {
+      return await this.options.sdk.Sandbox.get(name)
+    } catch (error) {
+      if (error instanceof this.options.sdk.SandboxNotFoundError) return undefined
+      throw error
+    }
+  }
+
+  private async readBinding(id: string): Promise<Binding | undefined> {
+    try {
+      const value: unknown = JSON.parse(await readFile(this.bindingPath(id), 'utf8'))
+      if (!value || typeof value !== 'object') throw new Error('invalid binding')
+      const binding = value as Partial<Binding>
+      if (
+        binding.version !== 1 ||
+        binding.environmentId !== id ||
+        typeof binding.spec !== 'string' ||
+        typeof binding.sandboxId !== 'string' ||
+        typeof binding.configHash !== 'string'
+      ) {
+        throw new Error('invalid binding')
+      }
+      return binding as Binding
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+      throw error
+    }
+  }
+
+  private async open(environment: MicrosandboxEnvironment): Promise<Sandbox> {
+    const name = this.name(environment.id)
+    const spec = this.spec(environment)
+    const binding = await this.readBinding(environment.id)
+    const existing = await this.find(name)
+    if (binding || existing) {
+      if (
+        !binding ||
+        !existing ||
+        binding.spec !== spec ||
+        binding.sandboxId !== existing.id ||
+        binding.configHash !== hash(stableJson(existing.config()))
+      ) {
+        throw new Error(
+          `microsandbox environment ${environment.id} has missing or changed persisted configuration; discard it before recreating`
+        )
+      }
+      if (existing.status === 'running' || existing.status === 'starting' || existing.status === 'draining') {
+        await existing.stopWithTimeout(STOP_TIMEOUT_MS)
+      }
+      const sandbox = await existing.connectOrStart({ detached: true })
+      try {
+        await this.startBridge(environment.id, sandbox)
+        return sandbox
+      } catch (error) {
+        await sandbox.stopWithTimeout(STOP_TIMEOUT_MS)
+        throw error
+      }
+    }
+    const sandbox = await this.builder(name, environment.mounts)
+      .vsock(this.options.sockets.mcp, 5000)
+      .vsock(this.options.sockets.gitcred, 5001)
+      .create()
+    try {
+      const persisted = await this.options.sdk.Sandbox.get(name)
+      const binding: Binding = {
+        version: 1,
+        environmentId: environment.id,
+        spec,
+        sandboxId: persisted.id,
+        configHash: hash(stableJson(persisted.config()))
+      }
+      const path = this.bindingPath(environment.id)
+      await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+      const temporary = `${path}.${randomUUID()}.tmp`
+      try {
+        await writeFile(temporary, JSON.stringify(binding), { mode: 0o600, flag: 'wx' })
+        await rename(temporary, path)
+      } finally {
+        await rm(temporary, { force: true })
+      }
+      await this.startBridge(environment.id, sandbox)
+      return sandbox
+    } catch (error) {
+      await sandbox.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+      await rm(this.bindingPath(environment.id), { force: true })
+      throw error
+    }
+  }
+
+  private async startBridge(id: string, sandbox: Sandbox): Promise<void> {
+    const handle = await sandbox.execStreamWith(MICROSANDBOX_NODE, (exec) =>
+      exec.args([MICROSANDBOX_GUEST_ENTRY, 'sockets']).stdinPipe().tty(false)
+    )
+    const stdin = await handle.takeStdin()
+    if (!stdin) {
+      await handle.kill()
+      throw new Error('microsandbox socket bridge did not provide a stream')
+    }
+    const bridge = new MicrosandboxProcess(
+      handle,
+      stdin,
+      (data) => process.stderr.write(data),
+      () => {}
+    )
+    try {
+      const reader = bridge.fromAgent.getReader()
+      let ready = ''
+      const timer = setTimeout(() => {
+        void bridge.stop(STOP_TIMEOUT_MS).catch((error: unknown) => bridge.fail(error))
+      }, STOP_TIMEOUT_MS)
+      try {
+        while (ready !== 'ready\n') {
+          const chunk = await reader.read()
+          if (chunk.done) throw new Error('microsandbox socket bridge exited before becoming ready')
+          ready += Buffer.from(chunk.value).toString('utf8')
+          if (!'ready\n'.startsWith(ready))
+            throw new Error('microsandbox socket bridge returned invalid readiness output')
+        }
+      } finally {
+        clearTimeout(timer)
+        reader.releaseLock()
+      }
+      this.bridges.set(id, bridge)
+      bridge.onExit(() => {
+        if (this.bridges.get(id) === bridge) {
+          this.bridges.delete(id)
+          this.options.log?.error(`microsandbox: socket bridge exited for ${id}`)
+          const state = this.environments.get(id)
+          if (state) {
+            state.bridgeFailed = true
+            this.stopFailedEnvironment(id)
+          }
+        }
+      })
+    } catch (error) {
+      await bridge.stop(STOP_TIMEOUT_MS)
+      throw error
+    }
+  }
+
+  private stopFailedEnvironment(id: string): void {
+    void this.closeEnvironment(id, false, true).catch((error: unknown) => {
+      this.options.log?.error(`microsandbox: failed to stop environment ${id}: ${String(error)}`)
+    })
+  }
+
+  private acquire(environment: MicrosandboxEnvironment): { state: EnvironmentState; release: () => void } {
+    if (this.closed) throw new Error('microsandbox manager is shutting down')
+    let state = this.environments.get(environment.id)
+    if (state?.closing) throw new Error(`microsandbox environment ${environment.id} is stopping`)
+    if (state?.bridgeFailed) {
+      this.stopFailedEnvironment(environment.id)
+      throw new Error(`microsandbox environment ${environment.id} socket bridge failed; stopping before retry`)
+    }
+    const spec = this.spec(environment)
+    if (state && state.spec !== spec)
+      throw new Error(`microsandbox environment ${environment.id} configuration changed while active`)
+    if (!state) {
+      state = {
+        environment,
+        spec,
+        sandbox: this.open(environment),
+        active: 0,
+        processes: new Set(),
+        pending: new Set(),
+        lastUsed: Date.now()
+      }
+      this.environments.set(environment.id, state)
+      const opening = state
+      void state.sandbox.catch(() => {
+        if (this.environments.get(environment.id) === opening) this.environments.delete(environment.id)
+      })
+    }
+    state.active++
+    state.lastUsed = Date.now()
+    let released = false
+    return {
+      state,
+      release: () => {
+        if (!released) {
+          released = true
+          state.active--
+          state.lastUsed = Date.now()
+        }
+      }
+    }
+  }
+
+  private async startProcess(
+    environment: MicrosandboxEnvironment,
+    command: string,
+    args: string[],
+    options: Pick<MicrosandboxExecOptions, 'env' | 'cwd' | 'abort'>,
+    stderr: (data: Uint8Array) => void,
+    files: SpawnRequest['files'] = [],
+    hints: SpawnRequest['hints'] = []
+  ): Promise<MicrosandboxProcess> {
+    const { state, release } = this.acquire(environment)
+    let ready!: () => void
+    const pending = new Promise<void>((resolve) => {
+      ready = resolve
+    })
+    state.pending.add(pending)
+    try {
+      const sandbox = await state.sandbox
+      if (this.closed) throw new Error('microsandbox manager is shutting down')
+      options.abort?.throwIfAborted()
+      if (!this.bridges.has(environment.id))
+        throw new Error(`microsandbox environment ${environment.id} socket bridge is not running`)
+      const env = { ...options.env }
+      for (const hint of hints ?? []) {
+        if (env[hint.envVar]) continue
+        const output = await sandbox.execWith('/bin/sh', (exec) =>
+          exec.args(['-c', 'command -v -- "$1"', 'sh', hint.command]).envs(env)
+        )
+        const path = output.stdout().trim()
+        if (output.success && posix.isAbsolute(path)) env[hint.envVar] = path
+      }
+      for (const file of files ?? []) {
+        SinkRelPathSchema.parse(file.relPath)
+        if (!posix.isAbsolute(file.root)) throw new Error('microsandbox materialization root must be absolute')
+        const path = posix.join(file.root, ...file.relPath)
+        await sandbox.fs().mkdir(posix.dirname(path))
+        await sandbox.fs().write(path, file.content)
+        const output = await sandbox.exec('chmod', ['0600', path])
+        if (!output.success) throw new Error('microsandbox could not protect materialized file permissions')
+      }
+      options.abort?.throwIfAborted()
+      const handle = await sandbox.execStreamWith(command, (exec) =>
+        exec
+          .args(args)
+          .cwd(options.cwd ?? environment.workspaceRoot)
+          .envs(env)
+          .stdinPipe()
+          .tty(false)
+      )
+      const stdin = await handle.takeStdin()
+      if (!stdin) {
+        await handle.kill()
+        throw new Error('microsandbox did not provide process stdin')
+      }
+      const runtime = new MicrosandboxProcess(handle, stdin, stderr, () => {
+        state.processes.delete(runtime)
+        release()
+      })
+      state.processes.add(runtime)
+      return runtime
+    } catch (error) {
+      release()
+      throw error
+    } finally {
+      state.pending.delete(pending)
+      ready()
+    }
+  }
+
+  private launch(environment: MicrosandboxEnvironment, request: SpawnRequest): Promise<SpawnedRuntime> {
+    return this.startProcess(
+      environment,
+      request.command,
+      request.args,
+      { env: request.env },
+      (data) => {
+        if (!request.suppressChildStderr) process.stderr.write(data)
+      },
+      request.files,
+      request.hints
+    )
+  }
+
+  private async closeEnvironment(id: string, remove: boolean, drain = false): Promise<void> {
+    const state = this.environments.get(id)
+    if (state?.closing) {
+      await state.closing
+      if (remove) await this.closeEnvironment(id, true)
+      return
+    }
+    if (state?.active && !drain) throw new Error(`microsandbox environment ${id} has ${state.active} active executions`)
+    const closing = (async () => {
+      try {
+        if (state && drain) {
+          await Promise.all([...state.pending])
+          await Promise.all([...state.processes].map((process) => process.stop(STOP_TIMEOUT_MS)))
+        }
+        const binding = await this.readBinding(id)
+        const handle = await this.find(this.name(id))
+        if (handle) {
+          if (!binding || handle.id !== binding.sandboxId)
+            throw new Error(`microsandbox environment ${id} identity changed`)
+          const bridge = this.bridges.get(id)
+          if (bridge) {
+            this.bridges.delete(id)
+            await bridge.stop(STOP_TIMEOUT_MS)
+          }
+          if (remove) await handle.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+          else await handle.stopWithTimeout(STOP_TIMEOUT_MS)
+        }
+        if (remove) await rm(this.bindingPath(id), { force: true })
+        this.environments.delete(id)
+      } finally {
+        if (state) state.closing = undefined
+      }
+    })()
+    if (state) state.closing = closing
+    await closing
+  }
+}
+
+class MicrosandboxProcess implements SpawnedRuntime {
+  readonly toAgent: WritableStream<Uint8Array>
+  readonly fromAgent: ReadableStream<Uint8Array>
+  readonly exited: Promise<number>
+  private readonly listeners = new Set<() => void>()
+  private output!: ReadableStreamDefaultController<Uint8Array>
+  private wakeOutput?: () => void
+  private finishExit!: (code: number) => void
+  private rejectExit!: (error: unknown) => void
+  private finished = false
+  private stopping?: Promise<void>
+  private discardOutput = false
+  private outputCancelled = false
+  private failing?: Promise<void>
+  private failure?: unknown
+
+  constructor(
+    private readonly handle: ExecHandle,
+    private readonly stdin: ExecSink,
+    private readonly stderr: (data: Uint8Array) => void,
+    private readonly release: () => void
+  ) {
+    this.exited = new Promise((resolve, reject) => {
+      this.finishExit = resolve
+      this.rejectExit = reject
+    })
+    void this.exited.catch(() => {})
+    this.toAgent = new WritableStream({
+      write: (data) => this.stdin.write(data),
+      close: () => this.closeStdin(),
+      abort: () => this.stop(STOP_TIMEOUT_MS)
+    })
+    this.fromAgent = new ReadableStream(
+      {
+        start: (controller) => {
+          this.output = controller
+        },
+        pull: () => {
+          this.wakeOutput?.()
+          this.wakeOutput = undefined
+        },
+        cancel: () => {
+          this.outputCancelled = true
+          return this.stop(STOP_TIMEOUT_MS)
+        }
+      },
+      { highWaterMark: 64 * 1024, size: (chunk) => chunk.byteLength }
+    )
+    void this.pump().catch((error: unknown) => this.fail(error))
+  }
+
+  onExit(listener: () => void): void {
+    if (this.finished) queueMicrotask(listener)
+    else this.listeners.add(listener)
+  }
+
+  closeStdin(): Promise<void> {
+    return this.stdin.close()
+  }
+
+  stop(deadlineMs: number, eofGraceMs = 0): Promise<void> {
+    if (!this.stopping) {
+      const stopping = this.stopProcess(deadlineMs, eofGraceMs)
+      this.stopping = stopping
+      void stopping.catch(() => {
+        if (this.stopping === stopping) this.stopping = undefined
+      })
+    }
+    return this.stopping
+  }
+
+  fail(error: unknown): Promise<void> {
+    return (this.failing ??= this.failProcess(error))
+  }
+
+  private async failProcess(error: unknown): Promise<void> {
+    if (this.finished) return
+    this.failure = error
+    this.discardOutput = true
+    this.wakeOutput?.()
+    try {
+      await this.handle.kill()
+    } catch (killError) {
+      error = new AggregateError([error, killError], 'microsandbox process failure and cleanup failure')
+      this.failure = error
+    }
+    if (this.finished) return
+    this.output.error(error)
+    this.rejectExit(error)
+    this.finish()
+  }
+
+  private finish(): void {
+    this.finished = true
+    this.wakeOutput?.()
+    this.release()
+    for (const listener of this.listeners) listener()
+    this.listeners.clear()
+  }
+
+  private async pump(): Promise<void> {
+    for await (const event of this.handle) {
+      if (!event) throw new Error('microsandbox emitted an unsupported process failure event')
+      if (event.kind === 'stdout' && !this.discardOutput) {
+        while ((this.output.desiredSize ?? 0) <= 0 && !this.discardOutput && !this.finished) {
+          await new Promise<void>((resolve) => {
+            this.wakeOutput = resolve
+          })
+        }
+        if (!this.discardOutput && !this.finished) this.output.enqueue(event.data)
+      } else if (event.kind === 'stderr') {
+        this.stderr(event.data)
+      } else if (event.kind === 'exited') {
+        if (this.finished) return
+        if (this.failure !== undefined) {
+          this.output.error(this.failure)
+          this.rejectExit(this.failure)
+        } else {
+          if (!this.outputCancelled) this.output.close()
+          this.finishExit(event.code)
+        }
+        this.finish()
+        return
+      }
+    }
+    throw new Error('microsandbox process stream ended without an exit event')
+  }
+
+  private async waitExit(ms: number): Promise<boolean> {
+    if (this.finished) return true
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        this.exited.then(
+          () => true,
+          () => true
+        ),
+        new Promise<false>((resolve) => {
+          timer = setTimeout(() => resolve(false), Math.max(0, ms))
+        })
+      ])
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }
+
+  private async stopProcess(deadlineMs: number, eofGraceMs: number): Promise<void> {
+    if (this.finished) return
+    this.discardOutput = true
+    this.wakeOutput?.()
+    const deadline = Date.now() + Math.max(0, deadlineMs)
+    try {
+      await this.closeStdin()
+    } catch (error) {
+      if (this.finished) return
+      await this.handle.kill()
+      if (!(await this.waitExit(STOP_TIMEOUT_MS))) throw error
+      return
+    }
+    if (eofGraceMs > 0 && (await this.waitExit(Math.min(eofGraceMs, deadlineMs)))) return
+    if (this.finished) return
+    try {
+      await this.handle.signal(15)
+    } catch (error) {
+      if (this.finished) return
+      await this.handle.kill()
+      if (!(await this.waitExit(STOP_TIMEOUT_MS))) throw error
+      return
+    }
+    if (await this.waitExit(deadline - Date.now())) return
+    await this.handle.kill()
+    if (!(await this.waitExit(STOP_TIMEOUT_MS))) throw new Error('microsandbox process did not exit after SIGKILL')
+  }
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, (_key, entry: unknown) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return entry
+    return Object.fromEntries(Object.entries(entry).sort(([a], [b]) => a.localeCompare(b)))
+  })
+}
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}

--- a/packages/daemon/src/microsandbox/guest-cli.ts
+++ b/packages/daemon/src/microsandbox/guest-cli.ts
@@ -1,0 +1,143 @@
+import { spawn } from 'node:child_process'
+import { createExecHandler } from '../shim/exec-handler.js'
+import { MICROSANDBOX_SOCKET_BRIDGES } from './guest.js'
+
+const SOCKET_BRIDGE = String.raw`
+import json, os, signal, socket, stat, sys, threading
+
+listeners = []
+paths = []
+connections = set()
+lock = threading.Lock()
+stopped = threading.Event()
+
+def pump(source, target):
+    try:
+        while True:
+            data = source.recv(65536)
+            if not data:
+                break
+            target.sendall(data)
+    except OSError:
+        pass
+    finally:
+        try:
+            target.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+def connect(client, port):
+    upstream = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+    with lock:
+        connections.update((client, upstream))
+    try:
+        upstream.connect((2, port))
+        reverse = threading.Thread(target=pump, args=(upstream, client), daemon=True)
+        reverse.start()
+        pump(client, upstream)
+        reverse.join()
+    except OSError:
+        pass
+    finally:
+        with lock:
+            connections.difference_update((client, upstream))
+        client.close()
+        upstream.close()
+
+def accept(listener, port):
+    while not stopped.is_set():
+        try:
+            client, _ = listener.accept()
+        except OSError:
+            return
+        threading.Thread(target=connect, args=(client, port), daemon=True).start()
+
+def stop(signum, frame):
+    stopped.set()
+
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+try:
+    for bridge in json.loads(sys.argv[1]):
+        path = bridge['path']
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        if os.path.lexists(path):
+            if not stat.S_ISSOCK(os.lstat(path).st_mode):
+                raise RuntimeError('socket path is occupied: ' + path)
+            os.unlink(path)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(path)
+        paths.append(path)
+        os.chmod(path, 0o600)
+        listener.listen()
+        listeners.append(listener)
+        threading.Thread(target=accept, args=(listener, bridge['port']), daemon=True).start()
+    print('ready', flush=True)
+    stopped.wait()
+finally:
+    for listener in listeners:
+        listener.close()
+    with lock:
+        for connection in connections:
+            connection.close()
+    for path in paths:
+        os.unlink(path)
+`
+
+async function serveSockets(): Promise<void> {
+  const child = spawn('/usr/bin/python3', ['-u', '-c', SOCKET_BRIDGE, JSON.stringify(MICROSANDBOX_SOCKET_BRIDGES)], {
+    stdio: 'inherit'
+  })
+  const stop = (): void => {
+    child.kill('SIGTERM')
+  }
+  process.once('SIGTERM', stop)
+  process.once('SIGINT', stop)
+  try {
+    await new Promise<void>((resolve, reject) => {
+      child.once('error', reject)
+      child.once('exit', (code, signal) => {
+        if (code === 0) resolve()
+        else reject(new Error(`socket bridge exited with ${signal ?? code}`))
+      })
+    })
+  } finally {
+    process.removeListener('SIGTERM', stop)
+    process.removeListener('SIGINT', stop)
+  }
+}
+
+async function main(): Promise<void> {
+  const argument = process.argv[2]
+  if (argument === 'sockets') return await serveSockets()
+  if (!argument) throw new Error('expected a guest request or sockets mode')
+  const {
+    workspaceRoot,
+    payload,
+    capability = 'exec'
+  } = JSON.parse(argument) as {
+    workspaceRoot?: unknown
+    payload?: unknown
+    capability?: unknown
+  }
+  if (typeof workspaceRoot !== 'string' || workspaceRoot.length === 0) {
+    throw new Error('workspaceRoot is required')
+  }
+  if (capability !== 'exec' && capability !== 'read') throw new Error('unsupported guest capability')
+  const abort = new AbortController()
+  const stop = (): void => abort.abort()
+  process.once('SIGTERM', stop)
+  process.once('SIGINT', stop)
+  try {
+    const result = await createExecHandler({ workspaceRoot })(capability, payload, abort.signal)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+  } finally {
+    process.removeListener('SIGTERM', stop)
+    process.removeListener('SIGINT', stop)
+  }
+}
+
+await main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/packages/daemon/src/microsandbox/guest.ts
+++ b/packages/daemon/src/microsandbox/guest.ts
@@ -1,0 +1,93 @@
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { GitExecResultSchema, ShimGitRunner, type GitExecPayload } from '../shim/git-exec.js'
+import { ShimChannelLostError, type ShimRequester } from '../shim/channels.js'
+import { ShimWorkspaceFs } from '../shim/workspace-fs-channel.js'
+import { GitTransportError, type GitRunner } from '../workspace/git-runner.js'
+import type { WorkspaceFs } from '../workspace/workspace-fs.js'
+
+export const MICROSANDBOX_NODE = '/usr/local/bin/node'
+export const MICROSANDBOX_GUEST_ENTRY = '/opt/agentconnect-local/guest.js'
+export const MICROSANDBOX_SOCKET_BRIDGES = [
+  { path: '/run/agentconnect/mcp.sock', port: 5000 },
+  { path: '/run/agentconnect/gitcred.sock', port: 5001 }
+] as const
+
+export interface MicrosandboxExecuteOptions {
+  env?: Record<string, string>
+  cwd?: string
+  abort?: AbortSignal
+  timeoutMs?: number
+  maxBytes?: number
+}
+
+export type MicrosandboxExecute = (
+  command: string,
+  args: string[],
+  options?: MicrosandboxExecuteOptions
+) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+
+interface GuestRequestOptions {
+  execute: MicrosandboxExecute
+  workspaceRoot: string
+}
+
+function guestRequester(options: GuestRequestOptions): ShimRequester {
+  return {
+    request: async (capability, payload, requestOptions) => {
+      let result
+      try {
+        result = await options.execute(
+          MICROSANDBOX_NODE,
+          [MICROSANDBOX_GUEST_ENTRY, JSON.stringify({ workspaceRoot: options.workspaceRoot, capability, payload })],
+          { ...requestOptions, maxBytes: MAX_FRAME_BYTES }
+        )
+      } catch (error) {
+        throw new ShimChannelLostError(`microsandbox could not execute the request: ${String(error)}`)
+      }
+      if (result.exitCode !== 0) {
+        throw new ShimChannelLostError(
+          result.stderr.trim() || `microsandbox guest handler exited with code ${result.exitCode}`
+        )
+      }
+      try {
+        return JSON.parse(result.stdout)
+      } catch {
+        throw new ShimChannelLostError('microsandbox guest handler returned invalid JSON')
+      }
+    }
+  }
+}
+
+export function microsandboxWorkspaceFs(options: GuestRequestOptions): WorkspaceFs {
+  return new ShimWorkspaceFs({ ...guestRequester(options), agentId: options.workspaceRoot }, options.workspaceRoot)
+}
+
+/** Each Git request runs the existing guest handler in a disposable process. */
+export function microsandboxGitRunner(options: {
+  execute: MicrosandboxExecute
+  workspaceRoot: string
+  cwd?: string
+  env?: Record<string, string>
+  mapEnv?: (env: Record<string, string>) => Record<string, string>
+  abort?: AbortSignal
+}): GitRunner {
+  const requester = guestRequester(options)
+  return new ShimGitRunner(
+    {
+      request: async (_capability, payload, requestOptions) => {
+        const gitPayload = payload as GitExecPayload
+        if (gitPayload.env !== undefined && options.mapEnv) {
+          payload = { ...gitPayload, env: options.mapEnv({ ...gitPayload.env }) }
+        }
+        try {
+          return GitExecResultSchema.parse(await requester.request('exec', payload, requestOptions))
+        } catch (error) {
+          throw new GitTransportError(error instanceof Error ? error.message : String(error), error)
+        }
+      }
+    },
+    options.cwd,
+    options.env,
+    options.abort
+  )
+}

--- a/packages/daemon/src/microsandbox/install.ts
+++ b/packages/daemon/src/microsandbox/install.ts
@@ -1,0 +1,55 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { RuntimeStore } from '../runtimes/runtime-store.js'
+import { MicrosandboxManager } from './driver.js'
+import type { Config } from '../config/config-schema.js'
+import type { Logger } from '../log.js'
+
+export const MICROSANDBOX_VERSION = '0.6.17'
+
+export function microsandboxGuestEntry(root: string): string {
+  for (const path of [
+    fileURLToPath(new URL('./microsandbox/guest.js', import.meta.url)),
+    fileURLToPath(new URL('../../dist/microsandbox/guest.js', import.meta.url))
+  ]) {
+    if (!existsSync(path)) continue
+    const target = join(root, 'microsandbox', 'helpers', 'guest.js')
+    mkdirSync(dirname(target), { recursive: true, mode: 0o700 })
+    // A daemon upgrade changes its install path, not the mount identity of retained VMs.
+    if (!existsSync(target) || !readFileSync(target).equals(readFileSync(path))) copyFileSync(path, target)
+    return target
+  }
+  throw new Error('microsandbox guest helper is missing; rebuild the daemon package')
+}
+
+export async function installMicrosandbox(opts: {
+  root: string
+  config: NonNullable<Config['sandbox']['microsandbox']>
+  sockets: { mcp: string; gitcred: string }
+  log: Logger
+}): Promise<MicrosandboxManager> {
+  if (process.platform !== 'linux') throw new Error('microsandbox currently requires a Linux host with KVM')
+  const state = join(opts.root, 'microsandbox')
+  mkdirSync(state, { recursive: true, mode: 0o700 })
+  // The SDK has process-wide local state; this daemon owns its home for its entire lifetime.
+  process.env.MSB_HOME = state
+  process.env.MSB_BACKEND = 'local'
+  const installed = await new RuntimeStore({ root: opts.root, log: opts.log }).ensure({
+    name: 'microsandbox',
+    range: MICROSANDBOX_VERSION,
+    bin: 'msb',
+    args: []
+  })
+  if (installed.version !== MICROSANDBOX_VERSION) {
+    throw new Error(`microsandbox requires version ${MICROSANDBOX_VERSION}; found ${installed.version}`)
+  }
+  const installedRequire = createRequire(join(installed.tree, 'package.json'))
+  const sdk = (await import(
+    pathToFileURL(installedRequire.resolve('microsandbox')).href
+  )) as typeof import('microsandbox')
+  const platform = `@superradcompany/microsandbox-linux-${process.arch}-gnu`
+  const command = join(dirname(installedRequire.resolve(`${platform}/package.json`)), 'bin', 'msb')
+  return new MicrosandboxManager({ ...opts, sdk, msbCommand: { command, args: [] } })
+}

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -1,0 +1,158 @@
+import { existsSync, lstatSync, mkdirSync, realpathSync, statSync } from 'node:fs'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key.js'
+import { sandboxBoundary } from '../acp/sandbox.js'
+import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
+import { GITCRED_SOCKET_ENV } from '../gitcred/env.js'
+import { privateRuntimeHomeFor, type PreparedRuntimeLaunch } from '../launch/prepare.js'
+import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
+import { compactReadRoots, normalizeSandboxMounts } from '../runtimes/read-roots.js'
+import { prepareSharedRuntimeCredentials } from '../runtimes/runtime-credentials.js'
+import { prepareRuntimeHome, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
+import { SANDBOX_TUNNEL_PATHS } from '../shim/sandbox-paths.js'
+import { SESSIONS_DIR } from '../workspace/session-layout.js'
+import { MICROSANDBOX_GUEST_ENTRY, MICROSANDBOX_SOCKET_BRIDGES } from './guest.js'
+
+const IMAGE_PATH = '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+const HOST_IPC_ENV = [
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  'DBUS_SESSION_BUS_ADDRESS',
+  'DBUS_SYSTEM_BUS_ADDRESS',
+  'DISPLAY',
+  'WAYLAND_DISPLAY',
+  'PULSE_SERVER',
+  'PIPEWIRE_REMOTE',
+  'GPG_AGENT_INFO',
+  'GNOME_KEYRING_CONTROL',
+  'SESSION_MANAGER',
+  'TMUX',
+  'VSCODE_IPC_HOOK_CLI',
+  'NOTIFY_SOCKET',
+  'TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE',
+  'DOCKER_HOST',
+  'CONTAINER_HOST',
+  'BUILDKIT_HOST',
+  'PODMAN_HOST'
+]
+
+export interface PrepareMicrosandboxLaunchOptions {
+  runtimeId: string
+  runtime?: RuntimeDef
+  scopeDir: string
+  cwd: string
+  hostKey?: HostKey
+  explicitEnv?: Record<string, string>
+  stateSourceEnv?: NodeJS.ProcessEnv
+  trustedSessionDir?: string
+  trustedWorkspaceWriteRoots?: string[]
+  trustedRuntimeReadRoots?: string[]
+  trustedMounts?: SandboxMount[]
+  mounts: SandboxMount[]
+  guestEntry: string
+}
+
+function contains(root: string, path: string): boolean {
+  const rel = relative(root, path)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions): PreparedRuntimeLaunch & {
+  microsandbox: { mounts: SandboxMount[]; workspaceRoot: string }
+} {
+  if (opts.runtime?.externalExecution) {
+    throw new Error(`runtime "${opts.runtimeId}" executes outside the microsandbox VM`)
+  }
+  const scopeDir = realpathSync(resolve(opts.scopeDir))
+  const hostEnv = opts.stateSourceEnv ?? process.env
+  let runtimeHome =
+    opts.hostKey && hostKeySessionKey(opts.hostKey) !== undefined
+      ? join(scopeDir, SESSIONS_DIR, hostKeyDirName(opts.hostKey), 'home')
+      : privateRuntimeHomeFor(scopeDir, undefined)
+  const sessionDir = opts.trustedSessionDir ? realpathSync(opts.trustedSessionDir) : undefined
+  if (sessionDir) {
+    const parts = relative(scopeDir, sessionDir).split(sep)
+    if (parts.length !== 2 || parts[0] !== SESSIONS_DIR || !parts[1] || !statSync(sessionDir).isDirectory()) {
+      throw new Error('microsandbox session directory must be one existing scopeDir/sessions/<leaf> directory')
+    }
+    runtimeHome = join(sessionDir, 'home')
+  }
+  const boundary = sandboxBoundary({ agentDir: scopeDir, cwd: opts.cwd, runtimeHome })
+  if (sessionDir && !contains(sessionDir, boundary.writable[0]!)) {
+    throw new Error('microsandbox cwd is outside its session directory')
+  }
+  const scopePath = (path: string): string =>
+    sandboxBoundary({ agentDir: scopeDir, cwd: path, runtimeHome }).writable[0]!
+  const writable = [
+    ...boundary.writable,
+    ...(sessionDir ? [sessionDir] : []),
+    ...(opts.trustedWorkspaceWriteRoots ?? []).map(scopePath)
+  ]
+  const configDirs = [join(scopeDir, 'run', 'config-files'), join(scopeDir, '.agentconnect', 'runtime-policy')].map(
+    scopePath
+  )
+  for (const path of [...writable, ...configDirs]) mkdirSync(path, { recursive: true, mode: 0o700 })
+
+  const credentials = prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
+  runtimeHome = prepareRuntimeHome(opts.runtimeId, scopeDir, hostEnv, runtimeHome, credentials?.seedExclusions)
+  credentials?.preparePrivateHome(runtimeHome)
+  writable.push(...(credentials?.writablePaths ?? []))
+  const readRoots = (opts.trustedRuntimeReadRoots ?? []).filter((path) => {
+    if (!existsSync(path)) return false
+    const stat = statSync(path)
+    return stat.isFile() || stat.isDirectory()
+  })
+  const automaticSource = (path: string): string => {
+    const source = realpathSync(path)
+    if (contains(source, scopeDir) || (hostEnv.HOME && contains(source, resolve(hostEnv.HOME)))) {
+      throw new Error(`microsandbox automatic mount would expose an entire agent or host HOME: ${source}`)
+    }
+    return source
+  }
+  const writeRoots = compactReadRoots(writable.map(automaticSource))
+  const automatic: SandboxMount[] = [
+    ...compactReadRoots([...configDirs, ...readRoots].map(automaticSource))
+      .filter((path) => !writeRoots.some((write) => contains(write, path)))
+      .map((source) => ({ source, target: source, readOnly: true })),
+    ...writeRoots.map((source) => ({ source, target: source, readOnly: false })),
+    ...normalizeSandboxMounts(opts.trustedMounts ?? [], hostEnv, 'microsandbox').map((mount) => ({
+      ...mount,
+      source: automaticSource(mount.source)
+    }))
+  ]
+  const guestEntry = realpathSync(opts.guestEntry)
+  if (!statSync(guestEntry).isFile()) throw new Error('microsandbox guest entry must be a regular file')
+  automatic.push({ source: guestEntry, target: MICROSANDBOX_GUEST_ENTRY, readOnly: true })
+  const configured = normalizeSandboxMounts(opts.mounts, hostEnv, 'microsandbox')
+  const ownedTargets = [
+    ...automatic.map((mount) => mount.target),
+    ...MICROSANDBOX_SOCKET_BRIDGES.map((bridge) => bridge.path)
+  ]
+  for (const mount of configured) {
+    if (ownedTargets.some((target) => contains(mount.target, target) || contains(target, mount.target))) {
+      throw new Error(`sandbox.mounts target overlaps an automatic microsandbox mount: ${mount.target}`)
+    }
+  }
+
+  const env = { ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, hostEnv), ...credentials?.env }
+  for (const name of HOST_IPC_ENV) delete env[name]
+  for (const { envVar } of opts.runtime ? runtimeExecutableHints(opts.runtime) : []) {
+    if (opts.explicitEnv?.[envVar] === undefined) delete env[envVar]
+  }
+  env.PATH = opts.explicitEnv?.PATH ?? IMAGE_PATH
+  env.TMPDIR = env.TMP = env.TEMP = '/tmp'
+  env.CLAUDE_TMPDIR = env.CLAUDE_CODE_TMPDIR = '/tmp'
+  env.XDG_RUNTIME_DIR = join(runtimeHome, '.run')
+  if (existsSync(env.XDG_RUNTIME_DIR) && !lstatSync(env.XDG_RUNTIME_DIR).isDirectory()) {
+    throw new Error('microsandbox private XDG runtime path must be a real directory')
+  }
+  mkdirSync(env.XDG_RUNTIME_DIR, { recursive: true, mode: 0o700 })
+  env[GITCRED_SOCKET_ENV] = SANDBOX_TUNNEL_PATHS.gitcred
+  return {
+    env,
+    inheritProcessEnv: false,
+    gitMetadataWriteRoots: [],
+    runtimeHome,
+    microsandbox: { mounts: [...automatic, ...configured], workspaceRoot: scopeDir }
+  }
+}

--- a/packages/daemon/src/microsandbox/support.ts
+++ b/packages/daemon/src/microsandbox/support.ts
@@ -1,0 +1,23 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { SandboxMount } from '../config/config-schema.js'
+import { gitcredShimPath } from '../cp/gitcred-server.js'
+
+const GIT_CREDENTIAL_HELPER = '#!/bin/sh\nexec /opt/agentconnect/bin/git-credential "$@"\n'
+
+export function microsandboxSupportMounts(root: string, sessionGitConfigPath?: string): SandboxMount[] {
+  const helpers = join(root, 'microsandbox', 'helpers')
+  mkdirSync(helpers, { recursive: true, mode: 0o700 })
+  chmodSync(helpers, 0o700)
+  const source = join(helpers, 'git-credential')
+  if (!existsSync(source) || readFileSync(source, 'utf8') !== GIT_CREDENTIAL_HELPER) {
+    writeFileSync(source, GIT_CREDENTIAL_HELPER, { mode: 0o755 })
+  }
+  chmodSync(source, 0o755)
+  return [
+    { source, target: gitcredShimPath(root), readOnly: true },
+    ...(sessionGitConfigPath && existsSync(sessionGitConfigPath)
+      ? [{ source: sessionGitConfigPath, target: sessionGitConfigPath, readOnly: true }]
+      : [])
+  ]
+}

--- a/packages/daemon/src/microsandbox/workspace-fs.ts
+++ b/packages/daemon/src/microsandbox/workspace-fs.ts
@@ -1,0 +1,38 @@
+import { LocalWorkspaceFs, type WorkspaceFs } from '../workspace/workspace-fs.js'
+
+// Existing VMs perform mutations themselves so virtiofs observes directory renames immediately.
+export class MicrosandboxWorkspaceFs extends LocalWorkspaceFs {
+  constructor(
+    private readonly resolve: (path: string) => WorkspaceFs | undefined,
+    private readonly releaseMount?: (path: string) => Promise<boolean>
+  ) {
+    super()
+  }
+
+  override async mkdir(path: string, mode?: number): Promise<void> {
+    const guest = this.resolve(path)
+    return guest ? await guest.mkdir(path, mode) : await super.mkdir(path, mode)
+  }
+
+  override async writeFile(path: string, content: string, options?: { mode?: number }): Promise<void> {
+    const guest = this.resolve(path)
+    return guest ? await guest.writeFile(path, content, options) : await super.writeFile(path, content, options)
+  }
+
+  override async rename(from: string, to: string): Promise<void> {
+    const guest = this.resolve(from) ?? this.resolve(to)
+    return guest ? await guest.rename(from, to) : await super.rename(from, to)
+  }
+
+  override async rmdir(path: string): Promise<boolean> {
+    const guest = this.resolve(path)
+    return guest ? await guest.rmdir(path) : await super.rmdir(path)
+  }
+
+  override async rmTree(path: string): Promise<void> {
+    // A guest cannot remove its mountpoint; stop that VM before deleting the host source.
+    if (await this.releaseMount?.(path)) return await super.rmTree(path)
+    const guest = this.resolve(path)
+    return guest ? await guest.rmTree(path) : await super.rmTree(path)
+  }
+}

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -61,6 +61,9 @@ export interface RuntimeFactsHost {
   store(): RuntimeFactsStore
   draining(): boolean
   catalog(): ResolvedRuntimeCatalog
+  localProbeCatalog(): ResolvedRuntimeCatalog
+  // The advertised runtime's execution location; a same-ID host install may also exist.
+  executionLocation(runtimeId: string): 'host' | 'sandbox'
   admittedRuntimes(): Record<string, RuntimeDef>
   refreshAdmitted(): void
   reportedRuntimeIds(): string[]
@@ -247,10 +250,10 @@ export class RuntimeFactsRegistry {
    *  runtime may only be temporarily unresolved); rows older than 30 days are
    *  garbage-collected. The store reads only this member's rows, so a member can
    *  never boot advertising models a peer's image runs and its own does not. */
-  async hydrateFromCache(): Promise<void> {
+  async hydrateFromCache(excludedRuntimeIds: ReadonlySet<string> = new Set()): Promise<void> {
     try {
       for (const meta of await this.host.store().listRuntimeCatalogMetas()) {
-        if (!this.host.catalog().entries[meta.runtimeId]) continue
+        if (excludedRuntimeIds.has(meta.runtimeId) || !this.host.catalog().entries[meta.runtimeId]) continue
         await this.rebuildCatalog(meta.runtimeId)
         const cachedModels = (await this.host.store().listRuntimeModelCaps(meta.runtimeId)).map((r) => r.modelId)
         if (cachedModels.length > 0 && (this.models.get(meta.runtimeId) ?? []).length === 0) {
@@ -352,7 +355,7 @@ export class RuntimeFactsRegistry {
     }
 
     const log = this.host.log()
-    const catalog = this.host.catalog()
+    const catalog = this.host.localProbeCatalog()
     const fresh = this.lastProbeAtMs > 0 && this.host.clock().now() - this.lastProbeAtMs < PROBE_TTL_MS
     const curatedCandidates = this.host.curatedAdmission().probeCandidates(catalog)
     if (fresh && Object.keys(curatedCandidates).length === 0) {
@@ -366,11 +369,14 @@ export class RuntimeFactsRegistry {
         ? {}
         : Object.fromEntries(
             Object.entries(catalog.entries)
-              .filter(([, entry]) => entry.source !== 'curated')
+              .filter(([id, entry]) => entry.source !== 'curated' && this.host.executionLocation(id) === 'host')
               .map(([id, entry]) => [id, entry.runtime])
           )
     const probeCount = Object.keys(ordinaryRuntimes).length + Object.keys(curatedCandidates).length
-    if (probeCount === 0) return
+    if (probeCount === 0) {
+      this.emitFacts()
+      return
+    }
 
     this.probing = true
     const probeIds = [...Object.keys(ordinaryRuntimes), ...Object.keys(curatedCandidates)]
@@ -387,11 +393,18 @@ export class RuntimeFactsRegistry {
       // seconds. `facts/daemon-runtimes` is idempotent REPLACE fenced by `seq`
       // (design runtime-model-catalog.md §6), so per-result frames converge.
       const applied = new Set<string>()
+      let emitted = false
       const onResult = async (result: RuntimeProbeResult): Promise<void> => {
         if (applied.has(result.runtime)) return
         applied.add(result.runtime)
+        // A same-ID host runtime needs admission, but its probe must not replace the image's facts.
+        if (this.host.executionLocation(result.runtime) !== 'host') {
+          if (catalog.entries[result.runtime]?.source === 'curated') this.host.curatedAdmission().record(result)
+          return
+        }
         await this.applyProbeResult(result)
         this.emitFacts()
+        emitted = true
       }
       const batches: Array<Promise<RuntimeProbeResult[]>> = []
       if (Object.keys(ordinaryRuntimes).length > 0) {
@@ -410,7 +423,7 @@ export class RuntimeFactsRegistry {
               if (!entry || !parseArchiveLaunch(id, entry)) return rt
               log.info(`probe: installing the vendor archive for "${id}" before probing it`)
               await this.host.localizeRuntime(id)
-              return this.host.catalog().entries[id]?.runtime
+              return this.host.localProbeCatalog().entries[id]?.runtime
             },
             launchFor: (id, runtime, scopeDir, cwd) => {
               const runInSandbox = effectiveRunInSandbox(
@@ -468,7 +481,7 @@ export class RuntimeFactsRegistry {
       // from the snapshot — so restamp the batch now that every result is in.
       const reportedBefore = this.host.reportedRuntimeIds().join(' ')
       for (const result of results) {
-        if (this.host.catalog().entries[result.runtime]?.source === 'curated') {
+        if (catalog.entries[result.runtime]?.source === 'curated') {
           this.host.curatedAdmission().record(result)
         }
       }
@@ -476,7 +489,7 @@ export class RuntimeFactsRegistry {
       // Each result already emitted the REPLACE snapshot that prunes vanished ids, so
       // the CP is owed one only when the sweep produced none, or when restamping
       // brought a runtime back that had expired mid-sweep.
-      if (applied.size === 0 || this.host.reportedRuntimeIds().join(' ') !== reportedBefore) {
+      if (!emitted || this.host.reportedRuntimeIds().join(' ') !== reportedBefore) {
         this.emitFacts()
       }
       // Probe results can change runtime-derived registration capabilities, and
@@ -634,11 +647,8 @@ export class RuntimeFactsRegistry {
         }
         await this.rebuildCatalog(r.runtime)
       }
-      // Phase 2 enumerates model by model in an isolated HOME on THIS host, which `--k8s` does not
-      // have: its runtimes live in a pod. A cluster probe therefore stops at the phase-1 seed
-      // rather than scheduling a discovery that could only fail (or, for a native driver, run the
-      // wrong machine's executable).
-      if (!this.host.launch().k8s) {
+      // Phase 2 uses host executables, so image runtimes stop at the sandbox's phase-1 facts.
+      if (this.host.executionLocation(r.runtime) === 'host') {
         this.host.noteCatalogProbe({
           runtimeId: r.runtime,
           rt: entry.runtime,

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -1,8 +1,8 @@
 import { closeSync, existsSync, openSync, readFileSync, readSync, realpathSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
-import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
-import type { McpServerDef, RuntimeDef, SandboxMount } from '../config/config-schema.js'
+import { basename, dirname, isAbsolute, join, parse, posix, relative, resolve, sep } from 'node:path'
+import type { McpServerDef, RuntimeDef, SandboxBackend, SandboxMount } from '../config/config-schema.js'
 import { resolveCommandPath } from './probe.js'
 
 /**
@@ -47,18 +47,40 @@ function existingRoot(path: string, env: NodeJS.ProcessEnv, label = 'trusted run
   return realpathSync(expanded)
 }
 
-/** SRT exposes canonical host paths in place; duplicate writable grants take precedence. */
+function guestMountTarget(path: string): string {
+  if (!posix.isAbsolute(path) || path.includes('\0')) {
+    throw new Error(`sandbox.mounts target must be an absolute POSIX guest path: ${path}`)
+  }
+  const target = posix.normalize(path).replace(/\/$/, '')
+  if (!target) throw new Error('sandbox.mounts target must not be the guest root')
+  return target
+}
+
+/** Canonical host sources use host targets for SRT and guest coordinates for microsandbox. */
 export function normalizeSandboxMounts(
   mounts: readonly SandboxMount[],
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  backend: SandboxBackend = 'srt'
 ): SandboxMount[] {
   const normalized = new Map<string, SandboxMount>()
   for (const mount of mounts) {
     const source = existingRoot(mount.source, env, 'sandbox.mounts source')
-    const target = existingRoot(mount.target, env, 'sandbox.mounts target')
-    if (source !== target) throw new Error(`sandbox.mounts requires source and target to be the same path for srt`)
-    const previous = normalized.get(source)
-    normalized.set(source, { source, target, readOnly: mount.readOnly && (previous?.readOnly ?? true) })
+    const target =
+      backend === 'srt' ? existingRoot(mount.target, env, 'sandbox.mounts target') : guestMountTarget(mount.target)
+    if (backend === 'srt' && source !== target) {
+      throw new Error('sandbox.mounts requires source and target to be the same path for srt')
+    }
+    if (backend === 'microsandbox') {
+      const stat = statSync(source)
+      if (!stat.isFile() && !stat.isDirectory()) {
+        throw new Error(`sandbox.mounts source must be a file or directory for microsandbox: ${source}`)
+      }
+    }
+    const previous = normalized.get(target)
+    if (previous && previous.source !== source) {
+      throw new Error(`sandbox.mounts cannot map different sources to the same target: ${target}`)
+    }
+    normalized.set(target, { source, target, readOnly: mount.readOnly && (previous?.readOnly ?? true) })
   }
   return [...normalized.values()]
 }

--- a/packages/daemon/src/workspace/workspace-fs.ts
+++ b/packages/daemon/src/workspace/workspace-fs.ts
@@ -64,8 +64,8 @@ export interface WorkspaceFs {
  */
 export interface WorkspacePlacement {
   fs: WorkspaceFs
-  /** The pod's workspace mount; every path the manager composes for this agent hangs off it. */
-  mount: string
+  /** The workspace mount; omit to keep paths in the daemon host's coordinates. */
+  mount?: string
 }
 
 /** Today's behaviour: the daemon's own disk, through `node:fs`. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -293,7 +293,7 @@ export class WorkspaceManager {
   // coalescing is the intent. For a cluster workspace the same path is a DIFFERENT filesystem per
   // agent, so coalescing there would hand one agent the other's clone; the agent id disambiguates.
   cloneKey(agentId: string, cwd: string): string {
-    return this.gitRunnerResolver?.(agentId, cwd) ? `${agentId}\u0000${cwd}` : cwd
+    return this.sandboxMountFor(agentId) ? `${agentId}\u0000${cwd}` : cwd
   }
 
   async withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -87,6 +87,34 @@ function quietHost(): AcpHost {
 }
 
 describe('runChat', () => {
+  it('rejects microsandbox before selecting, probing, or launching a runtime', async () => {
+    const files = scaffold()
+    writeFileSync(
+      files.configPath,
+      JSON.stringify({
+        version: 1,
+        sandbox: { backend: 'microsandbox', microsandbox: { image: 'runtime:test' } }
+      })
+    )
+    const resolveCatalog = vi.fn()
+    const probeRuntimes = vi.fn()
+    const hostFactory = vi.fn()
+
+    await expect(
+      runChat({
+        ...files,
+        agentsDir: join(files.root, 'missing-agents'),
+        message: 'hi',
+        resolveCatalog,
+        probeRuntimes,
+        hostFactory
+      })
+    ).rejects.toThrow('chat does not support microsandbox yet')
+    expect(resolveCatalog).not.toHaveBeenCalled()
+    expect(probeRuntimes).not.toHaveBeenCalled()
+    expect(hostFactory).not.toHaveBeenCalled()
+  })
+
   it('single-shot: discovers the lone agent, spawns runtime, streams the echoed reply', async () => {
     const { agentsDir, configPath, root } = scaffold()
     const out = capture()

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -96,7 +96,46 @@ describe('loadConfig', () => {
   })
 
   it('rejects an unimplemented sandbox backend', () => {
-    expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox' } })).toThrow()
+    expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'docker' } })).toThrow()
+  })
+
+  it('requires an explicit microsandbox image and defaults its resource allocation', () => {
+    expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox' } })).toThrow(
+      'sandbox.microsandbox.image'
+    )
+    for (const image of [undefined, '', '  ']) {
+      expect(() =>
+        ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox', microsandbox: { image } } })
+      ).toThrow()
+    }
+    expect(
+      ConfigSchema.parse({
+        version: 1,
+        sandbox: { backend: 'microsandbox', microsandbox: { image: 'registry.example.test/runtime:test' } }
+      }).sandbox
+    ).toEqual({
+      backend: 'microsandbox',
+      mounts: [],
+      microsandbox: { image: 'registry.example.test/runtime:test', cpus: 2, memoryMiB: 2048, diskGiB: 10 }
+    })
+  })
+
+  it.each([
+    ['cpus', 255],
+    ['memoryMiB', 0xffffffff],
+    ['diskGiB', Math.floor(0xffffffff / 1024)]
+  ])('bounds microsandbox %s to positive integers supported by the backend', (field, max) => {
+    const config = (value: number) => ({
+      version: 1,
+      sandbox: {
+        backend: 'microsandbox',
+        microsandbox: { image: 'registry.example.test/runtime:test', [field]: value }
+      }
+    })
+    for (const value of [0, -1, 1.5, Number(max) + 1]) {
+      expect(() => ConfigSchema.parse(config(value))).toThrow()
+    }
+    expect(() => ConfigSchema.parse(config(Number(max)))).not.toThrow()
   })
 
   it.each(['sandboxReadRoots', 'sandboxWriteRoots'])('rejects removed security.%s rather than ignoring it', (field) => {

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -170,6 +170,28 @@ function pendingFor(daemon: Daemon, acpSessionId: string): any {
 }
 
 describe('Daemon session lifecycle (#118)', () => {
+  it.each([true, false])('installs a host runtime only for local execution (runInSandbox=%s)', async (runInSandbox) => {
+    const root = scaffold()
+    const host = quietHost()
+    const daemon = new Daemon({ root, hostFactory: () => host as never })
+    try {
+      await daemon.start()
+      const d = daemon as any
+      d.cfg.sandbox.backend = 'microsandbox'
+      d.agents.get('bot-a').runInSandbox = runInSandbox
+      vi.spyOn(d, 'prepareAgentWorkspace').mockResolvedValue(join(root, 'workspace'))
+      const install = vi.spyOn(d, 'ensureRuntimeInstalled').mockResolvedValue(undefined)
+
+      await d.ensureHostAsync('bot-a')
+
+      expect(host.start).toHaveBeenCalledOnce()
+      if (runInSandbox) expect(install).not.toHaveBeenCalled()
+      else expect(install).toHaveBeenCalledExactlyOnceWith('claude', true)
+    } finally {
+      await daemon.stop()
+    }
+  })
+
   it('prepares the workspace before every direct cold-host lifecycle start', async () => {
     const root = scaffold()
     const workspace = join(root, 'agents', 'bot-a', 'workspace')
@@ -2573,6 +2595,34 @@ describe('Daemon session retention GC (#485)', () => {
     expect(await (daemon as any).store.getSession('expired-gated')).toBeDefined()
 
     await daemon.stop()
+  })
+
+  it('keeps the session row until VM destruction succeeds and retries the next sweep', async () => {
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => quietHost() as any,
+      clock: new FakeClock()
+    })
+    await daemon.start()
+    await sweepRetention(daemon)
+    const discard = vi
+      .fn(async () => {
+        expect(await (daemon as any).store.getSession('expired-vm')).toBeDefined()
+        expect((daemon as any).workspaceDispatchFences.has('bot-a')).toBe(true)
+      })
+      .mockRejectedValueOnce(new Error('temporary VM destroy failure'))
+    ;(daemon as any).microsandbox = { discard, stopAll: vi.fn(async () => {}) }
+    try {
+      await seedSession(daemon, 'expired-vm', 'closed', -8 * 24 * 3_600_000)
+      await sweepRetention(daemon)
+      expect(await (daemon as any).store.getSession('expired-vm')).toBeDefined()
+      await sweepRetention(daemon)
+      expect(await (daemon as any).store.getSession('expired-vm')).toBeUndefined()
+      expect(discard).toHaveBeenCalledTimes(2)
+    } finally {
+      await daemon.stop()
+    }
   })
 
   it('retention "never" disables the sweep entirely', async () => {

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -1,0 +1,337 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runInNewContext } from 'node:vm'
+import type { ExecEvent } from 'microsandbox'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MicrosandboxManager, type MicrosandboxManagerOptions } from '../src/microsandbox/driver.js'
+import { MICROSANDBOX_NODE } from '../src/microsandbox/guest.js'
+import { SANDBOX_MCP_BRIDGE_ENTRY } from '../src/shim/sandbox-paths.js'
+
+class FakeExec {
+  private readonly queue: Array<ExecEvent | undefined> = []
+  private wake?: () => void
+  readonly writes: Uint8Array[] = []
+  readonly signal = vi.fn(async (_signal: number) => this.push({ kind: 'exited', code: 0 }))
+  readonly kill = vi.fn(async () => this.push({ kind: 'exited', code: 137 }))
+
+  push(event: ExecEvent | undefined): void {
+    this.queue.push(event)
+    this.wake?.()
+  }
+
+  async takeStdin() {
+    return {
+      write: async (data: Uint8Array) => {
+        this.writes.push(data)
+        this.push({ kind: 'stdout', data })
+      },
+      close: async () => {}
+    }
+  }
+
+  async *[Symbol.asyncIterator]() {
+    for (;;) {
+      while (!this.queue.length)
+        await new Promise<void>((resolve) => {
+          this.wake = resolve
+        })
+      const event = this.queue.shift()
+      yield event
+      if (event?.kind === 'exited') return
+    }
+  }
+}
+
+function fakeSdk() {
+  class SandboxNotFoundError extends Error {}
+  const sandboxes = new Map<string, FakeSandbox>()
+  const created: FakeSandbox[] = []
+  const processes: FakeExec[] = []
+  let onRun: ((process: FakeExec) => void) | undefined
+
+  class FakeSandbox {
+    readonly id = `vm-${created.length}`
+    status = 'running'
+    readonly processes: FakeExec[] = []
+    readonly spec = { image: 'test-image' }
+    readonly stopWithTimeout = vi.fn(async () => {
+      this.status = 'stopped'
+      for (const process of this.processes) process.push({ kind: 'exited', code: 0 })
+    })
+    readonly destroy = vi.fn(async () => {
+      await this.stopWithTimeout()
+      sandboxes.delete(this.name)
+    })
+
+    constructor(readonly name: string) {}
+    config() {
+      return this.spec
+    }
+    async startDetached() {
+      this.status = 'running'
+      return this
+    }
+    async connectOrStart() {
+      return this.startDetached()
+    }
+    async ping() {}
+    readonly exec = vi.fn(async (command: string, args: string[]) => {
+      expect(command).toBe(MICROSANDBOX_NODE)
+      expect(args[0]).toBe('-e')
+      let stdout = ''
+      const python = vi.fn((_command: string, _args: string[]) => {})
+      runInNewContext(args[1]!, {
+        require: (name: string) => {
+          if (name === 'node:child_process') return { execFileSync: python }
+          expect(name).toBe('node:fs')
+          return {
+            existsSync: (path: string) => path === SANDBOX_MCP_BRIDGE_ENTRY,
+            readFileSync: (path: string) => {
+              expect(path).toBe('/opt/agentconnect/runtime/k8s-runtimes.json')
+              return JSON.stringify({ runtimes: [{ id: 'test' }] })
+            }
+          }
+        },
+        process: {
+          argv: [MICROSANDBOX_NODE, ...args.slice(2)],
+          execPath: '/image/node',
+          stdout: { write: (value: string) => (stdout += value) }
+        }
+      })
+      expect(python).toHaveBeenCalledWith(
+        '/usr/bin/python3',
+        ['-c', expect.stringContaining('socket.socket(socket.AF_VSOCK')],
+        { timeout: 10_000 }
+      )
+      return { success: true, code: 0, stdout: () => stdout }
+    })
+    async execStreamWith(_command: string, configure: (options: unknown) => unknown) {
+      let args: string[] = []
+      const options = {
+        args(value: string[]) {
+          args = value
+          return options
+        },
+        cwd() {
+          return options
+        },
+        envs() {
+          return options
+        },
+        stdinPipe() {
+          return options
+        },
+        tty() {
+          return options
+        }
+      }
+      configure(options)
+      const process = new FakeExec()
+      this.processes.push(process)
+      if (args[1] === 'sockets') process.push({ kind: 'stdout', data: Buffer.from('ready\n') })
+      else {
+        processes.push(process)
+        onRun?.(process)
+      }
+      return process
+    }
+  }
+
+  const sdk = {
+    SandboxNotFoundError,
+    Sandbox: {
+      async get(name: string) {
+        const sandbox = sandboxes.get(name)
+        if (!sandbox) throw new SandboxNotFoundError()
+        return sandbox
+      },
+      builder(name: string) {
+        const builder = {
+          image() {
+            return builder
+          },
+          rootDisk() {
+            return builder
+          },
+          cpus() {
+            return builder
+          },
+          memory() {
+            return builder
+          },
+          deploymentProfile() {
+            return builder
+          },
+          detached() {
+            return builder
+          },
+          ephemeral() {
+            return builder
+          },
+          quietLogs() {
+            return builder
+          },
+          volume() {
+            return builder
+          },
+          vsock() {
+            return builder
+          },
+          async create() {
+            const sandbox = new FakeSandbox(name)
+            created.push(sandbox)
+            sandboxes.set(name, sandbox)
+            return sandbox
+          }
+        }
+        return builder
+      }
+    }
+  } as unknown as MicrosandboxManagerOptions['sdk']
+  return {
+    sdk,
+    created,
+    processes,
+    runWith: (callback: (process: FakeExec) => void) => {
+      onRun = callback
+    }
+  }
+}
+
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'microsandbox-driver-'))
+  roots.push(root)
+  const fake = fakeSdk()
+  const options: MicrosandboxManagerOptions = {
+    root,
+    config: { image: 'test-image', cpus: 2, memoryMiB: 2048, diskGiB: 10 },
+    sdk: fake.sdk,
+    msbCommand: { command: process.execPath, args: ['-e', ''] },
+    sockets: { mcp: '/host/mcp.sock', gitcred: '/host/gitcred.sock' }
+  }
+  const manager = new MicrosandboxManager(options)
+  const environment = { id: 'agent/session-example', mounts: [], workspaceRoot: '/workspace' }
+  const request = { command: '/usr/local/bin/node', args: ['agent.js'], env: {} }
+  return { ...fake, manager, options, environment, request }
+}
+
+describe('microsandbox process and VM ownership', () => {
+  it('shares a VM, preserves binary ACP data, and refuses suspend while another execution is active', async () => {
+    const { manager, environment, request, created, processes } = await fixture()
+    const [first, second] = await Promise.all([
+      manager.driverFor(environment).launch(request),
+      manager.driverFor(environment).launch(request)
+    ])
+    expect(created).toHaveLength(1)
+    const writer = first.toAgent.getWriter()
+    const reader = first.fromAgent.getReader()
+    const bytes = Uint8Array.of(0, 255, 10, 13, 128)
+    await writer.write(bytes)
+    expect((await reader.read()).value).toEqual(bytes)
+    await expect(manager.suspend(environment.id)).rejects.toThrow('2 active executions')
+    await first.stop(0)
+    await expect(manager.suspend(environment.id)).rejects.toThrow('1 active executions')
+    processes[1]!.signal.mockImplementation(async () => {})
+    await second.stop(1)
+    expect(processes[1]!.kill).toHaveBeenCalledOnce()
+    await manager.suspendIdle(Date.now())
+    expect(created[0]!.status).toBe('stopped')
+    expect(await manager.environmentIds()).toEqual([environment.id])
+    await manager.discard(environment.id)
+    expect(await manager.environmentIds()).toEqual([])
+  })
+
+  it('kills an SDK failure event and releases the execution without hanging readers', async () => {
+    const { manager, environment, request, processes, runWith } = await fixture()
+    runWith((process) => process.push(undefined))
+    const runtime = await manager.driverFor(environment).launch(request)
+    const exited = new Promise<void>((resolve) => runtime.onExit(resolve))
+    await expect(runtime.fromAgent.getReader().read()).rejects.toThrow('unsupported process failure event')
+    await exited
+    expect(processes[0]!.kill).toHaveBeenCalledOnce()
+    await manager.suspend(environment.id)
+  })
+
+  it('fences saved VMs at startup and refuses changed persistent configuration', async () => {
+    const { manager, options, environment, request, created } = await fixture()
+    const runtime = await manager.driverFor(environment).launch(request)
+    await runtime.stop(0)
+    const resumed = new MicrosandboxManager(options)
+    expect(await resumed.environmentIds()).toEqual([environment.id])
+    await expect(resumed.prepare()).resolves.toEqual({
+      runtimes: [{ id: 'test' }],
+      mcpBridge: { command: '/image/node', args: [SANDBOX_MCP_BRIDGE_ENTRY] }
+    })
+    expect(created[0]!.status).toBe('stopped')
+    created[0]!.spec.image = 'changed-outside-daemon'
+    await expect(resumed.driverFor(environment).launch(request)).rejects.toThrow('changed persisted configuration')
+    await manager.discard(environment.id)
+  })
+
+  it('retries a failed VM lookup without retaining a rejected launch', async () => {
+    const { manager, options, environment, request } = await fixture()
+    vi.spyOn(options.sdk.Sandbox, 'get').mockRejectedValueOnce(new Error('temporary lookup failure'))
+    await expect(manager.driverFor(environment).launch(request)).rejects.toThrow('temporary lookup failure')
+    const runtime = await manager.driverFor(environment).launch(request)
+    await runtime.stop(0)
+    await manager.discard(environment.id)
+  })
+
+  it('drains a failed bridge before retrying VM stop and resuming from the retained disk', async () => {
+    const { manager, environment, request, created, processes } = await fixture()
+    const driver = manager.driverFor(environment)
+    const runtime = await driver.launch(request)
+    const terminal = vi.fn()
+    runtime.onExit(terminal)
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let stopping!: () => void
+    const stopped = new Promise<void>((resolve) => {
+      stopping = resolve
+    })
+    processes[0]!.signal.mockImplementationOnce(async () => {
+      stopping()
+      await blocked
+      processes[0]!.push({ kind: 'exited', code: 0 })
+    })
+    const vm = created[0]!
+    vm.stopWithTimeout.mockRejectedValueOnce(new Error('temporary VM stop failure'))
+    vm.processes[0]!.push({ kind: 'exited', code: 1 })
+    await stopped
+    await expect(driver.launch(request)).rejects.toThrow('is stopping')
+    expect(vm.stopWithTimeout).not.toHaveBeenCalled()
+    const firstStop = manager.suspend(environment.id)
+    release()
+    await expect(firstStop).rejects.toThrow('temporary VM stop failure')
+    expect(terminal).toHaveBeenCalledOnce()
+    expect(await manager.environmentIds()).toEqual([environment.id])
+
+    await expect(driver.launch(request)).rejects.toThrow('socket bridge failed')
+    await manager.suspend(environment.id)
+    expect(vm.status).toBe('stopped')
+    const recovered = await driver.launch(request)
+    expect(created).toHaveLength(1)
+    expect(vm.status).toBe('running')
+    const bytes = Buffer.from('recovered\n')
+    await recovered.toAgent.getWriter().write(bytes)
+    expect((await recovered.fromAgent.getReader().read()).value).toEqual(bytes)
+    await recovered.stop(0)
+    await manager.discard(environment.id)
+  })
+
+  it('enforces output bounds by killing the guest command', async () => {
+    const { manager, environment, processes, runWith } = await fixture()
+    runWith((process) => process.push({ kind: 'stderr', data: Buffer.from('oversized') }))
+    await expect(manager.exec(environment, 'test', [], { maxBytes: 4 })).rejects.toThrow('output limit exceeded')
+    expect(processes[0]!.kill).toHaveBeenCalledOnce()
+    await manager.suspend(environment.id)
+  })
+})

--- a/packages/daemon/test/microsandbox-guest.test.ts
+++ b/packages/daemon/test/microsandbox-guest.test.ts
@@ -1,0 +1,178 @@
+import { execFile, execFileSync } from 'node:child_process'
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import {
+  MICROSANDBOX_GUEST_ENTRY,
+  MICROSANDBOX_NODE,
+  microsandboxGitRunner,
+  microsandboxWorkspaceFs,
+  type MicrosandboxExecute
+} from '../src/microsandbox/guest.js'
+import { GitTransportError } from '../src/workspace/git-runner.js'
+import { MicrosandboxWorkspaceFs } from '../src/microsandbox/workspace-fs.js'
+import { applyMemoryFsPayload, type MemoryFsPayload } from '../src/shim/memory-fs-channel.js'
+import { ShimChannelLostError } from '../src/shim/channels.js'
+import { pathExecutor } from './fixtures/memory-fs-pod.js'
+
+const roots: string[] = []
+const entry = fileURLToPath(new URL('../src/microsandbox/guest-cli.ts', import.meta.url))
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function repository(): string {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'ac-microsandbox-git-')))
+  roots.push(root)
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: root, stdio: 'ignore' })
+  writeFileSync(join(root, 'file with spaces.txt'), 'untracked\n')
+  return root
+}
+
+const executeLocally: MicrosandboxExecute = async (command, args, options) => {
+  expect(command).toBe(MICROSANDBOX_NODE)
+  expect(args[0]).toBe(MICROSANDBOX_GUEST_ENTRY)
+  expect(options?.maxBytes).toBe(MAX_FRAME_BYTES)
+  return await new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      ['--conditions=development', '--import', 'tsx', entry, ...args.slice(1)],
+      {
+        encoding: 'utf8',
+        timeout: options?.timeoutMs,
+        signal: options?.abort,
+        maxBuffer: options?.maxBytes
+      },
+      (error, stdout, stderr) => {
+        if (error && typeof error.code !== 'number') return reject(error)
+        resolve({ exitCode: typeof error?.code === 'number' ? error.code : 0, stdout, stderr })
+      }
+    )
+  })
+}
+
+describe('microsandbox guest Git process', () => {
+  it('keeps host reads while routing active-VM mutations through the existing workspace protocol', async () => {
+    const root = repository()
+    const requests: MemoryFsPayload[] = []
+    const executor = pathExecutor()
+    let active = false
+    let unavailable = false
+    const guest = microsandboxWorkspaceFs({
+      workspaceRoot: root,
+      execute: async (command, args, options) => {
+        expect(command).toBe(MICROSANDBOX_NODE)
+        expect(args[0]).toBe(MICROSANDBOX_GUEST_ENTRY)
+        expect(options?.maxBytes).toBe(MAX_FRAME_BYTES)
+        if (unavailable) throw new Error('VM stopped')
+        const request = JSON.parse(args[1]!)
+        expect(request.capability).toBe('read')
+        expect(request.workspaceRoot).toBe(root)
+        requests.push(request.payload)
+        const reply = await applyMemoryFsPayload(request.payload, root, executor)
+        return { exitCode: 0, stdout: JSON.stringify(reply), stderr: '' }
+      }
+    })
+    const fs = new MicrosandboxWorkspaceFs(() => (active ? guest : undefined))
+    const staging = join(root, 'staging')
+    const published = join(root, 'published')
+    await fs.mkdir(staging, 0o700)
+    await fs.writeFile(join(staging, 'marker'), 'before VM')
+    expect(requests).toEqual([])
+
+    active = true
+    await fs.rename(staging, published)
+    await fs.mkdir(join(published, 'empty'))
+    await fs.writeFile(join(published, 'marker'), 'from VM', { mode: 0o600 })
+    expect(requests.map((request) => request.op)).toEqual([
+      'memory-rename',
+      'memory-mkdir',
+      'memory-append',
+      'memory-commit'
+    ])
+    expect(await fs.stat(published)).toBe('dir')
+    expect(await fs.readFile(join(published, 'marker'))).toBe('from VM')
+    expect(await fs.readdir(published)).toEqual(['empty', 'marker'])
+    expect(requests).toHaveLength(4)
+    expect(await fs.rmdir(published)).toBe(false)
+    expect(await fs.rmdir(join(published, 'empty'))).toBe(true)
+    await fs.rmTree(published)
+    expect(await fs.stat(published)).toBe('missing')
+
+    unavailable = true
+    await expect(fs.mkdir(published)).rejects.toBeInstanceOf(ShimChannelLostError)
+    expect(await fs.stat(published)).toBe('missing')
+    const refused = await executeLocally(
+      MICROSANDBOX_NODE,
+      [
+        MICROSANDBOX_GUEST_ENTRY,
+        JSON.stringify({ workspaceRoot: root, capability: 'read', payload: { op: 'memory-stat', root, rel: '..' } })
+      ],
+      { maxBytes: MAX_FRAME_BYTES }
+    )
+    expect(refused.exitCode).toBe(0)
+    expect(JSON.parse(refused.stdout)).toMatchObject({ ok: false, refusal: { kind: 'path' } })
+  })
+
+  it('runs the shipped handler with argv JSON and retains environment, parsing, and output bounds', async () => {
+    const root = repository()
+    const abort = new AbortController()
+    const sourceEnv = {
+      PATH: '/host/toolchain/bin',
+      HOME: '/host/home',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null'
+    }
+    const env = { ...sourceEnv, PATH: process.env.PATH ?? '', HOME: root }
+    const execute: MicrosandboxExecute = async (command, args, options) => {
+      const request = JSON.parse(args[1]!)
+      expect(request.workspaceRoot).toBe(root)
+      expect(request.payload.env).toEqual(env)
+      expect(options?.env).toBeUndefined()
+      expect(options?.abort).toBe(abort.signal)
+      expect(options?.timeoutMs).toBe(135_000)
+      return await executeLocally(command, args, options)
+    }
+    const runner = microsandboxGitRunner({
+      execute,
+      workspaceRoot: root,
+      cwd: root,
+      abort: abort.signal,
+      env: { INITIAL_ENV_MUST_NOT_SURVIVE: '1' },
+      mapEnv: (received) => {
+        expect(received).toEqual(sourceEnv)
+        return { ...received, PATH: env.PATH, HOME: root }
+      }
+    }).withEnv(sourceEnv)
+    const status = await runner.status()
+    expect(status.current).toBe('main')
+    expect(status.clean).toBe(false)
+    expect(status.files).toEqual([{ path: 'file with spaces.txt', index: '?', working_dir: '?' }])
+    const bounded = await runner.readBounded(['status', '--short'], 2)
+    expect(bounded.out.byteLength).toBe(2)
+    expect(bounded.overflow).toBe(true)
+  })
+
+  it('preserves handler refusal and treats a missing or malformed process reply as transport failure', async () => {
+    const root = repository()
+    const runner = microsandboxGitRunner({ execute: executeLocally, workspaceRoot: root, cwd: root })
+    await expect(runner.raw(['status', '-c', 'core.pager=unsafe'])).rejects.toThrow('argument -c is refused')
+    const outside = microsandboxGitRunner({ execute: executeLocally, workspaceRoot: root, cwd: tmpdir() })
+    await expect(outside.status()).rejects.toThrow('cwd escapes the workspace root')
+    for (const execute of [
+      async () => ({ exitCode: 0, stdout: 'not JSON', stderr: '' }),
+      async () => ({ exitCode: 0, stdout: '{}', stderr: '' }),
+      async () => {
+        throw new Error('VM stopped')
+      }
+    ]) {
+      await expect(microsandboxGitRunner({ execute, workspaceRoot: root }).status()).rejects.toBeInstanceOf(
+        GitTransportError
+      )
+    }
+  })
+})

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { prepareMicrosandboxLaunch, type PrepareMicrosandboxLaunchOptions } from '../src/microsandbox/launch.js'
+import { MICROSANDBOX_GUEST_ENTRY } from '../src/microsandbox/guest.js'
+import { microsandboxSupportMounts } from '../src/microsandbox/support.js'
+import { gitcredShimPath } from '../src/cp/gitcred-server.js'
+import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
+import * as credentials from '../src/runtimes/runtime-credentials.js'
+
+const roots: string[] = []
+function fixture(): PrepareMicrosandboxLaunchOptions & { root: string; hostHome: string } {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'ac-msb-')))
+  roots.push(root)
+  const scopeDir = join(root, 'agent')
+  const cwd = join(scopeDir, 'workspace')
+  const hostHome = join(root, 'host')
+  const guestEntry = join(root, 'guest.js')
+  mkdirSync(cwd, { recursive: true })
+  mkdirSync(hostHome)
+  writeFileSync(guestEntry, 'export {}')
+  return {
+    root,
+    hostHome,
+    runtimeId: 'test',
+    scopeDir,
+    cwd,
+    guestEntry,
+    mounts: [],
+    stateSourceEnv: { HOME: hostHome }
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('prepareMicrosandboxLaunch', () => {
+  it('exposes only launch surfaces and preserves configured guest targets and an explicit guest PATH', () => {
+    const opts = fixture()
+    const tool = join(opts.root, 'tool.js')
+    const missing = join(opts.root, 'missing.js')
+    writeFileSync(tool, 'tool')
+    const launch = prepareMicrosandboxLaunch({
+      ...opts,
+      stateSourceEnv: {
+        HOME: opts.hostHome,
+        PATH: '/host/bin',
+        SSH_AUTH_SOCK: '/host/agent.sock',
+        DBUS_SESSION_BUS_ADDRESS: 'unix:/host/bus'
+      },
+      trustedRuntimeReadRoots: [tool, missing],
+      mounts: [{ source: tool, target: '/tools/tool.js', readOnly: true }]
+    })
+    expect(launch.inheritProcessEnv).toBe(false)
+    expect(launch.sandbox).toBeUndefined()
+    expect(launch.microsandbox.workspaceRoot).toBe(opts.scopeDir)
+    expect(launch.microsandbox.mounts).toEqual(
+      expect.arrayContaining([
+        { source: opts.cwd, target: opts.cwd, readOnly: false },
+        { source: join(opts.scopeDir, 'home'), target: join(opts.scopeDir, 'home'), readOnly: false },
+        { source: tool, target: tool, readOnly: true },
+        { source: tool, target: '/tools/tool.js', readOnly: true },
+        { source: opts.guestEntry, target: MICROSANDBOX_GUEST_ENTRY, readOnly: true }
+      ])
+    )
+    expect(launch.microsandbox.mounts.some((mount) => mount.source === opts.scopeDir)).toBe(false)
+    expect(existsSync(missing)).toBe(false)
+    expect(launch.env.PATH).toBe(
+      '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+    )
+    expect(launch.env.SSH_AUTH_SOCK).toBeUndefined()
+    expect(launch.env.DBUS_SESSION_BUS_ADDRESS).toBeUndefined()
+    expect(launch.env.TMPDIR).toBe('/tmp')
+    expect(launch.env.AC_GITCRED_SOCKET).toBe('/run/agentconnect/gitcred.sock')
+    expect(prepareMicrosandboxLaunch({ ...opts, explicitEnv: { PATH: '/guest/tools:/usr/bin' } }).env.PATH).toBe(
+      '/guest/tools:/usr/bin'
+    )
+  })
+
+  it.each([
+    ['claude-acp', 'CLAUDE_CODE_EXECUTABLE'],
+    ['codex-acp', 'CODEX_PATH']
+  ])('resolves %s executable hints in the guest unless explicitly configured', (command, envVar) => {
+    const opts = fixture()
+    const launchOpts = {
+      ...opts,
+      runtime: { command, args: [], env: [] },
+      stateSourceEnv: { ...opts.stateSourceEnv, [envVar]: '/host/runtime' }
+    }
+    expect(prepareMicrosandboxLaunch(launchOpts).env[envVar]).toBeUndefined()
+    expect(prepareMicrosandboxLaunch({ ...launchOpts, explicitEnv: { [envVar]: '/guest/runtime' } }).env[envVar]).toBe(
+      '/guest/runtime'
+    )
+  })
+
+  it('mounts one complete session for changing Git directories without exposing other sessions', () => {
+    const opts = fixture()
+    const sessionDir = join(opts.scopeDir, 'sessions', 'session-a')
+    const cwd = join(sessionDir, 'workspace')
+    const other = join(opts.scopeDir, 'sessions', 'session-b')
+    mkdirSync(cwd, { recursive: true })
+    mkdirSync(other)
+    const launch = prepareMicrosandboxLaunch({ ...opts, cwd, trustedSessionDir: sessionDir })
+    expect(launch.runtimeHome).toBe(join(sessionDir, 'home'))
+    expect(launch.microsandbox.mounts).toContainEqual({ source: sessionDir, target: sessionDir, readOnly: false })
+    expect(
+      launch.microsandbox.mounts.some((mount) => other === mount.target || other.startsWith(mount.target + '/'))
+    ).toBe(false)
+    expect(() => prepareMicrosandboxLaunch({ ...opts, trustedSessionDir: sessionDir })).toThrow(
+      'cwd is outside its session'
+    )
+    expect(() => prepareMicrosandboxLaunch({ ...opts, trustedSessionDir: dirname(sessionDir) })).toThrow(
+      'scopeDir/sessions/<leaf>'
+    )
+    expect(() => prepareMicrosandboxLaunch({ ...opts, trustedWorkspaceWriteRoots: [opts.scopeDir] })).toThrow(
+      'not inside the agent dir'
+    )
+  })
+
+  it('allows a one-off host to keep its private HOME separate from its input directory', () => {
+    const opts = fixture()
+    const hostKey = sessionHostKey('agent', 'internal-extraction')
+    const cwd = join(opts.scopeDir, 'memory', 'extraction', 'input')
+    mkdirSync(cwd, { recursive: true })
+    const launch = prepareMicrosandboxLaunch({ ...opts, cwd, hostKey })
+    const home = join(opts.scopeDir, 'sessions', hostKeyDirName(hostKey), 'home')
+    expect(launch.runtimeHome).toBe(home)
+    expect(launch.microsandbox.mounts).toContainEqual({ source: home, target: home, readOnly: false })
+    expect(launch.microsandbox.mounts.some((mount) => mount.source === dirname(home))).toBe(false)
+  })
+
+  it('preserves the host Git helper and protects its guest alias and nested Git config as read-only mounts', () => {
+    const opts = fixture()
+    const helper = gitcredShimPath(opts.root)
+    const gitConfig = join(opts.cwd, 'session.gitconfig')
+    mkdirSync(dirname(helper), { recursive: true })
+    writeFileSync(helper, 'original host helper')
+    writeFileSync(gitConfig, '[core]\n hooksPath = /dev/null\n')
+    const trustedMounts = microsandboxSupportMounts(opts.root, gitConfig)
+    expect(readFileSync(helper, 'utf8')).toBe('original host helper')
+    expect(readFileSync(trustedMounts[0]!.source, 'utf8')).toBe(
+      '#!/bin/sh\nexec /opt/agentconnect/bin/git-credential "$@"\n'
+    )
+    if (process.platform !== 'win32') expect(statSync(trustedMounts[0]!.source).mode & 0o777).toBe(0o755)
+    expect(microsandboxSupportMounts(opts.root, join(opts.root, 'missing.gitconfig'))).toEqual([trustedMounts[0]])
+    const launch = prepareMicrosandboxLaunch({ ...opts, trustedMounts })
+    expect(launch.microsandbox.mounts).toEqual(
+      expect.arrayContaining([
+        { source: opts.cwd, target: opts.cwd, readOnly: false },
+        { source: gitConfig, target: gitConfig, readOnly: true },
+        { source: trustedMounts[0]!.source, target: helper, readOnly: true }
+      ])
+    )
+    for (const target of [helper, dirname(helper), gitConfig]) {
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          trustedMounts,
+          mounts: [{ source: opts.hostHome, target, readOnly: false }]
+        })
+      ).toThrow('overlaps an automatic')
+    }
+  })
+
+  it('rejects operator mounts shadowing private data, helper code, or socket bridges', () => {
+    const opts = fixture()
+    for (const target of [
+      opts.scopeDir,
+      join(opts.scopeDir, 'home', 'replacement'),
+      dirname(MICROSANDBOX_GUEST_ENTRY),
+      '/run/agentconnect'
+    ]) {
+      expect(() =>
+        prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: opts.hostHome, target, readOnly: false }] })
+      ).toThrow('overlaps an automatic')
+    }
+    expect(() => prepareMicrosandboxLaunch({ ...opts, trustedRuntimeReadRoots: [opts.scopeDir] })).toThrow(
+      'entire agent or host HOME'
+    )
+    expect(() =>
+      prepareMicrosandboxLaunch({
+        ...opts,
+        runtime: { command: 'external', args: [], env: [], externalExecution: true }
+      })
+    ).toThrow('outside the microsandbox VM')
+  })
+
+  it('reuses the native Codex auth-file link and exposes only the shared credential file', () => {
+    const opts = fixture()
+    const hostCodex = join(opts.hostHome, '.codex')
+    const auth = join(hostCodex, 'auth.json')
+    mkdirSync(hostCodex)
+    writeFileSync(auth, JSON.stringify({ OPENAI_API_KEY: 'synthetic-test-key' }))
+    const original = credentials.prepareSharedRuntimeCredentials
+    vi.spyOn(credentials, 'prepareSharedRuntimeCredentials').mockImplementation((options) =>
+      original({ ...options, platform: 'linux' })
+    )
+    const launch = prepareMicrosandboxLaunch({ ...opts, runtimeId: 'codex-acp' })
+    expect(readlinkSync(join(launch.runtimeHome!, '.codex', 'auth.json'))).toBe(auth)
+    expect(launch.microsandbox.mounts).toContainEqual({ source: auth, target: auth, readOnly: false })
+    expect(
+      launch.microsandbox.mounts.some((mount) => mount.source === hostCodex || mount.source === opts.hostHome)
+    ).toBe(false)
+  })
+
+  it.skipIf(process.platform === 'win32')('filters host Unix sockets from file mounts', async () => {
+    const opts = fixture()
+    const socket = join(opts.root, 'ipc')
+    const server = createServer()
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socket, resolve)
+    })
+    try {
+      const launch = prepareMicrosandboxLaunch({ ...opts, trustedRuntimeReadRoots: [socket] })
+      expect(launch.microsandbox.mounts.some((mount) => mount.source === socket)).toBe(false)
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+})

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -234,6 +234,104 @@ describe('daemon activation gate provenance rule', () => {
   })
 })
 
+describe('microsandbox runtime facts', () => {
+  it('probes host definitions while preserving image facts and same-ID host admission', async () => {
+    const dir = root()
+    await seedCache(
+      dir,
+      ['local', 'shared', 'guest-only'].map((runtimeId) => ({
+        runtimeId,
+        models: [{ id: 'old-host-model', caps: { fastMode: true } }]
+      }))
+    )
+    const clock = new FakeClock()
+    clock.advance(10_000)
+    let catalog = catalogOf({ local: FAKE_RT })
+    const probe = vi.fn(async (runtimes: Record<string, RuntimeDef>): Promise<RuntimeProbeResult[]> =>
+      Object.keys(runtimes).map((runtime) => ({
+        runtime,
+        ok: true,
+        models: ['host-model'],
+        probedVersion: 'host-version',
+        acpProtocolVersion: 1
+      }))
+    )
+    const daemon = new Daemon({
+      root: dir,
+      clock,
+      resolveCatalog: async () => catalog,
+      installed: (runtimes) => Object.fromEntries(Object.entries(runtimes).filter(([id]) => id !== 'guest-only')),
+      probeRuntimes: probe,
+      hostFactory: () => ({}) as never,
+      sandboxMechanism: null
+    })
+
+    try {
+      await daemon.start()
+      catalog = catalogOf({ local: FAKE_RT, shared: FAKE_RT, 'guest-only': FAKE_RT })
+      catalog.entries.shared!.source = 'curated'
+      const d = daemon as any
+      d.cfg.sandbox.backend = 'microsandbox'
+      d.microsandboxTable = {
+        runtimes: ['shared', 'guest-only'].map((id) => ({
+          id,
+          command: `/image/bin/${id}`,
+          args: ['acp'],
+          version: 'image-version',
+          models: ['image-model'],
+          acp: { protocolVersion: 9 }
+        }))
+      }
+      const install = vi.spyOn(d, 'installManagedRuntimePackages')
+      const agents = [
+        { runtime: 'shared', runInSandbox: true },
+        { runtime: 'local', runInSandbox: false }
+      ]
+      await d.discoverRuntimes(dir, d.cfg, agents)
+      expect(install.mock.calls[0]![1]).toEqual(['local'])
+      d.cfg.security.requireSandbox = true
+      await d.discoverRuntimes(dir, d.cfg, agents)
+      expect(install.mock.calls[1]![1]).toEqual([])
+      d.cfg.security.requireSandbox = false
+      await d.hydrateRuntimeCaches()
+      expect(d.runtimeFacts.profileFor('local').modelCatalog.models[0].id).toBe('old-host-model')
+      const noteProbe = stubCatalogSvc(daemon)
+      const emitted = captureEmits(daemon)
+
+      await d.runtimeFacts.probeAndEmit(true)
+
+      expect(probe.mock.calls.map(([runtimes]) => runtimes)).toEqual([{ local: FAKE_RT }, { shared: FAKE_RT }])
+      expect(noteProbe).toHaveBeenCalledOnce()
+      expect(noteProbe.mock.calls[0]![0]).toMatchObject({ runtimeId: 'local', rt: FAKE_RT })
+      expect(() => d.curatedRuntimeAdmission.assertLaunch('shared', 'curated')).not.toThrow()
+      for (const id of ['shared', 'guest-only']) {
+        expect(d.runtimeFacts.profileFor(id)).toMatchObject({
+          runtime: id,
+          version: 'image-version',
+          models: ['image-model'],
+          modelsSource: 'cached',
+          acpProtocolVersion: 9
+        })
+        expect(d.runtimeFacts.profileFor(id).modelCatalog).toBeUndefined()
+        expect(await d.store.getRuntimeCatalogMeta(id)).toMatchObject({ fingerprint: 'fp-cache' })
+      }
+      expect(d.localRuntimeCatalog.runtimes.shared.command).toBe('fake-agent')
+      expect(d.microsandboxCatalog.runtimes.shared.command).toBe('/image/bin/shared')
+
+      d.localRuntimeCatalog = catalogOf({})
+      clock.advance(5 * 60_000)
+      probe.mockClear()
+      emitted.length = 0
+      await d.runtimeFacts.probeAndEmit(true)
+      expect(probe).not.toHaveBeenCalled()
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]!.find((profile) => profile.runtime === 'shared')?.models).toEqual(['image-model'])
+    } finally {
+      await daemon.stop()
+    }
+  })
+})
+
 describe('daemon last-good advertisement fallback', () => {
   it('a transient first probe failure keeps cached models + catalog; a later success replaces them without phase 2', async () => {
     const dir = root()

--- a/packages/daemon/test/read-roots.test.ts
+++ b/packages/daemon/test/read-roots.test.ts
@@ -128,6 +128,57 @@ describe('trusted runtime read roots', () => {
     expect(() => normalizeSandboxMounts([{ ...mount, target: root }])).toThrow(/same|equal|remap/i)
   })
 
+  it('maps canonical microsandbox sources to guest paths without resolving those paths on the host', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-vm-mounts-'))
+    temporaryRoots.push(root)
+    const store = join(root, 'store')
+    const nested = join(store, 'nested')
+    const alias = join(root, 'store-link')
+    mkdirSync(nested, { recursive: true })
+    symlinkSync(store, alias, 'junction')
+    const mounts = [
+      { source: '~/store-link', target: '/cache/../cache/store/', readOnly: true },
+      { source: store, target: '/cache/store', readOnly: false },
+      { source: nested, target: '/cache/store/nested', readOnly: true },
+      { source: store, target: '/other-cache', readOnly: true }
+    ]
+    const expected = [
+      { source: realpathSync(store), target: '/cache/store', readOnly: false },
+      { source: realpathSync(nested), target: '/cache/store/nested', readOnly: true },
+      { source: realpathSync(store), target: '/other-cache', readOnly: true }
+    ]
+    for (const entries of [mounts, [...mounts].reverse()]) {
+      const normalized = normalizeSandboxMounts(entries, { HOME: root }, 'microsandbox')
+      expect(normalized).toHaveLength(expected.length)
+      expect(normalized).toEqual(expect.arrayContaining(expected))
+    }
+    expect(() =>
+      normalizeSandboxMounts(
+        [...mounts, { source: nested, target: '/cache/store/', readOnly: false }],
+        { HOME: root },
+        'microsandbox'
+      )
+    ).toThrow(/different sources to the same target/)
+  })
+
+  it('accepts microsandbox file mounts and rejects invalid source or guest paths', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-vm-mount-paths-'))
+    temporaryRoots.push(root)
+    const file = join(root, 'config')
+    writeFileSync(file, 'configuration')
+    const normalize = (source: string, target = '/cache') =>
+      normalizeSandboxMounts([{ source, target, readOnly: true }], {}, 'microsandbox')
+    expect(() => normalize(join(root, 'missing'))).toThrow(/source does not exist/)
+    expect(() => normalize('relative/source')).toThrow(/source must be absolute/)
+    expect(normalize(file)).toEqual([{ source: realpathSync(file), target: '/cache', readOnly: true }])
+    for (const target of ['relative/target', '~/cache', 'C:\\cache', '/cache\0invalid']) {
+      expect(() => normalize(root, target)).toThrow(/absolute POSIX guest path/)
+    }
+    for (const target of ['/', '//', '/cache/..']) {
+      expect(() => normalize(root, target)).toThrow(/must not be the guest root/)
+    }
+  })
+
   it('rejects relative operator read roots', () => {
     expect(() =>
       trustedRuntimeReadRoots({

--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -11,6 +11,7 @@ import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 const workspaces = new WorkspaceManager()
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import { gitFor } from '../src/workspace/git-injection.js'
+import { localWorkspaceFs } from '../src/workspace/workspace-fs.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
 // The resolver seam that lets a cluster workspace run git on its sandbox pod instead of this disk.
@@ -21,6 +22,7 @@ const roots: string[] = []
 
 afterEach(() => {
   workspaces.setGitRunnerResolver(undefined)
+  workspaces.setFsResolver(undefined)
   workspaces.setSandboxMode(false)
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
@@ -201,12 +203,13 @@ describe('workspace-manager git runner seam', () => {
     expect(existsSync(worktree)).toBe(false)
   })
 
-  it('does not coalesce two CLUSTER agents onto one clone, even at the same path', async () => {
+  it.each([true, false])('deduplicates clones by filesystem ownership (remote=%s)', async (remote) => {
     // The single-flight lock was keyed on the textual cwd. For local agents that is the intent:
     // one path means one checkout. For cluster agents the same path is a different filesystem per
     // agent, so coalescing hands one agent the other's clone — and it looks like success.
-    const home = mkdtempSync(join(tmpdir(), 'ac-seam-clone-'))
+    const home = realpathSync(mkdtempSync(join(tmpdir(), 'ac-seam-clone-')))
     roots.push(home)
+    if (remote) workspaces.setFsResolver(() => ({ mount: home, fs: localWorkspaceFs }))
     const shared = join(home, 'checkout')
     const cloned: string[] = []
     let release!: () => void
@@ -235,7 +238,7 @@ describe('workspace-manager git runner seam', () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
     release()
     await Promise.all([first, second])
-    expect(cloned.sort()).toEqual(['bot-one', 'bot-two'])
+    expect(cloned.sort()).toEqual(remote ? ['bot-one', 'bot-two'] : ['bot-one'])
   })
 
   it('has no git call site left outside the seam', () => {

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -29,6 +29,8 @@ import { ShimGitRunner, type GitExecPayload } from '../src/shim/git-exec.js'
 import type { ShimRequester } from '../src/shim/channels.js'
 import { sessionHomeIn } from '../src/workspace/session-layout.js'
 import { WorkspaceManager, type PrepareSessionWorkspaceRequest } from '../src/workspace/workspace-manager.js'
+import { MicrosandboxWorkspaceFs } from '../src/microsandbox/workspace-fs.js'
+import { LocalWorkspaceFs } from '../src/workspace/workspace-fs.js'
 
 // Real git against real repositories (git-workspace-model.md §11): the claims are about the disk — where a confined session's clones land, that nothing of theirs reaches the primary, that a review is fetched and verified inside the clone, and what retirement removes or keeps.
 
@@ -53,6 +55,7 @@ afterAll(() => rmSync(join(SHIM, '..'), { recursive: true, force: true }))
 afterEach(() => {
   gitRuns.length = 0
   workspaces.setGitRunnerResolver(undefined)
+  workspaces.setFsResolver(undefined)
   remotes.clear()
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
@@ -492,6 +495,49 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
 })
 
 describe('retiring a confined session', () => {
+  it('checks Git safety before stopping a mounted session and removes its host source only after stop succeeds', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    const sessionDir = leafOf(agent)
+    let stopFails = true
+    let stopAttempts = 0
+    let active = true
+    const guest = new LocalWorkspaceFs()
+    guest.rmTree = async () => {
+      throw new Error('EBUSY: cannot remove guest mountpoint')
+    }
+    const fs = new MicrosandboxWorkspaceFs(
+      () => (active ? guest : undefined),
+      async (path) => {
+        if (path !== sessionDir) return false
+        expect(gitRuns.some(({ args }) => args[0] === 'rev-list' && args.includes('--all'))).toBe(true)
+        stopAttempts++
+        if (stopFails) throw new Error('VM still has active executions')
+        expect(existsSync(sessionDir)).toBe(true)
+        active = false
+        return true
+      }
+    )
+    workspaces.setFsResolver(() => ({ fs }))
+    gitRuns.length = 0
+    const dirty = join(cwd, 'wip.md')
+    writeFileSync(dirty, 'keep until safe')
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(stopAttempts).toBe(0)
+    rmSync(dirty)
+
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({
+      outcome: 'failed',
+      error: 'VM still has active executions'
+    })
+    expect(existsSync(sessionDir)).toBe(true)
+    stopFails = false
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
+    expect(stopAttempts).toBe(2)
+    expect(existsSync(sessionDir)).toBe(false)
+  })
+
   it('removes the whole session directory, its HOME included, when every clone is clean and pushed', async () => {
     const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
     serveAll(agent)

--- a/packages/daemon/tsdown.microsandbox.config.ts
+++ b/packages/daemon/tsdown.microsandbox.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: { guest: 'src/microsandbox/guest-cli.ts' },
+  outDir: 'dist/microsandbox',
+  format: ['esm'],
+  platform: 'node',
+  fixedExtension: false,
+  deps: { alwaysBundle: [/.*/] },
+  shims: true,
+  dts: false,
+  sourcemap: true,
+  clean: false
+})

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -38,6 +38,8 @@ export const WINDOWS_EXCLUDED = [
   'test/shim-channels.test.ts',
   'test/skills-cli-cell.test.ts',
   'test/runtime-launch.test.ts',
+  'test/microsandbox-launch.test.ts',
+  'test/microsandbox-guest.test.ts',
   // The sandbox-pod plane. A pod is always Linux, so its coordinates, its shim and its confined
   // `gh`/`glab` shells are POSIX by construction — a Windows daemon never stands one up. A new suite
   // over that plane belongs here; the ones absent from this list do pass on Windows today.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,9 @@ importers:
       json:
         specifier: ^11.0.0
         version: 11.0.0
+      microsandbox:
+        specifier: 0.6.17
+        version: 0.6.17
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(tsx@4.23.12)(typescript@6.0.3)
@@ -3187,6 +3190,38 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@superradcompany/microsandbox-darwin-arm64@0.6.17':
+    resolution: {integrity: sha512-H+h+lNGlPWpt9qQ9k/MOFAApLFloA22zJAzormM1CSISkyaLBromH4bt9XlCP3nhG3/oHuYnO7FqhKZN+klVgA==}
+    engines: {node: '>= 22'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.6.17':
+    resolution: {integrity: sha512-j7YfBbVKDpF1fC38FPI0Ut1iThpUf0U4+I4IA+lBTyxo3ptux0b2ouY0CDSB+okrWTCe/kxgxUhgOKc9V3gOPA==}
+    engines: {node: '>= 22'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@superradcompany/microsandbox-linux-x64-gnu@0.6.17':
+    resolution: {integrity: sha512-o9IXJNWi1Ml9VMD0IAbLdUTeujbmY39z5reuez03Svxrqy8AlGGJoNR6Nh+oAm5p0Ytke8BChI9OlYcSFFCPHw==}
+    engines: {node: '>= 22'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@superradcompany/microsandbox-win32-arm64-msvc@0.6.17':
+    resolution: {integrity: sha512-M2wdSTTEBRKJXpYX3P0+5tQJep17HY1p7UTFLxFsiWH+xEJ6z5RvYb1U2i5BvNVvyymkfBbh5rnyBSv8vnyDcg==}
+    engines: {node: '>= 22'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@superradcompany/microsandbox-win32-x64-msvc@0.6.17':
+    resolution: {integrity: sha512-1Acpg7zb7o+R1BRV2pWFyMAKTqm7YvMJFPMjAA6H69jAyPTVBdJw3TVCLiN2RR5lHLvV2EdHmx/awl9X5Oj8/g==}
+    engines: {node: '>= 22'}
+    cpu: [x64]
+    os: [win32]
 
   '@swc/core-darwin-arm64@1.16.1':
     resolution: {integrity: sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==}
@@ -6687,6 +6722,11 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  microsandbox@0.6.17:
+    resolution: {integrity: sha512-1JpOtboSgnv2qGzwIRF2GwiMH+79RnY/I6QNriA9WCqsmoSWh5sYoeRNpAPnuUhxm9GYztWNvFST+aZ3+p8iYg==}
+    engines: {node: '>= 22'}
+    hasBin: true
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -11725,6 +11765,21 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@superradcompany/microsandbox-darwin-arm64@0.6.17':
+    optional: true
+
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.6.17':
+    optional: true
+
+  '@superradcompany/microsandbox-linux-x64-gnu@0.6.17':
+    optional: true
+
+  '@superradcompany/microsandbox-win32-arm64-msvc@0.6.17':
+    optional: true
+
+  '@superradcompany/microsandbox-win32-x64-msvc@0.6.17':
+    optional: true
+
   '@swc/core-darwin-arm64@1.16.1':
     optional: true
 
@@ -15423,6 +15478,14 @@ snapshots:
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
+
+  microsandbox@0.6.17:
+    optionalDependencies:
+      '@superradcompany/microsandbox-darwin-arm64': 0.6.17
+      '@superradcompany/microsandbox-linux-arm64-gnu': 0.6.17
+      '@superradcompany/microsandbox-linux-x64-gnu': 0.6.17
+      '@superradcompany/microsandbox-win32-arm64-msvc': 0.6.17
+      '@superradcompany/microsandbox-win32-x64-msvc': 0.6.17
 
   mime-types@2.1.35:
     dependencies:


### PR DESCRIPTION
Add a daemon-configured microsandbox backend for Linux hosts with KVM. SRT remains the default; selecting microsandbox requires an explicit runtime image and accepts per-VM CPU, memory, disk, and shared mount settings.

The backend reuses the existing ACP driver and guest Git/filesystem handlers. Isolated sessions get separate VMs, shared sessions reuse their agent VM, and stop/start retains disks and workspace files. It discovers the image runtime/MCP capabilities, carries daemon tool channels over vsock, and keeps host runtime discovery separate. Workspace mutations run inside an active VM to avoid stale directory views after host-side renames. Failed launches, bridge exits, and session retirement have explicit cleanup/retry behavior.

The SDK is pinned to 0.6.17 and installed through RuntimeStore. Flat-disk restart uses the upstream CLI's image materialization path without patching the SDK. Docker, published ports, automatic release-image selection, and the standalone `chat` command remain outside this increment; `chat` explicitly refuses this backend.

Validation:

- Built the self-contained daemon and guest bundles; daemon typecheck, ESLint, and formatting passed.
- 6,059 daemon tests passed, with 88 skipped. Twelve macOS-incompatible shim tests were independently reproduced on current main; their files were excluded from this pass.
- All PR checks passed, including Linux sandbox tests and both Windows shards; review regressions also passed.
- On an isolated Linux/KVM daemon using the existing pool image: installed the SDK, created a fresh repository session, initialized ACP and the actual MCP bridge, exercised Git, restored files after daemon restart, and retired the VM.
- The actual expired-session sweep retained dirty work, then checked and removed a clean session's host directory, VM, binding, and database row. All deletion assertions ran before test teardown. Guest ACP startup also passed with an invalid inherited host executable path.
- A real Claude turn returned the exact requested marker with zero tool calls. The running daemon service was not changed or restarted.

Created by Codex . GPT-6
