### PR TITLE
feat(daemon): bundle microsandbox image and on-demand Docker tools

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -19,7 +19,7 @@
 #      PID 1 ignores SIGTERM is a pod that only ever dies by SIGKILL.
 #   2. The shim is root-owned and not writable by the user the runtime runs as. The runtime is
 #      the untrusted party; a shim it can rewrite is a shim it can replace.
-#   3. It runs as non-root, with no capability to become root.
+#   3. It defaults to non-root; pool pods prevent privilege escalation.
 #   4. It mounts no service-account token of its own. The pod template governs that projection,
 #      and the image must not smuggle in an identity of its own.
 
@@ -114,6 +114,10 @@ ARG CLAUDE_ACP_VERSION=0.75.1
 ARG CODEX_ACP_VERSION=1.10.0-agentconnect.2
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.30
 ARG AGENT_BROWSER_VERSION=0.37.0
+ARG DOCKER_VERSION=5:29.8.0-1~debian.12~bookworm
+ARG CONTAINERD_VERSION=2.3.5-1~debian.12~bookworm
+ARG DOCKER_BUILDX_VERSION=0.37.0-1~debian.12~bookworm
+ARG DOCKER_COMPOSE_VERSION=5.5.1-1~debian.12~bookworm
 
 # git and ca-certificates are load-bearing — the workspace surface runs git IN here over the
 # shim's exec channel. openssh-client is for ssh remotes; tini is PID 1.
@@ -126,6 +130,20 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 # `python` as well as `python3` — plenty of tooling still spawns the unsuffixed name.
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+
+# Docker's signed Debian repository supplies exact versions; the image never starts dockerd automatically.
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod 0644 /etc/apt/keyrings/docker.asc \
+  && printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable\n' \
+    "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install --no-install-recommends -y \
+    "docker-ce=${DOCKER_VERSION}" "docker-ce-cli=${DOCKER_VERSION}" \
+    "containerd.io=${CONTAINERD_VERSION}" "docker-buildx-plugin=${DOCKER_BUILDX_VERSION}" \
+    "docker-compose-plugin=${DOCKER_COMPOSE_VERSION}" sudo \
+  && rm -rf /var/lib/apt/lists/* \
+  && dockerd --version && docker --version && docker buildx version && docker compose version
 
 # Chrome's shared libraries: `agent-browser install` installs these with `sudo apt-get`, which uid 10001 cannot.
 # The 25-soname `ldd chrome` closure only — headless CDP was verified without libgtk-3-0 (+116 MB) and xvfb (+167 MB).
@@ -252,6 +270,12 @@ RUN printf '%s\n' \
 RUN groupadd --gid 10001 agent \
   && useradd --uid 10001 --gid 10001 --home-dir /agent --shell /usr/sbin/nologin --create-home agent \
   && chown 10001:10001 /agent
+
+# VM users can start Docker on demand; pool no-new-privileges still prevents sudo elevation.
+RUN usermod --append --groups docker agent \
+  && printf 'agent ALL=(root) NOPASSWD: /usr/bin/dockerd\n' > /etc/sudoers.d/agent-dockerd \
+  && chmod 0440 /etc/sudoers.d/agent-dockerd \
+  && visudo --check --file /etc/sudoers.d/agent-dockerd
 
 # Where the shim serves the daemon's unix sockets (src/shim/tunnel.ts SANDBOX_TUNNEL_PATHS).
 # Created HERE because /run is root-owned and the shim runs as 10001: without an owned directory

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -1,14 +1,14 @@
 # Daemon Sandbox Backends
 
 **Status: Partially implemented.** SRT remains the default. The opt-in Linux
-microsandbox backend implements explicit image selection, resource configuration,
-guest execution, host mounts, and retained-disk stop/start. A complete real-daemon
-workload remains an acceptance gate. Default release image selection, Docker,
-network configuration, and port publication remain **Proposed**.
+microsandbox backend implements release image defaults and explicit overrides,
+resource configuration, guest execution, host mounts, retained-disk stop/start,
+and Docker/Compose tooling that agents can start inside each VM when needed.
+Networking has one fixed requirement for isolated sessions: public internet
+access, with no access to other session VMs or host/private networks. End-to-end
+network and workload validation remains pending.
 
-The first VM implementation uses the existing workspace modes and lifecycle.
-Docker, Compose, and development networking are subsequent additions to that
-execution path.
+The VM implementation uses the existing workspace modes and lifecycle.
 
 This extends [daemon configuration and lifecycle](daemon-detailed-design.md) and
 uses the existing [execution-driver seam](cluster-spawn-and-shim.md#1-why-a-seam-at-all).
@@ -28,8 +28,8 @@ The daemon-owned `sandbox` object in `~/.agentconnect/config.json` defaults to
 }
 ```
 
-The current microsandbox configuration requires an explicit image. Replace the
-example reference with a compatible runtime image:
+Release builds include the shared runtime image reference. This example uses
+that default:
 
 ```json
 {
@@ -46,7 +46,6 @@ example reference with a compatible runtime image:
       }
     ],
     "microsandbox": {
-      "image": "registry.example.com/agentconnect/runtime-sandbox:build-tag",
       "cpus": 2,
       "memoryMiB": 2048,
       "diskGiB": 10
@@ -57,21 +56,21 @@ example reference with a compatible runtime image:
 
 The resource values shown are the defaults, not measured minimums or capacity
 recommendations. All three are positive integers bounded by the SDK's supported
-numeric ranges. The VM configuration is strict: `docker` and `network` fields
-are not accepted yet.
+numeric ranges. Source/development builds have no release image default and
+require an explicit `sandbox.microsandbox.image`, such
+as `registry.example.com/agentconnect/runtime-sandbox:build-tag`. An explicit image
+also overrides the release default. Networking is fixed backend behavior; the
+strict VM configuration has no network modes, port mappings, or outbound-proxy
+settings.
 
-| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                                                                           |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sandbox.backend`              | Implemented: `srt` is the default; `microsandbox` selects the Linux VM implementation for sandboxed launches.                                                                                                                                                                                                                         |
-| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                                                                           |
-| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                                      |
-| `sandbox.microsandbox.image`   | Implemented: required, non-empty OCI reference when selecting microsandbox. No bundled release default or Kubernetes image lookup is used.                                                                                                                                                                                            |
-| `cpus`, `memoryMiB`, `diskGiB` | Implemented: per-VM CPU allocation, memory limit, and disk capacity; defaults are `2`, `2048`, and `10`. Host capacity planning remains the operator's responsibility.                                                                                                                                                                |
-| `docker`                       | Proposed: start an independent Docker daemon inside each VM. Requires Docker tools in the selected image; never means mounting the host Docker socket. Default false until the Docker-enabled shared image and workload checks are delivered.                                                                                         |
-| `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths; microsandbox accepts absolute guest targets. Workspace, HOME, and runtime state remain automatically provisioned.                                                  |
-| `network.access`               | Proposed: `development` allows public, private-network, and host connectivity subject to mandatory control/admin exclusions; `public` allows public egress and required daemon endpoints; `none` disables external egress. The proposed default is `development`; the current implementation retains upstream public-only networking. |
-| `network.ports`                | Proposed: guest service ports exposed through daemon-assigned host ports. `host: 0` requests an available port. The backend binds and verifies the mapping; retry allocation conflicts and release mappings on teardown.                                                                                                              |
-| `network.outboundProxy`        | Proposed: optional host-side SOCKS URL for microsandbox's outbound transport.                                                                                                                                                                                                                                                         |
+| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sandbox.backend`              | Implemented: `srt` is the default; `microsandbox` selects the Linux VM implementation for sandboxed launches.                                                                                                                                                                        |
+| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                          |
+| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                     |
+| `sandbox.microsandbox.image`   | Implemented: optional, non-empty OCI override. Release builds default to their bundled shared-image reference; development builds require an explicit image. No Kubernetes image lookup is used.                                                                                     |
+| `cpus`, `memoryMiB`, `diskGiB` | Implemented: per-VM CPU allocation, memory limit, and disk capacity; defaults are `2`, `2048`, and `10`. Host capacity planning remains the operator's responsibility.                                                                                                               |
+| `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths; microsandbox accepts absolute guest targets. Workspace, HOME, and runtime state remain automatically provisioned. |
 
 ### Shared mounts and manual conversion
 
@@ -162,8 +161,8 @@ mount specification, and a hash of the SDK's saved configuration. Reuse rejects
 missing or changed bindings and configuration rather than silently recreating the
 VM. A retained VM keeps its original configuration. Restarting the daemon does
 not upgrade it or migrate its disk; configuration changes require an explicit
-retirement/recreation or a future data-migration operation. Resolved-image metadata
-and upgrade tooling remain proposed.
+retirement/recreation or a future data-migration operation. Image digest
+resolution and upgrade tooling remain proposed.
 
 Kubernetes mode retains `K8sDriver`, its resource configuration, and image rollout.
 An explicitly configured local microsandbox backend
@@ -237,7 +236,7 @@ paths. This change does not redesign Git storage.
 
 ### Current image contract and flat disks
 
-An explicit OCI image is required. The runtime image must contain Node at
+The resolved OCI image must contain Node at
 `/usr/local/bin/node`, Python 3 for the guest helper, the declared runtime tools,
 and `/opt/agentconnect/runtime/k8s-runtimes.json`. The existing pool image contains
 these components. Startup reads and validates that table in a real VM; individual
@@ -264,71 +263,87 @@ image forms, and tests stop/start. The VM continues to use its flat disk. This
 uses the upstream CLI and package without an upstream source patch; cold image
 preparation includes the extra materialization cost.
 
-### Proposed release image selection and Docker
+### Release image selection and Docker
 
-Add release-generated metadata bundled with the daemon containing the published
-`runtimeSandboxImage` OCI reference. Generate it from the release workflow's
-component-version output, so local daemons use the same artifact as the pool
-without querying a cluster. This is new metadata: today's `poolRuntimeImage()`
-resolves the Kubernetes SandboxTemplate, and is not a local default resolver.
-An explicit daemon image would override this metadata; builds without metadata
-would still require an explicit image. This default resolver is not implemented.
-The current shared image does not include a configured Docker daemon.
+The release build bundles `dist/release.json` with a `runtimeSandboxImage` OCI
+reference. It names the current release's `runtime-sandbox:v<version>` alias.
+The image workflow creates this alias even when it reuses an older component
+image, so it identifies the same shared artifact as the pool without querying a
+cluster. The daemon package is published before image finalization; the matching
+image workflow must complete before this default can be pulled. A missing image
+fails preflight rather than selecting another version.
+Runtime-image input changes also trigger daemon package publication so its
+bundled default follows the updated image.
+The shared release image is currently Linux amd64; an arm64 daemon must configure
+a compatible image explicitly.
 
-For `docker=true`, extend that shared image with Docker Engine and the Compose
-plugin, and explicitly start dockerd inside the VM with guest privileges before
-launching the harness. Configure the harness user to reach the guest Docker
-socket. Keep Docker opt-in for sessions that do not need its resource cost. A
-custom image must satisfy the same runtime/tool contract or fail its admission
-probe; do not silently install missing tools on every session start.
+An explicit daemon image overrides this metadata. Development builds remove
+release metadata and require an explicit image; they do not derive a default
+from the development package version. Upgrading to a different default image
+reference remains a configuration change under the persisted-VM checks above.
+Pin an explicit image to retain the same reference across daemon upgrades.
 
-Docker data and build caches would use the retained flat disk. Docker Engine,
-Compose, and Testcontainers compatibility remain separate acceptance work; the
-current backend neither starts dockerd nor exposes a `docker` setting.
+The shared image contains pinned Docker Engine, CLI, containerd, Buildx, and
+Compose packages. Its ordinary container user and shim entrypoint remain in
+place. Image construction installs and verifies the tools; it does not start
+Docker. Inside a microsandbox VM, the agent can start Docker when a task needs it:
 
-### Current network and proposed development/preview experience
+```sh
+sudo -n dockerd > /tmp/dockerd.log 2>&1 &
+docker info
+```
 
-The current implementation selects upstream's `single-tenant` deployment profile
-and leaves its default public-only network policy unchanged: public egress and
-gateway DNS are available; private, host, loopback, link-local, and metadata
-destinations are denied. There are no published ports and no daemon network or
-outbound-proxy settings yet. The following development and preview behavior is
-**Proposed**, not enabled by selecting microsandbox today.
+Wait for that command's Docker server to become ready before using containers.
+The image grants the `agent` user permission to run `dockerd` through sudo and
+access the Docker group's Unix socket. It does not grant unrestricted sudo.
+A custom image owns its corresponding tools and startup permissions.
 
-Development networking should let package managers, Git, databases, and web
-servers behave normally. The proposed profile admits the connectivity described
-in section 1 without per-domain approval prompts. Translate upstream's public-only
-rules deliberately; they are not the proposed development profile. The stricter
-multi-tenant profile is not selected here: it disables host access and port
-publication needed by this future local workflow.
+There is no daemon Docker configuration, automatic startup, health gate, or
+Docker process supervisor. Docker failures are ordinary tool failures and do not
+stop an otherwise healthy agent VM. The host Docker socket is not mounted by the
+backend; ambient host Docker contexts and connection paths are removed from guest
+launches. Managed-pool pod privileges are unchanged by the image's installed tools.
 
-Before broad development rules, deny the daemon's registered control/admin
-listeners and deployment-configured management endpoints, including the local
-Setup Server. Match their actual ports across the host gateway and all relevant
-IPv4/IPv6 addresses; the `host` group alone does not cover every LAN alias.
-Admission fails if these rules cannot be installed. Unknown host services require
-operator configuration; this profile does not discover every management service.
-Apply destination policy before an outbound SOCKS proxy as well.
+Docker image layers, named volumes, and build caches live on the retained flat
+disk. Stopping retains them; after a VM restart the agent starts dockerd again
+when needed. VM retirement deletes them. Docker-published ports belong to the
+VM's network namespace, so two sessions can use the same internal port. This does not publish the port on the
+daemon host or provide a remote browser preview.
 
-When the runtime needs an allowed host service, guest `127.0.0.1` refers to the
-guest. Use `host.microsandbox.internal` and configure the destination listener and
-network rules for that route. SRT retains its existing network integration. See
-[microsandbox networking](https://docs.microsandbox.dev/networking/overview) and
-[its outbound proxy](https://docs.microsandbox.dev/networking/outbound-proxy).
+### Session network isolation
 
-Two sessions could both use guest ports 3000 and 5432. The daemon would allocate separate
-host listeners and report their effective mappings; the browser would get an address
-for the selected session. Remote-daemon preview needs a separately provided
-tunnel or preview route: returning that machine's localhost URL is not
-a working remote preview. Live preview bytes must not be added to the CP control
-WebSocket.
+In session-isolation mode, each session's VM has its own network environment.
+The required behavior is fixed:
 
-Native microsandbox port mappings are creation-time configuration in the inspected
-API; its modify interface does not expose changing ports/network. First support
-declared ports. Automatic discovery and opening arbitrary ports in a running
-session requires a daemon-owned guest forwarding channel, including WebSocket
-upgrade for development servers, and is a later deliverable. Do not claim the SDK
-already supplies that experience.
+- Sessions can access the public internet, including DNS, Git, and package registries.
+- Sessions cannot connect directly to other session VMs or to host/private-network services.
+- Services inside one session can communicate normally, including guest loopback
+  and Docker container networks.
+
+Shared workspace mode continues to reuse the agent's VM and therefore its
+network environment; separate conversations in that mode are not isolated VMs.
+SRT retains its existing network integration.
+
+The current manager selects upstream's `single-tenant` deployment profile,
+retains its default public-only outbound policy, and configures no published
+ports. See [microsandbox networking](https://docs.microsandbox.dev/networking/overview).
+The backend uses the SDK guest channel for daemon communication. This does not
+require allowing guest access to the host's general network services.
+The existing policy is the implementation baseline; complete-session tests must
+still establish public egress and denied host/private/peer connectivity, including
+applicable IPv4/IPv6 host addresses and aliases. The upstream
+[host category](https://github.com/superradcompany/microsandbox/blob/v0.6.17/crates/network/lib/policy/destination.rs#L40)
+covers the VM gateway; a routable public address belonging to the host can still classify
+as public. Blocking that route remains an implementation/validation gap. Selecting
+a deployment profile alone is not evidence that these checks passed.
+
+Two isolated sessions can each listen on guest port 3000 or publish a Docker
+container on guest port 5432 without a conflict. Those ports belong to separate
+VM networks. Allocating different host ports is only needed when exposing these
+services through listeners on the daemon host; it does not create session
+isolation. Host port publication, dynamic preview forwarding, and remote browser
+access are outside this delivery scope. No daemon networking configuration is
+added for them.
 
 ### Stop, restart, and retirement
 
@@ -364,24 +379,29 @@ Delivery is split into independently reviewable steps:
    explicit image and resources, Linux VM boot/runtime-table/stop-start checks,
    SDK-backed ACP streams and guest Git, shared host filesystem paths, and retained
    environment lifecycle. Keep upstream public-only networking and SRT as default.
-3. **Proposed — image and development features:** add release image metadata,
-   Docker/Compose support, and configured networking/declared ports with admin
-   exclusions. These configuration fields are not part of the current schema.
-4. **Proposed — developer experience and measurement:** run real projects and add
-   dynamic preview forwarding separately. Change the default only after compatibility
-   and resource measurements support it.
+3. **Implemented — release image and Docker:** bundle the shared release image
+   reference with explicit override support, and provide Docker/Compose tools
+   and manual startup permissions in the image. Verify actual workloads and
+   lifecycle below.
+4. **Pending — network and workload validation:** verify public egress, denied
+   host/private/peer connectivity, and concurrent sessions using the same guest
+   ports. Complete native-tool, Docker, and lifecycle checks; fix demonstrated
+   gaps without adding network modes or host port publication.
+5. **Pending — performance measurement:** run real projects at increasing session
+   counts. Change the default only after compatibility and resource measurements
+   support it.
 
 Implementation status above does not establish successful end-to-end daemon
 execution. The current VM slice still needs complete-session and lifecycle
-evidence; proposed features have their own subsequent acceptance gates:
+evidence, with the following acceptance checks:
 
 | Area                       | Required evidence                                                                                                                                                                                                                                                           |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Existing behavior          | Default SRT, required/optional sandbox policy, and Kubernetes execution remain usable. No-KVM behavior is explicit.                                                                                                                                                         |
 | Mounts                     | SRT accepts equal normalized paths and rejects remapping; read-only is the default and writable mounts reach native tools. Verify nested/duplicate entries, VM guest targets and mount flags, package-cache access, and host-data preservation on retirement.               |
-| Image and complete session | Explicit image preparation, ACP initialize/new/load, output, cancellation, cleanup, and a real native-tool turn succeed. Proposed release image defaults need separate verification when implemented.                                                                       |
-| Docker — Proposed          | Compose and Testcontainers work, including DNS, random ports, bind mounts, build cache, and cleanup helpers. Two sessions use the same internal ports.                                                                                                                      |
-| Networking                 | Verify current public Git/npm egress and denied host/private destinations. Proposed profiles additionally need an allowed host database, preview/WebSockets, and control/admin exclusions across gateway/address aliases, including with SOCKS.                             |
+| Image and complete session | Explicit image preparation, ACP initialize/new/load, output, cancellation, cleanup, and a real native-tool turn succeed. Verify the release image default, explicit overrides, and metadata-free development builds.                                                        |
+| Docker                     | Compose and Testcontainers work, including DNS, random ports, bind mounts, build cache, and cleanup helpers. Two sessions use the same internal ports.                                                                                                                      |
+| Networking                 | Verify public DNS/Git/npm egress, denied host/private/peer connections across applicable IPv4/IPv6 addresses and aliases, and successful same-port listeners in two isolated sessions. Guest loopback and Docker networking must remain usable.                             |
 | Lifecycle                  | Idle stop preserves work/cache; start re-establishes ACP; daemon restart fences old hosts; dirty/unpushed work prevents destructive retirement.                                                                                                                             |
 | Performance                | Measure cold image preparation, warm disk clone, stopped-session restart, ACP-ready latency, and Git/install/build duration. At 1/10/20 sessions, record whole-environment memory, peaks, disk growth, CPU limits, and cleanup. Record reflink versus sparse-copy behavior. |
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "agent:chat": "tsx src/index.ts --agents-dir ./test/fixtures/sample-agent chat",
     "agent:run": "tsx src/index.ts --agents-dir ./test/fixtures/sample-agent run",
-    "build": "pnpm --filter '{.}^...' build && tsdown && pnpm run build:shim && tsdown --config tsdown.microsandbox.config.ts && node scripts/prepare-bundled-skills.mjs && node scripts/assert-self-contained.mjs",
+    "build": "pnpm --filter '{.}^...' build && tsdown && pnpm run build:shim && tsdown --config tsdown.microsandbox.config.ts && node scripts/prepare-bundled-skills.mjs && node scripts/prepare-release-image.mjs && node scripts/assert-self-contained.mjs",
     "build:shim": "tsdown --config tsdown.shim.config.ts && node scripts/prepare-shim-skills.mjs && node scripts/emit-shim-gh-wrapper.mjs",
     "clean": "rm -rf dist",
     "dev": "tsx watch src/index.ts run",

--- a/packages/daemon/scripts/prepare-release-image.mjs
+++ b/packages/daemon/scripts/prepare-release-image.mjs
@@ -1,0 +1,17 @@
+import { rmSync, writeFileSync } from 'node:fs'
+
+const metadata = new URL('../dist/release.json', import.meta.url)
+const version = process.env.AGENTCONNECT_RELEASE_VERSION
+
+// A development rebuild must not keep a previous release's default image.
+rmSync(metadata, { force: true })
+if (version !== undefined) {
+  if (!/^\d+\.\d+\.\d+(?:-rc\.\d+)?$/.test(version)) {
+    throw new Error('AGENTCONNECT_RELEASE_VERSION must be a stable or rc release version')
+  }
+  // build.yaml publishes this alias even when the runtime image retains an older effective tag.
+  writeFileSync(
+    metadata,
+    JSON.stringify({ runtimeSandboxImage: `ghcr.io/agentconnect-md/runtime-sandbox:v${version}` }) + '\n'
+  )
+}

--- a/packages/daemon/scripts/smoke-microsandbox-docker.mts
+++ b/packages/daemon/scripts/smoke-microsandbox-docker.mts
@@ -1,0 +1,304 @@
+// Run with tsx: smoke-microsandbox-docker.mts <image> <msb-binary> [sdk-module] [cache-dir] [guest-helper].
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, statfs, symlink, writeFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { MicrosandboxManager, type MicrosandboxEnvironment } from '../src/microsandbox/driver.js'
+import { MICROSANDBOX_GUEST_ENTRY } from '../src/microsandbox/guest.js'
+
+const [image, msbBinary, sdkModule, cacheDir, helperArgument] = process.argv.slice(2)
+if (!image || !msbBinary)
+  throw new Error('usage: smoke-microsandbox-docker.mts <image> <msb-binary> [sdk-module] [cache-dir] [guest-helper]')
+const root = await mkdtemp(join(tmpdir(), 'acd-'))
+const helper = resolve(helperArgument ?? fileURLToPath(new URL('../dist/microsandbox/guest.js', import.meta.url)))
+const home = join(root, 'home')
+await mkdir(home)
+await mkdir(join(root, 'microsandbox'))
+if (cacheDir) await symlink(resolve(cacheDir), join(root, 'microsandbox', 'cache'))
+process.env = {
+  PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
+  HOME: home,
+  MSB_HOME: join(root, 'microsandbox'),
+  MSB_BACKEND: 'local',
+  XDG_CACHE_HOME: join(root, 'cache')
+}
+const sdk: typeof import('microsandbox') = await import(
+  sdkModule ? pathToFileURL(resolve(sdkModule)).href : 'microsandbox'
+)
+const sockets = { mcp: join(root, 'mcp.sock'), gitcred: join(root, 'git.sock') }
+const servers: Server[] = []
+for (const path of Object.values(sockets)) {
+  const server = createServer((socket) => socket.end())
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(path, resolve)
+  })
+  servers.push(server)
+}
+const manager = new MicrosandboxManager({
+  root,
+  sdk,
+  sockets,
+  msbCommand: { command: resolve(msbBinary), args: [] },
+  config: { image, cpus: 2, memoryMiB: 2048, diskGiB: 8 },
+  log: { info: console.log, warn: console.warn, error: console.error, debug: () => {}, trace: () => {} }
+})
+const environments: MicrosandboxEnvironment[] = []
+const env = {
+  HOME: '/agent',
+  PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+  DOCKER_HOST: 'unix:///var/run/docker.sock'
+}
+const imageName = 'ac-docker-smoke:local'
+const volumeName = 'ac-docker-smoke-data'
+const step = (name: string, detail: Record<string, unknown> = {}) =>
+  console.log(JSON.stringify({ step: name, ...detail }))
+async function freeBytes() {
+  const disk = await statfs(root)
+  return disk.bavail * disk.bsize
+}
+async function run(environment: MicrosandboxEnvironment, command: string, args: string[]) {
+  const result = await manager.exec(environment, command, args, {
+    cwd: environment.workspaceRoot,
+    env,
+    timeoutMs: 180_000
+  })
+  assert.equal(result.exitCode, 0, `${command} ${args.join(' ')}: ${result.stderr}`)
+  return result.stdout.trim()
+}
+async function startDocker(environment: MicrosandboxEnvironment) {
+  const cold = await manager.exec(environment, '/usr/bin/docker', ['info'], {
+    cwd: environment.workspaceRoot,
+    env
+  })
+  assert.notEqual(cold.exitCode, 0, 'Docker started without the agent requesting it')
+  await run(environment, '/usr/bin/sudo', ['-n', '/usr/bin/dockerd', '--version'])
+  await run(environment, '/bin/sh', ['-c', 'sudo -n /usr/bin/dockerd > /tmp/dockerd.log 2>&1 < /dev/null &'])
+  const deadline = Date.now() + 60_000
+  for (;;) {
+    const ready = await manager.exec(environment, '/usr/bin/docker', ['info', '--format', '{{.ServerVersion}}'], {
+      cwd: environment.workspaceRoot,
+      env
+    })
+    if (ready.exitCode === 0) return ready.stdout.trim()
+    if (Date.now() >= deadline) throw new Error(await run(environment, '/usr/bin/tail', ['-60', '/tmp/dockerd.log']))
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+}
+async function session(name: string) {
+  const workspace = join(root, name)
+  await mkdir(workspace)
+  const environment: MicrosandboxEnvironment = {
+    id: `docker-smoke/${name}`,
+    workspaceRoot: workspace,
+    mounts: [
+      { source: workspace, target: workspace, readOnly: false },
+      { source: helper, target: MICROSANDBOX_GUEST_ENTRY, readOnly: true }
+    ]
+  }
+  environments.push(environment)
+  return environment
+}
+let passed = false
+try {
+  step('start', { root })
+  await manager.prepare()
+  const beforeFirst = await freeBytes()
+  const first = await session('first')
+  assert.equal(await run(first, '/usr/bin/id', ['-u']), '10001')
+  step('runtime-user', { identity: await run(first, '/usr/bin/id', []) })
+  const version = await startDocker(first)
+  step('docker-manually-started-as-runtime-user', { version })
+  await writeFile(
+    join(first.workspaceRoot, 'Dockerfile'),
+    'FROM busybox:1.37.0\nRUN mkdir /www && printf COMPOSE_OK > /www/index.html\n'
+  )
+  await writeFile(
+    join(first.workspaceRoot, 'compose.yaml'),
+    `services:
+  web:
+    build: .
+    image: ${imageName}
+    command: [sh, -c, "echo SESSION_A > /cache/marker; httpd -f -p 8080 -h /www"]
+    volumes: [data:/cache]
+    healthcheck:
+      test: [CMD, wget, -qO-, http://localhost:8080]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+  check:
+    image: busybox:1.37.0
+    depends_on:
+      web: {condition: service_healthy}
+    command: [sh, -c, 'test "$(wget -qO- http://web:8080)" = COMPOSE_OK']
+volumes:
+  data: {name: ${volumeName}}
+`
+  )
+  await run(first, '/usr/bin/docker', [
+    'compose',
+    'up',
+    '--build',
+    '--abort-on-container-exit',
+    '--exit-code-from',
+    'check'
+  ])
+  await run(first, '/usr/bin/docker', ['compose', 'down'])
+  const built = await run(first, '/usr/bin/docker', ['image', 'inspect', imageName, '--format', '{{.Id}}'])
+  await run(first, '/usr/bin/docker', [
+    'run',
+    '--rm',
+    '--user',
+    '10001:10001',
+    '-v',
+    `${first.workspaceRoot}:/work`,
+    'busybox:1.37.0',
+    'sh',
+    '-c',
+    'echo BIND_OK > /work/container-marker'
+  ])
+  assert.equal((await readFile(join(first.workspaceRoot, 'container-marker'), 'utf8')).trim(), 'BIND_OK')
+  step('compose-build-service-dns-and-workspace-bind-passed')
+  await manager.suspend(first.id)
+  const remaining = await freeBytes()
+  const firstAllocation = Math.max(0, beforeFirst - remaining)
+  assert.ok(remaining - firstAllocation >= 2 * 1024 ** 3, 'second VM would leave less than 2 GiB free')
+  const second = await session('second')
+  await startDocker(second)
+  const absent = await manager.exec(second, '/usr/bin/docker', ['image', 'inspect', imageName], {
+    cwd: second.workspaceRoot,
+    env
+  })
+  assert.notEqual(absent.exitCode, 0, 'second session inherited the first session image')
+  assert.equal(await run(second, '/usr/bin/docker', ['volume', 'ls', '--format', '{{.Name}}']), '')
+  await run(second, '/usr/bin/docker', [
+    'run',
+    '--rm',
+    '-v',
+    `${volumeName}:/cache`,
+    'busybox:1.37.0',
+    'sh',
+    '-c',
+    'echo SESSION_B > /cache/marker'
+  ])
+  await startDocker(first)
+  assert.equal(await run(first, '/usr/bin/docker', ['image', 'inspect', imageName, '--format', '{{.Id}}']), built)
+  assert.equal(
+    await run(first, '/usr/bin/docker', [
+      'run',
+      '--rm',
+      '-v',
+      `${volumeName}:/cache`,
+      'busybox:1.37.0',
+      'cat',
+      '/cache/marker'
+    ]),
+    'SESSION_A'
+  )
+  step('two-session-docker-state-isolated-and-retained-after-resume')
+  for (const [environment, marker] of [
+    [first, 'FIRST'],
+    [second, 'SECOND']
+  ] as const) {
+    await run(environment, '/usr/bin/docker', [
+      'run',
+      '-d',
+      '--name',
+      'same-port',
+      '-p',
+      '18080:8080',
+      'busybox:1.37.0',
+      'sh',
+      '-c',
+      `mkdir /www; echo ${marker} > /www/index.html; httpd -f -p 8080 -h /www`
+    ])
+    assert.equal(
+      await run(environment, '/usr/bin/curl', [
+        '--retry',
+        '10',
+        '--retry-connrefused',
+        '--retry-delay',
+        '1',
+        '-fsS',
+        'http://127.0.0.1:18080'
+      ]),
+      marker
+    )
+  }
+  await run(first, '/usr/bin/docker', [
+    'run',
+    '-d',
+    '--name',
+    'random-port',
+    '-p',
+    '8080',
+    imageName,
+    'httpd',
+    '-f',
+    '-p',
+    '8080',
+    '-h',
+    '/www'
+  ])
+  const published = await run(first, '/usr/bin/docker', ['port', 'random-port', '8080/tcp'])
+  const randomPort = published.match(/^0\.0\.0\.0:(\d+)/)?.[1]
+  assert.ok(randomPort, `missing random published port: ${published}`)
+  assert.equal(
+    await run(first, '/usr/bin/curl', [
+      '--retry',
+      '10',
+      '--retry-connrefused',
+      '--retry-delay',
+      '1',
+      '-fsS',
+      `http://127.0.0.1:${randomPort}`
+    ]),
+    'COMPOSE_OK'
+  )
+  step('simultaneous-vm-published-ports-isolated', { samePort: 18080, randomPort })
+  await run(first, '/usr/local/bin/npm', [
+    'install',
+    '--prefix',
+    join(first.workspaceRoot, 'testcontainers'),
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    'testcontainers@12.1.0'
+  ])
+  await writeFile(
+    join(first.workspaceRoot, 'testcontainers', 'smoke.mjs'),
+    `
+import assert from 'node:assert/strict';
+import { GenericContainer } from 'testcontainers';
+const container = await new GenericContainer('busybox:1.37.0')
+  .withCommand(['sh', '-c', 'mkdir /www; echo TESTCONTAINERS_OK > /www/index.html; httpd -f -p 8080 -h /www'])
+  .withExposedPorts(8080).start();
+try {
+  const response = await fetch('http://' + container.getHost() + ':' + container.getMappedPort(8080));
+  assert.equal((await response.text()).trim(), 'TESTCONTAINERS_OK');
+  console.log(container.getId());
+} finally { await container.stop(); }
+`
+  )
+  const testContainerId = await run(first, '/usr/local/bin/node', [
+    join(first.workspaceRoot, 'testcontainers', 'smoke.mjs')
+  ])
+  const removed = await manager.exec(first, '/usr/bin/docker', ['inspect', testContainerId], {
+    cwd: first.workspaceRoot,
+    env
+  })
+  assert.notEqual(removed.exitCode, 0, 'Testcontainers left its stopped container behind')
+  step('testcontainers-random-port-and-cleanup-passed')
+  for (const environment of environments) await manager.discard(environment.id)
+  assert.deepEqual(await manager.environmentIds(), [])
+  passed = true
+  step('discarded-all-session-vms')
+} finally {
+  for (const environment of environments) await manager.discard(environment.id).catch((error) => console.error(error))
+  await manager.stopAll()
+  await Promise.all(servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))))
+  if (passed) await rm(root, { recursive: true, force: true })
+  else console.error(`Inspection files retained at ${root}`)
+}

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -137,6 +137,21 @@ export type SandboxMount = z.infer<typeof SandboxMountSchema>
 const SandboxBackendSchema = z.enum(['srt', 'microsandbox'])
 export type SandboxBackend = z.infer<typeof SandboxBackendSchema>
 
+export const MicrosandboxConfigSchema = z
+  .object({
+    image: z.string().trim().min(1).optional(),
+    // The backend accepts u8 CPUs and u32 MiB resource sizes.
+    cpus: z.number().int().positive().max(255).default(2),
+    memoryMiB: z.number().int().positive().max(0xffffffff).default(2048),
+    diskGiB: z
+      .number()
+      .int()
+      .positive()
+      .max(Math.floor(0xffffffff / 1024))
+      .default(10)
+  })
+  .strict()
+
 export const ConfigSchema = z.object({
   version: z.literal(1),
   daemonId: z.string().optional(),
@@ -175,32 +190,9 @@ export const ConfigSchema = z.object({
     .object({
       backend: SandboxBackendSchema.default('srt'),
       mounts: z.array(SandboxMountSchema).default([]),
-      microsandbox: z
-        .object({
-          image: z.string().trim().min(1),
-          // The backend accepts u8 CPUs and u32 MiB resource sizes.
-          cpus: z.number().int().positive().max(255).default(2),
-          memoryMiB: z.number().int().positive().max(0xffffffff).default(2048),
-          diskGiB: z
-            .number()
-            .int()
-            .positive()
-            .max(Math.floor(0xffffffff / 1024))
-            .default(10)
-        })
-        .strict()
-        .optional()
+      microsandbox: MicrosandboxConfigSchema.optional()
     })
     .strict()
-    .superRefine((sandbox, ctx) => {
-      if (sandbox.backend === 'microsandbox' && !sandbox.microsandbox) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['microsandbox', 'image'],
-          message: 'sandbox.microsandbox.image is required for the microsandbox backend'
-        })
-      }
-    })
     .default({ backend: 'srt', mounts: [] }),
   security: z
     .object({

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1922,7 +1922,7 @@ export class Daemon {
       try {
         this.microsandbox = await installMicrosandbox({
           root,
-          config: cfg.sandbox.microsandbox!,
+          config: cfg.sandbox.microsandbox,
           sockets: { mcp: mcpSocketPath(root), gitcred: gitcredSocketPath(root) },
           log: this.log
         })

--- a/packages/daemon/src/microsandbox/install.ts
+++ b/packages/daemon/src/microsandbox/install.ts
@@ -4,8 +4,9 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { RuntimeStore } from '../runtimes/runtime-store.js'
 import { MicrosandboxManager } from './driver.js'
-import type { Config } from '../config/config-schema.js'
+import { MicrosandboxConfigSchema, type Config } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
+import { resolveMicrosandboxImage } from '../release-image.js'
 
 export const MICROSANDBOX_VERSION = '0.6.17'
 
@@ -26,11 +27,13 @@ export function microsandboxGuestEntry(root: string): string {
 
 export async function installMicrosandbox(opts: {
   root: string
-  config: NonNullable<Config['sandbox']['microsandbox']>
+  config: Config['sandbox']['microsandbox']
   sockets: { mcp: string; gitcred: string }
   log: Logger
 }): Promise<MicrosandboxManager> {
   if (process.platform !== 'linux') throw new Error('microsandbox currently requires a Linux host with KVM')
+  const config = MicrosandboxConfigSchema.parse(opts.config ?? {})
+  const image = resolveMicrosandboxImage(config.image)
   const state = join(opts.root, 'microsandbox')
   mkdirSync(state, { recursive: true, mode: 0o700 })
   // The SDK has process-wide local state; this daemon owns its home for its entire lifetime.
@@ -51,5 +54,5 @@ export async function installMicrosandbox(opts: {
   )) as typeof import('microsandbox')
   const platform = `@superradcompany/microsandbox-linux-${process.arch}-gnu`
   const command = join(dirname(installedRequire.resolve(`${platform}/package.json`)), 'bin', 'msb')
-  return new MicrosandboxManager({ ...opts, sdk, msbCommand: { command, args: [] } })
+  return new MicrosandboxManager({ ...opts, config: { ...config, image }, sdk, msbCommand: { command, args: [] } })
 }

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -136,6 +136,17 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
 
   const env = { ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, hostEnv), ...credentials?.env }
   for (const name of HOST_IPC_ENV) delete env[name]
+  // Drop ambient Docker client settings, but keep explicit guest config, including materialized registry config.
+  for (const name of [
+    'TESTCONTAINERS_HOST_OVERRIDE',
+    'DOCKER_CONTEXT',
+    'DOCKER_CONFIG',
+    'DOCKER_CERT_PATH',
+    'DOCKER_TLS',
+    'DOCKER_TLS_VERIFY'
+  ]) {
+    if (opts.explicitEnv?.[name] === undefined) delete env[name]
+  }
   for (const { envVar } of opts.runtime ? runtimeExecutableHints(opts.runtime) : []) {
     if (opts.explicitEnv?.[envVar] === undefined) delete env[envVar]
   }

--- a/packages/daemon/src/release-image.ts
+++ b/packages/daemon/src/release-image.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+
+export function resolveMicrosandboxImage(image?: string): string {
+  if (image !== undefined) return image
+  let metadata: unknown
+  try {
+    // The published bundle and release.json share dist/; source builds have no metadata beside src/.
+    metadata = JSON.parse(readFileSync(new URL('./release.json', import.meta.url), 'utf8'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error('sandbox.microsandbox.image is required for a build without release image metadata')
+    }
+    throw new Error('daemon release image metadata could not be read; set sandbox.microsandbox.image explicitly', {
+      cause: error
+    })
+  }
+  if (
+    !metadata ||
+    typeof metadata !== 'object' ||
+    !('runtimeSandboxImage' in metadata) ||
+    typeof metadata.runtimeSandboxImage !== 'string' ||
+    !metadata.runtimeSandboxImage.trim()
+  ) {
+    throw new Error('daemon release image metadata is invalid; set sandbox.microsandbox.image explicitly')
+  }
+  return metadata.runtimeSandboxImage
+}

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -99,11 +99,15 @@ describe('loadConfig', () => {
     expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'docker' } })).toThrow()
   })
 
-  it('requires an explicit microsandbox image and defaults its resource allocation', () => {
-    expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox' } })).toThrow(
-      'sandbox.microsandbox.image'
-    )
-    for (const image of [undefined, '', '  ']) {
+  it('allows the release image default without adding Docker lifecycle configuration', () => {
+    expect(ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox' } }).sandbox).toEqual({
+      backend: 'microsandbox',
+      mounts: []
+    })
+    expect(
+      ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox', microsandbox: {} } }).sandbox.microsandbox
+    ).toEqual({ cpus: 2, memoryMiB: 2048, diskGiB: 10 })
+    for (const image of ['', '  ']) {
       expect(() =>
         ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox', microsandbox: { image } } })
       ).toThrow()
@@ -116,8 +120,16 @@ describe('loadConfig', () => {
     ).toEqual({
       backend: 'microsandbox',
       mounts: [],
-      microsandbox: { image: 'registry.example.test/runtime:test', cpus: 2, memoryMiB: 2048, diskGiB: 10 }
+      microsandbox: {
+        image: 'registry.example.test/runtime:test',
+        cpus: 2,
+        memoryMiB: 2048,
+        diskGiB: 10
+      }
     })
+    expect(() =>
+      ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox', microsandbox: { docker: true } } })
+    ).toThrow('docker')
   })
 
   it.each([

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -60,7 +60,14 @@ describe('prepareMicrosandboxLaunch', () => {
         HOME: opts.hostHome,
         PATH: '/host/bin',
         SSH_AUTH_SOCK: '/host/agent.sock',
-        DBUS_SESSION_BUS_ADDRESS: 'unix:/host/bus'
+        DBUS_SESSION_BUS_ADDRESS: 'unix:/host/bus',
+        DOCKER_HOST: 'tcp://host-docker.example.test:2376',
+        DOCKER_CONTEXT: 'host-desktop',
+        DOCKER_CONFIG: '/host/docker',
+        DOCKER_CERT_PATH: '/host/docker/certs',
+        DOCKER_TLS: '1',
+        DOCKER_TLS_VERIFY: '1',
+        TESTCONTAINERS_HOST_OVERRIDE: 'host-docker.example.test'
       },
       trustedRuntimeReadRoots: [tool, missing],
       mounts: [{ source: tool, target: '/tools/tool.js', readOnly: true }]
@@ -84,11 +91,31 @@ describe('prepareMicrosandboxLaunch', () => {
     )
     expect(launch.env.SSH_AUTH_SOCK).toBeUndefined()
     expect(launch.env.DBUS_SESSION_BUS_ADDRESS).toBeUndefined()
+    for (const name of [
+      'DOCKER_HOST',
+      'DOCKER_CONTEXT',
+      'DOCKER_CONFIG',
+      'DOCKER_CERT_PATH',
+      'DOCKER_TLS',
+      'DOCKER_TLS_VERIFY',
+      'TESTCONTAINERS_HOST_OVERRIDE'
+    ]) {
+      expect(launch.env[name]).toBeUndefined()
+    }
     expect(launch.env.TMPDIR).toBe('/tmp')
     expect(launch.env.AC_GITCRED_SOCKET).toBe('/run/agentconnect/gitcred.sock')
-    expect(prepareMicrosandboxLaunch({ ...opts, explicitEnv: { PATH: '/guest/tools:/usr/bin' } }).env.PATH).toBe(
-      '/guest/tools:/usr/bin'
-    )
+    const dockerConfig = join(opts.scopeDir, 'run', 'config-files', 'docker')
+    const explicit = prepareMicrosandboxLaunch({
+      ...opts,
+      explicitEnv: { PATH: '/guest/tools:/usr/bin', DOCKER_CONFIG: dockerConfig }
+    })
+    expect(explicit.env.PATH).toBe('/guest/tools:/usr/bin')
+    expect(explicit.env.DOCKER_CONFIG).toBe(dockerConfig)
+    expect(explicit.microsandbox.mounts).toContainEqual({
+      source: join(opts.scopeDir, 'run', 'config-files'),
+      target: join(opts.scopeDir, 'run', 'config-files'),
+      readOnly: true
+    })
   })
 
   it.each([

--- a/packages/daemon/test/release-image.test.ts
+++ b/packages/daemon/test/release-image.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { stripTypeScriptTypes } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { resolveMicrosandboxImage } from '../src/release-image.js'
+
+const roots: string[] = []
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+it('requires an explicit image from source without using a package version as a guessed default', () => {
+  expect(() => resolveMicrosandboxImage()).toThrow('without release image metadata')
+  expect(resolveMicrosandboxImage('registry.example.test/sandbox@sha256:custom')).toBe(
+    'registry.example.test/sandbox@sha256:custom'
+  )
+})
+
+it('emits a release alias beside the packaged module, honors overrides, and clears it on a development rebuild', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ac-release-image-'))
+  roots.push(root)
+  mkdirSync(join(root, 'scripts'))
+  mkdirSync(join(root, 'dist'))
+  const emitter = join(root, 'scripts', 'prepare-release-image.mjs')
+  copyFileSync(new URL('../scripts/prepare-release-image.mjs', import.meta.url), emitter)
+  const entry = join(root, 'dist', 'index.mjs')
+  writeFileSync(entry, stripTypeScriptTypes(readFileSync(new URL('../src/release-image.ts', import.meta.url), 'utf8')))
+  const metadata = join(root, 'dist', 'release.json')
+  const run = (explicit?: string) =>
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        'const { resolveMicrosandboxImage } = await import(process.argv[1]); process.stdout.write(resolveMicrosandboxImage(process.argv[2]))',
+        pathToFileURL(entry).href,
+        ...(explicit === undefined ? [] : [explicit])
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+  const emit = (version?: string) => {
+    const env = { ...process.env }
+    delete env.AGENTCONNECT_RELEASE_VERSION
+    if (version !== undefined) env.AGENTCONNECT_RELEASE_VERSION = version
+    execFileSync(process.execPath, [emitter], { env, stdio: ['ignore', 'pipe', 'pipe'] })
+  }
+
+  for (const version of ['1.2.3', '1.2.4-rc.7']) {
+    emit(version)
+    expect(run()).toBe(`ghcr.io/agentconnect-md/runtime-sandbox:v${version}`)
+  }
+  writeFileSync(metadata, '{broken')
+  expect(run('registry.example.test/custom:stable')).toBe('registry.example.test/custom:stable')
+  expect(() => run()).toThrow('metadata could not be read')
+  emit()
+  expect(existsSync(metadata)).toBe(false)
+  expect(() => run()).toThrow('without release image metadata')
+})

--- a/scripts/component-versions.sh
+++ b/scripts/component-versions.sh
@@ -58,11 +58,8 @@ DAEMON_PATHS="packages/daemon packages/activation-policy packages/message packag
 # docker-bake.hcl. Changes to that pin, its owned Dockerfile, or this resolver
 # rebuild the image; unrelated app/package changes leave it on its effective tag.
 MEM0_BACKEND_PATHS="docker/mem0-backend.Dockerfile docker-bake.hcl scripts/component-versions.sh"
-# The runtime sandbox has its OWN Dockerfile, so it deliberately does not share COMMON's
-# docker/Dockerfile. Its inputs are the shim's source graph — the shim ships inside it and the two
-# halves of that channel must not drift apart — plus the pinned runtime versions and table
-# generator that the published runtime table describes.
-RUNTIME_SANDBOX_PATHS="docker/runtime-sandbox.Dockerfile docker/runtime-sandbox packages/daemon/src/shim packages/daemon/tsdown.shim.config.ts packages/daemon/package.json packages/protocol packages/connection docker-bake.hcl .dockerignore .npmrc .pnpmfile.mjs pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json scripts"
+# Keep runtime-image selection and the daemon's bundled default on the same input closure.
+. "$(dirname "$0")/runtime-sandbox-inputs.sh"
 
 # The channel's tags (prerelease tags carry a `-`), oldest → newest. Within one
 # channel `sort -V` compares version fields numerically (rc.9 < rc.10), so the

--- a/scripts/publish-daemon-if-changed.sh
+++ b/scripts/publish-daemon-if-changed.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-# Publishes the daemon to npm ONLY when something that lands in its bundle
-# changed since the previous release on this channel. The daemon actually
-# changes in well under half of releases (~43% as of 2026-07), and the fleet
-# upgrades manually — every skipped publish is one less no-op version.
+# Publish only when the daemon bundle or its default runtime image inputs change on this channel.
 #
 # Called by release.config.js's prepareCmd/publishCmd (cwd = repo root) with:
 #   $1 = previous release git tag on this channel ('' on a channel's first
@@ -42,35 +39,17 @@ case "$MODE" in
     ;;
 esac
 
-# Everything tsdown inlines into the daemon bundle: the daemon itself, its
-# workspace deps (keep in sync with packages/daemon/package.json), and
-# tsconfig.base.json (shapes the emitted JS). The lockfile is deliberately
-# NOT here: it is shared by every workspace package, so diffing it whole
-# republished the daemon whenever ANY package touched a dependency (a web
-# icons bump, say). It is checked separately below, scoped to the daemon's
-# importers.
-DAEMON_PATHS="packages/daemon packages/activation-policy packages/message packages/protocol packages/connection packages/k8s-client tsconfig.base.json"
-DAEMON_IMPORTERS="packages/daemon packages/activation-policy packages/message packages/protocol packages/connection packages/k8s-client"
+. "$REPO_ROOT/scripts/runtime-sandbox-inputs.sh"
+# The image consumes the full lockfile, so even unrelated dependency bumps now refresh its daemon default.
+DAEMON_PATHS="packages/daemon packages/activation-policy packages/message packages/protocol packages/connection packages/k8s-client tsconfig.base.json $RUNTIME_SANDBOX_PATHS"
 
 if [ -n "$LAST_TAG" ] && git rev-parse -q --verify "${LAST_TAG}^{commit}" > /dev/null; then
   # Word-splitting DAEMON_PATHS is deliberate: it is a list of pathspecs.
   # shellcheck disable=SC2086
   CHANGED=$(git diff --name-only "$LAST_TAG" HEAD -- $DAEMON_PATHS)
   if [ -z "$CHANGED" ]; then
-    # Package dirs untouched — but a floating-range resolution bump can still
-    # change the bundle without touching any package dir, so ask whether the
-    # lockfile's resolved closure for the daemon's importers moved. Prints
-    # "unchanged" only when certain; anything it can't parse counts as
-    # changed. The helper runs in a plain assignment — NOT inside the if
-    # condition, where errexit is suspended — so a git/node failure exits
-    # non-zero and aborts the release instead of publishing after a failed
-    # safety check.
-    # shellcheck disable=SC2086
-    LOCK_VERDICT=$(node "$REPO_ROOT/scripts/lockfile-closure-changed.mjs" "$LAST_TAG" HEAD $DAEMON_IMPORTERS)
-    if [ "$LOCK_VERDICT" = "unchanged" ]; then
-      echo "daemon bundle inputs unchanged since ${LAST_TAG} — skipping ${SKIP_LABEL} (checked: ${DAEMON_PATHS} + lockfile closure of ${DAEMON_IMPORTERS})"
-      exit 0
-    fi
+    echo "daemon bundle and runtime image inputs unchanged since ${LAST_TAG} — skipping ${SKIP_LABEL} (checked: ${DAEMON_PATHS})"
+    exit 0
   fi
 fi
 
@@ -83,7 +62,7 @@ if [ "$MODE" = prepare ]; then
   # is equivalent here — the bundle is already built by tsdown and deps are
   # stripped below.
   pnpm exec json -I -f package.json -e "this.version='$VALUE'"
-  pnpm run build
+  AGENTCONNECT_RELEASE_VERSION="$VALUE" pnpm run build
   pnpm exec json -I -f package.json -e 'this.dependencies={}'
   exit 0
 fi

--- a/scripts/publish-daemon-if-changed.test.mjs
+++ b/scripts/publish-daemon-if-changed.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+
+test(
+  'daemon publication follows runtime-image inputs while unrelated source changes still skip',
+  { skip: process.platform === 'win32' },
+  (t) => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-daemon-release-'))
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+    const repo = join(root, 'repo')
+    const bin = join(root, 'bin')
+    const log = join(root, 'pnpm.log')
+    mkdirSync(repo)
+    mkdirSync(bin)
+    writeFileSync(log, '')
+    // A fake executable records both phases; this fixture can never invoke a real npm publisher.
+    writeFileSync(
+      join(bin, 'pnpm'),
+      '#!/bin/sh\nprintf "%s|%s\\n" "${AGENTCONNECT_RELEASE_VERSION-}" "$*" >> "$RELEASE_TEST_LOG"\n',
+      { mode: 0o755 }
+    )
+    const env = {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      RELEASE_TEST_LOG: log,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1'
+    }
+    delete env.AGENTCONNECT_RELEASE_VERSION
+    const run = (command, args) => execFileSync(command, args, { cwd: repo, env, encoding: 'utf8' })
+    const git = (...args) =>
+      run('git', [
+        '-c',
+        'user.name=Release Test',
+        '-c',
+        'user.email=release@example.test',
+        '-c',
+        'commit.gpgsign=false',
+        ...args
+      ])
+    const write = (path, content) => {
+      mkdirSync(dirname(join(repo, path)), { recursive: true })
+      writeFileSync(join(repo, path), content)
+    }
+    mkdirSync(join(repo, 'scripts'))
+    for (const script of ['component-versions.sh', 'publish-daemon-if-changed.sh', 'runtime-sandbox-inputs.sh']) {
+      copyFileSync(new URL(script, import.meta.url), join(repo, 'scripts', script))
+    }
+    write('packages/daemon/package.json', '{"name":"release-test","version":"1.0.0-dev"}\n')
+    write('docker/runtime-sandbox.Dockerfile', 'FROM scratch\n')
+    write('pnpm-lock.yaml', 'lockfileVersion: 9.0\n')
+    git('-c', 'init.templateDir=', 'init', '--quiet')
+    const commit = (tag) => {
+      git('add', '.')
+      git('commit', '--quiet', '-m', tag)
+      git('tag', tag)
+    }
+    commit('v1.0.0')
+
+    const components = (tag) =>
+      Object.fromEntries(
+        run('bash', ['scripts/component-versions.sh', tag])
+          .trim()
+          .split('\n')
+          .map((line) => line.split('='))
+      )
+    const publish = (previous, version) => {
+      writeFileSync(log, '')
+      run('sh', ['scripts/publish-daemon-if-changed.sh', previous, version, 'prepare'])
+      run('sh', ['scripts/publish-daemon-if-changed.sh', previous, 'latest', 'publish'])
+      return readFileSync(log, 'utf8')
+    }
+
+    write('docker/runtime-sandbox.Dockerfile', 'FROM scratch\nLABEL revision="new"\n')
+    commit('v1.0.1')
+    assert.equal(components('v1.0.1').runtimeSandbox, 'v1.0.1')
+    assert.equal(components('v1.0.1').daemon, 'v1.0.0')
+    const imageRelease = publish('v1.0.0', '1.0.1')
+    assert.match(imageRelease, /^1\.0\.1\|run build$/m)
+    assert.match(imageRelease, /^\|publish --no-git-checks --ignore-scripts --tag latest$/m)
+
+    write('packages/web/src/page.ts', 'export const page = "new"\n')
+    commit('v1.0.2')
+    assert.equal(components('v1.0.2').runtimeSandbox, 'v1.0.1')
+    assert.equal(publish('v1.0.1', '1.0.2'), '')
+
+    write('pnpm-lock.yaml', 'lockfileVersion: 9.0\n# a dependency changed\n')
+    commit('v1.0.3')
+    assert.equal(components('v1.0.3').runtimeSandbox, 'v1.0.3')
+    assert.match(publish('v1.0.2', '1.0.3'), /^1\.0\.3\|run build$/m)
+  }
+)

--- a/scripts/runtime-sandbox-inputs.sh
+++ b/scripts/runtime-sandbox-inputs.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Shared inputs for the runtime image and the daemon package that pins it as its default.
+RUNTIME_SANDBOX_PATHS="docker/runtime-sandbox.Dockerfile docker/runtime-sandbox packages/daemon/src/shim packages/daemon/tsdown.shim.config.ts packages/daemon/package.json packages/protocol packages/connection docker-bake.hcl .dockerignore .npmrc .pnpmfile.mjs pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json scripts"

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -77,6 +77,34 @@ check('runs as a non-root user', () => {
   return `uid ${uid} (USER ${configured})`
 })
 
+check('Docker Engine, Buildx and Compose are installed without starting a daemon', () => {
+  return inImage('set -e; dockerd --version; docker --version; docker buildx version; docker compose version')
+})
+
+check('the runtime user may elevate only the Docker daemon command', () => {
+  return inImage(
+    'set -e; getent group docker | cut -d: -f4 | tr , "\\n" | grep -qx agent; sudo -n /usr/bin/dockerd --version; if sudo -n /usr/bin/id -u >/dev/null 2>&1; then exit 1; fi'
+  )
+})
+
+check('pool no-new-privileges prevents the Docker sudo grant', () => {
+  execFileSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '--security-opt',
+      'no-new-privileges=true',
+      '--entrypoint',
+      'sh',
+      image,
+      '-c',
+      'if sudo -n /usr/bin/dockerd --version >/dev/null 2>&1; then exit 1; fi'
+    ],
+    { encoding: 'utf8' }
+  )
+})
+
 // PID 1 has to reap the runtime's children and forward SIGTERM; without that a drain can only
 // ever end in SIGKILL, and every drain looks like a crash.
 check('tini is PID 1 and forwards signals', () => {


### PR DESCRIPTION
Published daemons can select microsandbox without specifying an image: release metadata points to the shared runtime image for that release. Explicit image overrides remain supported, and development builds require an explicit image. Runtime-image input changes also publish a fresh daemon package so its default reference stays current.

The image supplies pinned Docker Engine, Buildx, and Compose plus permission for the ordinary agent user to start `dockerd` with sudo when needed. There is no daemon Docker setting, automatic startup, readiness gate, or Docker process supervision. The image's existing user/entrypoint and pool privilege restrictions remain in place. Guest launch removes ambient host Docker client settings while preserving explicit guest configuration.

The network design requires public egress with host/private/peer isolation for session VMs, without configurable network modes, host port publication, or preview forwarding. Host public-address enforcement and complete network/workload validation remain pending.

Validation:

- Daemon typecheck and complete build passed.
- 57 focused config, release-image, launch, and manager tests passed; 2 release-script regressions passed using a fake publisher.
- Lint, formatting, shell syntax, and diff checks passed.
- The runtime image verifier passed on the published pool image with the new Docker installation and sudo layers, including non-root execution and pool no-new-privileges behavior. This was a derived image test, not a rebuild of the latest runtime adapters.
- A real-manager smoke script covers manual Docker startup, Compose/build/DNS, bind writes, retained and isolated Docker state, concurrent identical ports, random ports, Testcontainers, and cleanup. It has not run against the new image yet: the previous attempt was stopped by the test host's disk-capacity guard before pulling the image or creating VMs.

The default release image currently targets Linux amd64. Image aliases become available after the matching image workflow finishes; an unavailable image fails preflight.

Follow-up to #1855, which is now merged. Keep this PR unmerged for now.

Created by Codex . GPT-6
