### PR TITLE
docs(designs): migration completion is its own frame, not a store op

### DIFF
--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -306,8 +306,9 @@ the provider still does not (§6, §9).** The binding change is the trigger: whe
 owning daemon applies a binding whose `home` became `control-plane`, it copies `memory/`
 and `channels/` once through the two ports (`copyMemoryTree(from, to)`, under the
 directory lock), the change log with them — sidecar lines become rows, one batch,
-bounded by the sidecar cap — and reports completion, which the CP records on the
-binding. Until that record exists the agent's memory is unavailable the way an
+bounded by the sidecar cap — and reports completion on a frame of its own,
+`memory/home/migrated` → `memory/home/migrated/ok`, which the CP records on the
+binding; it is not an op in the store set, because it is not a file operation. Until that record exists the agent's memory is unavailable the way an
 unreachable home is (no standing context, tools answer unavailable, distillation waits
 in the outbox), so nothing writes the target while the copy runs. That is what makes
 the copy restartable by doing nothing clever: the source is frozen from the moment the


### PR DESCRIPTION
## Why

§3.2.1 says the daemon reports migration completion and the CP records it on the binding, but never says on what. The choice was between adding a `migrated` op to the store set the CP handler dispatches on, or a frame of its own.

## What this records

A frame of its own: `memory/home/migrated` → `memory/home/migrated/ok`. It is not a file operation, so it does not join the store op set — keeping the CP's store handler free of a special case that has nothing to do with files.

Design only, no code. One sentence in `docs/designs/memory-evolution.md` §3.2.1; follows #1786 and #1858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
