### PR TITLE
fix(message): surface Slack Lists, canvases, and file mentions to the agent

### DIFF
--- a/docs/designs/inbound-file-attachments.md
+++ b/docs/designs/inbound-file-attachments.md
@@ -134,6 +134,18 @@ parens as a dangling `— saved to …`; and the session manager's marker separa
 normalizer. Keeping the path inside the parens (and parens out of sanitized names, §2.1)
 means the strip regex and the name-keyed forwarding lookup both survive unchanged.
 
+**A Slack List or canvas is never an attachment.** Slack delivers both as `files` entries
+(`filetype: list` / `quip`, with a `url_private`), so the marker used to read
+`[attached: list (application/vnd.slack-list)]` — no id, no link, and the suggestion of a
+download. A model needs the opposite: the id its tool takes. `extractSlackMessageText` now
+renders the reference into the message text itself — the inline `list_record` / `canvas` /
+`file` rich-text elements as `<url|title (Slack List F…)>`, and a bare share (a `files` entry
+nothing in the body mentions) the same way from its title and permalink — while
+`toSlackAttachment` drops those files, so the marker stays about bytes. The same applies to
+the element types the extractor does not model: a leaf that carries `text` / `url` keeps
+them instead of vanishing, because Slack's own fallback `text` spells every such mention as a
+bare file id, which is the one rendering a model cannot act on.
+
 Around the marker, `attachmentToBlock`'s ladder changes rung by rung:
 
 - **Images keep their block.** The full-resolution bytes still become an ACP `image` block

--- a/packages/message/src/slack-message-text.ts
+++ b/packages/message/src/slack-message-text.ts
@@ -14,6 +14,22 @@ export interface SlackTextBearingMessage {
   text?: unknown
   blocks?: unknown
   attachments?: unknown
+  files?: unknown
+}
+
+/**
+ * A Slack file that is a REFERENCE to a hosted surface, not bytes: a canvas (`quip`, the
+ * Quip lineage Slack never renamed) or a List. What a model needs from one is the id its tool
+ * takes, not a download — `readCanvas` / `readList` do the reading.
+ */
+export function slackReferenceFileKind(
+  file: { filetype?: unknown; mode?: unknown; mimetype?: unknown } | null | undefined
+): 'List' | 'Canvas' | undefined {
+  if (!file) return undefined
+  if (file.filetype === 'list' || file.mode === 'list' || file.mimetype === 'application/vnd.slack-list') return 'List'
+  if (file.filetype === 'quip' || file.mode === 'quip' || file.mimetype === 'application/vnd.slack-docs')
+    return 'Canvas'
+  return undefined
 }
 
 function record(value: unknown): UnknownRecord | undefined {
@@ -42,6 +58,20 @@ function linkedLabel(label: string, url: string): string {
   if (!label || label === url) return url
   return `<${url}|${label}>`
 }
+
+/**
+ * A reference to a Slack-hosted surface (a List, a canvas, a file), rendered so a model can
+ * ACT on it: the kind and the id are always spelled out — `readList` / `readCanvas` take that
+ * id — with the display text and link kept around them when Slack sent any. Slack's own
+ * fallback `text` renders these as the bare id, which is exactly what a model cannot read.
+ */
+function surfaceReference(kind: string, id: string, text: string, url: string, rowId = ''): string {
+  if (!id) return linkedLabel(text, url)
+  const ref = `Slack ${kind} ${id}${rowId ? ` row ${rowId}` : ''}`
+  return linkedLabel(text ? `${text} (${ref})` : ref, url)
+}
+
+const REFERENCE_RE = /<[^|>]+\|(?:[^>]*\()?Slack (?:List|Canvas|file) ([A-Za-z0-9]+)(?: row [A-Za-z0-9]+)?\)?>/g
 
 function richElementText(value: unknown): string {
   const element = record(value)
@@ -74,10 +104,50 @@ function richElementText(value: unknown): string {
     }
     case 'date':
       return string(element.fallback)
+    // Slack-hosted surfaces mentioned inline. Their fallback `text` is the bare file id.
+    case 'list_record':
+      return surfaceReference(
+        'List',
+        string(element.file_id),
+        string(element.text),
+        string(element.url),
+        string(element.record_id)
+      )
+    case 'canvas':
+      return surfaceReference(
+        'Canvas',
+        string(element.file_id),
+        string(element.text) || string(element.label),
+        string(element.url)
+      )
+    case 'file':
+      return surfaceReference('file', string(element.file_id), string(element.text), string(element.url))
+    case 'message_mention': {
+      const channel = string(element.channel_id)
+      const ts = string(element.message_ts)
+      return linkedLabel(
+        string(element.text) || (channel && ts ? `message ${ts} in <#${channel}>` : ''),
+        string(element.url)
+      )
+    }
+    case 'canvas_message_unfurl': {
+      const channel = string(element.root_message_channel)
+      const ts = string(element.root_message_ts)
+      return channel && ts ? `message ${ts} in <#${channel}>` : ''
+    }
+    case 'tag':
+      return string(element.text)
+    case 'color':
+      return string(element.value)
     default: {
-      if (!Array.isArray(element.elements)) return ''
-      const separator = element.type === 'rich_text_section' || element.type === 'rich_text_preformatted' ? '' : '\n'
-      return join(element.elements.map(richElementText), separator)
+      if (Array.isArray(element.elements)) {
+        const separator = element.type === 'rich_text_section' || element.type === 'rich_text_preformatted' ? '' : '\n'
+        return join(element.elements.map(richElementText), separator)
+      }
+      // A leaf this extractor does not know (`attachment_mention`, `work_object_mention`,
+      // `workflow_mention`, `citation`, whatever Slack adds next): keep the text and link every
+      // one of them carries rather than dropping the reference on the floor.
+      return linkedLabel(string(element.text) || string(element.product_name), string(element.url))
     }
   }
 }
@@ -159,8 +229,10 @@ function attachmentText(value: unknown): string {
   return structured || string(attachment.fallback)
 }
 
+// A rendered surface reference collapses to its bare id, which is how Slack's fallback `text`
+// spells the same mention — so the two views of one message dedupe instead of both surviving.
 function canonical(value: string): string {
-  return value.replace(/\s+/g, ' ').trim()
+  return value.replace(REFERENCE_RE, '$1').replace(/\s+/g, ' ').trim()
 }
 
 /** Join top-level text with visible blocks/attachments while removing the common
@@ -169,7 +241,13 @@ function uniqueText(parts: string[]): string {
   const kept: { value: string; key: string }[] = []
   for (const value of parts.map((part) => part.trim()).filter(Boolean)) {
     const key = canonical(value)
-    if (kept.some((part) => part.key === key || (key.length > 8 && part.key.includes(key)))) continue
+    // Same text in two renderings: keep the one that spells more (the layout view over the fallback).
+    const same = kept.find((part) => part.key === key)
+    if (same) {
+      if (value.length > same.value.length) same.value = value
+      continue
+    }
+    if (kept.some((part) => key.length > 8 && part.key.includes(key))) continue
     for (let i = kept.length - 1; i >= 0; i--) {
       const previous = kept[i]!
       if (previous.key.length > 8 && key.includes(previous.key)) kept.splice(i, 1)
@@ -182,7 +260,23 @@ function uniqueText(parts: string[]): string {
     .trim()
 }
 
+/** A List or canvas SHARED on the message (its `files`), unless the body already mentions it —
+ *  a share without a mention has no blocks element, and the file entry is then the only carrier. */
+function referenceFilesText(value: unknown, body: string): string {
+  if (!Array.isArray(value)) return ''
+  return join(
+    value.map((entry) => {
+      const file = record(entry)
+      const kind = slackReferenceFileKind(file)
+      const id = string(file?.id)
+      if (!file || !kind || !id || body.includes(`Slack ${kind} ${id}`)) return ''
+      return surfaceReference(kind, id, string(file.title), string(file.permalink))
+    })
+  )
+}
+
 export function extractSlackMessageText(message: SlackTextBearingMessage): string {
   const attachments = Array.isArray(message.attachments) ? message.attachments.map(attachmentText) : []
-  return uniqueText([string(message.text), blocksText(message.blocks), ...attachments])
+  const body = uniqueText([string(message.text), blocksText(message.blocks), ...attachments])
+  return join([body, referenceFilesText(message.files, body)])
 }

--- a/packages/message/src/slack-message.ts
+++ b/packages/message/src/slack-message.ts
@@ -1,5 +1,5 @@
 import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/protocol'
-import { extractSlackMessageText } from './slack-message-text.js'
+import { extractSlackMessageText, slackReferenceFileKind } from './slack-message-text.js'
 
 /** The subset of a Slack file element carried through normalization. */
 export interface SlackFile {
@@ -138,6 +138,9 @@ export function slackTextAddressesAnyone(text: string): boolean {
  * tombstoned files that have no stable id and provider URL. */
 export function toSlackAttachment(file: SlackFile | null | undefined): PlatformAttachment | null {
   if (!file || typeof file !== 'object') return null
+  // A List or canvas is a reference the message TEXT now carries (`extractSlackMessageText`), not
+  // bytes; as an attachment it read `[attached: list (application/vnd.slack-list)]` — no id, no link.
+  if (slackReferenceFileKind(file)) return null
   const sourceUrl = file.url_private_download ?? file.url_private
   if (!file.id || !sourceUrl) return null
   const thumbnailUrl = file.thumb_360 ?? file.thumb_720 ?? file.thumb_1024

--- a/packages/message/test/slack-surface-references.test.ts
+++ b/packages/message/test/slack-surface-references.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { extractSlackMessageText } from '../src/slack-message-text.js'
+import { normalizeSlackMessage, toSlackAttachment } from '../src/slack-message.js'
+
+const LIST_URL = 'https://slack.example.test/lists/T1/F0LIST'
+const CANVAS_URL = 'https://slack.example.test/docs/T1/F0CANVAS'
+
+/** A List shared inline, exactly as Slack delivered it: the fallback `text` spells the bare
+ *  file id, the `list_record` element carries the link, and the `files` entry repeats it. */
+const listMention = {
+  text: 'can you see F0LIST',
+  blocks: [
+    {
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_section',
+          elements: [
+            { type: 'text', text: 'can you see ' },
+            { type: 'list_record', file_id: 'F0LIST', url: LIST_URL }
+          ]
+        }
+      ]
+    }
+  ],
+  files: [
+    {
+      id: 'F0LIST',
+      filetype: 'list',
+      mode: 'list',
+      mimetype: 'application/vnd.slack-list',
+      name: 'list',
+      title: 'Untitled list',
+      url_private: 'https://files.example.test/T1-F0LIST/list',
+      permalink: LIST_URL
+    }
+  ]
+}
+
+function section(...elements: Record<string, unknown>[]) {
+  return [{ type: 'rich_text', elements: [{ type: 'rich_text_section', elements }] }]
+}
+
+describe('Slack-hosted surfaces mentioned inline', () => {
+  it('renders a list_record as a link that names the kind and the id, and drops the bare-id fallback', () => {
+    expect(extractSlackMessageText(listMention)).toBe(`can you see <${LIST_URL}|Slack List F0LIST>`)
+  })
+
+  it('keeps the display text and the row when Slack sends them', () => {
+    const text = extractSlackMessageText({
+      blocks: section({ type: 'list_record', file_id: 'F0LIST', record_id: 'Rec1', text: 'Roadmap', url: LIST_URL })
+    })
+    expect(text).toBe(`<${LIST_URL}|Roadmap (Slack List F0LIST row Rec1)>`)
+  })
+
+  it('renders a canvas mention the same way, from its label when it has no text', () => {
+    expect(
+      extractSlackMessageText({
+        blocks: section({ type: 'canvas', file_id: 'F0CANVAS', label: 'Q3 plan', url: CANVAS_URL })
+      })
+    ).toBe(`<${CANVAS_URL}|Q3 plan (Slack Canvas F0CANVAS)>`)
+    expect(extractSlackMessageText({ blocks: section({ type: 'canvas', file_id: 'F0CANVAS' }) })).toBe(
+      'Slack Canvas F0CANVAS'
+    )
+  })
+
+  it('renders a file mention with its id', () => {
+    expect(extractSlackMessageText({ blocks: section({ type: 'file', file_id: 'F0DOC', text: 'spec.pdf' }) })).toBe(
+      'spec.pdf (Slack file F0DOC)'
+    )
+  })
+
+  it('renders message mentions and canvas message unfurls as an addressable channel + ts', () => {
+    expect(
+      extractSlackMessageText({
+        blocks: section({ type: 'message_mention', channel_id: 'C1', message_ts: '1700000000.000100' })
+      })
+    ).toBe('message 1700000000.000100 in <#C1>')
+    expect(
+      extractSlackMessageText({
+        blocks: section({
+          type: 'canvas_message_unfurl',
+          root_message_channel: 'C1',
+          root_message_ts: '1700000000.000100'
+        })
+      })
+    ).toBe('message 1700000000.000100 in <#C1>')
+  })
+
+  it('keeps the text and link of the leaf element types it does not model', () => {
+    const text = extractSlackMessageText({
+      blocks: section(
+        {
+          type: 'work_object_mention',
+          entity_id: 'E1',
+          app_id: 'A1',
+          text: 'PROJ-1',
+          url: 'https://tracker.example.test/PROJ-1'
+        },
+        { type: 'text', text: ' ' },
+        { type: 'citation', url: 'https://source.example.test/1', text: 'Source', index: 1, details: {} },
+        { type: 'text', text: ' ' },
+        { type: 'attachment_mention', url: 'https://app.example.test/a' },
+        { type: 'text', text: ' ' },
+        { type: 'tag', text: 'In progress' },
+        { type: 'text', text: ' ' },
+        { type: 'color', value: '#F405B3' }
+      )
+    })
+    expect(text).toBe(
+      '<https://tracker.example.test/PROJ-1|PROJ-1> <https://source.example.test/1|Source> https://app.example.test/a In progress #F405B3'
+    )
+  })
+})
+
+describe('Slack-hosted surfaces shared on a message', () => {
+  it('surfaces a shared List from its file entry when nothing in the body mentions it', () => {
+    const text = extractSlackMessageText({ text: '', files: listMention.files })
+    expect(text).toBe(`<${LIST_URL}|Untitled list (Slack List F0LIST)>`)
+  })
+
+  it('does not repeat a file entry the body already renders', () => {
+    expect(extractSlackMessageText(listMention)).not.toContain('Untitled list')
+  })
+
+  it('surfaces a shared canvas by its quip file type', () => {
+    const text = extractSlackMessageText({
+      text: 'notes',
+      files: [
+        {
+          id: 'F0CANVAS',
+          filetype: 'quip',
+          mimetype: 'application/vnd.slack-docs',
+          title: 'Retro',
+          permalink: CANVAS_URL
+        }
+      ]
+    })
+    expect(text).toBe(`notes\n<${CANVAS_URL}|Retro (Slack Canvas F0CANVAS)>`)
+  })
+
+  it('never turns a List or canvas into a downloadable attachment', () => {
+    expect(toSlackAttachment(listMention.files[0])).toBeNull()
+    expect(
+      toSlackAttachment({
+        id: 'F0CANVAS',
+        filetype: 'quip',
+        mimetype: 'application/vnd.slack-docs',
+        url_private: 'https://files.example.test/c'
+      })
+    ).toBeNull()
+    expect(
+      toSlackAttachment({
+        id: 'F0IMG',
+        filetype: 'png',
+        mimetype: 'image/png',
+        url_private: 'https://files.example.test/i'
+      })?.id
+    ).toBe('F0IMG')
+  })
+
+  it('normalizes a List mention to text only — the reference, no attachment marker', () => {
+    const normalized = normalizeSlackMessage({ type: 'message', channel: 'C1', ts: '1.0', user: 'U1', ...listMention })
+    expect(normalized?.text).toBe(`can you see <${LIST_URL}|Slack List F0LIST>`)
+    expect(normalized?.attachments).toBeUndefined()
+  })
+})


### PR DESCRIPTION
A List mentioned in a Slack message reached the agent as nothing it could act on. Captured from a real event, Slack delivers one mention three ways at once, and each lost the reference on our side:

| carrier | what Slack sends | what the agent got |
| --- | --- | --- |
| `blocks` | a `rich_text` element `{ type: "list_record", file_id, url }` | nothing — `richElementText` did not model the type and rendered `""` |
| `text` | the fallback rendering: the bare file id (`can you see F0…`) | exactly that: an id with no hint of what it is |
| `files` | `{ filetype: "list", mimetype: "application/vnd.slack-list", url_private, permalink }` | `[attached: list (application/vnd.slack-list)]` — no id, no link, and the suggestion of a download |

So the agent asked which list, then said there was no attachment, and only found the List once the user had repeated the word enough times to make the bare id guessable. `list_record` is one of the element types Slack documents for `rich_text_section`, next to `canvas`, `file`, `message_mention`, `canvas_message_unfurl`, `attachment_mention`, `work_object_mention`, `workflow_mention`, `citation`, `tag`, and `color` — every one of them took the same empty-string path.

`extractSlackMessageText` now renders these so a model can act on them, always naming the kind and the id the tool takes:

- `list_record`, `canvas`, and `file` elements become `<url|title (Slack List F…)>` (a `record_id` adds the row);
- `message_mention` and `canvas_message_unfurl` become the channel and ts a thread read takes;
- `tag` and `color` keep their text; every leaf type the extractor does not model keeps the `text` / `url` it carries instead of vanishing;
- a List or canvas SHARED on a message with nothing in the body mentioning it is rendered the same way from its `files` entry (title + permalink) — that share has no blocks element, so the file entry is the only carrier.

The fallback-vs-layout dedupe learns that a rendered reference and its bare id are one mention, and keeps the rendering that spells more — so the two views of one message no longer both survive. `toSlackAttachment` drops List and canvas files (`list` / `quip`), so the `[attached: …]` marker stays about bytes. The thread-history read reuses both functions, so backfilled context gets the same rendering.

Validation: the `list_record` case is pinned to the shape of the captured event; canvas / file / message / unfurl / tag / color / the generic leaf are built from Slack's documented element fields, and the canvas file shape (`filetype: quip`, `application/vnd.slack-docs`) from Slack's own data-export reference. Message package 54/54, the daemon suites that touch Slack text or files 420/420, relay ingest 44/44, typecheck on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
