### PR TITLE
feat(web): default a deployment subscription to created

### DIFF
--- a/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
@@ -91,7 +91,7 @@ function githubHook(partial: Record<string, unknown>): unknown {
   }
 }
 
-// acme/api is watched for BOTH subjects; acme/web only for issues.
+// acme/api is watched for EVERY offered subject; acme/web only for issues.
 const PR_ROW = githubHook({
   id: 'hook-pr',
   repoId: '1',
@@ -107,6 +107,14 @@ const ISSUES_ROW = githubHook({
   repoFullName: 'acme/api',
   family: 'issues',
   events: ['issues:*', 'issue_comment:created']
+})
+const DEPLOY_ROW = githubHook({
+  id: 'hook-deploy',
+  repoId: '1',
+  name: 'acme/api',
+  repoFullName: 'acme/api',
+  family: 'deployment',
+  events: ['deployment:created']
 })
 const WEB_ISSUES_ROW = githubHook({
   id: 'hook-web',
@@ -166,7 +174,7 @@ function triggerOrder(scope: HTMLElement): string[] {
 }
 
 beforeEach(() => {
-  mocks.hooks = [ISSUES_ROW, PR_ROW, WEB_ISSUES_ROW]
+  mocks.hooks = [ISSUES_ROW, PR_ROW, DEPLOY_ROW, WEB_ISSUES_ROW]
   mocks.createGithubHook.mockReset()
   mocks.createGithubHook.mockResolvedValue({ id: 'hook-new' })
   mocks.openModal.mockReset()
@@ -180,15 +188,16 @@ afterEach(async () => {
 })
 
 describe('AgentDetailView, code-host repository blocks', () => {
-  it('keeps a repository two rows and names it once', async () => {
+  it('keeps a repository one row per family and names it once', async () => {
     const scope = await render()
-    // Two families ⇒ two rows, and exactly one of them names the repo (once per responsive tree).
+    // Three families ⇒ three rows, and exactly one of them names the repo (once per responsive tree).
     expect(repoNames(scope, 'acme/api')).toHaveLength(2)
     expect(repoNames(scope, 'acme/web')).toHaveLength(2)
-    // Repos sorted by name, a repo's rows adjacent, change proposals before issues.
+    // Repos sorted by name, a repo's rows adjacent, change proposals before issues before deployments.
     expect(triggerOrder(scope)).toEqual([
       'Trigger for acme/api PRs',
       'Trigger for acme/api Issues',
+      'Trigger for acme/api Deploys',
       'Trigger for acme/web Issues'
     ])
   })
@@ -199,6 +208,7 @@ describe('AgentDetailView, code-host repository blocks', () => {
     // Every row's own X is the only removal — a repo goes away one family at a time.
     expect(byTitle(scope, 'Stop watching PRs')).toHaveLength(1)
     expect(byTitle(scope, 'Stop watching Issues')).toHaveLength(2)
+    expect(byTitle(scope, 'Stop watching Deploys')).toHaveLength(1)
   })
 
   it('deletes just one family from the per-row control', async () => {
@@ -225,7 +235,7 @@ describe('AgentDetailView, code-host repository blocks', () => {
 
   it('offers a + menu only on a repository missing a family, inline on its first row', async () => {
     const scope = await render()
-    // acme/api watches both offered subjects, so only acme/web carries the + (once per responsive tree).
+    // acme/api watches every offered subject, so only acme/web carries the + (once per responsive tree).
     const triggers = byTitle(scope, 'Watch another subject')
     expect(triggers).toHaveLength(2)
     for (const trigger of triggers) {
@@ -234,6 +244,7 @@ describe('AgentDetailView, code-host repository blocks', () => {
     // The menu (body-portaled) lists only what is missing.
     await act(async () => triggers[0]!.click())
     expect(menuItem('Add Pull requests')).toBeTruthy()
+    expect(menuItem('Add Deployments')).toBeTruthy()
     expect(menuItem('Add Issues')).toBeUndefined()
   })
 

--- a/packages/web/src/lib/code-host-hook-groups.test.ts
+++ b/packages/web/src/lib/code-host-hook-groups.test.ts
@@ -30,17 +30,19 @@ function hook(partial: Partial<HookDto> & Pick<HookDto, 'id'>): HookDto {
 }
 
 describe('orderedGithubHookRows', () => {
-  it('keeps a repository as two rows, change proposals first', () => {
+  it('keeps a repository as one row per family, change proposals first', () => {
     const rows = orderedGithubHookRows([
       hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] }),
+      hook({ id: 'c', repoId: '1', repoFullName: 'acme/api', family: 'deployment', events: ['deployment:created'] }),
       hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] })
     ])
-    expect(rows.map((row) => row.hook.id)).toEqual(['b', 'a'])
-    expect(rows.map((row) => row.family)).toEqual(['pull_request', 'issues'])
+    expect(rows.map((row) => row.hook.id)).toEqual(['b', 'a', 'c'])
+    expect(rows.map((row) => row.family)).toEqual(['pull_request', 'issues', 'deployment'])
     expect(rows.every((row) => row.repoKey === '1')).toBe(true)
     // The block's edges: the opener names the repo, the closer carries the divider.
     expect(rows.map((row) => [row.first, row.last])).toEqual([
       [true, false],
+      [false, false],
       [false, true]
     ])
     // Nothing left to add, so no row offers a chip.
@@ -51,7 +53,7 @@ describe('orderedGithubHookRows', () => {
     const rows = orderedGithubHookRows([
       hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] })
     ])
-    expect(rows[0]!.addFamilies).toEqual(['pull_request'])
+    expect(rows[0]!.addFamilies).toEqual(['pull_request', 'deployment'])
     // A one-row block opens and closes on the same row.
     expect([rows[0]!.first, rows[0]!.last]).toEqual([true, true])
   })
@@ -59,7 +61,8 @@ describe('orderedGithubHookRows', () => {
   it('never offers the held-back push subject', () => {
     const rows = orderedGithubHookRows([
       hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] }),
-      hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] })
+      hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] }),
+      hook({ id: 'c', repoId: '1', repoFullName: 'acme/api', family: 'deployment', events: ['deployment:created'] })
     ])
     expect(rows.flatMap((row) => row.addFamilies)).toEqual([])
   })
@@ -79,8 +82,8 @@ describe('orderedGithubHookRows', () => {
       hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: null, events: ['pull_request:*'] })
     ])
     expect(rows.map((row) => row.family)).toEqual(['pull_request', null])
-    // The unplaceable row covers nothing, so issues is still on offer — on the first row.
-    expect(rows[0]!.addFamilies).toEqual(['issues'])
+    // The unplaceable row covers nothing, so issues and deployments are still on offer — on the first row.
+    expect(rows[0]!.addFamilies).toEqual(['issues', 'deployment'])
     expect(rows[1]!.addFamilies).toEqual([])
   })
 
@@ -90,7 +93,8 @@ describe('orderedGithubHookRows', () => {
       hook({ id: 'b', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] })
     ])
     expect(rows.map((row) => row.repoKey)).toEqual(['acme/api', 'acme/api'])
-    expect(rows.flatMap((row) => row.addFamilies)).toEqual([])
+    // One block, so the one unwatched subject is offered once rather than per row.
+    expect(rows.flatMap((row) => row.addFamilies)).toEqual(['deployment'])
   })
 })
 

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -28,8 +28,8 @@ describe('GH_TRIGGER_LABEL', () => {
     expect(githubDefaultTriggerMode('issues')).toBe('first')
     expect(githubDefaultTriggerMode('push')).toBe('first')
     expect(GH_TRIGGER_LABEL[githubDefaultTriggerMode('issues')]).toBe('opened')
-    // A deployment watch is about how it ends, so it opens on every status.
-    expect(githubDefaultTriggerMode('deployment')).toBe('every')
+    // A deployment opens on creation too — every-status is one turn per state, so it is opted into.
+    expect(githubDefaultTriggerMode('deployment')).toBe('first')
   })
 
   it('spells the cadences out for the create surfaces', () => {

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -130,10 +130,10 @@ export function githubMentionUsage(agentName: string, teamOwner?: string | null)
 /** The default create-form selection: pull requests only. */
 export const GH_DEFAULT_FAMILIES: readonly GhFamily[] = ['pull_request']
 
-/** The cadence a create surface opens a new subject on — a change proposal and a deployment on every
- *  update (a deployment watch is about how it ends), the rest on the opening. */
+/** The cadence a create surface opens a new subject on — a change proposal on every update, the rest
+ *  on the opening (a deployment's every-status cadence fires once per state and is opted into). */
 export function githubDefaultTriggerMode(fam: GhFamily): GhTriggerMode {
-  return fam === 'pull_request' || fam === 'deployment' ? 'every' : 'first'
+  return fam === 'pull_request' ? 'every' : 'first'
 }
 
 /** The comment subscription that rides updated/mention-only modes for thread families. */


### PR DESCRIPTION
A deployment subject picked from the console opened on the every-status
cadence, which runs one turn per state GitHub posts against a single
deployment — queued, in progress, success, and every retry. That is a
deliberate choice a user can make, not the one a new subscription should
arrive already making, so the default is now `created`: one turn when a
deployment starts. The every-status watch is the neighbouring segment on the
same trigger control, unchanged.

Also repairs two suites the fourth subject family reached without updating.
`code-host-hook-groups.test.ts` and `AgentDetailView.codehost.test.tsx` still
described a world with two offered subjects, so eight assertions about
row ordering and the "watch another subject" offer were failing on `main`.
Both fixtures now give a fully-watched repository all three rows, so "nothing
left to add" keeps meaning what it says, and the deployment offer is stated
where a repository is genuinely missing one.

Note for existing installs: an App created before the deployment family
shipped still lacks `deployments: read` and the `deployment` /
`deployment_status` event subscriptions. GitHub exposes no API for either, so
they have to be added in the App's own settings and the new permission
approved on each installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
