### PR TITLE
fix(memory): prevent Mem0 enumeration from skipping records

### DIFF
--- a/packages/memory-plugin-mem0/src/cloud.test.ts
+++ b/packages/memory-plugin-mem0/src/cloud.test.ts
@@ -321,3 +321,45 @@ describe('Mem0 Cloud V3 plugin contract', () => {
     await client.close()
   })
 })
+
+describe('Mem0 Cloud enumeration budgets', () => {
+  it.each([1, 20, 50, 100])('enumerates every record with requested limit %i', async (limit) => {
+    const sizes: number[] = []
+    const rows = Array.from({ length: 37 }, (_, i) => ({ id: `memory-${i}`, memory: `Fact ${i}` }))
+    const upstream = await startUpstream((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      const size = Number(url.searchParams.get('page_size'))
+      const page = Number(url.searchParams.get('page'))
+      sizes.push(size)
+      const start = (page - 1) * size
+      send(res, 200, {
+        results: rows.slice(start, start + size),
+        next: start + size < rows.length ? 'https://example.com/memories?page=next' : null,
+        previous: null,
+        count: rows.length
+      })
+    })
+    const client = new Mem0CloudClient({ baseUrl: upstream.url })
+    const ids: string[] = []
+    let cursor: string | undefined
+    do {
+      const output = await client.list(
+        {
+          context: {
+            requestId: 'enumeration',
+            connection: { id: 'test', config: {} },
+            scope: { kind: 'agent', key: 'ac:agent:bot-a' }
+          },
+          limit,
+          ...(cursor ? { cursor } : {})
+        },
+        'test-key'
+      )
+      ids.push(...output.records.map((record) => record.id))
+      cursor = output.nextCursor
+      expect(sizes.length).toBeLessThanOrEqual(rows.length)
+    } while (cursor)
+    expect(ids).toEqual(rows.map((row) => row.id))
+    expect(sizes.every((size) => size === Math.min(limit, MEM0_CLOUD_MANIFEST.limits.maxBatchItems))).toBe(true)
+  })
+})

--- a/packages/memory-plugin-mem0/src/cloud.ts
+++ b/packages/memory-plugin-mem0/src/cloud.ts
@@ -313,9 +313,10 @@ export class Mem0CloudClient {
 
   async list(input: MemoryPluginListInput, apiKey: string, signal?: AbortSignal) {
     const page = pageCursor(input.cursor)
+    const limit = Math.min(input.limit, 20)
     const raw = await this.request(
       'list',
-      `/v3/memories/?page=${page}&page_size=${input.limit}`,
+      `/v3/memories/?page=${page}&page_size=${limit}`,
       apiKey,
       {
         method: 'POST',
@@ -327,7 +328,7 @@ export class Mem0CloudClient {
     const records: CanonicalMemoryRecord[] = []
     const ids = new Set<string>()
     for (const item of response.results) {
-      if (records.length >= input.limit || records.length >= 20) break
+      if (records.length >= limit) break
       const record = recordFromResult(item, input.context.scope)
       if (!record || ids.has(record.id)) continue
       ids.add(record.id)


### PR DESCRIPTION
Mem0 Cloud list requests could ask the backend for 50 records but emit only 20. When the backend returned its final page, the remaining records became unreachable.

Clamp the upstream page size to the adapter's 20-record output budget. This is the enumeration prerequisite for the unified memory interface in #1863; existing tool and plugin schemas remain unchanged.

Validation: regression enumerates all 37 records with requested limits 1, 20, 50 and 100. The 50/100 cases fail without the fix. Both Mem0 suites pass (17 tests), package typecheck and repository lint pass.
