### PR TITLE
fix(daemon): accept common sendMessage target encodings

### DIFF
--- a/packages/daemon/src/mcp/ops/messaging.ts
+++ b/packages/daemon/src/mcp/ops/messaging.ts
@@ -61,11 +61,22 @@ const AGENT_ID = z.string(AGENT_TARGET_SHAPE_ERROR).min(1, 'sendMessage: `toAgen
 const AGENT_TARGET_OBJECT = z.strictObject(
   {
     agentId: requiredString('agentId'),
-    needsReply: z.boolean('sendMessage: `toAgent.needsReply` must be a boolean').nullish()
+    needsReply: z
+      .union([
+        z.boolean('sendMessage: `toAgent.needsReply` must be a boolean'),
+        z.string().regex(/^(?:true|false)$/i, 'sendMessage: `toAgent.needsReply` must be a boolean')
+      ])
+      .nullish()
   },
   branchKeyError('agent target `toAgent`', ['agentId', 'needsReply'])
 )
 const AGENT_TARGET = z.union([AGENT_ID, AGENT_TARGET_OBJECT])
+
+function normalizeNeedsReply(value: boolean | string | null | undefined): boolean | undefined {
+  if (value === true) return true
+  if (typeof value === 'string' && value.toLowerCase() === 'true') return true
+  return undefined
+}
 
 /** `toUser`: one id works for every delivery form; a non-empty array is reserved for one visible
  *  channel-root post that @-mentions every listed member. */
@@ -106,10 +117,32 @@ export const SEND_MESSAGE_BRANCHES = {
 /** Normalize `toAgent`. `undefined` ⇒ this is not an agent target. */
 function parseAgentTarget(value: unknown): { toAgent?: string; needsReply?: boolean } {
   if (value === undefined || value === null) return {}
-  if (typeof value === 'string') return { toAgent: parseArgs(AGENT_ID, value) }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.startsWith('{')) {
+      let decoded: unknown
+      try {
+        decoded = JSON.parse(trimmed)
+      } catch {
+        throw new Error(AGENT_TARGET_SHAPE_ERROR)
+      }
+      if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+        throw new Error(AGENT_TARGET_SHAPE_ERROR)
+      }
+      const target = parseArgs(AGENT_TARGET_OBJECT, decoded)
+      return {
+        toAgent: target.agentId,
+        ...(normalizeNeedsReply(target.needsReply) === true ? { needsReply: true } : {})
+      }
+    }
+    return { toAgent: parseArgs(AGENT_ID, value) }
+  }
   if (typeof value !== 'object' || Array.isArray(value)) throw new Error(AGENT_TARGET_SHAPE_ERROR)
   const target = parseArgs(AGENT_TARGET_OBJECT, value)
-  return { toAgent: target.agentId, ...(target.needsReply === true ? { needsReply: true } : {}) }
+  return {
+    toAgent: target.agentId,
+    ...(normalizeNeedsReply(target.needsReply) === true ? { needsReply: true } : {})
+  }
 }
 
 /** Normalize `toUser` to the id list both delivery forms work from. */

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -120,9 +120,13 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
                       'platform member id such as Slack `U…`.'
                   },
                   needsReply: {
-                    type: 'boolean',
+                    oneOf: [
+                      { type: 'boolean' },
+                      { type: 'string', pattern: '^(?:[Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])$' }
+                    ],
                     description:
-                      'Set true whenever you expect an answer, a result, or a completion signal: the woken session ' +
+                      'Set true whenever you expect an answer, a result, or a completion signal. Boolean values are ' +
+                      'preferred; case-insensitive string values "true"/"false" are accepted for compatibility. The woken session ' +
                       'is told to report back into this session (done or failed) when it completes. Defaults to ' +
                       'false, which is fire-and-forget — the peer’s answer stays in its own conversation and you ' +
                       'learn nothing, not even that it failed.'

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -1985,6 +1985,29 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     expect(calls[1]!.needsReply).toBeUndefined()
   })
 
+  it.each(['true', 'True', 'TRUE', 'tRuE'])('normalizes string needsReply=%s to true', async (needsReply) => {
+    const { deps: d, calls } = wakeDeps()
+    await executeTool(ctx, 'sendMessage', { toAgent: { agentId: 'peer-1', needsReply }, message: 'report back' }, d)
+    expect(calls[0]).toMatchObject({ toAgentId: 'peer-1', needsReply: true })
+  })
+
+  it.each(['false', 'False', 'FALSE', 'fAlSe'])('normalizes string needsReply=%s to false', async (needsReply) => {
+    const { deps: d, calls } = wakeDeps()
+    await executeTool(ctx, 'sendMessage', { toAgent: { agentId: 'peer-1', needsReply }, message: 'fire and forget' }, d)
+    expect(calls[0]!.needsReply).toBeUndefined()
+  })
+
+  it('parses a JSON-stringified structured toAgent target', async () => {
+    const { deps: d, calls } = wakeDeps()
+    await executeTool(
+      ctx,
+      'sendMessage',
+      { toAgent: '{"agentId":"peer-1","needsReply":"True"}', message: 'report back' },
+      d
+    )
+    expect(calls[0]).toMatchObject({ toAgentId: 'peer-1', needsReply: true })
+  })
+
   it('the object toAgent form still composes with a visible channel post', async () => {
     const { deps: d, calls, gw } = wakeDeps()
     const res = (await executeTool(
@@ -2002,7 +2025,7 @@ describe('executeTool: sendMessage (wake / reply)', () => {
   it.each([
     { toAgent: {}, label: 'an object with no agentId' },
     { toAgent: { agentId: 'peer-1', urgent: true }, label: 'an unknown option' },
-    { toAgent: { agentId: 'peer-1', needsReply: 'yes' }, label: 'a non-boolean needsReply' },
+    { toAgent: { agentId: 'peer-1', needsReply: 'yes' }, label: 'an unsupported string needsReply' },
     { toAgent: ['peer-1'], label: 'an array' },
     { toAgent: 42, label: 'a number' }
   ])('rejects $label for toAgent instead of silently dropping it', async ({ toAgent }) => {
@@ -2010,6 +2033,15 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     await expect(executeTool(ctx, 'sendMessage', { toAgent, message: 'x' }, d)).rejects.toThrow()
     expect(calls).toHaveLength(0)
   })
+
+  it.each(['{', '{"agentId":"peer-1"', '{"agentId":"peer-1","needsReply":"maybe"}'])(
+    'rejects malformed or ambiguous JSON-stringified toAgent: %s',
+    async (toAgent) => {
+      const { deps: d, calls } = wakeDeps()
+      await expect(executeTool(ctx, 'sendMessage', { toAgent, message: 'x' }, d)).rejects.toThrow()
+      expect(calls).toHaveLength(0)
+    }
+  )
 })
 
 // viewSessionStatus is the read counterpart of a SessionTarget reply: the identity + coords come


### PR DESCRIPTION
## Summary

- Accept `toAgent` when it is provided as a JSON-encoded string.
- Accept case-insensitive `"true"` and `"false"` values for `needsReply`.
- Continue rejecting malformed JSON, unknown fields, and invalid boolean strings.
- Update the MCP tool schema and add regression coverage.

## Validation

- MCP daemon tests: 193 tests passed across `mcp-tools.test.ts` and `mcp-ops.test.ts`.
- TypeScript typecheck passed.
- Prettier passed.
- `git diff --check` passed.

Closes #1840