### PR TITLE
docs(designs): the change log has one reader, and under a CP home the CP answers it itself

### DIFF
--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -250,8 +250,13 @@ composes the record — it holds `before`, `after` and `source` — and sends it
 write as a second, best-effort D→C request, `memory/history` (a batch, since adoption
 records every changed file at once), exactly the provenance-never-fails-the-write rule
 the sidecar has today; retention (`MAX_HISTORY_VERSIONS_PER_FILE` and the byte cap) is a
-delete rather than a rewrite. A `daemon` home keeps the sidecar file; `listMemoryHistory`
-reads whichever the home provides, and the console frame is unchanged.
+delete rather than a rewrite. The daemon never reads it back: the change log has one
+reader, the console, and under a `control-plane` home the CP answers the `memory/history`
+frame from its own table without asking the daemon at all — the one console read that
+already works with the daemon offline. Dream adoption is unaffected: its drift decision
+comes from the in-process write ledger and a content diff against the dream's own
+snapshot, not from the log, and its provenance rows go out as one more batch. A
+`daemon` home keeps the sidecar file and today's frame path.
 
 **Why the port survives the split.** Those two carried the whole case against putting a
 POSIX-shaped op set on this wire. What is left is the memory files themselves: capped at
@@ -288,11 +293,11 @@ refuses to activate a `control-plane` binding with that reason.
 
 **What stays on the daemon.** Everything above the port: the directory lock, retention,
 frontmatter normalization, index generation, the write ledger, the dream fence.
-Console traffic is unchanged in this step — the `memory/*` C→D frames still go to the
-owning daemon, which now answers from the CP-backed port instead of
-waking a pod (#1077's wake stays for `daemon`-home cluster trees only until those are
-gone). Answering list/read/history straight from the table, and so with the daemon
-offline, is a later step. Per-file cap stays `MAX_MEMORY_FILE_BYTES`. The dream runner is
+Console traffic is unchanged in this step except for the change log above — the other
+`memory/*` C→D frames still go to the owning daemon, which now answers from the
+CP-backed port instead of waking a pod (#1077's wake stays for `daemon`-home cluster
+trees only until those are gone). Answering list and read straight from the table, and
+so with the daemon offline, is a later step. Per-file cap stays `MAX_MEMORY_FILE_BYTES`. The dream runner is
 unchanged and keeps staging beside its extraction host; on the pool its `withMemoryHome`
 still binds the agent pod, for the extraction host and the staging root, not the store.
 


### PR DESCRIPTION
## Why

Follow-up to #1786, which merged one commit before this landed on its branch.

§3.2.1 left the change log's read path half-said: it named the console frame as unchanged and `listMemoryHistory` as reading "whichever the home provides", which implies a daemon-side read of the CP table — a CP → daemon → CP round trip that nobody needs. Checking the readers settles it: the console is the change log's only reader. Memory tools and standing context never touch it, and dream adoption decides drift from the in-process write ledger plus a content diff against the dream's own snapshot, not from the log (`dream/runner.ts`, `rebaseDistillWrites`); adoption's own provenance rows are one more batch out.

## What this records

- Under a `control-plane` home the daemon only ever writes the change log. The CP answers the `memory/history` frame from its own table without asking the daemon — which also makes it the one console read that already works with the daemon offline.
- A `daemon` home keeps the sidecar file and today's frame path.
- The "console traffic is unchanged in this step" sentence now carves out the change log, so "answering straight from the table is a later step" applies to list and read only.

Design only, no code. Touches `docs/designs/memory-evolution.md` §3.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
