### PR TITLE
feat(setup,control-plane,web): keep the deployment Slack app's manifest current, and stop assuming it is

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1777,7 +1777,10 @@ export const BotListDto = z.array(BotDto)
  * manifest into an existing Slack app and checking the workspace installation's
  * actually granted bot scopes. URLs are public Slack settings deep links only. */
 export const SlackBotRefreshDto = z.object({
-  manifest: z.enum(['synced', 'manual_update_required', 'unknown']),
+  /** `deployment_update_required`: a built-in app's manifest, audited read-only, lacks required scopes; the Setup Server fixes it. */
+  manifest: z.enum(['synced', 'manual_update_required', 'deployment_update_required', 'unknown']),
+  /** The required bot scopes the manifest does not declare (`deployment_update_required` only). */
+  manifestMissingScopes: z.array(z.string()),
   authorization: z.enum(['current', 'reinstall_required', 'invalid', 'app_mismatch', 'unknown']),
   /** Slack's own code behind `invalid` (`invalid_auth`, `token_revoked`, …): the diagnosis, since `invalid_auth` also answers an IP-allowlisted caller. Null otherwise. */
   rejection: z.string().nullable(),

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -27,7 +27,12 @@ import { BotId } from '../../domain/ids.js'
 import { denyViewerWrite, orgOf } from '../rbac.js'
 import { SlackBotRefreshDto, ErrorDto, IdParam, type SlackBotRefreshDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
-import { checkSlackBotScopes, mergeManagedSlackManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
+import {
+  checkSlackBotScopes,
+  mergeManagedSlackManifest,
+  missingDeclaredBotScopes,
+  slackOAuthRedirectUri
+} from '../slack-manifest.js'
 import { relayHttpBase } from '../relay-ingress.js'
 
 /** Slack errors from the manifest export/update that mean "this app is not
@@ -122,16 +127,18 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         if (checked?.status === 'ok' && checked.scopes?.length) {
           await deps.repos.bot.setGrantedScopes(bot.orgId, bot.id, checked.scopes)
         }
-        // A built-in app's manifest is deployment-managed rather than owned by
-        // the signed-in user's Slack config token. Refresh still verifies its
-        // installed scopes so the Console can offer the platform OAuth reinstall.
-        let manifest: SlackBotRefreshDtoT['manifest'] = bot.prebuilt ? 'synced' : 'manual_update_required'
+        // A built-in app's manifest belongs to the deployment: it is only AUDITED here
+        // (read-only, when the caller's config token can export it) and fixed from the
+        // Setup Server. A custom app's manifest is synced in place. Neither is assumed
+        // synced: unverified stays `manual_update_required`, which claims nothing.
+        let manifest: SlackBotRefreshDtoT['manifest'] = 'manual_update_required'
+        let manifestMissingScopes: string[] = []
         const api = slack.configApi
         // Manifest sync needs a config token that owns THIS app — i.e. the caller's
         // own (per-user), resolved through the §9 tooling-credential facet: the SAME
         // instance the registry advertises and the install funnel uses, so the two
         // flows cannot disagree about which store answers or when a token is stale.
-        if (!bot.prebuilt && api && appIdentityMatches && req.principal) {
+        if (api && appIdentityMatches && req.principal) {
           const config = (await slack.toolingCredentials?.resolveAccessToken(
             bot.orgId,
             req.principal.userId,
@@ -139,7 +146,10 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           )) ?? { ok: false as const, reason: 'unreachable' as const }
           if (config.ok) {
             const exported = await api.exportApp(config.accessToken, bot.slackAppId)
-            if (exported.ok) {
+            if (exported.ok && bot.prebuilt) {
+              manifestMissingScopes = missingDeclaredBotScopes(exported.manifest)
+              manifest = manifestMissingScopes.length > 0 ? 'deployment_update_required' : 'synced'
+            } else if (exported.ok) {
               const redirectUrl = deps.config.PUBLIC_CP_URL
                 ? slackOAuthRedirectUri(deps.config.PUBLIC_CP_URL)
                 : undefined
@@ -184,6 +194,7 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
 
         return {
           manifest,
+          manifestMissingScopes,
           authorization,
           rejection: checked?.status === 'invalid' ? checked.error : null,
           missingScopes,

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -59,6 +59,12 @@ export function checkSlackBotScopes(granted: readonly string[] | null | undefine
   return missing.length > 0 ? { status: 'short', missing } : { status: 'complete' }
 }
 
+/** Required bot scopes an exported manifest does not DECLARE — the deployment app's drift, which only the Setup Server may fix. */
+export function missingDeclaredBotScopes(manifest: Record<string, unknown>): string[] {
+  const declared = new Set(stringList(asRecord(asRecord(manifest.oauth_config).scopes).bot))
+  return SLACK_BOT_SCOPES.filter((scope) => !declared.has(scope))
+}
+
 type ManifestRecord = Record<string, unknown>
 
 function asRecord(value: unknown): ManifestRecord {

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -1444,6 +1444,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({
       manifest: 'synced',
+      manifestMissingScopes: [],
       authorization: 'current',
       rejection: null,
       missingScopes: [],
@@ -1491,6 +1492,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({
       manifest: 'manual_update_required',
+      manifestMissingScopes: [],
       authorization: 'current',
       rejection: null,
       missingScopes: [],

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -249,8 +249,10 @@ describe('GET /integrations/slack/platform/callback', () => {
       url: `${ORG}/bots/${bot!.id}/slack/refresh`
     })
     expect(refreshed.statusCode).toBe(200)
+    // No config token here, so the deployment app's manifest is unverified and claimed nothing about.
     expect(refreshed.json()).toMatchObject({
-      manifest: 'synced',
+      manifest: 'manual_update_required',
+      manifestMissingScopes: [],
       authorization: 'current',
       missingScopes: []
     })

--- a/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
+++ b/packages/control-plane/test/integration/slack-tooling-credentials.route.test.ts
@@ -90,9 +90,10 @@ class CountingConfigApi implements SlackConfigApi {
       }
     }
   }
+  exportResult: SlackManifestExportResult = { ok: true, manifest: { display_information: { name: 'Kept' } } }
   async exportApp(configToken: string): Promise<SlackManifestExportResult> {
     this.exportCalls.push(configToken)
-    return { ok: true, manifest: { display_information: { name: 'Kept' } } }
+    return this.exportResult
   }
   async updateApp(configToken: string): Promise<SlackManifestUpdateResult> {
     this.updateCalls.push(configToken)
@@ -308,6 +309,91 @@ describe('providerToolingCredentials — the Settings→Bots manifest refresh', 
 
     expect(res.statusCode).toBe(200)
     expect(res.json().manifest).toBe('unknown')
+    expect(api.exportCalls).toEqual([])
+  })
+})
+
+describe('the Settings→Bots refresh audits a built-in app instead of syncing it', () => {
+  /** A platform (deployment) bot row, as a workspace install leaves it: no funnel, no xapp. */
+  async function platformBot(appId: string): Promise<string> {
+    const botId = randomUUID()
+    await prisma.bot.create({
+      data: {
+        id: botId,
+        orgId: DEFAULT_ORG_ID,
+        platform: 'slack',
+        name: 'AgentConnect (Acme)',
+        prebuilt: true,
+        transport: 'http',
+        slackAppId: appId,
+        teamId: 'T1'
+      }
+    })
+    await prisma.botSecret.create({ data: { botId, botToken: 'xoxb-platform', appToken: null, signingSecret: 'ss' } })
+    return botId
+  }
+  const verifierFor = (appId: string) => async () => ({
+    status: 'ok' as const,
+    name: 'AgentConnect',
+    appId,
+    teamId: 'T1',
+    teamName: 'Acme',
+    scopes: [...SLACK_BOT_SCOPES]
+  })
+
+  it("reports 'deployment_update_required' with the undeclared scopes, and never writes the deployment app", async () => {
+    const { app, api } = withFunnel()
+    const botId = await platformBot('A0PLATFORM1')
+    app.platformStubs.verifySlackBot = verifierFor('A0PLATFORM1')
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-fresh',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+    api.exportResult = {
+      ok: true,
+      manifest: {
+        oauth_config: { scopes: { bot: SLACK_BOT_SCOPES.filter((s) => s !== 'lists:read' && s !== 'im:read') } }
+      }
+    }
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      manifest: 'deployment_update_required',
+      manifestMissingScopes: ['im:read', 'lists:read'],
+      authorization: 'current'
+    })
+    expect(api.exportCalls).toEqual(['xoxe.xoxp-fresh'])
+    expect(api.updateCalls).toEqual([])
+  })
+
+  it("reports 'synced' only when the export declares every required scope", async () => {
+    const { app, api } = withFunnel()
+    const botId = await platformBot('A0PLATFORM2')
+    app.platformStubs.verifySlackBot = verifierFor('A0PLATFORM2')
+    await storeConfig(app, {
+      accessToken: 'xoxe.xoxp-fresh',
+      refreshToken: 'xoxe-refresh',
+      accessExpiresAt: new Date(Date.now() + HOUR)
+    })
+    api.exportResult = { ok: true, manifest: { oauth_config: { scopes: { bot: [...SLACK_BOT_SCOPES] } } } }
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.json()).toMatchObject({ manifest: 'synced', manifestMissingScopes: [] })
+    expect(api.updateCalls).toEqual([])
+  })
+
+  it('claims nothing about the manifest without a config token', async () => {
+    const { app, api } = withFunnel()
+    const botId = await platformBot('A0PLATFORM3')
+    app.platformStubs.verifySlackBot = verifierFor('A0PLATFORM3')
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/slack/refresh` })
+
+    expect(res.json()).toMatchObject({ manifest: 'manual_update_required', manifestMissingScopes: [] })
     expect(api.exportCalls).toEqual([])
   })
 })

--- a/packages/setup/src/server/html.ts
+++ b/packages/setup/src/server/html.ts
@@ -294,12 +294,13 @@ export const SETUP_HTML = String.raw`<!doctype html>
         </div>
         <div class="subsection">
           <label id="slack-name-field" class="field">App name<input id="slack-name" value="AgentConnect"></label>
-          <label class="field">Temporary App configuration token<input id="slack-token" type="password" autocomplete="new-password" placeholder="Used only for create or check"></label>
+          <label class="field">Temporary App configuration token<input id="slack-token" type="password" autocomplete="new-password" placeholder="Used only for create, check or update"></label>
         </div>
         <div class="row">
           <button id="create-slack">Create Slack App</button>
           <button id="connect-slack-login" hidden>Use for Logto sign-in</button>
           <button id="check-slack" hidden>Check match</button>
+          <button id="reconcile-slack" hidden>Apply update</button>
           <button id="clear-slack" class="danger" hidden>Clear configuration</button>
           <a id="slack-settings" class="button" target="_blank" rel="noopener" hidden>Open Slack settings</a>
         </div>
@@ -720,6 +721,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
       el('connect-slack-login').hidden = !slack || !values.logto || Boolean(values.logto.slackConnector) || !bootstrapInfo?.slackAvailable;
       el('clear-slack').hidden = !slack;
       el('check-slack').hidden = !slack;
+      el('reconcile-slack').hidden = !slack;
       el('slack-settings').hidden = !slack;
       if (slack) {
         el('slack-settings').href = 'https://api.slack.com/apps/' + encodeURIComponent(slack.appId);
@@ -1283,6 +1285,27 @@ export const SETUP_HTML = String.raw`<!doctype html>
       message(result.status === 'pass' ? 'Slack App matches the default integration manifest.' : 'Slack App settings need an update.', result.status !== 'pass');
     }
 
+    async function reconcileSlack() {
+      const token = requiredInput('slack-token', 'the temporary Slack App configuration token');
+      const result = await json(await fetch(api + '/reconcile/slack', {
+        method: 'POST', headers: { 'content-type': 'application/json', ...bearer() },
+        body: JSON.stringify({ configToken: token })
+      }));
+      el('slack-token').value = '';
+      showDiff('slack-drift', result.diff || []);
+      match('slack-match', result.status === 'pass' ? 'pass' : 'warn', result.status === 'pass' ? 'Matches' : 'Update required');
+      message(
+        result.status !== 'pass'
+          ? 'Slack App was updated but some settings still differ.'
+          : result.applied.length === 0
+            ? 'Slack App already matches the default integration manifest.'
+            : result.permissionsUpdated
+              ? 'Slack App updated. Reinstall it in each workspace to grant the added scopes.'
+              : 'Slack App updated.',
+        result.status !== 'pass'
+      );
+    }
+
     async function checkGoogle() {
       const report = await checkLogto();
       const connector = report.findings.find((finding) => finding.id === 'logto.connectors');
@@ -1623,6 +1646,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
     el('cancel-slack-configuration').onclick = cancelConfigurationEdit;
     el('clear-slack').onclick = () => clearProvider('slack').catch((error) => message(error.message, true));
     el('check-slack').onclick = () => checkSlack().catch((error) => message(error.message, true));
+    el('reconcile-slack').onclick = () => reconcileSlack().catch((error) => message(error.message, true));
     el('save-gitlab').onclick = () => saveGitlab().catch((error) => message(error.message, true));
     el('cancel-gitlab-configuration').onclick = cancelConfigurationEdit;
     el('clear-gitlab').onclick = () => clearProvider('gitlab').catch((error) => message(error.message, true));

--- a/packages/setup/src/server/index.ts
+++ b/packages/setup/src/server/index.ts
@@ -54,6 +54,7 @@ import {
   auditSlackManifest,
   buildSlackDeploymentManifest,
   diffSlackManifest,
+  reconcileSlackManifest,
   requireProviderAppEndpoints,
   slackConfiguredUrls
 } from '../slack-app.js'
@@ -186,7 +187,7 @@ export interface SetupServerDeps {
   makeLogtoSetupClient?: (config: LogtoManagementConfig) => Pick<LogtoAdminClaimClient, 'reconcileSetup'>
   feishuRegistrationProvider?: Pick<FeishuRegistrationProvider, 'begin' | 'poll'>
   auditFeishuAppSetup?: FeishuAppSetupAuditor
-  slackConfigApi?: Pick<SlackConfigApi, 'createApp' | 'exportApp'>
+  slackConfigApi?: Pick<SlackConfigApi, 'createApp' | 'exportApp' | 'updateApp'>
   localAuthBootstrap?: {
     issuer: string
     managementEndpoint?: string
@@ -1301,6 +1302,65 @@ export function buildSetupServer(deps: SetupServerDeps, options: SetupServerOpti
       actual: observed,
       expected,
       settingsUrl: `https://api.slack.com/apps/${encodeURIComponent(slack.appId)}`,
+      restartRequired: false as const
+    }
+  })
+
+  // The deployment app's manifest is the one thing `check/slack` can see but not fix: `SLACK_BOT_SCOPES`
+  // grows with releases while the app on Slack keeps the set it was created with, and a Slack-side
+  // reinstall then grants only that stale set. This applies the same diff the check reports.
+  app.post('/api/v1/reconcile/slack', { preHandler: requireConfigurationAccess }, async (request, reply) => {
+    const parsed = CheckSlackBody.safeParse(request.body)
+    if (!parsed.success) return problem(reply, 400, 'a Slack App configuration token is required')
+    const current = await deps.store.getAdmin()
+    const slack = current?.values.slack
+    if (!current || !slack) return problem(reply, 409, 'the deployment Slack App is not configured')
+    let manifest: Record<string, unknown>
+    try {
+      manifest = expectedSlackManifest(current.values, await resolveLogtoConnectorIds())
+    } catch (error) {
+      return problem(reply, 409, error instanceof Error ? error.message : 'Slack App configuration is incomplete')
+    }
+    const settingsUrl = `https://api.slack.com/apps/${encodeURIComponent(slack.appId)}`
+    const exported = await slackConfigApi.exportApp(parsed.data.configToken, slack.appId)
+    if (!exported.ok) return problem(reply, 502, `Slack App settings could not be read: ${exported.error}`)
+    const before = auditSlackManifest(exported.manifest, manifest)
+    if (before.length === 0) {
+      return {
+        provider: 'slack' as const,
+        status: 'pass' as const,
+        applied: [] as string[],
+        missing: [] as string[],
+        diff: [],
+        permissionsUpdated: false,
+        settingsUrl,
+        restartRequired: false as const
+      }
+    }
+    const updated = await slackConfigApi.updateApp(
+      parsed.data.configToken,
+      slack.appId,
+      reconcileSlackManifest(exported.manifest, manifest)
+    )
+    if (!updated.ok) return problem(reply, 502, `Slack App settings could not be updated: ${updated.error}`)
+    // Re-read rather than trust the write: what Slack kept is the only truth the badge may show.
+    const after = await slackConfigApi.exportApp(parsed.data.configToken, slack.appId)
+    if (!after.ok)
+      return problem(reply, 502, `Slack App settings were updated but could not be re-read: ${after.error}`)
+    const missing = auditSlackManifest(after.manifest, manifest)
+    return {
+      provider: 'slack' as const,
+      status: missing.length === 0 ? ('pass' as const) : ('fail' as const),
+      applied: before.filter((id) => !missing.includes(id)),
+      missing,
+      diff: diffSlackManifest(after.manifest, manifest).map(({ field, current, expected }) => ({
+        field,
+        current,
+        expected
+      })),
+      // Scopes changed ⇒ every workspace must reinstall to pick them up; Slack says so on the update.
+      permissionsUpdated: updated.permissionsUpdated,
+      settingsUrl,
       restartRequired: false as const
     }
   })

--- a/packages/setup/src/slack-app.ts
+++ b/packages/setup/src/slack-app.ts
@@ -152,6 +152,45 @@ export function diffSlackManifest(actual: SlackManifest, expected: SlackManifest
   return diff
 }
 
+/** `actual` with every field `diffSlackManifest` inspects brought to `expected`, everything else kept, so reconcile-then-diff is empty. */
+export function reconcileSlackManifest(actual: SlackManifest, expected: SlackManifest): SlackManifest {
+  const actualOauth = asRecord(actual.oauth_config)
+  const expectedOauth = asRecord(expected.oauth_config)
+  const actualScopes = asRecord(actualOauth.scopes)
+  const expectedScopes = asRecord(expectedOauth.scopes)
+  const actualSettings = asRecord(actual.settings)
+  const expectedSettings = asRecord(expected.settings)
+  const actualEvents = asRecord(actualSettings.event_subscriptions)
+  const expectedEvents = asRecord(expectedSettings.event_subscriptions)
+  const actualInteractivity = asRecord(actualSettings.interactivity)
+  const expectedInteractivity = asRecord(expectedSettings.interactivity)
+  const union = (current: unknown, required: unknown) => [...new Set([...asStrings(current), ...asStrings(required)])]
+  const urlOf = (value: unknown, key: string) => (typeof value === 'string' ? { [key]: value } : {})
+  return {
+    ...actual,
+    oauth_config: {
+      ...actualOauth,
+      // The redirect list is fully managed (the diff wants set equality); scopes and events are additive.
+      redirect_urls: asStrings(expectedOauth.redirect_urls),
+      scopes: { ...actualScopes, bot: union(actualScopes.bot, expectedScopes.bot) }
+    },
+    settings: {
+      ...actualSettings,
+      event_subscriptions: {
+        ...actualEvents,
+        bot_events: union(actualEvents.bot_events, expectedEvents.bot_events),
+        ...urlOf(expectedEvents.request_url, 'request_url')
+      },
+      interactivity: {
+        ...actualInteractivity,
+        ...urlOf(expectedInteractivity.request_url, 'request_url'),
+        ...urlOf(expectedInteractivity.message_menu_options_url, 'message_menu_options_url')
+      },
+      socket_mode_enabled: expectedSettings.socket_mode_enabled
+    }
+  }
+}
+
 /** Returns stable field names only; it never includes provider response values. */
 export function auditSlackManifest(actual: SlackManifest, expected: SlackManifest): string[] {
   return diffSlackManifest(actual, expected).map((item) => item.id)

--- a/packages/setup/test/slack-manifest-reconcile.test.ts
+++ b/packages/setup/test/slack-manifest-reconcile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { buildInstallManifest } from '@agentconnect.md/control-plane/slack-manifest'
+import { diffSlackManifest, reconcileSlackManifest } from '../src/slack-app.js'
+
+const expected = buildInstallManifest(
+  'AgentConnect',
+  'https://api.example.test/v1/integrations/slack/platform/callback',
+  {
+    httpRelayBase: 'https://relay.example.test',
+    additionalRedirectUrls: [
+      'https://auth.example.test/callback/slack',
+      'https://console.example.test/auth/social/callback'
+    ]
+  }
+)
+
+/** A deployment app created by an older release: fewer scopes and events, Socket Mode, a hand-edited description. */
+const stale = {
+  display_information: { name: 'AgentConnect Test', description: 'hand-written, keep me' },
+  features: { bot_user: { display_name: 'AgentConnect Test', always_online: true } },
+  oauth_config: {
+    redirect_urls: ['https://api.example.test/v1/integrations/slack/platform/callback'],
+    scopes: { bot: ['chat:write', 'channels:history', 'not:required'], user: ['openid', 'email', 'profile'] }
+  },
+  settings: {
+    event_subscriptions: { bot_events: ['app_mention'], request_url: 'https://old.example.test/slack/events' },
+    interactivity: { is_enabled: true, request_url: 'https://old.example.test/slack/interactions' },
+    socket_mode_enabled: true
+  }
+}
+
+describe('reconcileSlackManifest', () => {
+  it('brings every field the check inspects to the expected value and keeps the rest', () => {
+    const reconciled = reconcileSlackManifest(stale, expected)
+
+    expect(diffSlackManifest(reconciled, expected)).toEqual([])
+    const display = reconciled.display_information as Record<string, unknown>
+    expect(display.description).toBe('hand-written, keep me')
+    const scopes = (reconciled.oauth_config as { scopes: { bot: string[]; user: string[] } }).scopes
+    // Additive: the extra bot scope and the sign-in user scopes survive.
+    expect(scopes.bot).toContain('not:required')
+    expect(scopes.user).toEqual(['openid', 'email', 'profile'])
+    const settings = reconciled.settings as { socket_mode_enabled: boolean; interactivity: { is_enabled: boolean } }
+    expect(settings.socket_mode_enabled).toBe(false)
+    expect(settings.interactivity.is_enabled).toBe(true)
+  })
+
+  it('is a no-op on a manifest that already matches', () => {
+    expect(diffSlackManifest(expected, expected)).toEqual([])
+    expect(reconcileSlackManifest(expected, expected)).toEqual(expected)
+  })
+})

--- a/packages/setup/test/slack-reconcile.route.test.ts
+++ b/packages/setup/test/slack-reconcile.route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * `POST /api/v1/reconcile/slack`: the write-side twin of `check/slack`. The deployment
+ * Slack App keeps the scope set it was created with while `SLACK_BOT_SCOPES` grows; this
+ * route brings the app's manifest to the expected one with the caller's config token.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import {
+  DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
+  type DeploymentConfigStore,
+  type DeploymentConfigValuesV1
+} from '@agentconnect.md/control-plane/deployment-config-store'
+import type {
+  SlackManifestExportResult,
+  SlackManifestUpdateResult
+} from '@agentconnect.md/control-plane/slack-config-api'
+import { buildSetupServer } from '../src/server/index.js'
+
+const STALE_MANIFEST = {
+  display_information: { name: 'AgentConnect Test', description: 'keep me' },
+  oauth_config: {
+    redirect_urls: ['https://api.example.test/v1/integrations/slack/platform/callback'],
+    scopes: { bot: ['chat:write', 'channels:history'], user: ['openid', 'email', 'profile'] }
+  },
+  settings: {
+    event_subscriptions: { bot_events: ['app_mention'], request_url: 'https://relay.example.test/slack/events' },
+    interactivity: { is_enabled: true, request_url: 'https://relay.example.test/slack/interactions' },
+    socket_mode_enabled: false
+  }
+}
+
+/** Slack's manifest store, in memory: export reads it, update replaces it. */
+class FakeSlackConfigApi {
+  manifest: Record<string, unknown> = structuredClone(STALE_MANIFEST)
+  updates: Record<string, unknown>[] = []
+  exportCalls: string[] = []
+  async createApp() {
+    return { ok: false as const, error: 'unused' }
+  }
+  async exportApp(configToken: string): Promise<SlackManifestExportResult> {
+    this.exportCalls.push(configToken)
+    return { ok: true, manifest: this.manifest }
+  }
+  async updateApp(_token: string, _appId: string, manifest: unknown): Promise<SlackManifestUpdateResult> {
+    this.updates.push(manifest as Record<string, unknown>)
+    this.manifest = manifest as Record<string, unknown>
+    return { ok: true, permissionsUpdated: true }
+  }
+}
+
+let running: FastifyInstance | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+function server(values: DeploymentConfigValuesV1): { app: FastifyInstance; slack: FakeSlackConfigApi } {
+  const admin = {
+    schemaVersion: 1 as const,
+    revision: 4,
+    values,
+    secrets: [] as { key: string; configured: boolean; fingerprint: string | null; updatedAt: Date | null }[],
+    adminClaimedFor: null,
+    updatedAt: new Date('2026-09-01T00:00:00.000Z')
+  }
+  const store = {
+    getAdmin: async () => admin,
+    getRuntime: async () => null,
+    markAdminClaimed: async () => {}
+  } as unknown as DeploymentConfigStore
+  const slack = new FakeSlackConfigApi()
+  const app = buildSetupServer({
+    store,
+    publicUrl: 'http://localhost:8091',
+    slackConfigApi: slack,
+    localAuthBootstrap: {
+      issuer: 'https://auth.example.test',
+      services: {
+        web: 'https://console.example.test',
+        controlPlane: 'https://api.example.test',
+        relay: 'https://relay.example.test'
+      }
+    }
+  })
+  running = app
+  return { app, slack }
+}
+
+const CONFIGURED: DeploymentConfigValuesV1 = {
+  ...DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1,
+  slack: { appId: 'A0DEPLOY', clientId: '1.1' }
+}
+
+const reconcile = (app: FastifyInstance, configToken = 'xoxe.xoxp-temporary') =>
+  app.inject({ method: 'POST', url: '/api/v1/reconcile/slack', payload: { configToken } })
+
+describe('POST /api/v1/reconcile/slack', () => {
+  it('applies the diff the check reports, keeps user-owned fields, and re-reads the result', async () => {
+    const { app, slack } = server(CONFIGURED)
+
+    const res = await reconcile(app)
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { status: string; applied: string[]; missing: string[]; permissionsUpdated: boolean }
+    expect(body.status).toBe('pass')
+    expect(body.missing).toEqual([])
+    expect(body.applied).toEqual(expect.arrayContaining(['scope:lists:read', 'scope:im:read', 'event:message.im']))
+    expect(body.permissionsUpdated).toBe(true)
+    expect(slack.updates).toHaveLength(1)
+    const submitted = slack.updates[0]!
+    expect((submitted.display_information as { description: string }).description).toBe('keep me')
+    expect((submitted.oauth_config as { scopes: { user: string[] } }).scopes.user).toEqual([
+      'openid',
+      'email',
+      'profile'
+    ])
+    // Export before the write and again after it: the answer is what Slack kept.
+    expect(slack.exportCalls).toEqual(['xoxe.xoxp-temporary', 'xoxe.xoxp-temporary'])
+    // The token never reaches the browser.
+    expect(JSON.stringify(body)).not.toContain('xoxe')
+  })
+
+  it('writes nothing when the app already matches', async () => {
+    const { app, slack } = server(CONFIGURED)
+    await reconcile(app)
+    slack.updates = []
+
+    const res = await reconcile(app)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ status: 'pass', applied: [], permissionsUpdated: false })
+    expect(slack.updates).toEqual([])
+  })
+
+  it('needs a config token and a configured deployment app', async () => {
+    const { app, slack } = server(CONFIGURED)
+    expect((await app.inject({ method: 'POST', url: '/api/v1/reconcile/slack', payload: {} })).statusCode).toBe(400)
+    expect(slack.updates).toEqual([])
+
+    const bare = server(DEFAULT_DEPLOYMENT_CONFIG_VALUES_V1)
+    expect((await reconcile(bare.app)).statusCode).toBe(409)
+    expect(bare.slack.updates).toEqual([])
+  })
+})

--- a/packages/web/src/components/console/platforms/slack/refresh-notice.test.ts
+++ b/packages/web/src/components/console/platforms/slack/refresh-notice.test.ts
@@ -4,6 +4,7 @@ import { slackManifestScopeFragment, slackRefreshNoticeState } from './refresh-n
 
 const refreshResult = (overrides: Partial<SlackBotRefreshDto> = {}): SlackBotRefreshDto => ({
   manifest: 'synced',
+  manifestMissingScopes: [],
   authorization: 'current',
   rejection: null,
   missingScopes: [],
@@ -68,6 +69,50 @@ describe('slackRefreshNoticeState', () => {
         label: 'Open App Manifest'
       },
       scopeFragment: '"chat:write.customize",\n"lists:read",'
+    })
+  })
+
+  it('sends a built-in app with a short grant to the platform reinstall, claiming nothing about its manifest', () => {
+    expect(
+      slackRefreshNoticeState(
+        refreshResult({
+          manifest: 'manual_update_required',
+          authorization: 'reinstall_required',
+          missingScopes: ['lists:read']
+        }),
+        { builtin: true }
+      )
+    ).toMatchObject({
+      needsAttention: true,
+      message: 'Reinstall the workspace to grant the missing scopes.',
+      action: {
+        href: 'https://api.slack.com/apps/A0123/install-on-team?',
+        label: 'Reinstall workspace'
+      },
+      scopeFragment: null
+    })
+  })
+
+  it('flags a built-in app whose manifest lacks required scopes, with the list to paste and the Setup Server as the fix', () => {
+    expect(
+      slackRefreshNoticeState(
+        refreshResult({
+          manifest: 'deployment_update_required',
+          manifestMissingScopes: ['im:read', 'lists:read'],
+          authorization: 'reinstall_required',
+          missingScopes: ['lists:read']
+        }),
+        { builtin: true }
+      )
+    ).toMatchObject({
+      needsAttention: true,
+      message:
+        "This app's manifest is missing scopes AgentConnect requires. Update it from the Setup Server (Slack → Apply update), or paste the copied list into oauth_config.scopes.bot in the App Manifest editor, then reinstall the workspace.",
+      action: {
+        href: 'https://app.slack.com/app-settings/T0123/A0123/app-manifest',
+        label: 'Open App Manifest'
+      },
+      scopeFragment: '"im:read",\n"lists:read",'
     })
   })
 

--- a/packages/web/src/components/console/platforms/slack/refresh-notice.ts
+++ b/packages/web/src/components/console/platforms/slack/refresh-notice.ts
@@ -23,16 +23,23 @@ export function slackManifestScopeFragment(scopes: readonly string[]): string {
  * uncertainty into a persistent warning. Explicit manifest failures remain
  * actionable, and authorization failures always take priority over manifest UI.
  */
-export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefreshNoticeState {
-  const needsAttention = result.authorization !== 'current' || result.manifest === 'unknown'
+export function slackRefreshNoticeState(
+  result: SlackBotRefreshDto,
+  // A built-in app's manifest is the deployment's: its short grant is fixed by the platform reinstall, never by hand.
+  { builtin = false }: { builtin?: boolean } = {}
+): SlackRefreshNoticeState {
+  const deploymentStale = result.manifest === 'deployment_update_required'
+  const needsAttention = result.authorization !== 'current' || result.manifest === 'unknown' || deploymentStale
   // A short grant we could not sync is fixed in Slack's MANIFEST editor: the OAuth picker hides scopes by plan, the manifest takes them all.
-  const manualScopes = result.authorization === 'reinstall_required' && result.manifest !== 'synced'
+  const manualScopes = !builtin && result.authorization === 'reinstall_required' && result.manifest !== 'synced'
   let action: SlackRefreshNoticeState['action'] = null
 
   if (result.authorization === 'invalid') {
     action = { href: result.reinstallUrl, label: 'Reinstall workspace' }
   } else if (result.authorization === 'app_mismatch') {
     action = { href: result.settingsUrl, label: 'Open Slack' }
+  } else if (deploymentStale) {
+    action = { href: result.manifestUrl, label: 'Open App Manifest' }
   } else if (result.authorization === 'reinstall_required') {
     action = manualScopes
       ? { href: result.manifestUrl, label: 'Open App Manifest' }
@@ -52,6 +59,12 @@ export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefres
     message = `Slack rejected the stored bot token (${result.rejection ?? 'invalid'}). Reinstall the app if needed, then recreate this integration with the current Bot User OAuth Token.`
   } else if (result.authorization === 'app_mismatch') {
     message = 'The stored bot token belongs to a different Slack app. Recreate this integration with matching tokens.'
+  } else if (deploymentStale) {
+    message = `This app's manifest is missing scopes AgentConnect requires. Update it from the Setup Server (Slack → Apply update), or paste the copied list into oauth_config.scopes.bot in the App Manifest editor${
+      result.authorization === 'reinstall_required' ? ', then reinstall the workspace' : ''
+    }.`
+  } else if (result.authorization === 'reinstall_required' && builtin) {
+    message = 'Reinstall the workspace to grant the missing scopes.'
   } else if (result.authorization === 'reinstall_required' && !manualScopes) {
     message = 'Slack app configuration is synced. Reinstall it to grant the missing scopes.'
   } else if (result.authorization === 'reinstall_required') {
@@ -71,7 +84,10 @@ export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefres
     needsAttention,
     message,
     action,
-    scopeFragment:
-      manualScopes && result.missingScopes.length > 0 ? slackManifestScopeFragment(result.missingScopes) : null
+    scopeFragment: manualScopes
+      ? slackManifestScopeFragment(result.missingScopes)
+      : deploymentStale
+        ? slackManifestScopeFragment(result.manifestMissingScopes)
+        : null
   }
 }

--- a/packages/web/src/components/console/platforms/slack/settings.tsx
+++ b/packages/web/src/components/console/platforms/slack/settings.tsx
@@ -211,7 +211,9 @@ function SlackRowActions({ bot, canWrite }: { bot: BotDto; canWrite: boolean }) 
   const card = useSlackBotCard()
   if (!bot.slackAppId || !canWrite) return null
   const entry = card.entryFor(bot.id)
-  const needsAttention = entry?.result ? slackRefreshNoticeState(entry.result).needsAttention : false
+  const needsAttention = entry?.result
+    ? slackRefreshNoticeState(entry.result, { builtin: bot.prebuilt }).needsAttention
+    : false
   const refreshing = card.refreshingBot(bot.id)
   return (
     <button
@@ -267,7 +269,12 @@ function SlackRefreshNotice({
   reinstalling?: boolean
   onReinstall?: () => void
 }) {
-  const { needsAttention, message: defaultMessage, action, scopeFragment } = slackRefreshNoticeState(result)
+  const {
+    needsAttention,
+    message: defaultMessage,
+    action,
+    scopeFragment
+  } = slackRefreshNoticeState(result, { builtin })
   const [copied, setCopied] = useState(false)
   const message =
     builtin && result.authorization === 'invalid'
@@ -294,6 +301,9 @@ function SlackRefreshNotice({
     >
       <span className="min-w-0">
         <span>{message}</span>
+        {result.manifestMissingScopes.length > 0 && (
+          <span className="mono ml-1 text-[11px]">Manifest missing: {result.manifestMissingScopes.join(', ')}</span>
+        )}
         {result.missingScopes.length > 0 && (
           <span className="mono ml-1 text-[11px]">Missing: {result.missingScopes.join(', ')}</span>
         )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -924,7 +924,10 @@ export interface BotDto {
 }
 
 export interface SlackBotRefreshDto {
-  manifest: 'synced' | 'manual_update_required' | 'unknown'
+  /** `deployment_update_required`: a built-in app's manifest, audited read-only, lacks required scopes; the Setup Server fixes it. */
+  manifest: 'synced' | 'manual_update_required' | 'deployment_update_required' | 'unknown'
+  /** The required bot scopes the manifest does not declare (`deployment_update_required` only). */
+  manifestMissingScopes: string[]
   authorization: 'current' | 'reinstall_required' | 'invalid' | 'app_mismatch' | 'unknown'
   /** Slack's own code behind `invalid` (`invalid_auth`, `token_revoked`, …); null otherwise. */
   rejection: string | null


### PR DESCRIPTION
## What

The deployment (built-in) Slack app keeps the scope set it was created with while `SLACK_BOT_SCOPES` grows with releases, and nothing brought the two back together: the Setup Server's `check/slack` could show the drift but not fix it, and the console hard-coded a built-in bot's manifest as `synced`, so the Integrations page read "configuration up to date" against an app whose OAuth & Permissions page declared half the required scopes. A workspace reinstall from the console still granted everything (the authorize URL names every scope), but any Slack-side reinstall grants only the stale declared set.

## How

- **Setup Server**: `POST /api/v1/reconcile/slack` applies exactly the diff `check/slack` reports — scopes and events additive, managed redirect/request URLs and Socket Mode set to the expected values — with the same temporary configuration token, then re-reads the app so the answer is what Slack kept. The Slack panel gets an "Apply update" button beside "Check match" and says when workspaces must reinstall (`permissions_updated`).
- **Control plane**: the Settings→Bots refresh now AUDITS a built-in app's manifest read-only when the caller's config token can export it: `manifest: 'deployment_update_required'` with `manifestMissingScopes` when required scopes are undeclared, `synced` only when verified. It never writes the deployment app. Unverified stays `manual_update_required`, which claims nothing (the notice already renders that as "workspace permissions match").
- **Console**: a built-in bot's notice points at the Setup Server for a stale manifest, with the undeclared scopes copyable as a paste-ready block as the fallback, and sends its short grant to the platform reinstall rather than the manual manifest path.

## Tests
- Setup: `reconcileSlackManifest` reconcile-then-diff is empty and keeps user-owned fields (description, user scopes, extra bot scopes); the route applies, re-reads, writes nothing when matching, and refuses without a token or a configured app.
- CP integration: a built-in app's manifest is audited with the undeclared scopes listed and never updated; `synced` only on a full declaration; no claim without a config token.
- Web: reducer cases for the built-in reinstall path and the stale-deployment state.

Follows #1864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
