### PR TITLE
feat(daemon): link reply files to session workspaces

### DIFF
--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -498,6 +498,13 @@ adapter owns everything platform-shaped. The GitHub poster/collector
 implements this same interface (no Layer-1 facets), removing the hardcoded
 `github` turn field from the dispatch path.
 
+After opening the runtime session, core supplies an optional file-link resolver to
+the output context. It captures the session's exact working directory, the roots the
+Console can browse, and the outward session URL. A surface calls it on assembled
+Markdown through the shared link sanitizer; it never receives filesystem roots or
+reads core session machinery. The webchat stream and code-host final surface use the
+same resolver, while file access remains fenced by the existing workspace reader.
+
 ### 7.4 Adapter strategy functions
 
 The ~20 branches that are neither transport nor pre-dispatch capability

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -145,6 +145,20 @@ become a reference, it and the following text stay together until the agent fini
 text block. Earlier paragraphs continue streaming normally, including in live previews,
 so an incomplete link definition cannot expose a local file target before it is resolved.
 
+File links in agent replies open the Console viewer for the replying Agent's workspace
+and session. Relative paths resolve from the runtime's working directory, including a
+configured subdirectory or an authorized additional repository. Isolated sessions keep
+their own checkout in the link; an unavailable or purged checkout must never fall back
+to a same-named file in the primary workspace. The viewer requires the reader's usual
+Agent, session, and repository access. The URL contains only workspace-relative paths.
+
+Inline links, reference-style links, and workspace image references use the same file
+viewer. Line or column citations open the file without a line jump. Ordinary web links
+stay unchanged, and code-host replies retain repository-relative links. Targets outside
+the known workspaces keep the readable text fallback, with host paths reduced to their
+file names. Webchat holds link-bearing text until its logical message is complete so its
+live reply and saved transcript use the same destination.
+
 ## A cold sandbox pod is announced, not waited out in silence
 
 A turn whose agent runs in the cluster and has no pod up yet must first claim (or resume) a

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -497,10 +497,8 @@ export function fastOptionFrom(configOptions: SessionConfigOption[] | null | und
 export class AcpHost {
   private spawned?: SpawnedRuntime
   private conn?: ClientConnection
-  // acpSessionIds this process created (or loaded). ACP sessions are in-memory in
-  // the subprocess, so an id persisted across a daemon restart / host eviction is
-  // unknown to a fresh process and must be re-created or re-loaded.
-  private live = new Set<string>()
+  // Only sessions created or loaded by this host have a trusted runtime working directory.
+  private live = new Map<string, string>()
   // sessionIds currently mid-load: `session/load` makes the agent REPLAY its whole
   // history via session/update, which we must NOT forward to the platform (it would
   // re-post the entire conversation). Cleared when the load resolves.
@@ -909,7 +907,7 @@ export class AcpHost {
       ...(_meta ? { _meta } : {})
     })
     announce?.(res.sessionId)
-    this.live.add(res.sessionId)
+    this.live.set(res.sessionId, cwd)
     const configOptions = await this.applySessionConfig(res.sessionId, res.configOptions)
     this.refreshOptionCaches(configOptions)
     this.sessionConfigs.set(res.sessionId, configOptions)
@@ -1099,6 +1097,11 @@ export class AcpHost {
     return this.live.has(sessionId)
   }
 
+  /** The working directory this host supplied to session/new or session/load. */
+  sessionCwd(sessionId: string): string | undefined {
+    return this.live.get(sessionId)
+  }
+
   /** True while a session/load is in flight — the session is this host's, but `live` does not hold it
    *  yet. A caller identifying "is this session mine" from an update must accept this window too, or
    *  it depends on whether the adapter emits before or after the load response. */
@@ -1161,7 +1164,7 @@ export class AcpHost {
         mcpServers: this.clampSessionMcpServers(mcpServers),
         ...(_meta ? { _meta } : {})
       })
-      this.live.add(sessionId)
+      this.live.set(sessionId, cwd)
       // Re-apply config prefs: ACP sessions restore their own last model/effort,
       // which may predate a CP-side agent edit.
       const configOptions = await this.applySessionConfig(sessionId, res.configOptions)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -388,6 +388,7 @@ import { z } from 'zod'
 import { isNoResponseBody } from './session/no-response.js'
 import { WorkspaceConflictError } from './cp/workspace-reader.js'
 import { createWorkspaceScope } from './cp/workspace-scope.js'
+import { createWorkspaceFileLinkResolver, type WorkspaceFileLinkResolver } from './messages/workspace-file-links.js'
 import { canonicalWorkspacePath, containedWorkspacePath, WorkspaceViolationError } from './workspace/workspace-files.js'
 import type { ShareReadResult, ShareTargetResult } from './mcp/ops/share-file.js'
 import { TaskViolationError } from './cp/task-reader.js'
@@ -940,7 +941,8 @@ export class Daemon {
       const registry = new TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>({
         platform: 'slack',
         elicitCards: slackElicitCards,
-        createConverger: (ctx) => new OutputConverger(ctx.mode as never, ctx.protectedAddresses ?? []),
+        createConverger: (ctx) =>
+          new OutputConverger(ctx.mode as never, ctx.protectedAddresses ?? [], ctx.resolveFileLink),
         initialTurnState: (ctx): SlackTurnState => {
           const recipient = slackStreamRecipient(ctx.message)
           return recipient ? { recipient } : {}
@@ -987,7 +989,7 @@ export class Daemon {
         // reply chain is the ONLY way back into this session; a DM already has one
         // implicit thread. Gated on showFooter, the delivery-chrome switch.
         createConverger: (ctx) =>
-          new TelegramConverger(ctx.mode as never, { continueHint: ctx.showFooter && !ctx.isDm }),
+          new TelegramConverger(ctx.mode as never, { continueHint: ctx.showFooter && !ctx.isDm }, ctx.resolveFileLink),
         initialTurnState: (ctx): TelegramTurnState => {
           const replyTo = this.telegramReplyTarget(ctx.message)
           return replyTo !== undefined ? { replyTo } : {}
@@ -996,13 +998,13 @@ export class Daemon {
       })
       registry.register({
         platform: 'discord',
-        createConverger: (ctx) => new DiscordConverger(ctx.mode as never),
+        createConverger: (ctx) => new DiscordConverger(ctx.mode as never, ctx.resolveFileLink),
         initialTurnState: () => ({}),
         apply: (p, action) => this.applyDiscordAction(p, action as DiscordAction)
       })
       registry.register({
         platform: 'feishu',
-        createConverger: (ctx) => new FeishuConverger(ctx.mode as never),
+        createConverger: (ctx) => new FeishuConverger(ctx.mode as never, ctx.resolveFileLink),
         initialTurnState: (): FeishuTurnState => ({}),
         apply: (p, action) => this.applyFeishuAction(p, action as FeishuAction),
         // Suppression teardown: stop the stream timer and cancel the CardKit
@@ -10947,15 +10949,7 @@ export class Daemon {
     // output mode — `conv` (built below, once the session key is known) only decides
     // what reaches Slack, never the transcript.
     const rec = new TranscriptRecorder()
-    // Daemon-side rendering only (not ACP); a fresh converger is built per turn, so a change
-    // applies from the next turn on, not mid-turn (see `mode`, resolved inside the plan).
-    const conv = plan.turnSurface.createConverger(plan.turnCtx)
     const replyConn = plan.suppressReplyConn ? undefined : this.replyConnFor(agentId, integrationId)
-    // slack-streaming-turn-output.md §3.1: the axis is decided here, from a synchronous
-    // capability read, because the converger is built before chat.startStream can be tried.
-    // The call itself is deferred to the turn's first task — a turn that runs no tools never
-    // opens a stream and is byte-identical to today.
-    if (conv instanceof OutputConverger && this.slackStreamingEligible(plan, replyConn)) conv.enableStreaming()
     // ONE lookup for the platform egress transport: the lease below and the port the output
     // surface emits through are the SAME object. Resolving it twice — once to lease, once at
     // turn-state seeding — leaves a window where reconciliation rebinds the integration
@@ -10967,7 +10961,14 @@ export class Daemon {
     // each copy once. Seeded HERE, before `openSession`, because the sandbox-bootstrap notice
     // below emits on this turn's `index` and must not collide with the reply's.
     const pendingWebchat = webchat
-      ? Object.assign(webchat, { index: 0, replyText: '', heldText: '', messageEmitted: false })
+      ? Object.assign(webchat, {
+          index: 0,
+          replyText: '',
+          heldText: '',
+          heldTextOffset: 0,
+          messageId: undefined,
+          messageEmitted: false
+        })
       : undefined
     // Admission is the displacement point: a sibling session's turn is cancelled before this
     // turn opens its (possibly cold) session, not after buildPending.
@@ -11035,7 +11036,17 @@ export class Daemon {
       run.entry.agentId,
       this.clock.now()
     )
-    const p = this.buildPending(run, { conv, rec, sessionId, outwardSessionId, webchat: pendingWebchat })
+    const resolveFileLink = await this.turnWorkspaceFileLinkResolver(run, sessionId, outwardSessionId)
+    const conv = plan.turnSurface.createConverger({ ...plan.turnCtx, resolveFileLink })
+    if (conv instanceof OutputConverger && this.slackStreamingEligible(plan, replyConn)) conv.enableStreaming()
+    const p = this.buildPending(run, {
+      conv,
+      rec,
+      sessionId,
+      outwardSessionId,
+      resolveFileLink,
+      webchat: pendingWebchat
+    })
     // Every turn re-stashes the stored title (fallback or runtime): the connection dedupes
     // repeats, and re-pushing heals a rename lost to a restart or an unregistered thread.
     // Substituted at push time — a first-message fallback carries raw `<@U…>` mentions, and
@@ -11417,6 +11428,54 @@ export class Daemon {
     }
   }
 
+  /** Resolve only viewer-addressable roots after this turn's runtime session and workspace have opened. */
+  private async turnWorkspaceFileLinkResolver(
+    run: TurnRun,
+    sessionId: string,
+    outwardSessionId: string
+  ): Promise<WorkspaceFileLinkResolver | undefined> {
+    const agent = this.agents.get(run.entry.agentId)
+    const host = run.entry.selectedHost?.host ?? this.hostForOwner(this.sessionOwnerKey(run.entry.agentId, run.key))
+    const cwd = host?.sessionCwd?.(sessionId)
+    if (!agent || !cwd) return undefined
+    try {
+      const session = await this.store.getSession(run.key)
+      if (!session) return undefined
+      const scopeSessionId = session.workspaceIsolation === 'session' ? outwardSessionId : undefined
+      const scope = createWorkspaceScope({
+        workspaces: this.workspaces,
+        agentOf: (id) => this.agents.get(id),
+        sessionOf: (id, outwardId) => this.store.getSessionByOutwardId(outwardId, id),
+        runtimeRootOf: (id) => this.k8sPlane?.workspaceRootFor(id)
+      })
+      const roots: Array<{ path: string; repo?: string }> = []
+      for (const repo of [undefined, ...this.workspaces.secondaryRoots(agent).map((root) => root.repoFullName)]) {
+        const location = await scope.location(agent.id, scopeSessionId, repo)
+        if (!location) continue
+        try {
+          const path = this.workspaces.sandboxMode
+            ? location.root
+            : this.workspaces.canonicalWorkspacePath(agent.id, location.root)
+          roots.push({ path, ...(repo === undefined ? {} : { repo }) })
+        } catch {
+          // An absent or retired checkout cannot supply a working file link.
+        }
+      }
+      if (!roots.length) return undefined
+      return createWorkspaceFileLinkResolver({
+        sessionUrl: this.sessionLink(
+          outwardSessionId,
+          this.sessionLinkSource(run.plan.platform, run.plan.integrationId)
+        ),
+        agentId: agent.id,
+        cwd,
+        roots
+      })
+    } catch {
+      return undefined
+    }
+  }
+
   /** Build this turn's live record from its plan and register it as the session's Pending turn. */
   private buildPending(
     run: TurnRun,
@@ -11425,6 +11484,7 @@ export class Daemon {
       rec: TranscriptRecorder
       sessionId: string
       outwardSessionId: string
+      resolveFileLink?: WorkspaceFileLinkResolver
       webchat: Pending['webchat']
     }
   ): Pending {
@@ -11465,9 +11525,11 @@ export class Daemon {
       builtinSystemToolCallIds: new Set(),
       acpSessionId: sessionId,
       outwardSessionId,
+      ...(turn.resolveFileLink ? { resolveFileLink: turn.resolveFileLink } : {}),
       ...(entry.selectedHost ? { selectedHost: entry.selectedHost } : {}),
       turnState: plan.turnSurface.initialTurnState({
         ...plan.turnCtx,
+        ...(turn.resolveFileLink ? { resolveFileLink: turn.resolveFileLink } : {}),
         ...(run.egressConn ? { egress: run.egressConn } : {})
       }),
       conn: run.replyConn,
@@ -12059,6 +12121,8 @@ export class Daemon {
         // reset the sentinel hold so the replacement gets its own check.
         p.webchat.replyText = ''
         p.webchat.heldText = ''
+        p.webchat.heldTextOffset = 0
+        delete p.webchat.messageId
         p.webchat.messageEmitted = false
         p.reply.text = ''
       }
@@ -12097,6 +12161,8 @@ export class Daemon {
           // would leave the stream open and the composer stuck busy.
           p.webchat.replyText = ''
           p.webchat.heldText = ''
+          p.webchat.heldTextOffset = 0
+          delete p.webchat.messageId
           if (!p.webchat.doneSent) {
             p.webchat.doneSent = true
             p.webchat.sink.output({
@@ -12217,14 +12283,16 @@ export class Daemon {
       // agent): drop the held stream text — nothing was ever streamed — and
       // commit no canonical post or transcript reply row.
       p.webchat.heldText = ''
+      p.webchat.heldTextOffset = 0
+      delete p.webchat.messageId
       p.reply.text = ''
     } else if (trimmedWebchatReply) {
       // A real reply that never diverged from the sentinel prefix mid-stream
       // (shorter than the sentinel) is still held — release it before commit.
-      webchatTurnOutput.flushHeldWebchatText(p.webchat)
+      webchatTurnOutput.flushHeldWebchatText(p.webchat, p.resolveFileLink)
       // A continuation turn records its reply at the platform post boundary instead
       // (appending here would duplicate the row), and its roster is fixed at one.
-      if (!p.webchat.continuation) {
+      if (!p.webchat.continuation && p.webchat.replyText.trim()) {
         // Shares the strictly-monotonic clock with the inbound user message so a fast
         // turn can't stamp both with the same ms and lose the reply to the unique index.
         // The ts the row actually lands on (post-collision-bump) doubles as the reply
@@ -12449,12 +12517,13 @@ export class Daemon {
       // Continuation: release any held stream text; the platform branch below owns the
       // visible notice + transcript, and the terminal-error `done` waits behind its
       // apply-chain drain so the console cannot admit a next turn mid-flush.
-      webchatTurnOutput.flushHeldWebchatText(p.webchat)
+      webchatTurnOutput.flushHeldWebchatText(p.webchat, p.resolveFileLink)
     } else if (p.webchat) {
-      // Reply text (including a runtime's mirrored error text) already streamed to
-      // the client via onAcpUpdate; the terminal done frame carries the reason.
-      // Record what streamed so the session reads back with it, like the success
-      // path does — the sink is a live transport with no post boundary of its own.
+      // Release a held partial reply before surfaceTurnFailure closes the browser stream.
+      const trimmedPartialReply = p.webchat.replyText.trim()
+      if (trimmedPartialReply && !isNoResponseBody(trimmedPartialReply)) {
+        webchatTurnOutput.flushHeldWebchatText(p.webchat, p.resolveFileLink)
+      }
       await this.surfaceTurnFailure(err, {
         agentId,
         agentName: plan.agentName,
@@ -12470,9 +12539,7 @@ export class Daemon {
         thread: msg.thread,
         statusThread: plan.statusThread
       })
-      const trimmedPartialReply = p.webchat.replyText.trim()
-      if (trimmedPartialReply && !isNoResponseBody(trimmedPartialReply)) {
-        webchatTurnOutput.flushHeldWebchatText(p.webchat)
+      if (p.webchat.replyText.trim() && !isNoResponseBody(p.webchat.replyText.trim())) {
         const partialPostId = randomUUID()
         const replyTs = await webchatTurnOutput.appendWebchatTextRow(
           this.store,
@@ -14185,7 +14252,7 @@ export class Daemon {
     // per mapped chunk, instead of driving the Slack renderer — but still records the
     // full activity log below, so a webchat session reads back like any other.
     // A continuation turn drives BOTH: the browser sink and the platform renderer (§5.2).
-    if (p.webchat) webchatTurnOutput.emitWebchatUpdate(p.webchat, update)
+    if (p.webchat) webchatTurnOutput.emitWebchatUpdate(p.webchat, update, p.resolveFileLink)
     if ((!p.webchat || p.webchat.continuation) && !isHeadlessGithubFinal && !(p.plan.stageAnswer && isAnswerChunk)) {
       // Segment commit: a boundary the live renderer flushes on delivers the staged text
       // ahead of it, so "say → work → say more" reaches the channel as it happens (the

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -23,6 +23,7 @@ import type { DiscordConnection } from '../discord/connection.js'
 import type { FeishuConnection } from '../feishu/connection.js'
 import type { GithubReplyTarget, HookDispatchContext } from '../github/hook-coords.js'
 import type { WebchatTurnContext } from '../webchat/types.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 
 /** Thrown to a `dispatch()` caller when the per-session admission queue is at its depth
  *  cap (§4.4 backpressure): the message is fast-failed, not buffered. Carries a stable
@@ -542,6 +543,8 @@ export interface TurnSignals {
  *  through it; the mutable rest is grouped by who writes it — platform chrome cursors,
  *  reply accumulation, the approval-wait meter (permissions/), and completion signals. */
 export interface Pending {
+  /** The same trusted workspace link resolver used by every output surface for this turn. */
+  resolveFileLink?: WorkspaceFileLinkResolver
   /** The pure decisions this turn was planned with — its identity, coordinates, output
    *  mode, and surface. Readonly by construction: nothing here is turn state. */
   readonly plan: TurnPlan
@@ -612,7 +615,14 @@ export interface Pending {
    * accumulates the agent's message chunks so the finished reply is recorded to the
    * transcript once (webchat has no Slack post boundary where text is otherwise saved).
    */
-  webchat?: WebchatTurnContext & { index: number; replyText: string; heldText: string; messageEmitted: boolean }
+  webchat?: WebchatTurnContext & {
+    index: number
+    replyText: string
+    heldText: string
+    heldTextOffset?: number
+    messageId?: string
+    messageEmitted: boolean
+  }
   /** Agent questions this turn has already told the channel it could not render (#1794), so a
    *  runtime re-raising the same unrenderable ask posts one notice rather than one per attempt. */
   declinedElicitNotices?: Set<string>

--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -1,6 +1,7 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -309,7 +310,10 @@ export class DiscordConverger {
   // The runtime's own message identity, which is the only boundary a speak-only run offers.
   private readonly messages = new AgentMessageRun()
 
-  constructor(private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high') {}
+  constructor(
+    private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high',
+    private readonly resolveFileLink?: WorkspaceFileLinkResolver
+  ) {}
 
   /** True while body text OR reasoning is pending — the daemon (re)arms the idle-flush timer on it. */
   hasBuffered(): boolean {
@@ -340,7 +344,7 @@ export class DiscordConverger {
     // A partial response-control marker must not flash in the live reply before onFinal drops it.
     if (!trimmed || isNoResponsePrefix(trimmed)) return []
     const raw = complete ? this.buf : this.buf.slice(0, referenceBufferStart(this.buf))
-    const text = flattenUnsafeLinks(raw)
+    const text = flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'live-reply', text: this.liveDisplay(text) }] : []
   }
 
@@ -360,7 +364,7 @@ export class DiscordConverger {
     // Hold while the body may still be / is the bare sentinel — a suppressed reply must not be
     // recorded or shown; onFinal makes the final drop. Non-sentinel bodies close normally.
     if (isNoResponsePrefix(this.buf.trim())) return []
-    const text = flattenUnsafeLinks(this.buf)
+    const text = flattenUnsafeLinks(this.buf, { resolveFileLink: this.resolveFileLink })
     this.recordDirty = false
     if (!text.trim()) return []
     return [
@@ -374,7 +378,7 @@ export class DiscordConverger {
   private drainReasoning(): DiscordAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
-    const text = flattenUnsafeLinks(this.reasoningBuf)
+    const text = flattenUnsafeLinks(this.reasoningBuf, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text) }] : []
   }
 
@@ -407,7 +411,7 @@ export class DiscordConverger {
   }
 
   private emitBody(raw: string): DiscordAction[] {
-    const text = flattenUnsafeLinks(raw)
+    const text = flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
     if (!text.trim()) return []
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` runs before
     // the connection check, so it lands even though replyConn is unset for this mode.

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -2,6 +2,7 @@ import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import type { WireFeishuCardActionTarget } from '@agentconnect.md/protocol'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 import { extractToolOutput } from '../session/tool-output.js'
@@ -413,7 +414,10 @@ export class FeishuConverger {
   // The runtime's own message identity, which is the only boundary a speak-only run offers.
   private readonly messages = new AgentMessageRun()
 
-  constructor(private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high') {}
+  constructor(
+    private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high',
+    private readonly resolveFileLink?: WorkspaceFileLinkResolver
+  ) {}
 
   onStart(): FeishuAction[] {
     return this.mode === 'none' ? [] : [{ kind: 'card-start' }]
@@ -437,7 +441,9 @@ export class FeishuConverger {
     // The pending buffer is the raw card's suffix; previously completed messages remain visible.
     const raw =
       held === undefined ? this.cardText : this.cardText.slice(0, this.cardText.length - this.buf.length + held)
-    return this.mode === 'none' || isNoResponsePrefix(raw.trim()) ? '' : flattenUnsafeLinks(raw)
+    return this.mode === 'none' || isNoResponsePrefix(raw.trim())
+      ? ''
+      : flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
   }
 
   /** Return one cumulative CardKit element update and mark that snapshot as emitted. */
@@ -463,7 +469,7 @@ export class FeishuConverger {
     const stream = includeStream ? this.streamUpdate(true) : []
     if (!this.recordDirty || !this.buf.trim()) return stream
     if (isNoResponsePrefix(this.buf.trim())) return []
-    const text = flattenUnsafeLinks(this.buf)
+    const text = flattenUnsafeLinks(this.buf, { resolveFileLink: this.resolveFileLink })
     this.recordDirty = false
     if (!text.trim()) return stream
     return [
@@ -477,7 +483,7 @@ export class FeishuConverger {
   private drainReasoning(): FeishuAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
-    const text = flattenUnsafeLinks(this.reasoningBuf)
+    const text = flattenUnsafeLinks(this.reasoningBuf, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text) }] : []
   }
 
@@ -493,7 +499,7 @@ export class FeishuConverger {
     if (isNoResponsePrefix(trimmed)) return []
     const cut = boundary ? this.buf.length : (referenceBufferStart(this.buf) ?? this.buf.length)
     if (cut === 0) return includeStream ? this.streamUpdate(boundary) : []
-    const text = flattenUnsafeLinks(this.buf.slice(0, cut))
+    const text = flattenUnsafeLinks(this.buf.slice(0, cut), { resolveFileLink: this.resolveFileLink })
     this.buf = this.buf.slice(cut)
     if (boundary) this.cardBoundary = true
     const stream = includeStream ? this.streamUpdate(boundary) : []
@@ -619,7 +625,7 @@ export class FeishuConverger {
   /** Turn end: persist the last body window and replace the streaming entity with the
    * completed answer. Optional shared attribution stays inside that same final card. */
   onFinal(attribution?: ReplyAttributionInfo): FeishuAction[] {
-    this.cardText = flattenUnsafeLinks(this.cardText)
+    this.cardText = flattenUnsafeLinks(this.cardText, { resolveFileLink: this.resolveFileLink })
     const display = this.cardText.trim()
     if (isNoResponseBody(display)) {
       this.buf = ''
@@ -639,7 +645,7 @@ export class FeishuConverger {
   /** Prompt failure after the card has started: preserve any useful runtime-authored
    * error text, otherwise append one concise failure line, then close the card. */
   onFailure(reason: string, attribution?: ReplyAttributionInfo): FeishuAction[] {
-    this.cardText = flattenUnsafeLinks(this.cardText)
+    this.cardText = flattenUnsafeLinks(this.cardText, { resolveFileLink: this.resolveFileLink })
     const display = this.cardText.trim()
     if (isNoResponseBody(display)) {
       this.buf = ''

--- a/packages/daemon/src/github/poster.ts
+++ b/packages/daemon/src/github/poster.ts
@@ -21,7 +21,7 @@
  */
 
 import type { GithubPublishedComment } from '@agentconnect.md/protocol'
-import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { flattenUnsafeLinks, type FlattenOptions } from '../messages/agent-links.js'
 import { renderAttributionMessage } from '../messages/attribution.js'
 import { isNoResponseBody } from '../session/no-response.js'
 
@@ -82,12 +82,10 @@ function record(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
 }
 
-function publicReplyText(text: string | undefined): string | undefined {
+function publicReplyText(text: string | undefined, linkOptions: FlattenOptions): string | undefined {
   const trimmed = text?.trim()
   if (!text || !trimmed || isNoResponseBody(trimmed)) return undefined
-  // A code host resolves a relative target against the repository, so only the host-absolute
-  // one is both broken and a disclosure of the daemon's filesystem layout.
-  return flattenUnsafeLinks(text, { resolvesRelativeTargets: true })
+  return flattenUnsafeLinks(text, linkOptions)
 }
 
 /**
@@ -167,9 +165,9 @@ export class GithubReplyCollector {
     }
   }
 
-  finalText(completed = true): string | undefined {
+  finalText(completed = true, linkOptions: FlattenOptions = { resolvesRelativeTargets: true }): string | undefined {
     const explicit = this.explicitFinalText()
-    if (explicit || !completed) return publicReplyText(explicit)
+    if (explicit || !completed) return publicReplyText(explicit, linkOptions)
 
     // Some codex-acp versions learn an item's phase only after its final delta,
     // so a real final can remain `unknown`. `exitedReviewMode` is also deliberately
@@ -186,7 +184,7 @@ export class GithubReplyCollector {
       )
       .sort((a, b) => a.lastSeen - b.lastSeen)
       .at(-1)?.text
-    return publicReplyText(unknown)
+    return publicReplyText(unknown, linkOptions)
   }
 
   private explicitFinalText(): string | undefined {

--- a/packages/daemon/src/messages/agent-links.ts
+++ b/packages/daemon/src/messages/agent-links.ts
@@ -1,5 +1,6 @@
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import type { Definition, Nodes } from 'mdast'
+import type { WorkspaceFileLinkResolver } from './workspace-file-links.js'
 
 const WEB_SCHEME = /^(?:https?|mailto):/i
 const HOST_ABSOLUTE = /^(?:[\\/]|[A-Za-z]:[\\/]|file:)/i
@@ -7,6 +8,8 @@ const HOST_ABSOLUTE = /^(?:[\\/]|[A-Za-z]:[\\/]|file:)/i
 export interface FlattenOptions {
   /** Keep a relative target linked: a code host resolves it against the repository, chat cannot. */
   resolvesRelativeTargets?: boolean
+  /** A daemon-owned mapping from runtime file targets to authenticated workspace URLs. */
+  resolveFileLink?: WorkspaceFileLinkResolver
 }
 
 /** Rewrite unsafe link targets without reformatting the rest of the Markdown source. */
@@ -24,7 +27,7 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
   const keeps = (url: string): boolean =>
     WEB_SCHEME.test(url) || (opts.resolvesRelativeTargets === true && !HOST_ABSOLUTE.test(url))
 
-  const render = (node: Nodes): string => {
+  const render = (node: Nodes, insideLink = false): string => {
     const start = node.position!.start.offset!
     const end = node.position!.end.offset!
     if (node.type === 'definition') return keeps(node.url) ? text.slice(start, end) : ''
@@ -33,7 +36,10 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
     let content = ''
     let label = ''
     if ('children' in node) {
-      const children = node.children.map((child) => ({ child, rendered: render(child) }))
+      const children = node.children.map((child) => ({
+        child,
+        rendered: render(child, insideLink || node.type === 'link' || node.type === 'linkReference')
+      }))
       const changed = children.some(
         ({ child, rendered }) => rendered !== text.slice(child.position!.start.offset!, child.position!.end.offset!)
       )
@@ -58,6 +64,8 @@ export function flattenUnsafeLinks(text: string, opts: FlattenOptions = {}): str
     const display = target.url.startsWith('#') ? '' : HOST_ABSOLUTE.test(target.url) ? basename(target.url) : target.url
     // Images have no useful visible label here; an autolink's label is the unsafe target itself.
     const visible = (node.type === 'link' && text[start] === '[') || node.type === 'linkReference' ? label : ''
+    const fileUrl = !insideLink ? opts.resolveFileLink?.(target.url) : undefined
+    if (fileUrl && /^https?:/i.test(fileUrl)) return `[${visible || inlineCode(display)}](<${fileUrl}>)`
     if (!display || visible.includes(display)) return visible || inlineCode(display)
     return visible ? `${visible} (${inlineCode(display)})` : inlineCode(display)
   }

--- a/packages/daemon/src/messages/workspace-file-links.ts
+++ b/packages/daemon/src/messages/workspace-file-links.ts
@@ -1,0 +1,67 @@
+import { posix, win32 } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export type WorkspaceFileLinkResolver = (target: string) => string | undefined
+
+export interface WorkspaceFileLinkContext {
+  sessionUrl: string
+  agentId: string
+  cwd: string
+  roots: readonly { path: string; repo?: string }[]
+}
+
+const WINDOWS_PATH = /^(?:[A-Za-z]:[\\/]|\\\\)/
+
+/** Map runtime paths into the existing authenticated viewer; file reads still enforce containment. */
+export function createWorkspaceFileLinkResolver(ctx: WorkspaceFileLinkContext): WorkspaceFileLinkResolver {
+  const paths = WINDOWS_PATH.test(ctx.cwd) ? win32 : posix
+  let session: URL
+  try {
+    session = new URL(ctx.sessionUrl)
+    if (!/^https?:$/.test(session.protocol)) return () => undefined
+  } catch {
+    return () => undefined
+  }
+  const roots = [...ctx.roots].sort((a, b) => b.path.length - a.path.length)
+  return (target) => {
+    if (!target || /^[#?]/.test(target)) return undefined
+    let file: string
+    try {
+      if (/^file:/i.test(target)) {
+        file = fileURLToPath(new URL(target), { windows: paths === win32 })
+      } else {
+        if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(target) && !WINDOWS_PATH.test(target)) return undefined
+        file = target.split(/[?#]/, 1)[0]!
+        try {
+          file = decodeURIComponent(file)
+        } catch {
+          // A filesystem path can contain a literal percent sign rather than a URL escape.
+        }
+      }
+    } catch {
+      return undefined
+    }
+    // Runtime file citations may carry a line/column; the viewer currently opens the whole file.
+    file = file.replace(/:\d+(?::\d+)?$/, '')
+    if (!file || /[\u0000-\u001f\u007f]/.test(file)) return undefined
+    if (paths === posix && WINDOWS_PATH.test(file)) return undefined
+    const absolute = paths.resolve(ctx.cwd, file)
+    for (const root of roots) {
+      const relative = paths.relative(root.path, absolute)
+      if (!relative || paths.isAbsolute(relative) || relative === '..' || relative.startsWith(`..${paths.sep}`))
+        continue
+      const segments = relative.split(paths.sep)
+      if (relative.split(/[\\/]/).some((segment) => segment.toLowerCase() === '.git')) return undefined
+      const url = new URL(session)
+      url.hash = ''
+      url.searchParams.set('view', 'flat')
+      url.searchParams.set('agent', ctx.agentId)
+      url.searchParams.set('file', segments.join('/'))
+      url.searchParams.delete('mode')
+      if (root.repo) url.searchParams.set('repo', root.repo)
+      else url.searchParams.delete('repo')
+      return url.href
+    }
+    return undefined
+  }
+}

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -44,6 +44,7 @@
 import type { GithubPublishedComment, PublishedHookOutput } from '@agentconnect.md/protocol'
 import type { GithubReplyCollector } from '../../github/poster.js'
 import type { GitlabPublishFailure } from '../../gitlab/poster.js'
+import type { WorkspaceFileLinkResolver } from '../../messages/workspace-file-links.js'
 
 /** GitHub's per-turn state (§7.3). Held in the turn's final-surface slot, which
  *  core stores opaquely and never reads. */
@@ -66,6 +67,7 @@ export interface GithubTurnState {
  *  structurally — a far smaller footprint than the chat surfaces need, because
  *  GitHub owns no anchors on the turn record. */
 export interface GithubTurn {
+  resolveFileLink?: WorkspaceFileLinkResolver
   plan: {
     statusThread: string
     transcriptChannel: string
@@ -138,7 +140,10 @@ export async function finalizeGithubTurn<TTurn extends GithubTurn>(
   // A headless GitHub hook has no platform-send boundary. Explicit final chunks
   // were withheld from the core converger, so persist the collector's one
   // logical final now instead of one row per idle/size flush.
-  const final = !opts.suppressed && opts.atEnd ? state.collector.finalText(true) : undefined
+  const final =
+    !opts.suppressed && opts.atEnd
+      ? state.collector.finalText(true, { resolvesRelativeTargets: true, resolveFileLink: turn.resolveFileLink })
+      : undefined
   if (state.deferredFinalTranscript && final?.trim()) {
     await host.appendTranscript({
       channel: turn.plan.transcriptChannel,

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -15,6 +15,8 @@ import { splitAtParagraphBoundary } from '../../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../../session/no-response.js'
 import { extractToolOutput } from '../../session/tool-output.js'
 import type { TurnOutputContext } from '../turn-output.js'
+import { flattenUnsafeLinks } from '../../messages/agent-links.js'
+import type { WorkspaceFileLinkResolver } from '../../messages/workspace-file-links.js'
 import { sanitizeTitle } from './message-strategy.js'
 
 /** Linear's plan-entry vocabulary. `canceled` has no ACP source today; it exists because
@@ -421,7 +423,8 @@ export class LinearConverger {
 
   constructor(
     private readonly mode: LinearOutputMode,
-    private readonly showFooter: boolean
+    private readonly showFooter: boolean,
+    private readonly resolveFileLink?: WorkspaceFileLinkResolver
   ) {
     this.policy = MODE_POLICY[mode]
   }
@@ -508,7 +511,7 @@ export class LinearConverger {
     if (this.settled) return []
     this.settled = true
     if (isNoResponseBody(this.sentinelTail.trim())) return this.discard()
-    const final = this.collector.finalText(true)?.trim() ?? ''
+    const final = this.collector.finalText(true, { resolveFileLink: this.resolveFileLink })?.trim() ?? ''
     // `none` is transcript-only (§5.2): the answer is still recorded, the feed still sees nothing.
     if (!this.policy.response) {
       this.discard()
@@ -675,7 +678,10 @@ export class LinearConverger {
       this.narration = tail
       text = ready
     }
-    return [...this.takePending(), { kind: 'activity', type: 'thought', body: text.trim() }]
+    const body = flattenUnsafeLinks(text.trim(), { resolveFileLink: this.resolveFileLink })
+    const actions = this.takePending()
+    if (body.trim()) actions.push({ kind: 'activity', type: 'thought', body })
+    return actions
   }
 
   /** Emit the reasoning accumulated SINCE THE LAST FLUSH. The in-place renderers keep a
@@ -687,7 +693,9 @@ export class LinearConverger {
     const trimmed = this.reasoning.trim()
     this.reasoning = ''
     if (!trimmed) return []
-    const tail = trimmed.length > MAX_REASONING ? `…${trimmed.slice(-MAX_REASONING)}` : trimmed
+    const safe = flattenUnsafeLinks(trimmed, { resolveFileLink: this.resolveFileLink })
+    if (!safe.trim()) return []
+    const tail = safe.length > MAX_REASONING ? `…${safe.slice(-MAX_REASONING)}` : safe
     return [{ kind: 'activity', type: 'thought', body: tail, ephemeral: true }]
   }
 
@@ -703,7 +711,7 @@ export class LinearConverger {
 
 /** Build this turn's converger. Fresh per turn, so a config change applies from the next one. */
 export function createLinearConverger(ctx: TurnOutputContext<unknown>): LinearConverger {
-  return new LinearConverger(normalizeMode(ctx.mode), ctx.showFooter)
+  return new LinearConverger(normalizeMode(ctx.mode), ctx.showFooter, ctx.resolveFileLink)
 }
 
 /** Seed the opaque per-turn state slot core stores and never reads. */

--- a/packages/daemon/src/platforms/turn-output.ts
+++ b/packages/daemon/src/platforms/turn-output.ts
@@ -35,12 +35,12 @@
  */
 
 import type { ElicitCardFacet } from './elicit-card.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 
-/** A turn's INPUTS, as a platform sees them. Deliberately limited to the
- *  triggering event and the two rendering switches: a surface may read what its
- *  own platform delivered, never core turn machinery — that limit is what keeps
- *  the `apply` bodies honest when they move to their platform modules. */
+/** Platform inputs and narrow rendering capabilities; core turn state stays inside the daemon. */
 export interface TurnOutputContext<TMessage> {
+  /** Rewrite a workspace target through the daemon's trusted session scope. */
+  resolveFileLink?: WorkspaceFileLinkResolver
   /** Resolved output mode for this turn (`none` … `high`). */
   mode: string
   /** Whether the conversation is a direct message. Telegram's continue-the-topic

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -25,6 +25,7 @@ export {
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
@@ -2179,7 +2180,8 @@ export class OutputConverger {
    */
   constructor(
     private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high',
-    private protectedAddresses: readonly string[] = []
+    private protectedAddresses: readonly string[] = [],
+    private readonly resolveFileLink?: WorkspaceFileLinkResolver
   ) {}
 
   /** True while body text OR reasoning is pending — the daemon uses this to (re)arm
@@ -2453,7 +2455,7 @@ export class OutputConverger {
     // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
     if (!trimmed || isNoResponsePrefix(trimmed)) return []
     const raw = complete ? this.buf : this.buf.slice(0, referenceBufferStart(this.buf))
-    const text = flattenUnsafeLinks(raw)
+    const text = flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'live-reply', text: this.liveDisplay(text) }] : []
   }
 
@@ -2476,7 +2478,7 @@ export class OutputConverger {
     // Hold while the body may still be / is the bare sentinel — a suppressed reply must not be
     // recorded or shown; onFinal makes the final drop. Non-sentinel bodies close normally.
     if (isNoResponsePrefix(this.buf.trim())) return []
-    const text = flattenUnsafeLinks(this.buf)
+    const text = flattenUnsafeLinks(this.buf, { resolveFileLink: this.resolveFileLink })
     this.recordDirty = false
     if (!text.trim()) return []
     return [
@@ -2495,7 +2497,7 @@ export class OutputConverger {
     // line of it under the container that already holds them.
     if (this.streaming || !this.reasoningDirty) return []
     this.reasoningDirty = false
-    const text = flattenUnsafeLinks(this.reasoningBuf)
+    const text = flattenUnsafeLinks(this.reasoningBuf, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text) }] : []
   }
 
@@ -2529,7 +2531,7 @@ export class OutputConverger {
   }
 
   private emitBody(raw: string): SlackAction[] {
-    const text = flattenUnsafeLinks(raw)
+    const text = flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
     if (!text.trim()) return []
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` is handled
     // before the connection check on every platform, so it lands even though replyConn is unset.

--- a/packages/daemon/src/telegram/render.ts
+++ b/packages/daemon/src/telegram/render.ts
@@ -1,6 +1,7 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { splitIntoSections } from '../messages/split-sections.js'
 import { flattenUnsafeLinks, referenceBufferStart } from '../messages/agent-links.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -198,7 +199,8 @@ export class TelegramConverger {
    *  reply to it could not resolve back to this session (the hint would be a lie there). */
   constructor(
     private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high',
-    opts: { continueHint?: boolean } = {}
+    opts: { continueHint?: boolean } = {},
+    private readonly resolveFileLink?: WorkspaceFileLinkResolver
   ) {
     this.hintEnabled = opts.continueHint === true && (mode === 'low' || mode === 'medium' || mode === 'high')
     this.bodyLimit = this.hintEnabled
@@ -236,7 +238,7 @@ export class TelegramConverger {
     // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
     if (!trimmed || isNoResponsePrefix(trimmed)) return []
     const raw = complete ? this.buf : this.buf.slice(0, referenceBufferStart(this.buf))
-    const text = flattenUnsafeLinks(raw)
+    const text = flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'live-reply', text: this.liveDisplay(text) }] : []
   }
 
@@ -256,7 +258,7 @@ export class TelegramConverger {
     // Hold while the body may still be / is the bare sentinel — a suppressed reply must not be
     // recorded or shown; onFinal makes the final drop. Non-sentinel bodies close normally.
     if (isNoResponsePrefix(this.buf.trim())) return []
-    const text = flattenUnsafeLinks(this.buf)
+    const text = flattenUnsafeLinks(this.buf, { resolveFileLink: this.resolveFileLink })
     this.recordDirty = false
     if (!text.trim()) return []
     return [
@@ -270,7 +272,7 @@ export class TelegramConverger {
   private drainReasoning(): TelegramAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
-    const text = flattenUnsafeLinks(this.reasoningBuf)
+    const text = flattenUnsafeLinks(this.reasoningBuf, { resolveFileLink: this.resolveFileLink })
     return text.trim() ? [{ kind: 'reasoning', text: renderReasoning(text), parseMode: 'HTML' }] : []
   }
 
@@ -305,7 +307,7 @@ export class TelegramConverger {
   }
 
   private emitBody(raw: string, final: boolean): TelegramAction[] {
-    const text = flattenUnsafeLinks(raw)
+    const text = flattenUnsafeLinks(raw, { resolveFileLink: this.resolveFileLink })
     if (!text.trim()) return []
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` runs before
     // the connection check, so it lands even though replyConn is unset for this mode.

--- a/packages/daemon/src/webchat/turn-output.ts
+++ b/packages/daemon/src/webchat/turn-output.ts
@@ -1,27 +1,24 @@
-/**
- * The webchat turn-output surface: the ACP-update → `WebchatEvent` mapping the turn
- * engine streams through a turn's sink, plus the two transcript helpers that share it.
- * Pure functions over the turn's webchat state (and, where a row is written, the store),
- * called directly by the turn engine.
- */
+// Webchat output mapping and canonical transcript helpers used by the turn engine.
 import type { SessionImageAttachment, WebchatEvent } from '@agentconnect.md/protocol'
 import type { LocalStore } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { isNoResponsePrefix } from '../session/no-response.js'
 import { planEntriesOf } from '../session/plan-entries.js'
+import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { agentMessageId } from '../messages/message-boundary.js'
+import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 import { chunkText } from './chunk.js'
 import type { Pending } from '../daemon/turn-types.js'
 
-/** One turn's live webchat state — the sink, its output cursor, and the sentinel hold. */
+/** One turn's live sink, output cursor, and buffered Markdown message. */
 export type WebchatTurnOutput = NonNullable<Pending['webchat']>
 
-/**
- * Map one ACP SessionUpdate to a WebchatEvent and stream it through the sink (→ relay
- * `rd/chat`, webchat's "send"). Only the streamable kinds map; usage and the rest are
- * handled elsewhere or dropped. A single event whose inline text would
- * blow the 256 KiB frame cap is split across multiple chunks, each with its own `index`.
- */
-export function emitWebchatUpdate(wc: WebchatTurnOutput, update: any): void {
+/** Map streamable ACP updates into indexed webchat events below the relay frame limit. */
+export function emitWebchatUpdate(
+  wc: WebchatTurnOutput,
+  update: any,
+  resolveFileLink?: WorkspaceFileLinkResolver
+): void {
   const emit = (event: WebchatEvent): void => {
     wc.sink.output({
       conversationId: wc.conversationId,
@@ -30,26 +27,27 @@ export function emitWebchatUpdate(wc: WebchatTurnOutput, update: any): void {
       event
     })
   }
+  const messageId = update?.sessionUpdate === 'agent_message_chunk' ? agentMessageId(update) : ''
+  const boundary =
+    (messageId && wc.messageId && messageId !== wc.messageId) ||
+    ['agent_thought_chunk', 'tool_call', 'tool_call_update', 'plan'].includes(update?.sessionUpdate)
+  if (boundary && !isNoResponsePrefix(wc.replyText.trim())) flushHeldWebchatText(wc, resolveFileLink)
+  if (messageId) wc.messageId = messageId
   switch (update?.sessionUpdate) {
     case 'agent_message_chunk': {
       const text = update.content?.type === 'text' ? (update.content.text ?? '') : ''
       if (text) {
-        wc.replyText += text // recorded once at turn end (no Slack post boundary)
-        // Response-choice hold (product-conventions §No-response control marker):
-        // while the whole accumulated body could still be the bare sentinel,
-        // keep it off the live stream — an agent silently declining a
-        // conversation-wide activation must not flash AC_NO_RESPONSE into the
-        // browser. Everything is released the instant the body diverges.
-        if (wc.messageEmitted) {
-          for (const t of chunkText(text)) emit({ kind: 'message', text: t })
-        } else {
-          wc.heldText += text
-          if (!isNoResponsePrefix(wc.heldText.trim())) {
-            const held = wc.heldText
-            wc.heldText = ''
-            wc.messageEmitted = true
-            for (const t of chunkText(held)) emit({ kind: 'message', text: t })
-          }
+        wc.replyText += text
+        wc.heldText += text
+        // Keep the sentinel and any Markdown that later chunks could turn into a file link off the stream.
+        if (!wc.messageEmitted && isNoResponsePrefix(wc.replyText.trim())) return
+        const linkStart = wc.heldText.search(/[<[\]]/)
+        const end = (linkStart < 0 ? wc.heldText : wc.heldText.slice(0, linkStart)).trimEnd().length
+        const ready = wc.heldText.slice(wc.heldTextOffset ?? 0, end)
+        wc.heldTextOffset = end
+        if (ready) {
+          wc.messageEmitted = true
+          for (const t of chunkText(ready)) emit({ kind: 'message', text: t })
         }
       }
       return
@@ -154,18 +152,22 @@ export async function appendWebchatTextRow(
   return fallback
 }
 
-/** Release stream text held back by the no-response sentinel check once the
- *  turn is known to be a real reply (it diverged only at the very end, e.g. a
- *  body shorter than the sentinel). */
-export function flushHeldWebchatText(wc: WebchatTurnOutput): void {
+/** Resolve one complete Markdown message before releasing its held suffix and recording the canonical reply. */
+export function flushHeldWebchatText(wc: WebchatTurnOutput, resolveFileLink?: WorkspaceFileLinkResolver): void {
   if (!wc.heldText) return
-  const held = wc.heldText
+  const rendered = flattenUnsafeLinks(wc.heldText, { resolveFileLink })
+  const held = rendered.slice(wc.heldTextOffset ?? 0)
+  wc.replyText = wc.replyText.slice(0, -wc.heldText.length) + rendered
   wc.heldText = ''
+  wc.heldTextOffset = 0
+  if (!held) return
   wc.messageEmitted = true
-  wc.sink.output({
-    conversationId: wc.conversationId,
-    turnId: wc.turnId,
-    index: wc.index++,
-    event: { kind: 'message', text: held }
-  })
+  for (const text of chunkText(held)) {
+    wc.sink.output({
+      conversationId: wc.conversationId,
+      turnId: wc.turnId,
+      index: wc.index++,
+      event: { kind: 'message', text }
+    })
+  }
 }

--- a/packages/daemon/src/webchat/turn-output.ts
+++ b/packages/daemon/src/webchat/turn-output.ts
@@ -41,7 +41,7 @@ export function emitWebchatUpdate(
         wc.heldText += text
         // Keep the sentinel and any Markdown that later chunks could turn into a file link off the stream.
         if (!wc.messageEmitted && isNoResponsePrefix(wc.replyText.trim())) return
-        const linkStart = wc.heldText.search(/[<[\]]/)
+        const linkStart = wc.heldText.search(/[!<[\]]/)
         const end = (linkStart < 0 ? wc.heldText : wc.heldText.slice(0, linkStart)).trimEnd().length
         const ready = wc.heldText.slice(wc.heldTextOffset ?? 0, end)
         wc.heldTextOffset = end

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -29,9 +29,12 @@ describe('AcpHost (against a fake ACP agent)', () => {
     )
     await host.start()
     const sessionId = await host.newSession('/tmp')
+    expect(host.sessionCwd(sessionId)).toBe('/tmp')
     const res = await host.prompt(sessionId, [{ type: 'text', text: 'hi' }])
     expect(res.stopReason).toBe('end_turn')
     expect(updates).toContainEqual({ sessionId, text: 'echo:hi' })
+    host.forgetSession(sessionId)
+    expect(host.sessionCwd(sessionId)).toBeUndefined()
     await host.stop()
   })
 
@@ -135,6 +138,9 @@ describe('AcpHost additional workspace directories', () => {
     await supported.start()
     await supported.newSession(cwd, [], undefined, undefined, [repoRoot])
     await supported.loadSession('persisted-session', cwd, [], undefined, undefined, [repoRoot])
+    expect(supported.sessionCwd('persisted-session')).toBe(cwd)
+    supported.discardSession('persisted-session')
+    expect(supported.sessionCwd('persisted-session')).toBeUndefined()
     await supported.stop()
 
     const unsupported = new AcpHost(
@@ -161,6 +167,7 @@ describe('AcpHost session deletion', () => {
     const sessionId = await host.newSession('/tmp')
     expect(await host.deleteSession(sessionId)).toBe(true)
     expect(host.hasSession(sessionId)).toBe(false)
+    expect(host.sessionCwd(sessionId)).toBeUndefined()
     await host.stop()
   })
 })

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
+import { emitWebchatUpdate, flushHeldWebchatText, type WebchatTurnOutput } from '../src/webchat/turn-output.js'
 import type { WebchatOutput, WebchatDone, RdChatEvent, RdMsgWebchat } from '@agentconnect.md/protocol'
 import { WAIT } from './wait-support.js'
 
@@ -59,6 +60,7 @@ function streamingHost(
     models?: string[]
     usage?: Record<string, number>
     initialUpdates?: unknown[]
+    error?: Error
   } = {}
 ) {
   const { stopReason = 'end_turn', model, models, usage, initialUpdates = [] } = opts
@@ -77,6 +79,7 @@ function streamingHost(
     setSessionFastMode: vi.fn(async () => true),
     prompt: vi.fn(async (sid: string, _blocks: unknown[]) => {
       for (const u of updates) onUpdate(sid, u)
+      if (opts.error) throw opts.error
       return { stopReason, ...(usage ? { usage } : {}) }
     }),
     cancel: vi.fn(async () => {}),
@@ -151,6 +154,97 @@ function fakeK8sPlane(bound: boolean) {
     stop: async () => {}
   }
 }
+
+describe('Webchat workspace file links', () => {
+  const fileUrl = 'https://console.example.test/sessions/session-1?file=report.md'
+  const resolveFileLink = (target: string) => (target.startsWith('/workspace/') ? fileUrl : undefined)
+  const live = () => {
+    const events: WebchatOutput[] = []
+    const wc: WebchatTurnOutput = {
+      conversationId: CONV,
+      turnId: 'turn-1',
+      index: 0,
+      replyText: '',
+      heldText: '',
+      messageEmitted: false,
+      sink: { output: (event) => events.push(event), done: () => {} }
+    }
+    const message = () => events.flatMap((o) => (o.event?.kind === 'message' ? [o.event.text] : [])).join('')
+    return { wc, events, message }
+  }
+
+  it('streams ordinary text while holding split inline and reference targets until the message completes', () => {
+    const { wc, message } = live()
+    emitWebchatUpdate(wc, text('See '), resolveFileLink)
+    expect(message()).toBe('See')
+    emitWebchatUpdate(wc, text('[report](/workspace/'), resolveFileLink)
+    emitWebchatUpdate(wc, text('report.md), or [source][file].\n\n[file]: /workspace/report.md'), resolveFileLink)
+    expect(message()).toBe('See')
+    flushHeldWebchatText(wc, resolveFileLink)
+    expect(message()).toBe(`See [report](<${fileUrl}>), or [source](<${fileUrl}>).\n\n`)
+    expect(wc.replyText).toBe(message())
+  })
+
+  it.each([thought('thinking'), toolCall('t1', 'Read report'), plan([{ content: 'Read report', status: 'pending' }])])(
+    'resolves the held message before a $sessionUpdate boundary',
+    (boundary) => {
+      const { wc, events, message } = live()
+      emitWebchatUpdate(wc, text('[report](/workspace/report.md)'), resolveFileLink)
+      emitWebchatUpdate(wc, boundary, resolveFileLink)
+      expect(events[0]?.event).toEqual({ kind: 'message', text: `[report](<${fileUrl}>)` })
+      expect(message()).toBe(wc.replyText)
+      expect(events.map((o) => o.index)).toEqual([0, 1])
+    }
+  )
+
+  it('keeps definitions scoped to named messages and preserves existing message concatenation', () => {
+    const { wc, message } = live()
+    emitWebchatUpdate(
+      wc,
+      { ...text('[report][file]\n\n[file]: /workspace/report.md'), messageId: 'a' },
+      resolveFileLink
+    )
+    emitWebchatUpdate(wc, { ...text('then [file]'), messageId: 'b' }, resolveFileLink)
+    expect(message()).toBe(`[report](<${fileUrl}>)\n\nthen`)
+    flushHeldWebchatText(wc, resolveFileLink)
+    expect(message()).toBe(`[report](<${fileUrl}>)\n\nthen [file]`)
+    expect(wc.replyText).toBe(message())
+  })
+
+  it.each([
+    ['Paragraph\n\n  ', '[file]: /workspace/report.md\n\n[file]'],
+    ['Literal ] before ', '[report](/workspace/report.md)'],
+    ['```md\n', '[report](/workspace/report.md)\n```']
+  ])('keeps streamed and canonical source identical when chunks affect surrounding Markdown', (first, second) => {
+    const { wc, message } = live()
+    emitWebchatUpdate(wc, text(first), resolveFileLink)
+    emitWebchatUpdate(wc, text(second), resolveFileLink)
+    flushHeldWebchatText(wc, resolveFileLink)
+    expect(message()).toBe(wc.replyText)
+    expect(message()).not.toBe('')
+  })
+
+  it('flushes a failed turn fragment through the same resolver and safe fallback', () => {
+    const { wc, message } = live()
+    emitWebchatUpdate(wc, text('[report](/workspace/report.md), [outside](/etc/private.txt)'), resolveFileLink)
+    flushHeldWebchatText(wc, resolveFileLink)
+    expect(message()).toBe(`[report](<${fileUrl}>), outside (\`private.txt\`)`)
+    expect(wc.replyText).toBe(message())
+    expect(wc.heldText).toBe('')
+  })
+
+  it('holds the no-response sentinel across work events and releases a real reply when it diverges', () => {
+    const { wc, message } = live()
+    emitWebchatUpdate(wc, text('AC_NO_'), resolveFileLink)
+    emitWebchatUpdate(wc, toolCall('t1', 'Read report'), resolveFileLink)
+    emitWebchatUpdate(wc, text('RESPONSE'), resolveFileLink)
+    expect(message()).toBe('')
+    emitWebchatUpdate(wc, text(' is the reserved marker.'), resolveFileLink)
+    expect(message()).toBe('AC_NO_RESPONSE is the reserved marker.')
+    flushHeldWebchatText(wc, resolveFileLink)
+    expect(wc.replyText).toBe(message())
+  })
+})
 
 describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
   it('maps message/thinking/tool chunks to webchat events with a monotonic index, then done', async () => {
@@ -1025,6 +1119,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
   it('handleWebchatCancel interrupts the in-flight turn without muting', async () => {
     let release!: () => void
+    let onUpdate!: (sid: string, update: unknown) => void
     const gate = new Promise<void>((r) => (release = r))
     const host = {
       start: vi.fn(async () => {}),
@@ -1032,14 +1127,21 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       modelOptions: vi.fn(() => null),
       hasSession: vi.fn(() => true),
       setSessionModel: vi.fn(async () => true),
-      prompt: vi.fn(async () => {
+      prompt: vi.fn(async (sid: string) => {
+        onUpdate(sid, text('[unfinished](/workspace/private'))
         await gate
         return { stopReason: 'end_turn' }
       }),
       cancel: vi.fn(async () => {}),
       stop: vi.fn(async () => {})
     }
-    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: (_agent, callback) => {
+        onUpdate = callback
+        return host as any
+      }
+    })
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as any).cpClient = cp
@@ -1053,7 +1155,11 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     )
     await vi.waitFor(
       () =>
-        expect([...(daemon as any).pending.values()].some((p: any) => p.webchat?.conversationId === CONV)).toBe(true),
+        expect(
+          [...(daemon as any).pending.values()].some(
+            (p: any) => p.webchat?.heldText === '[unfinished](/workspace/private'
+          )
+        ).toBe(true),
       WAIT
     )
 
@@ -1069,6 +1175,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await vi.waitFor(() => expect((daemon as any).pending.size).toBe(0), WAIT)
     expect(cp.dones).toHaveLength(1) // cancel-resolved prompt must not emit a second terminal frame
     expect(cp.outputs).toHaveLength(outputsBeforeCancel)
+    expect(cp.outputs.filter((output) => output.event?.kind === 'message')).toEqual([])
     await daemon.stop()
   })
 
@@ -1153,6 +1260,48 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
     // Exactly one terminal frame, carrying the failure reason and no stopReason.
     expect(cp.dones).toEqual([{ conversationId: CONV, turnId, error: 'spawn claude ENOENT' }])
+    await daemon.stop()
+  })
+
+  it('delivers a held file-link fragment before a terminal error and records the same canonical text', async () => {
+    const { factory } = streamingHost([text('[report](/etc/report.md)')], { error: new Error('runtime failed') })
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+    const delivery: string[] = []
+    const posts: string[] = []
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    const msg = {
+      msgId: `webchat:${CONV}`,
+      traceId: turnId,
+      source: 'user' as const,
+      platform: 'webchat' as const,
+      channel: CONV,
+      sender: { id: 'alice', isBot: false },
+      text: 'go',
+      mentionedBots: [] as string[],
+      isDm: true,
+      trigger: 'dm' as const
+    }
+    await expect(
+      (daemon as any).dispatch(AGENT_ID, msg, undefined, {
+        conversationId: CONV,
+        turnId,
+        sink: {
+          output: (output: WebchatOutput) => {
+            if (output.event?.kind === 'message') delivery.push(output.event.text)
+          },
+          done: (done: WebchatDone) => delivery.push(`done:${done.error}`)
+        },
+        postSink: (post: { post: { text: string } }) => posts.push(post.post.text)
+      })
+    ).rejects.toThrow('runtime failed')
+    expect(delivery).toEqual(['report (`report.md`)', 'done:runtime failed'])
+    expect(posts).toEqual(['report (`report.md`)'])
+    const rows = await (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`)
+    expect(
+      rows.filter((row: { sender: string }) => row.sender === AGENT_ID).map((row: { text: string }) => row.text)
+    ).toContain('report (`report.md`)')
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -185,6 +185,18 @@ describe('Webchat workspace file links', () => {
     expect(wc.replyText).toBe(message())
   })
 
+  it.each([
+    ['an inline image', ['![report](/workspace/report.png)'], ''],
+    ['a split image prefix', ['!', '[report](/workspace/report.png)'], ''],
+    ['a reference image', ['!', '[report][file]\n\n[file]: /workspace/report.png'], '\n\n']
+  ])('keeps the live viewer link intact when rewriting %s', (_label, chunks, suffix) => {
+    const { wc, message } = live()
+    for (const chunk of chunks) emitWebchatUpdate(wc, text(chunk), resolveFileLink)
+    flushHeldWebchatText(wc, resolveFileLink)
+    expect(wc.replyText).toBe(`[\`report.png\`](<${fileUrl}>)${suffix}`)
+    expect(message()).toBe(wc.replyText)
+  })
+
   it.each([thought('thinking'), toolCall('t1', 'Read report'), plan([{ content: 'Read report', status: 'pending' }])])(
     'resolves the held message before a $sessionUpdate boundary',
     (boundary) => {

--- a/packages/daemon/test/daemon-workspace-file-links.test.ts
+++ b/packages/daemon/test/daemon-workspace-file-links.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+import type { TurnRun } from '../src/daemon/turn-types.js'
+import type { WorkspaceFileLinkResolver } from '../src/messages/workspace-file-links.js'
+
+function context(isolation: 'shared' | 'session') {
+  const agent = { id: 'agent-a', workspace: { mode: 'git-repo', path: '/shared/primary' } }
+  const session = { key: 'session-key', workspaceIsolation: isolation }
+  const sessionOf = vi.fn(async () => session as typeof session | undefined)
+  const daemon = Object.assign(Object.create(Daemon.prototype), {
+    agents: new Map([[agent.id, agent]]),
+    store: { getSession: async () => session, getSessionByOutwardId: sessionOf },
+    workspaces: {
+      secondaryRoots: () => [{ repoFullName: 'org/docs' }],
+      sessionWorktreePath: () => '/isolated/primary',
+      consoleSecondaryRoot: () => ({ path: '/shared/docs' }),
+      sessionRootDirectory: () => '/isolated/docs',
+      consoleWorkspaceRoot: (_agent: unknown, path: string) => path,
+      canonicalWorkspacePath: (_id: string, path: string) => path
+    },
+    sessionLink: () => 'https://console.example.test/org/sessions/outward-a',
+    sessionLinkSource: () => undefined
+  }) as {
+    turnWorkspaceFileLinkResolver(
+      run: TurnRun,
+      acpSessionId: string,
+      outwardSessionId: string
+    ): Promise<WorkspaceFileLinkResolver | undefined>
+  }
+  const run = {
+    key: session.key,
+    entry: {
+      agentId: agent.id,
+      selectedHost: {
+        host: { sessionCwd: () => `/${isolation === 'session' ? 'isolated' : 'shared'}/primary/packages/app` }
+      }
+    },
+    plan: { platform: 'slack' }
+  } as unknown as TurnRun
+  return { daemon, run, sessionOf }
+}
+
+describe('daemon workspace file link context', () => {
+  it.each(['shared', 'session'] as const)(
+    'uses the exact runtime cwd and matching %s viewer roots',
+    async (isolation) => {
+      const { daemon, run } = context(isolation)
+      const resolve = await daemon.turnWorkspaceFileLinkResolver(run, 'acp-a', 'outward-a')
+      const relative = new URL(resolve!('../report.md')!)
+      expect(relative.pathname).toBe('/org/sessions/outward-a')
+      expect(relative.searchParams.get('agent')).toBe('agent-a')
+      expect(relative.searchParams.get('file')).toBe('packages/report.md')
+      const base = isolation === 'session' ? '/isolated' : '/shared'
+      const secondary = new URL(resolve!(`${base}/docs/digest.md`)!)
+      expect(secondary.searchParams.get('repo')).toBe('org/docs')
+      expect(secondary.searchParams.get('file')).toBe('digest.md')
+      if (isolation === 'session') expect(resolve!('/shared/primary/other-session.md')).toBeUndefined()
+    }
+  )
+
+  it('does not fall back to shared roots when the isolated session no longer resolves', async () => {
+    const { daemon, run, sessionOf } = context('session')
+    sessionOf.mockResolvedValue(undefined)
+    expect(await daemon.turnWorkspaceFileLinkResolver(run, 'acp-a', 'outward-a')).toBeUndefined()
+    expect(sessionOf).toHaveBeenCalledWith('outward-a', 'agent-a')
+  })
+})

--- a/packages/daemon/test/microsandbox-guest.test.ts
+++ b/packages/daemon/test/microsandbox-guest.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
-import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { MAX_FRAME_BYTES, type MemoryFsPayload } from '@agentconnect.md/protocol'
 import {
   MICROSANDBOX_GUEST_ENTRY,
   MICROSANDBOX_NODE,
@@ -14,7 +14,7 @@ import {
 } from '../src/microsandbox/guest.js'
 import { GitTransportError } from '../src/workspace/git-runner.js'
 import { MicrosandboxWorkspaceFs } from '../src/microsandbox/workspace-fs.js'
-import { applyMemoryFsPayload, type MemoryFsPayload } from '../src/shim/memory-fs-channel.js'
+import { applyMemoryFsPayload } from '../src/shim/memory-fs-channel.js'
 import { ShimChannelLostError } from '../src/shim/channels.js'
 import { pathExecutor } from './fixtures/memory-fs-pod.js'
 

--- a/packages/daemon/test/reference-link-delivery.test.ts
+++ b/packages/daemon/test/reference-link-delivery.test.ts
@@ -5,6 +5,8 @@ import { TelegramConverger } from '../src/telegram/render.js'
 import { DiscordConverger } from '../src/discord/render.js'
 import { FeishuConverger } from '../src/feishu/render.js'
 import { GithubReplyCollector } from '../src/github/poster.js'
+import { LinearConverger } from '../src/platforms/linear/turn-output.js'
+import { createWorkspaceFileLinkResolver } from '../src/messages/workspace-file-links.js'
 
 const chunk = (text: string): SessionUpdate => ({
   sessionUpdate: 'agent_message_chunk',
@@ -60,4 +62,49 @@ it('removes a newly activated host link from the shared code-host reply', () => 
   const reply = new GithubReplyCollector()
   reply.onUpdate(chunk('[report [source](/home/agent/source.md)](/home/agent/report.md)'))
   expect(reply.finalText()).toBe('\\[report source (`source.md`)\\](/home/agent/report.md)')
+})
+
+const resolveFileLink = createWorkspaceFileLinkResolver({
+  sessionUrl: 'https://console.example.test/acme/sessions/current',
+  agentId: 'agent-1',
+  cwd: '/agent/session/workspace',
+  roots: [{ path: '/agent/session/workspace' }]
+})
+
+it.each([
+  { name: 'Slack', create: () => new OutputConverger('minimal', [], resolveFileLink) },
+  { name: 'Telegram', create: () => new TelegramConverger('minimal', {}, resolveFileLink) },
+  { name: 'Discord', create: () => new DiscordConverger('minimal', resolveFileLink) },
+  { name: 'Feishu', create: () => new FeishuConverger('minimal', resolveFileLink) }
+])('opens a split workspace reference in the $name reply', ({ create }) => {
+  const c = create()
+  c.onUpdate(chunk('Read [the report][r].\n\n[r]: /agent/session/work'))
+  expect(bodies(c.flushBuffered())).toEqual([])
+  c.onUpdate(chunk('space/report.md'))
+  const finished = bodies(c.onFinal()).filter((body) => body?.includes('Read '))
+  expect(finished.length).toBeGreaterThan(0)
+  for (const body of finished) {
+    expect(body).toContain(resolveFileLink('report.md'))
+    expect(body).not.toContain('/agent/session/')
+  }
+})
+
+it('opens workspace files in the shared code-host final while preserving repository-relative links', () => {
+  const reply = new GithubReplyCollector()
+  reply.onUpdate(chunk('[report][r] and [source](src/main.ts).\n\n[r]: /agent/session/workspace/report.md'))
+  const final = reply.finalText(true, { resolvesRelativeTargets: true, resolveFileLink })
+  expect(final).toContain(resolveFileLink('report.md'))
+  expect(final).toContain('[source](src/main.ts)')
+  expect(final).not.toContain('/agent/session/')
+})
+
+it('opens relative workspace files in the Linear final response', () => {
+  const c = new LinearConverger('minimal', false, resolveFileLink)
+  c.onUpdate(chunk('[report](report.md)'))
+  const final = c.onFinal().find((action) => action.kind === 'activity' && action.type === 'response')
+  expect(final).toMatchObject({
+    kind: 'activity',
+    type: 'response',
+    body: expect.stringContaining(resolveFileLink('report.md')!)
+  })
 })

--- a/packages/daemon/test/workspace-file-links.test.ts
+++ b/packages/daemon/test/workspace-file-links.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import type { Nodes } from 'mdast'
+import { flattenUnsafeLinks } from '../src/messages/agent-links.js'
+import { createWorkspaceFileLinkResolver } from '../src/messages/workspace-file-links.js'
+
+const resolveFileLink = createWorkspaceFileLinkResolver({
+  sessionUrl: 'https://console.example.test/acme/sessions/session-1?source=slack',
+  agentId: 'agent-1',
+  cwd: '/srv/agent/sessions/one/workspace/packages/app',
+  roots: [
+    { path: '/srv/agent/sessions/one/workspace' },
+    { path: '/srv/agent/sessions/one/repos/acme/tools', repo: 'acme/tools' }
+  ]
+})
+
+function links(text: string): string[] {
+  const urls: string[] = []
+  const visit = (node: Nodes): void => {
+    if (node.type === 'link') urls.push(node.url)
+    if ('children' in node) node.children.forEach(visit)
+  }
+  visit(fromMarkdown(text))
+  return urls
+}
+
+describe('workspace file links', () => {
+  it.each([
+    ['/srv/agent/sessions/one/workspace/docs/report.md', 'docs/report.md'],
+    ['../../docs/report.md', 'docs/report.md'],
+    ['./notes.md', 'packages/app/notes.md'],
+    ['file:///srv/agent/sessions/one/workspace/docs/a%20b.md', 'docs/a b.md'],
+    ['/srv/agent/sessions/one/workspace/docs/a%23b%3F.md', 'docs/a#b?.md'],
+    ['/srv/agent/sessions/one/workspace/docs/100%.md', 'docs/100%.md'],
+    ['/srv/agent/sessions/one/workspace/docs/report.md:12:3', 'docs/report.md'],
+    ['/srv/agent/sessions/one/workspace/docs/report.md#L12-L20', 'docs/report.md']
+  ])('opens %s from the exact session and runtime working directory', (target, file) => {
+    const url = new URL(resolveFileLink(target)!)
+    expect(url.pathname).toBe('/acme/sessions/session-1')
+    expect(Object.fromEntries(url.searchParams)).toEqual({ source: 'slack', view: 'flat', agent: 'agent-1', file })
+    expect(url.href).not.toContain('/srv/')
+  })
+
+  it('routes an authorized secondary repository through the same session', () => {
+    const url = new URL(resolveFileLink('/srv/agent/sessions/one/repos/acme/tools/README.md')!)
+    expect(url.searchParams.get('repo')).toBe('acme/tools')
+    expect(url.searchParams.get('file')).toBe('README.md')
+    expect(url.pathname).toBe('/acme/sessions/session-1')
+  })
+
+  it.each([
+    '/etc/passwd',
+    '/srv/agent/sessions/two/workspace/report.md',
+    '/srv/agent/sessions/one/workspace-extra/report.md',
+    '../../../private.md',
+    '/srv/agent/sessions/one/workspace/.git/config',
+    '/srv/agent/sessions/one/workspace/dir%5C.git%5Cconfig',
+    '/srv/agent/sessions/one/workspace/%2e%2e/private.md',
+    '/srv/agent/sessions/one/workspace/bad%00.md',
+    'file://remote.example.test/srv/agent/sessions/one/workspace/report.md',
+    'https://example.test/report.md',
+    'javascript:alert(1)',
+    '#heading',
+    '?file=report.md'
+  ])('does not map an out-of-scope or non-file target: %s', (target) => {
+    expect(resolveFileLink(target)).toBeUndefined()
+  })
+
+  it('handles Windows paths independently of the daemon test host', () => {
+    const resolve = createWorkspaceFileLinkResolver({
+      sessionUrl: 'https://console.example.test/acme/sessions/windows',
+      agentId: 'agent-1',
+      cwd: 'C:\\agent\\workspace\\src',
+      roots: [{ path: 'C:\\agent\\workspace' }]
+    })
+    for (const target of ['C:\\agent\\workspace\\docs\\report.md', 'file:///C:/agent/workspace/docs/report.md']) {
+      expect(new URL(resolve(target)!).searchParams.get('file')).toBe('docs/report.md')
+    }
+    expect(resolve('D:\\agent\\workspace\\report.md')).toBeUndefined()
+    expect(resolve('C:\\agent\\workspace\\.GIT\\config')).toBeUndefined()
+  })
+
+  it('keeps file names with URL and Markdown punctuation inside a single target', () => {
+    const target = '/srv/agent/sessions/one/workspace/a%20(b)%26c%23d.md'
+    const rendered = flattenUnsafeLinks(`[report](<${target}>)`, { resolveFileLink })
+    const targets = links(rendered)
+    expect(targets).toHaveLength(1)
+    expect(new URL(targets[0]!).searchParams.get('file')).toBe('a (b)&c#d.md')
+  })
+
+  it('resolves inline and all reference forms while removing host definitions', () => {
+    const raw = '[inline](../../report.md), [named][r], [r][], [r].\n\n[r]: /srv/agent/sessions/one/workspace/report.md'
+    const rendered = flattenUnsafeLinks(raw, { resolveFileLink })
+    expect(links(rendered)).toHaveLength(4)
+    expect(new Set(links(rendered)).size).toBe(1)
+    expect(rendered).not.toContain('/srv/')
+    expect(flattenUnsafeLinks(rendered, { resolveFileLink })).toBe(rendered)
+  })
+
+  it('opens workspace images in the viewer without nesting links inside another link', () => {
+    const image = flattenUnsafeLinks('![plot](../../plot.png)', { resolveFileLink })
+    expect(new URL(links(image)[0]!).searchParams.get('file')).toBe('plot.png')
+    const nested = flattenUnsafeLinks('[![plot](../../plot.png)](../../report.md)', { resolveFileLink })
+    expect(links(nested)).toHaveLength(1)
+    expect(new URL(links(nested)[0]!).searchParams.get('file')).toBe('report.md')
+  })
+
+  it('keeps repository-relative code-host links and rewrites absolute workspace files', () => {
+    const rendered = flattenUnsafeLinks(
+      '[repo](docs/report.md), [local](/srv/agent/sessions/one/workspace/new.md), [outside](/tmp/private.md)',
+      { resolvesRelativeTargets: true, resolveFileLink }
+    )
+    expect(links(rendered)[0]).toBe('docs/report.md')
+    expect(new URL(links(rendered)[1]!).searchParams.get('file')).toBe('new.md')
+    expect(rendered).toContain('outside (`private.md`)')
+    expect(rendered).not.toContain('/tmp/')
+  })
+})

--- a/packages/web/src/components/console/viewer/SessionViewer.test.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.test.tsx
@@ -361,17 +361,25 @@ describe('SessionViewer scope', () => {
 describe('SessionViewer sliced reads', () => {
   const truncated = { content: 'a\nb\n', size: 200_000, truncated: true, nextOffset: 65_536, offset: 0 }
 
-  it('asks for the next slice at the offset the daemon named, not at the length of the text it decoded', async () => {
-    wire.slices[0] = truncated
-    wire.slices[65_536] = { content: 'c\n', size: 200_000, truncated: false, nextOffset: 200_000, offset: 65_536 }
-    await render()
-    expect(text()).toContain('Showing first 64.0 KB of 195.3 KB')
-    await pressButton('Load more')
-    expect(wire.calls[1]).toEqual({ path: 'src/app/page.tsx', offset: 65_536, sessionId: 'session-1' })
-    expect(code()).toBe('a\nb\nc')
-    expect(gutter()).toBe('1\n2\n3')
-    expect(text()).not.toContain('Showing first')
-  })
+  it.each([undefined, 'acme/secondary'])(
+    'keeps the daemon offset and repository scope on later slices: %s',
+    async (repo) => {
+      wire.slices[0] = truncated
+      wire.slices[65_536] = { content: 'c\n', size: 200_000, truncated: false, nextOffset: 200_000, offset: 65_536 }
+      await render({ repo })
+      expect(text()).toContain('Showing first 64.0 KB of 195.3 KB')
+      await pressButton('Load more')
+      expect(wire.calls[1]).toEqual({
+        path: 'src/app/page.tsx',
+        offset: 65_536,
+        sessionId: 'session-1',
+        ...(repo ? { repo } : {})
+      })
+      expect(code()).toBe('a\nb\nc')
+      expect(gutter()).toBe('1\n2\n3')
+      expect(text()).not.toContain('Showing first')
+    }
+  )
 
   it('keeps the slices it has when the next one fails, and offers the read again', async () => {
     wire.slices[0] = truncated
@@ -568,18 +576,26 @@ describe('SessionViewer staging', () => {
   const HUNK = '@@ -1,1 +1,1 @@\n-old\n+new\n'
   const stageButton = () => container?.querySelector<HTMLButtonElement>('[data-viewer-stage]') ?? undefined
 
-  it('stages the open path from the unstaged diff and re-reads it', async () => {
+  it.each([undefined, 'acme/secondary'])('stages the open path and re-reads the same repository: %s', async (repo) => {
     wire.diffs.unstaged = { diff: HUNK }
-    await render({ mode: 'diff', onIndexChanged: () => (indexChanges += 1) })
+    await render({ mode: 'diff', repo, onIndexChanged: () => (indexChanges += 1) })
     expect(wire.diffCalls).toHaveLength(1)
     expect(stageButton()?.dataset.viewerStage).toBe('stage')
     expect(text()).toContain('Stage file')
 
     await click('[data-viewer-stage]')
 
-    expect(wire.stageCalls).toEqual([{ kind: 'stage', paths: ['src/app/page.tsx'], sessionId: 'session-1' }])
+    expect(wire.stageCalls).toEqual([
+      { kind: 'stage', paths: ['src/app/page.tsx'], sessionId: 'session-1', ...(repo ? { repo } : {}) }
+    ])
     // The diff under the reader changed by definition, so it is re-read rather than left describing the tree before the write.
     expect(wire.diffCalls).toHaveLength(2)
+    expect(wire.diffCalls.at(-1)).toEqual({
+      path: 'src/app/page.tsx',
+      scope: 'unstaged',
+      sessionId: 'session-1',
+      ...(repo ? { repo } : {})
+    })
     // The fresh status the reply carries has no home in this pane, so the panel that owns the lists is told.
     expect(indexChanges).toBe(1)
   })

--- a/packages/web/src/components/console/viewer/SessionViewer.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.tsx
@@ -108,6 +108,7 @@ const PILL_OFF = `${PILL_BASE} bg-transparent text-(--text-secondary) hover:text
 export function SessionViewer({
   agentId,
   sessionId,
+  repo,
   path,
   mode = 'file',
   diffRefreshTick = 0,
@@ -118,6 +119,8 @@ export function SessionViewer({
   agentId: string
   /** ACP session id selecting that session's isolated worktree; omit for the agent's primary checkout. Pass it only for a session whose `workspaceIsolation` is `'session'` — the daemon answers a shared-workspace sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline". */
   sessionId?: string
+  /** An authorized secondary repository; omit for the primary workspace. */
+  repo?: string
   /** Workspace-relative path of the file to read. Changing it starts a fresh read; an older slice can never land in the newer one. */
   path: string
   /** Which read is on screen. It lives in the URL beside `file` (§4), so the caller owns it and this pane reports the pill instead of holding a second copy. */
@@ -151,7 +154,7 @@ export function SessionViewer({
     if (!fileWanted) return
     const requestId = ++requestRef.current
     setRead(PENDING)
-    fetchWorkspaceFile(agentId, { path, ...(sessionId ? { sessionId } : {}) }).then(
+    fetchWorkspaceFile(agentId, { path, ...(sessionId ? { sessionId } : {}), ...(repo ? { repo } : {}) }).then(
       (f) =>
         setRead((r) =>
           requestId === requestRef.current ? { ...r, loading: false, file: f, content: f.content ?? '' } : r
@@ -166,7 +169,7 @@ export function SessionViewer({
     return () => {
       requestRef.current += 1
     }
-  }, [agentId, sessionId, path, reloadTick, fileWanted])
+  }, [agentId, sessionId, repo, path, reloadTick, fileWanted])
 
   // One entry per read, so switching Diff → File → Diff redraws instead of re-reading. Keyed by the WHOLE read — checkout, worktree, path, scope, retry — not by the scope alone: the caller remounts this pane on a path change today, and a cache that relied on that would paint one path's diff under another's heading the day it stops.
   const [diffs, setDiffs] = useState<Record<string, DiffRead>>({})
@@ -174,7 +177,7 @@ export function SessionViewer({
   const diffScope = SCOPE_OF[mode]
   const wantDiff = mode !== 'file'
   // A newline joins the parts because a POSIX path may contain a space: two different reads must not collide on one key. Both ticks ride the key — the pane's own Retry and its own writes, and the caller's "the index moved under you" — so an invalidated diff is a NEW read rather than a mutated entry.
-  const diffKey = [agentId, sessionId ?? '', path, diffScope, diffTick, diffRefreshTick].join('\n')
+  const diffKey = [agentId, sessionId ?? '', repo ?? '', path, diffScope, diffTick, diffRefreshTick].join('\n')
   // Which reads this mount has already issued, so an effect firing again for an unrelated reason does not re-issue one that is already in flight.
   const askedRef = useRef(new Set<string>())
   useEffect(() => {
@@ -183,7 +186,12 @@ export function SessionViewer({
     askedRef.current.add(diffKey)
     setDiffs((current) => ({ ...current, [diffKey]: DIFF_PENDING }))
     // Deliberately NOT cancelled on cleanup. `diffKey` already names the read, so a late answer can only land on its own entry — while cancelling stranded it: leaving diff mode tore the read down, and coming back short-circuited on `askedRef`, so the pane span on a spinner with no Retry until the scope or the path changed.
-    fetchWorkspaceGitDiff(agentId, { path, scope: diffScope, ...(sessionId ? { sessionId } : {}) }).then(
+    fetchWorkspaceGitDiff(agentId, {
+      path,
+      scope: diffScope,
+      ...(sessionId ? { sessionId } : {}),
+      ...(repo ? { repo } : {})
+    }).then(
       (d) => setDiffs((current) => ({ ...current, [diffKey]: { ...DIFF_PENDING, loading: false, diff: d } })),
       (e) =>
         setDiffs((current) => ({
@@ -191,7 +199,7 @@ export function SessionViewer({
           [diffKey]: { ...DIFF_PENDING, loading: false, err: msg(e), errStatus: statusOf(e), errCode: codeOf(e) }
         }))
     )
-  }, [agentId, sessionId, path, diffScope, diffKey, wantDiff])
+  }, [agentId, sessionId, repo, path, diffScope, diffKey, wantDiff])
   const retryDiff = () => setDiffTick((tick) => tick + 1)
   // The header's Stage file / Unstage file (§4). One in flight at a time, and its failure is a footer line rather than a lost press.
   const [moving, setMoving] = useState(false)
@@ -209,7 +217,7 @@ export function SessionViewer({
     setMoveErr(null)
     try {
       const write = mode === 'staged' ? unstageWorkspacePaths : stageWorkspacePaths
-      await write(agentId, { paths: [path], ...(sessionId ? { sessionId } : {}) })
+      await write(agentId, { paths: [path], ...(sessionId ? { sessionId } : {}), ...(repo ? { repo } : {}) })
       // The reply's fresh status has no home in this pane, so the panel that owns the lists is told instead; the diff under the reader is re-read because it just changed by definition.
       setDiffTick((tick) => tick + 1)
       onIndexChanged?.()
@@ -231,7 +239,12 @@ export function SessionViewer({
     const at = nextOffset
     const readMtime = file?.mtime ?? null
     setRead((r) => ({ ...r, loadingMore: true, moreNote: null }))
-    fetchWorkspaceFile(agentId, { path, offset: at, ...(sessionId ? { sessionId } : {}) }).then(
+    fetchWorkspaceFile(agentId, {
+      path,
+      offset: at,
+      ...(sessionId ? { sessionId } : {}),
+      ...(repo ? { repo } : {})
+    }).then(
       (f) =>
         setRead((r) => {
           if (requestId !== requestRef.current) return r

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2266,17 +2266,20 @@ export default function SessionDetailView() {
   const viewerPath = searchParams.get('file') || null
   // Which workspace that path was read from. A merged conversation's header focus is component state that defaults to the current REPRESENTATIVE, and the representative changes as another participant becomes newest — so without this a link copied while focused on agent B reopens B's path against A's checkout.
   const viewerAgentParam = searchParams.get('agent')
+  const viewerRepo = searchParams.get('repo') || undefined
   // Which read of that path is on screen (§4's M2 addition to the same param set): the file, its unstaged diff, or its staged diff. A value this console does not know degrades to File mode — the one read every workspace can answer — rather than to an error.
   const viewerMode = viewerModeFromParam(searchParams.get('mode'))
   // REPLACE, never push. The viewer is a pane mode inside one route, not a place: pushing would spend a history entry per tree click, so a reader who read six files would need seven Back presses to leave the session, and Back would stop meaning "leave this session". The cost, accepted: Back does not step file-by-file within a visit. Writing through URLSearchParams is also what makes a path with slashes and spaces round-trip — `router.replace` on `.toString()`, `searchParams.get` back.
   const setViewerFile = useCallback(
-    (next: string | null, agentId?: string | null, mode: ViewerMode = 'file') => {
+    (next: string | null, agentId?: string | null, mode: ViewerMode = 'file', repo?: string) => {
       const query = new URLSearchParams(searchParams)
       if (next) query.set('file', next)
       else query.delete('file')
       // The workspace travels with the path, so the link resolves to the checkout it was made from rather than to whichever agent the header happens to focus on reopening.
       if (next && agentId) query.set('agent', agentId)
       else query.delete('agent')
+      if (next && repo) query.set('repo', repo)
+      else query.delete('repo')
       // File mode is the DEFAULT, so it writes no parameter at all: an M1 link stays byte-identical, and closing the viewer takes the mode with the path rather than leaving a mode behind for the next file opened.
       if (next && mode !== 'file') query.set('mode', mode)
       else query.delete('mode')
@@ -3535,8 +3538,11 @@ export default function SessionDetailView() {
   const workspaceTitle = hasSessionWorktree
     ? `Open ${focusedAgentLabel}’s ${focusedIsolation.checkout}`
     : `Open ${focusedAgentLabel}’s workspace`
-  // Scoped to this session's OWN worktree only where it has one. `hasSessionWorktree` is the same gate the Workspace link above uses, and it is load-bearing for the reads: the daemon answers a shared workspace's sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
-  const filesSessionId = hasSessionWorktree && headerFocusSessionId ? headerFocusSessionId : undefined
+  // Keep the historical scope after purge or workspace replacement so an unavailable checkout never falls back to primary.
+  const filesSessionId =
+    (focusedSessionDetail?.workspaceIsolation ?? focusedSession?.workspaceIsolation) === 'session'
+      ? headerFocusSessionId
+      : undefined
   const filesWorkdir = focusedAgent && focusedAgent.workdir !== '—' ? focusedAgent.workdir : undefined
   // A `?file=` on a session with no agent to read it from has nothing to open, so the conversation stays: the viewer never renders without a checkout behind it, nor before that checkout's scope is known, nor when the link named a workspace this conversation does not have.
   const viewerOpen = viewerPath !== null && filesAgentId !== null && filesScopeReady && !linkedFocusStale
@@ -4747,13 +4753,14 @@ export default function SessionDetailView() {
             {viewerOpen && viewerPath && filesAgentId ? (
               // Keyed on the whole WORKSPACE SCOPE, not just the path: the viewer resets its slice in a passive effect, which runs AFTER paint, so without a fresh mount one committed frame draws the previous read's bytes — and its line count and size — under the new heading. The path alone is not that scope: switching header focus from one agent to another while `?file=` holds still is the same stale paint. Same hazard `transcriptMatchesSession` guards for the transcript; nothing inside the viewer is worth carrying across either axis.
               <SessionViewer
-                key={`${filesAgentId}:${filesSessionId ?? 'primary'}:${viewerPath}`}
+                key={`${filesAgentId}:${filesSessionId ?? 'primary'}:${viewerRepo ?? 'workspace'}:${viewerPath}`}
                 agentId={filesAgentId}
                 {...(filesSessionId ? { sessionId: filesSessionId } : {})}
+                {...(viewerRepo ? { repo: viewerRepo } : {})}
                 path={viewerPath}
                 // NOT part of the mount key: the pill must redraw the pane it already has, and a remount would re-read the file (and the diff) on every toggle.
                 mode={viewerMode}
-                onModeChange={(mode) => setViewerFile(viewerPath, filesAgentId, mode)}
+                onModeChange={(mode) => setViewerFile(viewerPath, filesAgentId, mode, viewerRepo)}
                 diffRefreshTick={viewerDiffTick}
                 {...(canWriteWorkspace ? { onIndexChanged: onViewerIndexChanged } : {})}
                 onClose={() => {

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -15,6 +15,8 @@ const wire = vi.hoisted(() => ({
   listCalls: [] as Array<{ path: string; sessionId?: string }>,
   /** Whether the open session has a worktree of its own; a shared workspace must never be asked for one. */
   isolation: 'session' as 'session' | 'shared',
+  contentPurgedAt: undefined as string | undefined,
+  workspaceMode: 'git' as 'git' | 'scratch',
   /** Which credential vouches for the checkout. Both are git, so both have session worktrees. */
   workspaceProvider: 'github' as 'github' | 'gitlab',
   /** The Git tab's two reads. A from-scratch workspace by default, so every case that predates the tab sees what it saw. */
@@ -189,11 +191,20 @@ const session: Session = {
 
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
-    agents: [{ ...agent, workspace: { ...agent.workspace, provider: wire.workspaceProvider } }],
+    agents: [
+      {
+        ...agent,
+        workspace:
+          wire.workspaceMode === 'scratch'
+            ? { mode: 'scratch' }
+            : { ...agent.workspace, provider: wire.workspaceProvider }
+      }
+    ],
     allSessions: [
       {
         ...session,
         workspaceIsolation: wire.isolation,
+        contentPurgedAt: wire.contentPurgedAt,
         ...(wire.agentless ? { agentId: '', agentName: '' } : {}),
         ...(wire.playground ? { platform: 'playground' } : {})
       }
@@ -315,6 +326,8 @@ beforeEach(() => {
   wire.fileCalls = []
   wire.listCalls = []
   wire.isolation = 'session'
+  wire.contentPurgedAt = undefined
+  wire.workspaceMode = 'git'
   wire.workspaceProvider = 'github'
   wire.git = { isRepo: false }
   wire.log = { isRepo: false, commits: [], truncated: false, tracking: null }
@@ -518,9 +531,38 @@ describe('the workspace scope both surfaces read', () => {
     expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md' })
     expect(wire.listCalls[0]).toEqual({ path: '' })
   })
+
+  it.each(['purged', 'replaced'] as const)('keeps the linked session scope when its workspace is %s', async (state) => {
+    if (state === 'purged') wire.contentPurgedAt = '2026-09-08T12:00:00.000Z'
+    else wire.workspaceMode = 'scratch'
+    nav.search = 'view=flat&file=src%2Fnotes.md&agent=agent-1'
+
+    await render()
+
+    expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md', sessionId: 'session-1' })
+    expect(wire.listCalls[0]).toEqual({ path: '', sessionId: 'session-1' })
+  })
 })
 
 describe('the viewer route', () => {
+  it('keeps a secondary repository through file and diff reads, then drops it when the viewer closes', async () => {
+    nav.search = 'view=flat&file=src%2Fnotes.md&agent=agent-1&repo=acme%2Fsecondary'
+    await render()
+    expect(wire.fileCalls.at(-1)).toEqual({ path: 'src/notes.md', sessionId: 'session-1', repo: 'acme/secondary' })
+
+    await press('[data-viewer-mode="diff"]')
+
+    expect(new URLSearchParams(nav.search).get('repo')).toBe('acme/secondary')
+    expect(wire.diffCalls.at(-1)).toEqual({
+      path: 'src/notes.md',
+      scope: 'unstaged',
+      sessionId: 'session-1',
+      repo: 'acme/secondary'
+    })
+    await press('[data-viewer-close]')
+    expect(new URLSearchParams(nav.search).get('repo')).toBeNull()
+  })
+
   it('round-trips a nested path whose every segment has to be encoded', async () => {
     // A slash separator, a space, a `+` (which decodes back to a space if the param was written as a query value), parens and non-ASCII — the encoder has to survive all of them in both directions.
     const clickRow = async (text: string) => {

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -42,8 +42,38 @@ import {
   uploadMyProfilePicture,
   uploadOrgIcon,
   usageWindow,
-  fetchUsage
+  fetchUsage,
+  fetchWorkspaceGitDiff,
+  stageWorkspacePaths,
+  unstageWorkspacePaths
 } from './api'
+
+describe('workspace viewer repository scope', () => {
+  afterEach(() => {
+    setApiOrgId(null)
+    vi.unstubAllGlobals()
+  })
+
+  it('forwards the repository on diff reads and both index mutations', async () => {
+    const fetcher = vi.fn<typeof fetch>(
+      async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    )
+    vi.stubGlobal('fetch', fetcher)
+    setApiOrgId('org-1')
+    const scope = { sessionId: 'session-1', repo: 'acme/secondary' }
+
+    await fetchWorkspaceGitDiff('agent-1', { path: 'notes.md', ...scope })
+    await stageWorkspacePaths('agent-1', { paths: ['notes.md'], ...scope })
+    await unstageWorkspacePaths('agent-1', { paths: ['notes.md'], ...scope })
+
+    expect(fetcher).toHaveBeenCalledTimes(3)
+    for (const [url] of fetcher.mock.calls) {
+      const query = new URL(String(url), 'https://example.test').searchParams
+      expect(query.get('sessionId')).toBe('session-1')
+      expect(query.get('repo')).toBe('acme/secondary')
+    }
+  })
+})
 
 describe('session facet Agent labels', () => {
   afterEach(() => vi.unstubAllGlobals())

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3229,10 +3229,11 @@ export interface WorkspaceGitLogDto {
 // `WORKSPACE_*` code ⇒ the daemon rejected the path; 503 ⇒ offline or unplaced.
 export async function fetchWorkspaceGitDiff(
   agentId: string,
-  opts: { path: string; scope?: WorkspaceDiffScope; sessionId?: string }
+  opts: { path: string; scope?: WorkspaceDiffScope; sessionId?: string; repo?: string }
 ): Promise<WorkspaceGitDiffDto> {
   const q = new URLSearchParams({ path: opts.path })
   if (opts.sessionId) q.set('sessionId', opts.sessionId)
+  if (opts.repo) q.set('repo', opts.repo)
   if (opts.scope) q.set('scope', opts.scope)
   return apiGet<WorkspaceGitDiffDto>(
     `${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitdiff?${q.toString()}`
@@ -3317,10 +3318,11 @@ export interface WorkspaceGitMessageResultDto {
 // too old (`DAEMON_FEATURE_MISSING`); 403 ⇒ no edit access; 503 ⇒ offline or unplaced.
 export async function stageWorkspacePaths(
   agentId: string,
-  opts: { paths: string[]; sessionId?: string }
+  opts: { paths: string[]; sessionId?: string; repo?: string }
 ): Promise<WorkspaceGitStatusDto> {
   const q = new URLSearchParams()
   if (opts.sessionId) q.set('sessionId', opts.sessionId)
+  if (opts.repo) q.set('repo', opts.repo)
   const query = q.size ? `?${q.toString()}` : ''
   return apiPost<WorkspaceGitStatusDto>(
     `${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitstage${query}`,
@@ -3332,10 +3334,11 @@ export async function stageWorkspacePaths(
 // is lost. Same fresh-status answer and same failure surface as staging.
 export async function unstageWorkspacePaths(
   agentId: string,
-  opts: { paths: string[]; sessionId?: string }
+  opts: { paths: string[]; sessionId?: string; repo?: string }
 ): Promise<WorkspaceGitStatusDto> {
   const q = new URLSearchParams()
   if (opts.sessionId) q.set('sessionId', opts.sessionId)
+  if (opts.repo) q.set('repo', opts.repo)
   const query = q.size ? `?${q.toString()}` : ''
   return apiPost<WorkspaceGitStatusDto>(
     `${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitunstage${query}`,


### PR DESCRIPTION
Agent replies currently reduce workspace file links to text, leaving readers to find the file themselves. Map inline and reference-style file targets to the Console viewer using the runtime session's actual working directory and authorized workspace roots. Links keep the exact session and repository, so isolated checkouts and configured working subdirectories open the intended file.

Pass the same resolver to chat renderers, code-host final replies, and Webchat. Webchat buffers link and image syntax until a message boundary and persists the rendered text; failures release it before closing the stream. The viewer carries secondary-repository scope through file and diff reads, and unavailable historical checkouts never fall back to the primary workspace. Existing access and filesystem-containment checks remain authoritative. Line citations open the file without a line jump; out-of-workspace targets retain the readable fallback.

The microsandbox test imports its memory payload type from the protocol package after the type's move on main.

Validation: 696 focused daemon tests and 135 Web tests; daemon and Web typechecks; ESLint and Prettier; daemon/shim build with self-contained bundle checks. Rebased on current main.

Created by Codex . gpt-6-astra
