### PR TITLE
fix(slack): drop the plan-gated lists scopes from the required set

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -1178,6 +1178,12 @@ column's TYPE, and Slack publishes no schema endpoint for a list. So the columns
 from the rows a read returns and handed back with them — the read is not a convenience before
 the write, it is the only source of the ids and types the write needs.
 
+The two `lists:*` scopes are the one family NOT in `SLACK_BOT_SCOPES`. Slack Lists is a
+paid-plan feature: a free workspace can neither offer the scope in an app's config nor grant
+it, and since that list is the required set, asking for it would refuse every free-plan install
+outright. The tools stay declared on the port and answer `missing_scope` where the grant is
+absent — an installation-shaped gap, not a platform-shaped one.
+
 Three scopes in that same change have NO caller and say so: `channels:join`, `team:read`, and
 `users:read.email`. That is a deliberate exception to the scope-arrives-with-its-feature rule,
 taken because one list means every scope addition costs a reinstall of every installation —

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -1178,11 +1178,17 @@ column's TYPE, and Slack publishes no schema endpoint for a list. So the columns
 from the rows a read returns and handed back with them — the read is not a convenience before
 the write, it is the only source of the ids and types the write needs.
 
-The two `lists:*` scopes are the one family NOT in `SLACK_BOT_SCOPES`. Slack Lists is a
-paid-plan feature: a free workspace can neither offer the scope in an app's config nor grant
-it, and since that list is the required set, asking for it would refuse every free-plan install
-outright. The tools stay declared on the port and answer `missing_scope` where the grant is
-absent — an installation-shaped gap, not a platform-shaped one.
+That family is currently DARK, and the reason is worth recording. Slack Lists is a paid-plan
+feature, so a free workspace can neither offer `lists:read` / `lists:write` in an app's config
+nor grant them — and `SLACK_BOT_SCOPES` is the set an installation must hold, so asking for
+them there does not degrade a free-plan install, it refuses one. The scopes came out of that
+list, and the `lists` port flag came out with them: a port declares what THIS DEPLOYMENT can
+reach, and a tool no installation can call is worse than absent, because it costs every Slack
+session's tool list and answers `missing_scope` when a model tries it. The implementations stay
+put. Both come back together with optional scopes (`oauth_config.scopes.bot_optional`), which
+Slack presents separately at install and adds to the token afterwards; a port flag is answered
+before a connection exists, so a per-installation gate additionally needs the grant — `Bot.grantedScopes`,
+which the CP records and the daemon is not told — to reach the tool build.
 
 Three scopes in that same change have NO caller and say so: `channels:join`, `team:read`, and
 `users:read.email`. That is a deliberate exception to the scope-arrives-with-its-feature rule,

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -129,8 +129,6 @@ describe('buildInstallManifest', () => {
       'mpim:write',
       'bookmarks:read',
       'bookmarks:write',
-      'lists:read',
-      'lists:write',
       'channels:join',
       'team:read',
       'users:read.email',

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -1289,6 +1289,8 @@ export const ALL_TOOL_NAMES = [
       .concat([...EXTERNAL_MEMORY_TOOL_NAMES])
       // The pre-promotion review name: no longer injected, still dispatched for warm sessions.
       .concat(['submitGithubReview'])
+      // The list names: no longer injected (their scope left the manifest), still dispatched the same way.
+      .concat(['readList', 'addListItem', 'updateListItem'])
   )
 ]
 

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -158,7 +158,8 @@ const READ_PORTS = new Map<string, PlatformReadPorts>([
       scheduledMessages: true,
       canvas: true,
       bookmarks: true,
-      lists: true,
+      // NO `lists`: the manifest stopped asking for the paid-plan-only `lists:*`, so the three tools
+      // would reach no installation. The implementations stay; the flag returns with the scope.
       attachmentReadTool: SLACK_ATTACHMENT_TOOL
     }
   ],

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -86,10 +86,7 @@ describe('toolsForIntegrations', () => {
     'updateCanvas',
     'listBookmarks',
     'addBookmark',
-    'removeBookmark',
-    'readList',
-    'addListItem',
-    'updateListItem'
+    'removeBookmark'
   ]
 
   it('injects each port-gated tool only into a session ON a platform that declares the port', () => {

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -57,8 +57,7 @@ export const SLACK_BOT_SCOPES = [
   'mpim:write',
   'bookmarks:read',
   'bookmarks:write',
-  'lists:read',
-  'lists:write',
+  // NO `lists:*`: Lists is paid-plan-only, and a scope a free workspace cannot grant would fence it out of installing.
   // RESERVED — declared deliberately ahead of a caller, which the rule above otherwise forbids.
   // Every scope added later costs a reinstall of every installation, so the ones we know are
   // coming ride along with these and cost nothing extra: `channels:join` lets a future agent

--- a/packages/web/src/components/console/platforms/slack/manifest.test.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.test.ts
@@ -42,8 +42,6 @@ describe('manifest parity with the Control Plane', () => {
       'mpim:write',
       'bookmarks:read',
       'bookmarks:write',
-      'lists:read',
-      'lists:write',
       'channels:join',
       'team:read',
       'users:read.email',


### PR DESCRIPTION
`SLACK_BOT_SCOPES` is the set an installation MUST hold: `checkSlackBotScopes` diffs a grant against it, and both install funnels refuse a short grant outright — 409 `SLACK_MISSING_SCOPES` on the per-agent flow, `missing_scopes` on the platform callback.

That is sound only while every member is a scope any workspace can grant. `lists:read` / `lists:write` are not. Slack Lists is a paid-plan feature, and the gate sits on the app's OWN workspace, not on where the app is installed. Three app configurations under one account, searching `lists:` in the scope picker:

| app | owning workspace | plan | distributed | offered |
| --- | --- | --- | --- | --- |
| a publicly distributed app | free | free | yes | nothing — only scopes whose *description* contains "list" |
| a non-distributed app in the same workspace | free | free | no | **No items** |
| a non-distributed app elsewhere | paid | paid | no | `lists:read`, `lists:write` |

The second row is the control: Marketplace status is not what hides them, the plan is. So on the free-plan side, asking for the scope does not degrade an install — it refuses one.

Two commits:

1. Drop the two scopes from the required list. An app that already declares them keeps them: `mergeManagedSlackManifest` unions an app's current scopes with this list rather than replacing them.
2. Drop the `lists` read port with them. A port declares what this deployment can reach, and `readList` / `addListItem` / `updateListItem` now reach no installation — three tools that answer `missing_scope` cost every Slack session's tool list and invite a turn that cannot succeed. The implementations stay; the names stay reserved and auto-allowed exactly the way `submitGithubReview` is, since `executeTool` still dispatches them and a session warm with the old descriptor must not start hitting approval.

Re-offering Lists to the workspaces that can hold it is a separate change: Slack's own mechanism is optional scopes (`oauth_config.scopes.bot_optional`), presented separately at install and additive on the token, so a workspace that cannot grant them declines one feature instead of the whole install. A per-installation port gate additionally needs `Bot.grantedScopes` — which the Control Plane records and the daemon is never told — to reach the tool build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
