### PR TITLE
fix(daemon): sanitize reference-style file links in replies

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -139,6 +139,12 @@ agent finishes the text block (a tool call, a plan, a thinking step), or until t
 ends. Splits the reader already expects — a completed text block before the agent starts
 working, or a body longer than the platform's per-message limit — are unaffected.
 
+A Markdown reference can depend on a link definition near the end of the same text
+block. Once a paragraph contains a reference, a definition, or bracketed text that could
+become a reference, it and the following text stay together until the agent finishes that
+text block. Earlier paragraphs continue streaming normally, including in live previews,
+so an incomplete link definition cannot expose a local file target before it is resolved.
+
 ## A cold sandbox pod is announced, not waited out in silence
 
 A turn whose agent runs in the cluster and has no pod up yet must first claim (or resume) a

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -65,6 +65,7 @@
     "discord.js": "^14.27.0",
     "fflate": "^0.8.3",
     "grammy": "^1.45.1",
+    "mdast-util-from-markdown": "^2.0.3",
     "pg": "^8.22.0",
     "simple-git": "^3.36.0",
     "skills": "1.5.21",
@@ -78,6 +79,7 @@
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^12.0.4",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^24.13.3",
     "@types/pg": "^8.20.0",
     "@types/ws": "^8.18.1",

--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -1,6 +1,6 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
-import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -330,17 +330,18 @@ export class DiscordConverger {
    *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
    *  dropped and replaced by the generic failure notice. */
   flushTerminal(): DiscordAction[] {
-    if (this.mode === 'minimal') return this.liveRefresh()
+    if (this.mode === 'minimal') return this.liveRefresh(true)
     return [...this.drainReasoning(), ...this.flush()]
   }
 
   /** minimal: refresh the single in-place `live-reply` with the current segment. */
-  private liveRefresh(): DiscordAction[] {
+  private liveRefresh(complete = false): DiscordAction[] {
     const trimmed = this.buf.trim()
-    // Hold the live reply while the body could still be the bare response-control marker, so a
-    // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
+    // A partial response-control marker must not flash in the live reply before onFinal drops it.
     if (!trimmed || isNoResponsePrefix(trimmed)) return []
-    return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
+    const raw = complete ? this.buf : this.buf.slice(0, referenceBufferStart(this.buf))
+    const text = flattenUnsafeLinks(raw)
+    return text.trim() ? [{ kind: 'live-reply', text: this.liveDisplay(text) }] : []
   }
 
   /** minimal: a Discord message caps at 2000 chars; head-clamp the live view when longer
@@ -361,6 +362,7 @@ export class DiscordConverger {
     if (isNoResponsePrefix(this.buf.trim())) return []
     const text = flattenUnsafeLinks(this.buf)
     this.recordDirty = false
+    if (!text.trim()) return []
     return [
       { kind: 'live-reply', text: this.liveDisplay(text) },
       ...chunkForDiscord(text, DISCORD_MESSAGE_LIMIT).map(
@@ -372,7 +374,8 @@ export class DiscordConverger {
   private drainReasoning(): DiscordAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
-    return [{ kind: 'reasoning', text: renderReasoning(flattenUnsafeLinks(this.reasoningBuf)) }]
+    const text = flattenUnsafeLinks(this.reasoningBuf)
+    return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text) }] : []
   }
 
   private flush(): DiscordAction[] {
@@ -405,6 +408,7 @@ export class DiscordConverger {
 
   private emitBody(raw: string): DiscordAction[] {
     const text = flattenUnsafeLinks(raw)
+    if (!text.trim()) return []
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` runs before
     // the connection check, so it lands even though replyConn is unset for this mode.
     const recordOnly = this.mode === 'none'

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -1,7 +1,7 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import type { WireFeishuCardActionTarget } from '@agentconnect.md/protocol'
 import { AgentMessageRun } from '../messages/message-boundary.js'
-import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 import { extractToolOutput } from '../session/tool-output.js'
@@ -427,20 +427,25 @@ export class FeishuConverger {
 
   /** Whether a newer safe answer snapshot is ready for the periodic CardKit stream timer. */
   hasStreamingUpdate(): boolean {
-    const trimmed = this.cardText.trim()
-    return (
-      this.mode !== 'none' &&
-      trimmed.length > 0 &&
-      !isNoResponsePrefix(trimmed) &&
-      this.cardText !== this.lastStreamText
-    )
+    const text = this.cardSnapshot()
+    return text.trim().length > 0 && text !== this.lastStreamText
+  }
+
+  /** A timed preview holds reference-bearing blocks; completed messages release the whole snapshot. */
+  private cardSnapshot(complete = false): string {
+    const held = complete ? undefined : referenceBufferStart(this.buf)
+    // The pending buffer is the raw card's suffix; previously completed messages remain visible.
+    const raw =
+      held === undefined ? this.cardText : this.cardText.slice(0, this.cardText.length - this.buf.length + held)
+    return this.mode === 'none' || isNoResponsePrefix(raw.trim()) ? '' : flattenUnsafeLinks(raw)
   }
 
   /** Return one cumulative CardKit element update and mark that snapshot as emitted. */
-  streamUpdate(): FeishuAction[] {
-    if (!this.hasStreamingUpdate()) return []
-    this.lastStreamText = this.cardText
-    return [{ kind: 'card-stream', text: flattenUnsafeLinks(this.cardText) }]
+  streamUpdate(complete = false): FeishuAction[] {
+    const text = this.cardSnapshot(complete)
+    if (!text.trim() || text === this.lastStreamText) return []
+    this.lastStreamText = text
+    return [{ kind: 'card-stream', text }]
   }
 
   /** Idle-timer flush: update the answer card, record the buffered body, and drain
@@ -455,11 +460,12 @@ export class FeishuConverger {
    * stays one message and is replaced with the next answer segment after a tool boundary. */
   private closeSegment(includeStream = true): FeishuAction[] {
     this.segmentReset = true
-    const stream = includeStream ? this.streamUpdate() : []
+    const stream = includeStream ? this.streamUpdate(true) : []
     if (!this.recordDirty || !this.buf.trim()) return stream
     if (isNoResponsePrefix(this.buf.trim())) return []
     const text = flattenUnsafeLinks(this.buf)
     this.recordDirty = false
+    if (!text.trim()) return stream
     return [
       ...stream,
       ...chunkForFeishu(text, FEISHU_MESSAGE_LIMIT).map(
@@ -471,25 +477,29 @@ export class FeishuConverger {
   private drainReasoning(): FeishuAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
-    return [{ kind: 'reasoning', text: renderReasoning(flattenUnsafeLinks(this.reasoningBuf)) }]
+    const text = flattenUnsafeLinks(this.reasoningBuf)
+    return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text) }] : []
   }
 
-  /** Record one non-minimal body window. A semantic boundary starts the next answer
-   * chunk on a fresh paragraph inside the same card; an idle flush does not. */
+  /** Record a body window, keeping reference-bearing blocks together until a semantic boundary. */
   private flush(boundary: boolean, includeStream = true): FeishuAction[] {
     const trimmed = this.buf.trim()
     if (!trimmed) {
       this.buf = ''
       if (!this.cardText.trim()) this.cardText = ''
       if (boundary && this.cardText.trim()) this.cardBoundary = true
-      return includeStream ? this.streamUpdate() : []
+      return includeStream ? this.streamUpdate(boundary) : []
     }
     if (isNoResponsePrefix(trimmed)) return []
-    const text = flattenUnsafeLinks(this.buf)
-    this.buf = ''
+    const cut = boundary ? this.buf.length : (referenceBufferStart(this.buf) ?? this.buf.length)
+    if (cut === 0) return includeStream ? this.streamUpdate(boundary) : []
+    const text = flattenUnsafeLinks(this.buf.slice(0, cut))
+    this.buf = this.buf.slice(cut)
     if (boundary) this.cardBoundary = true
+    const stream = includeStream ? this.streamUpdate(boundary) : []
+    if (!text.trim()) return stream
     return [
-      ...(includeStream ? this.streamUpdate() : []),
+      ...stream,
       ...chunkForFeishu(text, FEISHU_MESSAGE_LIMIT).map(
         (t) => ({ kind: 'post', text: t, recordOnly: true }) as FeishuAction
       )
@@ -618,7 +628,7 @@ export class FeishuConverger {
       return this.mode === 'none' ? [] : [{ kind: 'card-cancel' }]
     }
     const actions =
-      this.mode === 'minimal' ? this.closeSegment(false) : [...this.drainReasoning(), ...this.flush(false, false)]
+      this.mode === 'minimal' ? this.closeSegment(false) : [...this.drainReasoning(), ...this.flush(true, false)]
     if (this.mode === 'none') return actions
     if (!display) return [...actions, { kind: 'card-cancel' }]
     this.cardText = display
@@ -641,7 +651,7 @@ export class FeishuConverger {
     const covered = display.includes(reason)
     const finalText = covered ? this.cardText : display ? `${this.cardText}\n\n${notice}` : notice
     const actions =
-      this.mode === 'minimal' ? this.closeSegment(false) : [...this.drainReasoning(), ...this.flush(false, false)]
+      this.mode === 'minimal' ? this.closeSegment(false) : [...this.drainReasoning(), ...this.flush(true, false)]
     if (!covered) actions.push({ kind: 'post', text: notice, recordOnly: true })
     if (this.mode === 'none') return actions
     this.cardText = finalText

--- a/packages/daemon/src/messages/agent-links.ts
+++ b/packages/daemon/src/messages/agent-links.ts
@@ -33,8 +33,13 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
     let content = ''
     let label = ''
     if ('children' in node) {
-      for (const child of node.children) {
-        const rendered = render(child)
+      const children = node.children.map((child) => ({ child, rendered: render(child) }))
+      const changed = children.some(
+        ({ child, rendered }) => rendered !== text.slice(child.position!.start.offset!, child.position!.end.offset!)
+      )
+      for (const { child, rendered: result } of children) {
+        // Literal syntax beside a rewritten link must not become an active outer link on the platform.
+        const rendered = changed && child.type === 'text' ? escapeLiteralOpeners(result) : result
         content += text.slice(cursor, child.position!.start.offset!) + rendered
         label += rendered
         cursor = child.position!.end.offset!
@@ -57,6 +62,11 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
     return visible ? `${visible} (${inlineCode(display)})` : inlineCode(display)
   }
   return render(tree)
+}
+
+/** Preserve existing escapes while keeping literal bracket and autolink openers inert. */
+function escapeLiteralOpeners(text: string): string {
+  return text.replace(/\\.|[<[]/g, (token) => (token.length === 1 ? `\\${token}` : token))
 }
 
 /** Hold a whole Markdown block when later definitions could still change its references. */

--- a/packages/daemon/src/messages/agent-links.ts
+++ b/packages/daemon/src/messages/agent-links.ts
@@ -39,7 +39,7 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
       )
       for (const { child, rendered: result } of children) {
         // Literal syntax beside a rewritten link must not become an active outer link on the platform.
-        const rendered = changed && child.type === 'text' ? escapeLiteralOpeners(result) : result
+        const rendered = changed && child.type === 'text' ? escapeLiteralLinkSyntax(result) : result
         content += text.slice(cursor, child.position!.start.offset!) + rendered
         label += rendered
         cursor = child.position!.end.offset!
@@ -64,9 +64,9 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
   return render(tree)
 }
 
-/** Preserve existing escapes while keeping literal bracket and autolink openers inert. */
-function escapeLiteralOpeners(text: string): string {
-  return text.replace(/\\.|[<[]/g, (token) => (token.length === 1 ? `\\${token}` : token))
+/** Escape both bracket sides so literal text cannot open or prematurely close a surrounding link. */
+function escapeLiteralLinkSyntax(text: string): string {
+  return text.replace(/\\.|[<[\]]/g, (token) => (token.length === 1 ? `\\${token}` : token))
 }
 
 /** Hold a whole Markdown block when later definitions could still change its references. */

--- a/packages/daemon/src/messages/agent-links.ts
+++ b/packages/daemon/src/messages/agent-links.ts
@@ -1,65 +1,73 @@
-// A runtime links a file it wrote by its absolute path, clickable in its own UI and nowhere else.
-// Delivered as a link that names the daemon's filesystem layout, it is what `startFailureDetail`
-// already refuses to do for refusal text — so flatten any target a reader could not follow.
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import type { Definition, Nodes } from 'mdast'
 
-// Only these reach a reader as a working link; every other target is flattened to text.
 const WEB_SCHEME = /^(?:https?|mailto):/i
-// An in-document anchor has nothing to jump to in a chat message, so it flattens to its label alone.
-const FRAGMENT = /^#/
-// Host-absolute in both shapes the daemon runs on, plus the `file://` form of the POSIX one.
-const HOST_ABSOLUTE = /^(?:\/|[A-Za-z]:[\\/]|file:\/\/)/
-// A label carries one level of balanced brackets so an image link — `[![alt](img)](target)`, the
-// shape a runtime uses to link the chart it just wrote — matches as ONE link, target included.
-const LABEL = String.raw`(?:[^\[\]]|\[[^\[\]]*\])*`
-// `[label](dest)` / `![alt](src)`, with the optional CommonMark title and `<dest>` bracket form.
-const LINK = String.raw`(!?)\[(${LABEL})\]\(\s*(<[^<>]*>|[^()\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^()]*\)))?\s*\)`
-// A fence opens or closes on a line whose first non-space run is >= 3 backticks or tildes.
-const FENCE = /^[ \t]*(`{3,}|~{3,})/
+const HOST_ABSOLUTE = /^(?:[\\/]|[A-Za-z]:[\\/]|file:)/i
 
 export interface FlattenOptions {
   /** Keep a relative target linked: a code host resolves it against the repository, chat cannot. */
   resolvesRelativeTargets?: boolean
 }
 
-/** Rewrite every link outside code so a target the reader cannot follow survives as text. */
+/** Rewrite unsafe link targets without reformatting the rest of the Markdown source. */
 export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): string {
-  if (!text.includes('](')) return text
-  // Built per call, not shared: the label pass below recurses, and a nested `replace` on one
-  // global regex would move the `lastIndex` the outer iteration is still walking.
-  const link = new RegExp(LINK, 'g')
-  return mapOutsideCode(text, (segment) => {
-    const spans = codeSpanRanges(segment)
-    return segment.replace(link, (whole, bang: string, label: string, rawDest: string, offset: number) => {
-      // A code span is skipped only when the link OPENS inside it — that is a sample of this syntax.
-      // A span the link merely contains is its LABEL, and a label never shields its own target.
-      if (spans.some(([start, end]) => offset >= start && offset < end)) return whole
-      // A label may itself hold a link, whose target is no safer for sitting inside another's.
-      const flatLabel = flattenUnsafeLinks(label, opts)
-      // A kept link keeps its own syntax; only its label changes, and `[label]` opens the match. The
-      // replacement is a FUNCTION: a string one is still scanned for `$&` and friends, and a label is
-      // agent-authored — `$&` there would re-emit the raw match, target unflattened.
-      const kept = (): string => (flatLabel === label ? whole : whole.replace(`[${label}]`, () => `[${flatLabel}]`))
-      const dest = rawDest.startsWith('<') ? rawDest.slice(1, -1).trim() : rawDest
-      if (WEB_SCHEME.test(dest)) return kept()
-      if (opts.resolvesRelativeTargets && !HOST_ABSOLUTE.test(dest)) return kept()
-      const display = FRAGMENT.test(dest) ? '' : HOST_ABSOLUTE.test(dest) ? basename(dest) : dest
-      // An image's alt text describes a picture nobody will see, so only its target survives.
-      const visible = bang ? '' : flatLabel
-      if (!display || visible.includes(display)) return visible || `\`${display}\``
-      return visible ? `${visible} (\`${display}\`)` : `\`${display}\``
-    })
-  })
+  if (!text.includes('[') && !text.includes('<')) return text
+  const tree = fromMarkdown(text)
+  const definitions = new Map<string, Definition>()
+  const index = (node: Nodes): void => {
+    // CommonMark resolves every reference against the first definition with that identifier.
+    if (node.type === 'definition' && !definitions.has(node.identifier)) definitions.set(node.identifier, node)
+    if ('children' in node) node.children.forEach(index)
+  }
+  index(tree)
+
+  const keeps = (url: string): boolean =>
+    WEB_SCHEME.test(url) || (opts.resolvesRelativeTargets === true && !HOST_ABSOLUTE.test(url))
+
+  const render = (node: Nodes): string => {
+    const start = node.position!.start.offset!
+    const end = node.position!.end.offset!
+    if (node.type === 'definition') return keeps(node.url) ? text.slice(start, end) : ''
+
+    let cursor = start
+    let content = ''
+    let label = ''
+    if ('children' in node) {
+      for (const child of node.children) {
+        const rendered = render(child)
+        content += text.slice(cursor, child.position!.start.offset!) + rendered
+        label += rendered
+        cursor = child.position!.end.offset!
+      }
+    }
+    content += text.slice(cursor, end)
+
+    const target =
+      node.type === 'link' || node.type === 'image'
+        ? node
+        : node.type === 'linkReference' || node.type === 'imageReference'
+          ? definitions.get(node.identifier)
+          : undefined
+    if (!target || keeps(target.url)) return content
+
+    const display = target.url.startsWith('#') ? '' : HOST_ABSOLUTE.test(target.url) ? basename(target.url) : target.url
+    // Images have no useful visible label here; an autolink's label is the unsafe target itself.
+    const visible = (node.type === 'link' && text[start] === '[') || node.type === 'linkReference' ? label : ''
+    if (!display || visible.includes(display)) return visible || inlineCode(display)
+    return visible ? `${visible} (${inlineCode(display)})` : inlineCode(display)
+  }
+  return render(tree)
 }
 
-/** Where each inline code span sits in one prose run, as [start, end) offsets. */
-function codeSpanRanges(prose: string): Array<[number, number]> {
-  if (!prose.includes('`')) return []
-  const ranges: Array<[number, number]> = []
-  const span = /`+[^`]*`+/g
-  for (let match = span.exec(prose); match; match = span.exec(prose)) {
-    ranges.push([match.index, match.index + match[0].length])
+/** Hold a whole Markdown block when later definitions could still change its references. */
+export function referenceBufferStart(text: string): number | undefined {
+  if (!text.includes('[')) return undefined
+  const needsDefinitions = (node: Nodes): boolean => {
+    if (node.type === 'definition' || node.type === 'linkReference' || node.type === 'imageReference') return true
+    if (node.type === 'text') return node.value.includes('[')
+    return 'children' in node && node.children.some(needsDefinitions)
   }
-  return ranges
+  return fromMarkdown(text).children.find(needsDefinitions)?.position?.start.offset
 }
 
 /** Last path segment of a host path, in either separator, ignoring trailing slashes. */
@@ -68,32 +76,10 @@ function basename(path: string): string {
   return trimmed.slice(trimmed.lastIndexOf('/') + 1) || trimmed
 }
 
-/** Apply `fn` outside fenced blocks: a fenced sample of this syntax is documentation, not a link. */
-function mapOutsideCode(text: string, fn: (segment: string) => string): string {
-  const out: string[] = []
-  let prose: string[] = []
-  let fence = ''
-  const flushProse = (): void => {
-    if (prose.length === 0) return
-    out.push(fn(prose.join('\n')))
-    prose = []
-  }
-  for (const line of text.split('\n')) {
-    const opener = FENCE.exec(line)?.[1]
-    if (fence) {
-      out.push(line)
-      // A closing fence must be at least as long as the one that opened the block.
-      if (opener && opener[0] === fence[0] && opener.length >= fence.length) fence = ''
-      continue
-    }
-    if (opener) {
-      flushProse()
-      out.push(line)
-      fence = opener
-      continue
-    }
-    prose.push(line)
-  }
-  flushProse()
-  return out.join('\n')
+/** A decoded destination may contain backticks, so quote it with a longer code delimiter. */
+function inlineCode(value: string): string {
+  const width = (value.match(/`+/g) ?? []).reduce((max, run) => Math.max(max, run.length), 0) + 1
+  const fence = '`'.repeat(width)
+  const padded = value.startsWith('`') || value.endsWith('`') || (value.startsWith(' ') && value.endsWith(' '))
+  return `${fence}${padded ? ` ${value} ` : value}${fence}`
 }

--- a/packages/daemon/src/messages/stream-boundary.ts
+++ b/packages/daemon/src/messages/stream-boundary.ts
@@ -1,39 +1,17 @@
-/**
- * Where a *streamed* reply may be cut into separate chat messages (§9.1 text-buffer).
- *
- * The daemon's idle-flush timer fires on a pause in the ACP stream, which says nothing
- * about whether the reply's text is complete: ACP text deltas are token-sized, so the
- * buffer routinely ends mid-sentence — and even mid-word ("…rebuilding the depend" /
- * "ency graph"). Posting it verbatim splits one answer across two chat messages at that
- * arbitrary point.
- *
- * A time-triggered flush therefore cuts only at a paragraph break — a blank line outside a
- * fenced code block, the one place CommonMark guarantees the preceding block has ended.
- * Anything after the last such break stays buffered for the next flush, for a semantic
- * boundary (tool call / plan / thinking, where the model really did finish a text block),
- * or for turn end. A buffer with no break yet is held whole.
- *
- * Semantic boundaries and turn end still drain the whole buffer — they are not this
- * function's business.
- */
+import { referenceBufferStart } from './agent-links.js'
 
 /** Opening/closing CommonMark fence: up to 3 spaces of indent, then 3+ backticks or tildes. */
 const FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
 
-/**
- * Split a streaming body into the part that is safe to send now and the tail that must stay
- * buffered. `ready` ends just past the last top-level blank line; `tail` is the rest.
- * `ready` is empty (and `tail` is the whole input) when no paragraph break has arrived yet.
- * `ready + tail` always reconstructs the input exactly, so no content is lost or duplicated.
- */
+/** Split at a completed paragraph before any block whose reference definitions may still arrive. */
 export function splitAtParagraphBoundary(text: string): { ready: string; tail: string } {
   let cut = 0
   let fence: string | undefined
   let pos = 0
+  const referenceStart = referenceBufferStart(text) ?? text.length
   while (pos < text.length) {
     const nl = text.indexOf('\n', pos)
-    // The trailing line has no newline yet — it is still streaming, so it can never be a
-    // boundary and nothing after the last complete line matters.
+    // A trailing line without its newline is still streaming.
     if (nl < 0) break
     const line = text.slice(pos, nl)
     pos = nl + 1
@@ -47,7 +25,7 @@ export function splitAtParagraphBoundary(text: string): { ready: string; tail: s
       fence = run
       continue
     }
-    if (!line.trim()) cut = pos
+    if (!line.trim() && pos <= referenceStart) cut = pos
   }
   const ready = text.slice(0, cut)
   return ready.trim() ? { ready, tail: text.slice(cut) } : { ready: '', tail: text }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -24,7 +24,7 @@ export {
   type SlackViewState
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
-import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
@@ -2437,7 +2437,7 @@ export class OutputConverger {
    *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
    *  dropped and replaced by the generic failure notice. */
   flushTerminal(): SlackAction[] {
-    if (this.mode === 'minimal') return this.liveRefresh()
+    if (this.mode === 'minimal') return this.liveRefresh(true)
     // A crashed turn settles like a stopped one: whatever was still in flight did not finish
     // BECAUSE the turn died, so those cards are honestly `error` under a "Failed" label — while
     // steps that already finished keep their state, (failed)-prefixed ones included. The ⚠️
@@ -2447,12 +2447,14 @@ export class OutputConverger {
 
   /** minimal: refresh the single in-place `live-reply` with the current segment (display only;
    *  the transcript record happens at segment boundaries). */
-  private liveRefresh(): SlackAction[] {
+  private liveRefresh(complete = false): SlackAction[] {
     const trimmed = this.buf.trim()
     // Hold the live reply while the body could still be the bare response-control marker, so a
     // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
     if (!trimmed || isNoResponsePrefix(trimmed)) return []
-    return [{ kind: 'live-reply', text: this.liveDisplay(flattenUnsafeLinks(this.buf)) }]
+    const raw = complete ? this.buf : this.buf.slice(0, referenceBufferStart(this.buf))
+    const text = flattenUnsafeLinks(raw)
+    return text.trim() ? [{ kind: 'live-reply', text: this.liveDisplay(text) }] : []
   }
 
   /** minimal: the single live message can hold one Block Kit `markdown` block (≤12000
@@ -2476,6 +2478,7 @@ export class OutputConverger {
     if (isNoResponsePrefix(this.buf.trim())) return []
     const text = flattenUnsafeLinks(this.buf)
     this.recordDirty = false
+    if (!text.trim()) return []
     return [
       final ? { kind: 'final-live-reply', text } : { kind: 'live-reply', text: this.liveDisplay(text) },
       ...splitIntoSections(text, undefined, this.protectedAddresses).map(
@@ -2492,7 +2495,8 @@ export class OutputConverger {
     // line of it under the container that already holds them.
     if (this.streaming || !this.reasoningDirty) return []
     this.reasoningDirty = false
-    return [{ kind: 'reasoning', text: renderReasoning(flattenUnsafeLinks(this.reasoningBuf)) }]
+    const text = flattenUnsafeLinks(this.reasoningBuf)
+    return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text) }] : []
   }
 
   private flush(): SlackAction[] {
@@ -2526,6 +2530,7 @@ export class OutputConverger {
 
   private emitBody(raw: string): SlackAction[] {
     const text = flattenUnsafeLinks(raw)
+    if (!text.trim()) return []
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` is handled
     // before the connection check on every platform, so it lands even though replyConn is unset.
     const recordOnly = this.mode === 'none'

--- a/packages/daemon/src/telegram/render.ts
+++ b/packages/daemon/src/telegram/render.ts
@@ -1,6 +1,6 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { splitIntoSections } from '../messages/split-sections.js'
-import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -225,17 +225,19 @@ export class TelegramConverger {
    *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
    *  dropped and replaced by the generic failure notice. */
   flushTerminal(): TelegramAction[] {
-    if (this.mode === 'minimal') return this.liveRefresh()
+    if (this.mode === 'minimal') return this.liveRefresh(true)
     return [...this.drainReasoning(), ...this.flush()]
   }
 
   /** minimal: refresh the single in-place `live-reply` with the current segment. */
-  private liveRefresh(): TelegramAction[] {
+  private liveRefresh(complete = false): TelegramAction[] {
     const trimmed = this.buf.trim()
     // Hold the live reply while the body could still be the bare response-control marker, so a
     // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
     if (!trimmed || isNoResponsePrefix(trimmed)) return []
-    return [{ kind: 'live-reply', text: this.liveDisplay(flattenUnsafeLinks(this.buf)) }]
+    const raw = complete ? this.buf : this.buf.slice(0, referenceBufferStart(this.buf))
+    const text = flattenUnsafeLinks(raw)
+    return text.trim() ? [{ kind: 'live-reply', text: this.liveDisplay(text) }] : []
   }
 
   /** minimal: a Telegram message caps at 4096 chars; head-clamp the live view when longer
@@ -256,6 +258,7 @@ export class TelegramConverger {
     if (isNoResponsePrefix(this.buf.trim())) return []
     const text = flattenUnsafeLinks(this.buf)
     this.recordDirty = false
+    if (!text.trim()) return []
     return [
       { kind: 'live-reply', text: this.liveDisplay(text) },
       ...splitIntoSections(text, TELEGRAM_MESSAGE_LIMIT).map(
@@ -267,7 +270,8 @@ export class TelegramConverger {
   private drainReasoning(): TelegramAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
-    return [{ kind: 'reasoning', text: renderReasoning(flattenUnsafeLinks(this.reasoningBuf)), parseMode: 'HTML' }]
+    const text = flattenUnsafeLinks(this.reasoningBuf)
+    return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text), parseMode: 'HTML' }] : []
   }
 
   /** `final` marks the turn-closing flush: its LAST post carries the continue hint (so a
@@ -302,6 +306,7 @@ export class TelegramConverger {
 
   private emitBody(raw: string, final: boolean): TelegramAction[] {
     const text = flattenUnsafeLinks(raw)
+    if (!text.trim()) return []
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` runs before
     // the connection check, so it lands even though replyConn is unset for this mode.
     const recordOnly = this.mode === 'none'

--- a/packages/daemon/test/agent-links.test.ts
+++ b/packages/daemon/test/agent-links.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { fromMarkdown } from 'mdast-util-from-markdown'
 import { flattenUnsafeLinks } from '../src/messages/agent-links.js'
 
 describe('flattenUnsafeLinks', () => {
@@ -90,11 +91,20 @@ describe('flattenUnsafeLinks', () => {
     )
   })
 
+  it('keeps a safe outer link with literal brackets when rewriting an image in its label', () => {
+    const result = flattenUnsafeLinks('[[label] ![chart](/tmp/chart.png)](https://example.test/report)')
+    expect(fromMarkdown(result).children[0]).toMatchObject({
+      type: 'paragraph',
+      children: [{ type: 'link', url: 'https://example.test/report' }]
+    })
+    expect(result).not.toContain('/tmp/')
+  })
+
   // Preserve dollar sequences as text, and keep the originally literal outer syntax inert.
   it.each([
-    ['[a $$ b [log](/tmp/a.log)](https://ci.test)', '\\[a $$ b log (`a.log`)](https://ci.test)'],
-    ['[$& label [i](/x/i.md)](https://e.test)', '\\[$& label i (`i.md`)](https://e.test)'],
-    ["[$` and $' [i](/x/i.md)](https://e.test)", "\\[$` and $' i (`i.md`)](https://e.test)"]
+    ['[a $$ b [log](/tmp/a.log)](https://ci.test)', '\\[a $$ b log (`a.log`)\\](https://ci.test)'],
+    ['[$& label [i](/x/i.md)](https://e.test)', '\\[$& label i (`i.md`)\\](https://e.test)'],
+    ["[$` and $' [i](/x/i.md)](https://e.test)", "\\[$` and $' i (`i.md`)\\](https://e.test)"]
   ])('keeps dollar sequences and surrounding literal text intact: %s', (input, expected) => {
     expect(flattenUnsafeLinks(input)).toBe(expected)
   })

--- a/packages/daemon/test/agent-links.test.ts
+++ b/packages/daemon/test/agent-links.test.ts
@@ -90,13 +90,12 @@ describe('flattenUnsafeLinks', () => {
     )
   })
 
-  // `String.replace` scans a STRING replacement for `$$`, `$&`, `` $` `` and `$'`, and a label is
-  // agent-authored — `$&` re-emitting the raw match would put an unflattened target back in the body.
+  // Preserve dollar sequences as text, and keep the originally literal outer syntax inert.
   it.each([
-    ['[a $$ b [log](/tmp/a.log)](https://ci.test)', '[a $$ b log (`a.log`)](https://ci.test)'],
-    ['[$& label [i](/x/i.md)](https://e.test)', '[$& label i (`i.md`)](https://e.test)'],
-    ["[$` and $' [i](/x/i.md)](https://e.test)", "[$` and $' i (`i.md`)](https://e.test)"]
-  ])("carries a dollar sequence in a kept link's label through verbatim: %s", (input, expected) => {
+    ['[a $$ b [log](/tmp/a.log)](https://ci.test)', '\\[a $$ b log (`a.log`)](https://ci.test)'],
+    ['[$& label [i](/x/i.md)](https://e.test)', '\\[$& label i (`i.md`)](https://e.test)'],
+    ["[$` and $' [i](/x/i.md)](https://e.test)", "\\[$` and $' i (`i.md`)](https://e.test)"]
+  ])('keeps dollar sequences and surrounding literal text intact: %s', (input, expected) => {
     expect(flattenUnsafeLinks(input)).toBe(expected)
   })
 

--- a/packages/daemon/test/agent-links.test.ts
+++ b/packages/daemon/test/agent-links.test.ts
@@ -113,6 +113,93 @@ describe('flattenUnsafeLinks', () => {
     expect(flattenUnsafeLinks('run `[x](/a/b.md)` then [y](/a/c.md)')).toBe('run `[x](/a/b.md)` then y (`c.md`)')
   })
 
+  describe('reference-style links', () => {
+    it('flattens full, collapsed and shortcut references and removes their shared host definition', () => {
+      const text =
+        'See [the digest][DAILY   REPORT], [daily report][], and [daily report].\n\n' +
+        '[Daily report]: </home/agent/digest.md> "Draft"'
+
+      expect(flattenUnsafeLinks(text).trimEnd()).toBe(
+        'See the digest (`digest.md`), daily report (`digest.md`), and daily report (`digest.md`).'
+      )
+    })
+
+    it('preserves safe references and their original definitions byte for byte', () => {
+      const text =
+        'See [the docs][DOCS], [docs][], [docs], and [email].\n\n' +
+        '[DoCs]: <https://example.test/docs?a=1&b=2>\n  "Original title"\n' +
+        '[email]: mailto:agent@example.test\n'
+
+      expect(flattenUnsafeLinks(text)).toBe(text)
+    })
+
+    it.each(['FILE:///home/agent/out.md', 'file:/home/agent/out.md', 'C:\\Users\\agent\\out.md'])(
+      'removes file targets from references in chat and code-host replies: %s',
+      (target) => {
+        const text = `[report][r]\n\n[r]: ${target}`
+        expect(flattenUnsafeLinks(text).trimEnd()).toBe('report (`out.md`)')
+        expect(flattenUnsafeLinks(text, { resolvesRelativeTargets: true }).trimEnd()).toBe('report (`out.md`)')
+      }
+    )
+
+    it('keeps decoded backticks in a filename inside inline code', () => {
+      expect(flattenUnsafeLinks('[report][r]\n\n[r]: /home/agent/a&#96;b.md').trimEnd()).toBe('report (``a`b.md``)')
+    })
+
+    it('preserves code samples, escaped brackets and unresolved prose while rewriting a real reference', () => {
+      const sample = [
+        '`[r]` and \\[r] and [unresolved].',
+        '',
+        '```md',
+        '[file][r]',
+        '[r]: /home/agent/example.md',
+        '```',
+        '',
+        '    [file][r]',
+        '    [r]: /home/agent/indented.md'
+      ].join('\n')
+      const text = `${sample}\n\nActual [file][r].\n\n[r]: /home/agent/out.md`
+
+      expect(flattenUnsafeLinks(text).trimEnd()).toBe(`${sample}\n\nActual file (\`out.md\`).`)
+    })
+
+    it.each([
+      {
+        definitions: '[r]: https://example.test/report\n[r]: /home/agent/private.md',
+        expectedBody: '[report][r]'
+      },
+      {
+        definitions: '[r]: /home/agent/private.md\n[r]: https://example.test/report',
+        expectedBody: 'report (`private.md`)'
+      }
+    ])(
+      'resolves duplicate labels using the first definition and removes host targets: $definitions',
+      ({ definitions, expectedBody }) => {
+        const result = flattenUnsafeLinks(`[report][r]\n\n${definitions}`)
+
+        expect(result.split('\n')[0]).toBe(expectedBody)
+        expect(result).toContain('[r]: https://example.test/report')
+        expect(result).not.toContain('/home/')
+      }
+    )
+
+    it('flattens both targets of a reference image linked to a host file', () => {
+      const text = '[![chart][img]][report]\n\n[img]: /tmp/chart.png\n[report]: /home/agent/report.html'
+
+      expect(flattenUnsafeLinks(text).trimEnd()).toBe('`chart.png` (`report.html`)')
+    })
+
+    it('keeps a safe outer reference linked after flattening its image label', () => {
+      const text = '[![chart][img]][report]\n\n[img]: /tmp/chart.png\n[report]: https://example.test/report'
+      const result = flattenUnsafeLinks(text)
+
+      expect(result).toContain('[`chart.png`][report]')
+      expect(result).toContain('[report]: https://example.test/report')
+      expect(result).not.toContain('/tmp/')
+      expect(result).not.toContain('[img]')
+    })
+  })
+
   describe('on a surface that resolves relative targets itself', () => {
     const onCodeHost = (text: string) => flattenUnsafeLinks(text, { resolvesRelativeTargets: true })
 
@@ -125,6 +212,13 @@ describe('flattenUnsafeLinks', () => {
 
     it('still flattens a host-absolute target, which resolves nowhere and names the daemon host', () => {
       expect(onCodeHost('wrote [the report](/home/sentio/workspace/report.md)')).toBe('wrote the report (`report.md`)')
+    })
+
+    it('keeps repository and fragment references while removing a host reference from the same reply', () => {
+      const safe = '[doc][] and [section].\n\n[doc]: docs/design.md\n[section]: #caveats'
+      const result = onCodeHost(`${safe}\n\nSaved [report][host].\n\n[host]: file:///home/agent/report.md`)
+
+      expect(result.trimEnd()).toBe(`${safe}\n\nSaved report (\`report.md\`).`)
     })
   })
 

--- a/packages/daemon/test/feishu-render.test.ts
+++ b/packages/daemon/test/feishu-render.test.ts
@@ -51,6 +51,33 @@ describe('FeishuConverger AC_NO_RESPONSE suppression', () => {
 })
 
 describe('Lark CardKit reply lifecycle', () => {
+  it('keeps reference uses and definitions together in the transcript while updating the live card', () => {
+    const c = new FeishuConverger('low')
+    c.onUpdate(chunk('Earlier paragraph.\n\nRead [the digest][r].\n\n'))
+    expect(c.flushBuffered().filter((action) => action.kind === 'post')).toEqual([
+      { kind: 'post', text: 'Earlier paragraph.\n\n', recordOnly: true }
+    ])
+    c.onUpdate(chunk('[r]: /home/agent/out.md'))
+    const updates = c.flushBuffered()
+    expect(updates.filter((action) => action.kind === 'post')).toEqual([])
+    expect(updates).toEqual([])
+    const final = c.onFinal()
+    expect(final.find((action) => action.kind === 'post')?.text.trim()).toBe('Read the digest (`out.md`).')
+    expect(final.find((action) => action.kind === 'card-final')?.text).toBe(
+      'Earlier paragraph.\n\nRead the digest (`out.md`).'
+    )
+  })
+
+  it('keeps a completed reference message visible when the next ordinary message streams', () => {
+    const c = new FeishuConverger('low')
+    c.onUpdate(chunk('Read [the digest][r].\n\n[r]: /home/agent/out.md'))
+    c.onUpdate({ sessionUpdate: 'tool_call', toolCallId: 'read', title: 'Read file' } as SessionUpdate)
+    c.onUpdate(chunk('Following prose.'))
+    expect(c.streamUpdate()).toEqual([
+      { kind: 'card-stream', text: 'Read the digest (`out.md`).\n\n\n\nFollowing prose.' }
+    ])
+  })
+
   it('streams cumulative text and finalizes the same reply with shared attribution', () => {
     const c = new FeishuConverger('low')
     expect(c.onStart()).toEqual([{ kind: 'card-start' }])

--- a/packages/daemon/test/reference-link-delivery.test.ts
+++ b/packages/daemon/test/reference-link-delivery.test.ts
@@ -4,6 +4,7 @@ import { OutputConverger } from '../src/slack/render.js'
 import { TelegramConverger } from '../src/telegram/render.js'
 import { DiscordConverger } from '../src/discord/render.js'
 import { FeishuConverger } from '../src/feishu/render.js'
+import { GithubReplyCollector } from '../src/github/poster.js'
 
 const chunk = (text: string): SessionUpdate => ({
   sessionUpdate: 'agent_message_chunk',
@@ -23,6 +24,12 @@ describe.each([
   { name: 'Discord', create: (mode: 'low' | 'minimal') => new DiscordConverger(mode) },
   { name: 'Feishu', create: (mode: 'low' | 'minimal') => new FeishuConverger(mode) }
 ])('$name reference delivery', ({ create }) => {
+  it('does not activate an outer host link when its nested link is flattened', () => {
+    const c = create('low')
+    c.onUpdate(chunk('[report [source](/home/agent/source.md)](/home/agent/report.md)'))
+    expect(bodies(c.onFinal())).toContain('\\[report source (`source.md`)](/home/agent/report.md)')
+  })
+
   it.each(['final', 'terminal'])(
     'holds incomplete reference definitions out of previews until %s completion',
     (completion) => {
@@ -47,4 +54,10 @@ describe.each([
       expect(bodies(c.onFinal())).toEqual([])
     }
   )
+})
+
+it('removes a newly activated host link from the shared code-host reply', () => {
+  const reply = new GithubReplyCollector()
+  reply.onUpdate(chunk('[report [source](/home/agent/source.md)](/home/agent/report.md)'))
+  expect(reply.finalText()).toBe('\\[report source (`source.md`)](/home/agent/report.md)')
 })

--- a/packages/daemon/test/reference-link-delivery.test.ts
+++ b/packages/daemon/test/reference-link-delivery.test.ts
@@ -27,7 +27,7 @@ describe.each([
   it('does not activate an outer host link when its nested link is flattened', () => {
     const c = create('low')
     c.onUpdate(chunk('[report [source](/home/agent/source.md)](/home/agent/report.md)'))
-    expect(bodies(c.onFinal())).toContain('\\[report source (`source.md`)](/home/agent/report.md)')
+    expect(bodies(c.onFinal())).toContain('\\[report source (`source.md`)\\](/home/agent/report.md)')
   })
 
   it.each(['final', 'terminal'])(
@@ -59,5 +59,5 @@ describe.each([
 it('removes a newly activated host link from the shared code-host reply', () => {
   const reply = new GithubReplyCollector()
   reply.onUpdate(chunk('[report [source](/home/agent/source.md)](/home/agent/report.md)'))
-  expect(reply.finalText()).toBe('\\[report source (`source.md`)](/home/agent/report.md)')
+  expect(reply.finalText()).toBe('\\[report source (`source.md`)\\](/home/agent/report.md)')
 })

--- a/packages/daemon/test/reference-link-delivery.test.ts
+++ b/packages/daemon/test/reference-link-delivery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionUpdate } from '@agentclientprotocol/sdk'
+import { OutputConverger } from '../src/slack/render.js'
+import { TelegramConverger } from '../src/telegram/render.js'
+import { DiscordConverger } from '../src/discord/render.js'
+import { FeishuConverger } from '../src/feishu/render.js'
+
+const chunk = (text: string): SessionUpdate => ({
+  sessionUpdate: 'agent_message_chunk',
+  content: { type: 'text', text }
+})
+
+const bodies = (actions: Array<{ kind: string; text?: string }>) =>
+  actions
+    .filter((action) =>
+      ['post', 'live-reply', 'final-live-reply', 'card-stream', 'card-final', 'reasoning'].includes(action.kind)
+    )
+    .map((action) => action.text)
+
+describe.each([
+  { name: 'Slack', create: (mode: 'low' | 'minimal') => new OutputConverger(mode) },
+  { name: 'Telegram', create: (mode: 'low' | 'minimal') => new TelegramConverger(mode) },
+  { name: 'Discord', create: (mode: 'low' | 'minimal') => new DiscordConverger(mode) },
+  { name: 'Feishu', create: (mode: 'low' | 'minimal') => new FeishuConverger(mode) }
+])('$name reference delivery', ({ create }) => {
+  it.each(['final', 'terminal'])(
+    'holds incomplete reference definitions out of previews until %s completion',
+    (completion) => {
+      const c = create('minimal')
+      c.onUpdate(chunk('Earlier paragraph.\n\nRead [the digest][r].\n\n[r]: </home/agent/secret'))
+      expect(bodies(c.flushBuffered())).toEqual(['Earlier paragraph.\n\n'])
+      c.onUpdate(chunk('.md>'))
+      expect(bodies(c.flushBuffered()).every((text) => text === 'Earlier paragraph.\n\n')).toBe(true)
+      const finished =
+        completion === 'final' ? c.onFinal() : 'flushTerminal' in c ? c.flushTerminal() : c.onFailure('Agent stopped')
+      const final = bodies(finished).map((text) => text?.trim())
+      expect(final).toContain('Earlier paragraph.\n\nRead the digest (`secret.md`).')
+    }
+  )
+
+  it.each(['low', 'minimal'] as const)(
+    'does not emit an empty %s reply after removing a standalone unsafe definition',
+    (mode) => {
+      const c = create(mode)
+      c.onUpdate(chunk('[r]: /home/agent/secret.md'))
+      expect(bodies(c.flushBuffered())).toEqual([])
+      expect(bodies(c.onFinal())).toEqual([])
+    }
+  )
+})

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -695,6 +695,19 @@ describe('OutputConverger', () => {
     expect(c.hasBuffered()).toBe(true) // still buffered, not dropped
   })
 
+  it('holds a reference across idle flushes until its later host-path definition can be flattened', () => {
+    const c = new OutputConverger('medium')
+    const chunk = (text: string) =>
+      c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } } as any)
+    chunk('Earlier paragraph.\n\nRead [the digest][r].\n\n')
+    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'Earlier paragraph.\n\n' }])
+    chunk('[r]: /home/agent/out.md\n\n')
+    expect(c.flushBuffered()).toEqual([])
+    const posts = c.onFinal().filter((action) => action.kind === 'post')
+    expect(posts).toHaveLength(1)
+    expect(posts[0]?.text.trim()).toBe('Read the digest (`out.md`).')
+  })
+
   it('flushTerminal drains a body with no paragraph break — the turn never reaches onFinal', () => {
     const c = new OutputConverger('medium')
     // A runtime that narrates its terminal error then rejects the prompt: one line, no break.

--- a/packages/daemon/test/stream-boundary.test.ts
+++ b/packages/daemon/test/stream-boundary.test.ts
@@ -44,6 +44,22 @@ describe('splitAtParagraphBoundary', () => {
     expect(splitAtParagraphBoundary('\n\nreal text')).toEqual({ ready: '', tail: '\n\nreal text' })
   })
 
+  it.each([
+    'Read [the digest][r].\n\nThe definition is still arriving.',
+    '[r]: https://example.test/digest\n\nRead [r].\n\n',
+    '- Read [the digest][r].\n\n- Another item.\n\n'
+  ])('keeps a reference-bearing block with later definitions and usages: %s', (tail) => {
+    expect(splitAtParagraphBoundary(`Earlier paragraph.\n\n${tail}`)).toEqual({
+      ready: 'Earlier paragraph.\n\n',
+      tail
+    })
+  })
+
+  it('still streams complete inline links and bracketed code samples', () => {
+    const ready = 'Read [the docs](https://example.test).\n\n`[sample]`\n\n```md\n[r]: /sample.md\n```\n\n'
+    expect(splitAtParagraphBoundary(`${ready}More text`)).toEqual({ ready, tail: 'More text' })
+  })
+
   it('is lossless — ready + tail reconstructs the input', () => {
     for (const text of ['a\n\nb\n\nc', '```\nx\n\ny\n```\n\nz', 'no break at all', '\n\n\n', '']) {
       const { ready, tail } = splitAtParagraphBoundary(text)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       grammy:
         specifier: ^1.45.1
         version: 1.46.0
+      mdast-util-from-markdown:
+        specifier: ^2.0.3
+        version: 2.0.3
       pg:
         specifier: ^8.22.0
         version: 8.23.0
@@ -376,6 +379,9 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^12.0.4
         version: 12.1.0
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3


### PR DESCRIPTION
Reference-style Markdown links could publish daemon filesystem paths because the outbound sanitizer only recognized inline links. Resolve full, collapsed, and shortcut references against their definitions, then apply the existing file-target fallback to links and images. Unsafe definitions are removed while unrelated Markdown formatting and code examples are preserved. Literal text surrounding a rewritten link stays escaped so the rewrite cannot activate a new outer link.

Keep reference-bearing blocks together across streaming pauses so definitions arriving later are available before the text is sent. Live reply previews also hold incomplete references, and segments reduced to empty text do not produce blank messages. The change covers the chat renderers and the shared GitHub/GitLab reply sanitizer.

Validation: 460 focused link, streaming, renderer, and code-host reply regressions; daemon typecheck; ESLint and Prettier; daemon and shim build with self-contained bundle checks.

Created by Codex . gpt-6-astra
