### PR TITLE
feat(daemon): CpMemoryFs — the shim client over the Control Plane connection

### DIFF
--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -107,6 +107,8 @@ import type { Logger } from '../log.js'
 export { CP_SUBPROTOCOL, CP_WS_PATH } from '@agentconnect.md/protocol'
 
 const ACK_TIMEOUT_MS = 5000
+/** One deadline for a `memory/store` op, the shim carrier's per-op timeout; there is never a second send. */
+const MEMORY_STORE_TIMEOUT_MS = 30_000
 const BACKOFF_BASE_MS = 1000
 const BACKOFF_CAP_MS = 30000
 // No-split invariant `T_reassign > T_fence`. The CP frees a lease at `renewedAt + leaseMs` and tells the member
@@ -1131,7 +1133,13 @@ export class CpClient {
     if (!this.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
       throw new WireError('INTERNAL', 'control plane does not serve the memory store', false)
     }
-    const rep = await this.request('memory/store', payload)
+    // One send, never a retransmit: `memory-append` onto a staged file is not idempotent, and the CP does not
+    // deduplicate request ids, so a reply that is merely late must not become a chunk written twice.
+    const frame = this.scopedFrame('memory/store', payload)
+    const rep = await this.correlator.request(frame, (e) => this.transport!.send(e), {
+      maxTries: 1,
+      ackTimeoutMs: MEMORY_STORE_TIMEOUT_MS
+    })
     if (rep.type !== 'memory/store/ok') {
       throw new WireError('INTERNAL', `expected memory/store/ok, got ${rep.type}`, false)
     }

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -58,6 +58,8 @@ import type {
   KnowledgeSearchOk,
   KnowledgeListReq,
   KnowledgeListOk,
+  MemoryStoreReq,
+  MemoryFsReply,
   OrgSkillsReq,
   OrgSkillsOk,
   OrganizationSuggestionsSyncReq,
@@ -77,6 +79,7 @@ import {
   SESSION_METADATA_ACK_FEATURE,
   SESSION_PURGE_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
+  AGENT_MEMORY_STORE_V1_FEATURE,
   DAEMON_BOOTSTRAP_PROTOCOL_VERSION,
   checkInboundFrameOrg,
   checkReplyFrameOrg,
@@ -922,8 +925,13 @@ export class CpClient {
     return rep.payload as WebchatMcpGrantRevoked
   }
 
+  /** The §2.1 legal-state gate every request checks: READY or DRAINING, over a live transport. */
+  connected(): boolean {
+    return (this.state === 'READY' || this.state === 'DRAINING') && this.transport !== undefined
+  }
+
   private requireReady(op: string): void {
-    if ((this.state !== 'READY' && this.state !== 'DRAINING') || !this.transport) {
+    if (!this.connected()) {
       throw new WireError('INTERNAL', `control plane unreachable for ${op} (client ${this.state})`, true)
     }
   }
@@ -1114,6 +1122,20 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected knowledge/search/ok, got ${rep.type}`, false)
     }
     return rep.payload as KnowledgeSearchOk
+  }
+
+  // `memory/store` (D→C REQ): one op against the named agent's CP-homed tree (memory-evolution.md §3.2.1), gated like
+  // `knowledgeSearch`. The typed refusals ride inside the reply; an error REP (`SCOPE_DENIED`, ...) rejects by its code.
+  async memoryStore(payload: MemoryStoreReq): Promise<MemoryFsReply> {
+    this.requireReady('memory/store')
+    if (!this.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+      throw new WireError('INTERNAL', 'control plane does not serve the memory store', false)
+    }
+    const rep = await this.request('memory/store', payload)
+    if (rep.type !== 'memory/store/ok') {
+      throw new WireError('INTERNAL', `expected memory/store/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as MemoryFsReply
   }
 
   async knowledgeList(payload: KnowledgeListReq): Promise<KnowledgeListOk> {

--- a/packages/daemon/src/cp/memory-fs.ts
+++ b/packages/daemon/src/cp/memory-fs.ts
@@ -1,0 +1,61 @@
+// The `control-plane` memory home: the shim client over the daemon's CP connection (memory-evolution.md §3.2.1).
+// Nothing selects it yet — `resolveMemoryHomePorts` still chooses between the local port and the sandbox port.
+import { AGENT_MEMORY_STORE_V1_FEATURE, type MemoryFsReply, type MemoryStoreReq } from '@agentconnect.md/protocol'
+import { WireError } from '@agentconnect.md/connection'
+import { MemoryHomeUnavailableError, memoryRelSegments, type MemoryFs } from '../memory/fs.js'
+import { MemoryFsClient, type MemoryFsRequester } from '../shim/memory-fs-channel.js'
+
+/** The slice of the CP connection this home rides: the legal-state gate, feature negotiation, the one request pair. */
+export interface CpMemoryStoreLink {
+  connected(): boolean
+  supportsServerFeature(feature: string): boolean
+  memoryStore(req: MemoryStoreReq): Promise<MemoryFsReply>
+}
+
+/** The agent's tree itself: the wire's `MemoryFsRoot` refuses an empty string, so `.` is the relative root. */
+export const CP_MEMORY_TREE_ROOT = '.'
+
+/** Compose a tree-relative root below another (`.` + `channels` → `channels`, `channels` + `c1` → `channels/c1`). */
+export function joinTreeRoot(root: string, rel: string): string {
+  return [...memoryRelSegments(root), ...memoryRelSegments(rel)].join('/') || CP_MEMORY_TREE_ROOT
+}
+
+/** The CP connection as one agent's requester: each op rides `memory/store` as `{ agentId, op }`. */
+export function cpMemoryFsRequester(link: CpMemoryStoreLink, agentId: string): MemoryFsRequester {
+  const home = `agent "${agentId}" keeps its memory in the Control Plane, which`
+  return async (op) => {
+    if (!link.connected()) throw new MemoryHomeUnavailableError('connection', `${home} is unreachable`)
+    if (!link.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+      throw new MemoryHomeUnavailableError('feature', `${home} does not serve the memory store`)
+    }
+    try {
+      return await link.memoryStore({ agentId, op })
+    } catch (err) {
+      if (err instanceof WireError && err.code === 'SCOPE_DENIED') {
+        throw new MemoryHomeUnavailableError('scope-denied', `${home} refused this member: ${err.message}`)
+      }
+      // A retryable wire error is the connection failing to carry the op (drop, no ack); the CP's own answers are final.
+      if (err instanceof WireError && err.retryable) {
+        throw new MemoryHomeUnavailableError('connection', `${home} dropped the request: ${err.message}`)
+      }
+      throw err
+    }
+  }
+}
+
+// The port over the CP. `root` is relative to the agent's tree — the CP resolves the tree, and no pod path ever
+// leaves this side — and `key` is the same in every daemon process for one agent and root.
+export class CpMemoryFs extends MemoryFsClient {
+  constructor(
+    private readonly link: CpMemoryStoreLink,
+    private readonly agentId: string,
+    root: string = CP_MEMORY_TREE_ROOT
+  ) {
+    const tree = joinTreeRoot(CP_MEMORY_TREE_ROOT, root)
+    super(cpMemoryFsRequester(link, agentId), tree, `control-plane:${agentId}:${tree}`)
+  }
+
+  subdir(rel: string): MemoryFs {
+    return new CpMemoryFs(this.link, this.agentId, joinTreeRoot(this.root, rel))
+  }
+}

--- a/packages/daemon/src/cp/memory-reader.ts
+++ b/packages/daemon/src/cp/memory-reader.ts
@@ -52,6 +52,7 @@ import {
   MemoryPathError,
   MemoryTooLargeError,
   MemoryConflictError,
+  MemoryHomeUnavailableError,
   MemorySandboxUnavailableError,
   type MemoryFs
 } from '../memory/store.js'
@@ -66,7 +67,13 @@ export class MemoryViolationError extends Error {
   }
 }
 
-export { MemoryPathError, MemoryTooLargeError, MemoryConflictError, MemorySandboxUnavailableError }
+export {
+  MemoryPathError,
+  MemoryTooLargeError,
+  MemoryConflictError,
+  MemoryHomeUnavailableError,
+  MemorySandboxUnavailableError
+}
 
 export interface MemoryReader {
   channels(req: MemoryChannelsReq): Promise<MemoryChannelsPage>

--- a/packages/daemon/src/memory/fs.ts
+++ b/packages/daemon/src/memory/fs.ts
@@ -5,8 +5,9 @@
  * runner, the CP memory reader) is a DIRECTORY abstraction over this port, so where the tree lives
  * is a placement decision, not a policy one: a local agent's home is `<agent.dir>` on this daemon's
  * disk (`LocalMemoryFs`), a cluster agent's is one root on its sandbox volume reached through the
- * shim (`shim/memory-fs-channel.ts`), and a later home is another implementation. Paths are relative
- * to the root; the root itself is absolute in the coordinates of the filesystem that holds it.
+ * shim (`shim/memory-fs-channel.ts`), and a `control-plane` home is that same client over the CP
+ * connection (`cp/memory-fs.ts`). Paths are relative to the root; the root itself is in the
+ * coordinates of whatever holds the tree — absolute on a disk, tree-relative on the CP.
  *
  * SECURITY (local): the daemon is outside the agent's sandbox, so a symlink planted in the writable
  * memory dir must not redirect a read or a write. Every operation canonicalises the parent chain one
@@ -42,11 +43,25 @@ export class MemoryConflictError extends Error {
   }
 }
 
-/** Raised when a cluster agent's memory home is on a sandbox that is not running — one resolution, no local fallback. */
-export class MemorySandboxUnavailableError extends Error {
-  readonly reason = 'sandbox-unavailable' as const
-  constructor(message: string) {
+/** Why a home is out of reach: no bound pod, or the CP connection, its feature, or this member's duty is missing. */
+export type MemoryHomeUnavailableReason = 'sandbox-unavailable' | 'connection' | 'feature' | 'scope-denied'
+
+/** Raised when an agent's memory home cannot be reached — one resolution, never a fallback to this member's disk. */
+export class MemoryHomeUnavailableError extends Error {
+  constructor(
+    readonly reason: MemoryHomeUnavailableReason,
+    message: string
+  ) {
     super(message)
+    this.name = 'MemoryHomeUnavailableError'
+  }
+}
+
+/** The sandbox home's case: a cluster agent's memory sits on a pod that is not running. */
+export class MemorySandboxUnavailableError extends MemoryHomeUnavailableError {
+  declare readonly reason: 'sandbox-unavailable'
+  constructor(message: string) {
+    super('sandbox-unavailable', message)
     this.name = 'MemorySandboxUnavailableError'
   }
 }

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -35,6 +35,7 @@ import {
 
 export {
   MemoryConflictError,
+  MemoryHomeUnavailableError,
   MemoryPathError,
   MemorySandboxUnavailableError,
   MemoryTooLargeError,

--- a/packages/daemon/src/shim/memory-fs-channel.ts
+++ b/packages/daemon/src/shim/memory-fs-channel.ts
@@ -1,4 +1,4 @@
-// The daemon's `MemoryFs` port over a cluster agent's sandbox volume; its op set is protocol `frames/memory-store.ts`.
+// The client half of the memory-fs op set (protocol `frames/memory-store.ts`) over any carrier, plus the sandbox carrier.
 // Only the port's primitives cross the wire — history, retention, the write ledger and the dream fence stay daemon policy.
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
@@ -116,16 +116,21 @@ const BASE64_READ_LIMIT = Math.floor(REPLY_BUDGET / 4) * 3
 /** A bound shim channel that knows which agent it serves (a `ShimSession`). */
 export type ShimMemoryChannel = ShimRequester & { readonly agentId: string }
 
-/** One channel round trip, with the two typed refusals rebuilt as the SAME classes the local port
- *  throws, so callers cannot tell the two trees apart. */
-export async function requestMemoryFs<T>(
-  channel: ShimMemoryChannel,
+/** One op to whichever carrier holds the tree, answered as the wire reply — the only thing the homes differ in. */
+export type MemoryFsRequester = (op: MemoryFsPayload) => Promise<MemoryFsReply>
+
+/** The shim channel as a requester: one `read`-capability round trip per op. */
+export function shimMemoryFsRequester(channel: ShimRequester, timeoutMs: number): MemoryFsRequester {
+  return async (op) => MemoryFsReplySchema.parse(await channel.request('read', op, { timeoutMs }))
+}
+
+/** Send one op and settle it, the two typed refusals rebuilt as the SAME classes the local port throws. */
+export async function settleMemoryFs<T>(
+  requester: MemoryFsRequester,
   payload: MemoryFsPayload,
-  schema: z.ZodType<T>,
-  timeoutMs: number
+  schema: z.ZodType<T>
 ): Promise<T> {
-  const raw = await channel.request('read', payload, { timeoutMs })
-  const reply = MemoryFsReplySchema.parse(raw)
+  const reply = await requester(payload)
   if (!reply.ok) {
     if (reply.refusal.kind === 'conflict') throw new MemoryConflictError(reply.refusal.message)
     throw new MemoryPathError(reply.refusal.message)
@@ -133,29 +138,31 @@ export async function requestMemoryFs<T>(
   return schema.parse(reply.value)
 }
 
-/**
- * The daemon's side: the port over an agent's bound shim channel. Every containment check and every
- * refusal happens on the pod, where the files are; this class only reassembles what one frame cannot
- * carry. `key` is per agent and root, so the daemon's locks and write ledger follow the tree across
- * channel renewals and rebinds.
- */
-export class ShimMemoryFs implements MemoryFs {
-  readonly key: string
+/** One channel round trip: {@link settleMemoryFs} over the shim requester, for the workspace seam's own primitive. */
+export function requestMemoryFs<T>(
+  channel: ShimMemoryChannel,
+  payload: MemoryFsPayload,
+  schema: z.ZodType<T>,
+  timeoutMs: number
+): Promise<T> {
+  return settleMemoryFs(shimMemoryFsRequester(channel, timeoutMs), payload, schema)
+}
 
-  constructor(
-    private readonly channel: ShimMemoryChannel,
+// The daemon's side of the op set over any requester: refusals happen where the files are; this reassembles frames.
+// A carrier supplies the requester, `root` in its coordinates, and a `key` that names the tree the same way across
+// renewals, rebinds and restarts, so the daemon's locks and write ledger follow it.
+export abstract class MemoryFsClient implements MemoryFs {
+  protected constructor(
+    private readonly requester: MemoryFsRequester,
     readonly root: string,
-    private readonly timeoutMs = 30_000
-  ) {
-    this.key = `sandbox:${channel.agentId}:${root}`
-  }
+    readonly key: string
+  ) {}
 
-  subdir(rel: string): MemoryFs {
-    return new ShimMemoryFs(this.channel, joinRel(this.root, rel), this.timeoutMs)
-  }
+  /** The same port re-rooted below this one; how roots compose is the carrier's business. */
+  abstract subdir(rel: string): MemoryFs
 
   private run<T>(payload: MemoryFsPayload, schema: z.ZodType<T>): Promise<T> {
-    return requestMemoryFs(this.channel, payload, schema, this.timeoutMs)
+    return settleMemoryFs(this.requester, payload, schema)
   }
 
   /**
@@ -296,6 +303,21 @@ export class ShimMemoryFs implements MemoryFs {
 
   async utimes(rel: string, mtime: string): Promise<void> {
     await this.run({ op: 'memory-utimes', root: this.root, rel, mtime }, z.null())
+  }
+}
+
+/** The port over an agent's bound shim channel: `root` is pod-absolute and `key` is per agent and root. */
+export class ShimMemoryFs extends MemoryFsClient {
+  constructor(
+    private readonly channel: ShimMemoryChannel,
+    root: string,
+    private readonly timeoutMs = 30_000
+  ) {
+    super(shimMemoryFsRequester(channel, timeoutMs), root, `sandbox:${channel.agentId}:${root}`)
+  }
+
+  subdir(rel: string): MemoryFs {
+    return new ShimMemoryFs(this.channel, joinRel(this.root, rel), this.timeoutMs)
   }
 }
 

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -1094,3 +1094,62 @@ describe('CpClient dispatch', () => {
     expect(rep.corr).toBe(f.id)
   })
 })
+
+describe('CpClient memory/store (D→C REQ)', () => {
+  const op = { op: 'memory-read', root: '.', rel: 'memory/index.md', offset: 0, limit: 1024 } as const
+
+  it('names the agent, stamps its org, and unwraps memory/store/ok', async () => {
+    const { client, t } = await readyClient(
+      { orgForAgent: (agentId) => (agentId === CRON_AGENT_ID ? 'org-1' : undefined) },
+      ['agent-memory-store-v1'],
+      'frame'
+    )
+    const pending = client.memoryStore({ agentId: CRON_AGENT_ID, op })
+    await tick()
+    const req = JSON.parse(t.sent[0]!)
+    expect(req).toMatchObject({ type: 'memory/store', orgId: 'org-1', payload: { agentId: CRON_AGENT_ID, op } })
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope('memory/store/ok', { ok: true, value: { exists: false } }, { corr: req.id, orgId: 'org-1' })
+      )
+    )
+    await expect(pending).resolves.toEqual({ ok: true, value: { exists: false } })
+  })
+
+  it('refuses before sending when the CP never advertised the feature, and surfaces an error REP by code', async () => {
+    const older = await readyClient({}, [])
+    await expect(older.client.memoryStore({ agentId: CRON_AGENT_ID, op })).rejects.toMatchObject({
+      code: 'INTERNAL',
+      retryable: false
+    })
+    expect(older.t.sent).toHaveLength(0)
+
+    const { client, t } = await readyClient({}, ['agent-memory-store-v1'])
+    const pending = client.memoryStore({ agentId: CRON_AGENT_ID, op })
+    await tick()
+    const req = JSON.parse(t.sent[0]!)
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'error',
+          { code: 'SCOPE_DENIED', message: 'agent is not served here', retryable: false },
+          { corr: req.id }
+        )
+      )
+    )
+    await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED', retryable: false })
+  })
+
+  it('fails fast off the legal states instead of queueing on a dead socket', async () => {
+    const { client, t } = await readyClient({}, ['agent-memory-store-v1'])
+    expect(client.connected()).toBe(true)
+    t.simulateClose(1006, 'gone')
+    await tick()
+    expect(client.connected()).toBe(false)
+    await expect(client.memoryStore({ agentId: CRON_AGENT_ID, op })).rejects.toMatchObject({
+      code: 'INTERNAL',
+      retryable: true
+    })
+    expect(t.sent).toHaveLength(0)
+  })
+})

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -1140,6 +1140,19 @@ describe('CpClient memory/store (D→C REQ)', () => {
     await expect(pending).rejects.toMatchObject({ code: 'SCOPE_DENIED', retryable: false })
   })
 
+  it('sends an op exactly once — a late reply must never append a chunk twice — and fails on one deadline', async () => {
+    const { client, t, clock } = await readyClient({}, ['agent-memory-store-v1'])
+    const stores = () => t.sent.filter((raw) => JSON.parse(raw).type === 'memory/store')
+    const pending = client.memoryStore({ agentId: CRON_AGENT_ID, op })
+    await tick()
+    // Well past the default ack timeout and its retransmissions: still the one frame.
+    clock.advance(29_000)
+    expect(stores()).toHaveLength(1)
+    clock.advance(1_000)
+    await expect(pending).rejects.toMatchObject({ code: 'INTERNAL', retryable: true })
+    expect(stores()).toHaveLength(1)
+  })
+
   it('fails fast off the legal states instead of queueing on a dead socket', async () => {
     const { client, t } = await readyClient({}, ['agent-memory-store-v1'])
     expect(client.connected()).toBe(true)

--- a/packages/daemon/test/memory-fs-cp.test.ts
+++ b/packages/daemon/test/memory-fs-cp.test.ts
@@ -1,0 +1,246 @@
+// `CpMemoryFs` — the shim client over the CP connection (memory-evolution.md §3.2.1): the same op set, sliced and
+// chunked the same way, against a tree-relative root, and one resolution when the home is out of reach.
+import { afterAll, describe, expect, it } from 'vitest'
+import { promises as fsp, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { WireError } from '@agentconnect.md/connection'
+import { MemoryStoreReq, type MemoryFsPayload, type MemoryFsReply } from '@agentconnect.md/protocol'
+import { CpMemoryFs, joinTreeRoot, type CpMemoryStoreLink } from '../src/cp/memory-fs.js'
+import {
+  MemoryConflictError,
+  MemoryHomeUnavailableError,
+  MemoryPathError,
+  MemorySandboxUnavailableError,
+  type MemoryFs
+} from '../src/memory/fs.js'
+import { MEMORY_INDEX, ensureMemory, listMemory, readMemoryFile, writeMemoryFile } from '../src/memory/store.js'
+import { ShimMemoryFs, applyMemoryFsPayload } from '../src/shim/memory-fs-channel.js'
+import { REPLY_BUDGET } from '../src/wire-slice.js'
+import { pathExecutor } from './fixtures/memory-fs-pod.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+
+const trees: string[] = []
+afterAll(() => {
+  for (const tree of trees.splice(0)) rmSync(tree, { recursive: true, force: true })
+})
+
+/** A stand-in for the CP's handler: the agent's tree is one directory and every `root` resolves beneath it. */
+function treeAnswerer(): { tree: string; answer: (op: MemoryFsPayload) => Promise<MemoryFsReply> } {
+  const tree = mkdtempSync(join(tmpdir(), 'ac-cp-tree-'))
+  trees.push(tree)
+  const executor = pathExecutor()
+  return { tree, answer: (op) => applyMemoryFsPayload({ ...op, root: join(tree, op.root) }, tree, executor) }
+}
+
+type FakeLink = CpMemoryStoreLink & { tree: string; requests: MemoryStoreReq[] }
+
+/** The CP connection as the adapter sees it, answering from a tree directory and recording every request. */
+function fakeLink(over: Partial<CpMemoryStoreLink> = {}): FakeLink {
+  const { tree, answer } = treeAnswerer()
+  const requests: MemoryStoreReq[] = []
+  return {
+    tree,
+    requests,
+    connected: () => true,
+    supportsServerFeature: (feature) => feature === 'agent-memory-store-v1',
+    // The wire's own parse, strict: a uuid agent, a non-empty root, and nothing beside `{ agentId, op }`.
+    async memoryStore(req) {
+      const parsed = MemoryStoreReq.parse(req)
+      requests.push(parsed)
+      return answer(parsed.op)
+    },
+    ...over
+  }
+}
+
+describe('CpMemoryFs (the port over the CP connection)', () => {
+  it('runs the managed memory tree on a tree-relative root, naming the agent on every request', async () => {
+    const link = fakeLink()
+    const fs = new CpMemoryFs(link, AGENT)
+    expect(fs.root).toBe('.')
+    expect(fs.key).toBe(`control-plane:${AGENT}:.`)
+    await ensureMemory(fs, 'bot-a')
+    expect(await fsp.readFile(join(link.tree, 'memory', MEMORY_INDEX), 'utf8')).toContain('# bot-a memory')
+    await writeMemoryFile(fs, 'deploys.md', '- region sea\n', undefined, 'tool')
+    expect(await readMemoryFile(fs, 'deploys.md')).toBe('- region sea\n')
+    expect((await listMemory(fs)).map((f) => f.name)).toEqual([MEMORY_INDEX, 'deploys.md'])
+    expect(link.requests.every((r) => r.agentId === AGENT && r.op.root === '.')).toBe(true)
+    expect(link.requests.map((r) => r.op.op)).toContain('memory-commit')
+  })
+
+  it('writes an ordinary file as one append and one commit, and slices a large one across multi-byte boundaries', async () => {
+    const link = fakeLink()
+    const fs = new CpMemoryFs(link, AGENT)
+    await fs.writeFile('memory/a.md', 'alpha')
+    expect(link.requests.map((r) => r.op.op)).toEqual(['memory-append', 'memory-commit'])
+
+    link.requests.length = 0
+    const big = 'é'.repeat(300_000) // 600 KB, multi-byte, more than two reply budgets
+    await fs.writeFile('memory/big.md', big)
+    expect(link.requests.filter((r) => r.op.op === 'memory-append').length).toBeGreaterThan(2)
+    link.requests.length = 0
+    const read = await fs.readFile('memory/big.md')
+    expect(read?.content).toBe(big)
+    expect(read?.size).toBe(Buffer.byteLength(big))
+    const reads = link.requests.map((r) => r.op).filter((op) => op.op === 'memory-read')
+    expect(reads.length).toBeGreaterThan(2)
+    expect(reads.every((op) => op.limit <= REPLY_BUDGET)).toBe(true)
+  })
+
+  it('carries the two typed refusals back as themselves and cleans a failed staging', async () => {
+    const link = fakeLink()
+    const fs = new CpMemoryFs(link, AGENT)
+    const st = await fs.writeFile('memory/a.md', 'v1')
+    await expect(
+      fs.writeFile('memory/a.md', 'v2', { ifMatchMtime: '2000-01-01T00:00:00.000Z' })
+    ).rejects.toBeInstanceOf(MemoryConflictError)
+    expect(link.requests.at(-1)?.op.op).toBe('memory-rm')
+    expect(await fsp.readdir(join(link.tree, 'memory'))).toEqual(['a.md'])
+    await fs.writeFile('memory/a.md', 'v2', { ifMatchMtime: st.mtime })
+    expect((await fs.readFile('memory/a.md'))?.content).toBe('v2')
+    await expect(fs.readFile('../outside')).rejects.toBeInstanceOf(MemoryPathError)
+    // A refusal the CP composes itself arrives as the same class.
+    const refusing = fakeLink({
+      memoryStore: async () => ({ ok: false, refusal: { kind: 'path' as const, message: 'not under the tree' } })
+    })
+    await expect(new CpMemoryFs(refusing, AGENT).readdir('memory')).rejects.toBeInstanceOf(MemoryPathError)
+  })
+
+  it('renames, removes, lists, and sets mtimes through the tree', async () => {
+    const link = fakeLink()
+    const fs = new CpMemoryFs(link, AGENT)
+    await fs.writeFile('memory/a.md', 'alpha')
+    await fs.mkdir('memory/topics')
+    expect(await fs.rename('memory/a.md', 'memory/topics/b.md')).toBe(true)
+    expect(await fs.rename('memory/absent.md', 'memory/c.md')).toBe(false)
+    expect(await fs.readdir('memory')).toEqual([{ name: 'topics', kind: 'dir' }])
+    const [entry] = await fs.readdir('memory/topics')
+    expect(entry).toMatchObject({ name: 'b.md', kind: 'file', size: 5 })
+    await fs.utimes('memory/topics/b.md', '2026-01-01T00:00:00.000Z')
+    expect((await fs.readFile('memory/topics/b.md'))?.mtime).toBe('2026-01-01T00:00:00.000Z')
+    await fs.rm('memory/topics')
+    await fs.rm('memory/never-there')
+    expect(await fs.readdir('memory')).toEqual([])
+    expect(await fs.readFile('memory/topics/b.md')).toBeNull()
+  })
+
+  it('re-roots below the tree without ever forming a pod path', async () => {
+    const link = fakeLink()
+    const fs = new CpMemoryFs(link, AGENT)
+    const channels = fs.subdir('channels')
+    expect(channels.root).toBe('channels')
+    expect(channels.key).toBe(`control-plane:${AGENT}:channels`)
+    expect(channels.subdir('c1').root).toBe('channels/c1')
+    expect(fs.subdir('.').root).toBe('.')
+    await channels.writeFile('c1/meta.md', 'meta')
+    expect(link.requests.map((r) => r.op.root)).toEqual(['channels', 'channels'])
+    expect(await fsp.readFile(join(link.tree, 'channels', 'c1', 'meta.md'), 'utf8')).toBe('meta')
+    expect(() => fs.subdir('../elsewhere')).toThrow(MemoryPathError)
+    expect(() => new CpMemoryFs(link, AGENT, '/srv/agent')).toThrow(MemoryPathError)
+    expect(new CpMemoryFs(link, AGENT, 'channels/').key).toBe(channels.key)
+    expect(joinTreeRoot('.', '')).toBe('.')
+  })
+
+  it("refuses with one resolution per reason, and never falls back to this member's disk", async () => {
+    const reason = (link: CpMemoryStoreLink) =>
+      new CpMemoryFs(link, AGENT).readFile('memory/a.md').then(
+        () => 'resolved',
+        (err: unknown) => (err instanceof MemoryHomeUnavailableError ? err.reason : err)
+      )
+    const closed = fakeLink({ connected: () => false })
+    expect(await reason(closed)).toBe('connection')
+    const older = fakeLink({ supportsServerFeature: () => false })
+    expect(await reason(older)).toBe('feature')
+    // Neither reached the wire, and nothing touched a tree.
+    expect(closed.requests).toEqual([])
+    expect(older.requests).toEqual([])
+    expect(await fsp.readdir(closed.tree)).toEqual([])
+
+    const rejecting = (err: Error) =>
+      fakeLink({
+        memoryStore: async () => {
+          throw err
+        }
+      })
+    expect(await reason(rejecting(new WireError('SCOPE_DENIED', 'agent is not served here', false)))).toBe(
+      'scope-denied'
+    )
+    expect(await reason(rejecting(new WireError('INTERNAL', 'no ack after 5 tries', true)))).toBe('connection')
+    // The CP's own answers are final: they surface as the wire error they are, not as an unreachable home.
+    const internal = await reason(rejecting(new WireError('INTERNAL', 'memory/store failed', false)))
+    expect(internal).toBeInstanceOf(WireError)
+    expect((internal as WireError).code).toBe('INTERNAL')
+
+    // The sandbox home's refusal is the same family, so one catch covers every home.
+    const asleep = new MemorySandboxUnavailableError('agent "bot-a" has no running sandbox')
+    expect(asleep).toBeInstanceOf(MemoryHomeUnavailableError)
+    expect(asleep.reason).toBe('sandbox-unavailable')
+  })
+
+  it('sends the very same op sequence the shim client sends — one code path, two carriers', async () => {
+    const shimSide = treeAnswerer()
+    const shimOps: MemoryFsPayload[] = []
+    const channel = {
+      agentId: AGENT,
+      async request(capability: string, payload: unknown) {
+        expect(capability).toBe('read')
+        shimOps.push(payload as MemoryFsPayload)
+        return shimSide.answer(payload as MemoryFsPayload)
+      }
+    }
+    const cpSide = treeAnswerer()
+    const cpOps: MemoryFsPayload[] = []
+    const link: CpMemoryStoreLink = {
+      connected: () => true,
+      supportsServerFeature: () => true,
+      async memoryStore(req) {
+        expect(req.agentId).toBe(AGENT)
+        cpOps.push(req.op)
+        return cpSide.answer(req.op)
+      }
+    }
+    // The same root string on both, so only the carrier differs (a pod root is absolute; this one is tree-relative).
+    await script(new ShimMemoryFs(channel, 'tree'))
+    await script(new CpMemoryFs(link, AGENT, 'tree'))
+    expect(cpOps.length).toBeGreaterThan(12)
+    expect(new Set(cpOps.map((op) => op.op))).toEqual(
+      new Set([
+        'memory-mkdir',
+        'memory-append',
+        'memory-commit',
+        'memory-read',
+        'memory-readdir',
+        'memory-rename',
+        'memory-utimes',
+        'memory-rm'
+      ])
+    )
+    expect(withoutTempNames(cpOps)).toEqual(withoutTempNames(shimOps))
+  })
+})
+
+/** Every op the port sends, once, with nothing in a payload that depends on the disk it lands on. */
+async function script(fs: MemoryFs): Promise<void> {
+  await fs.mkdir('memory')
+  await fs.writeFile('memory/a.md', 'alpha')
+  await fs.writeFile('memory/big.md', 'é'.repeat(300_000))
+  await fs.readFile('memory/big.md')
+  await fs.readFile('memory/absent.md')
+  await fs.readdir('memory')
+  await fs.rename('memory/a.md', 'memory/b.md')
+  await fs.utimes('memory/b.md', '2026-01-01T00:00:00.000Z')
+  await fs.subdir('channels').writeFile('c1/meta.md', 'meta')
+  await fs.writeFile('memory/b.md', 'beta', { ifMatchMtime: '2000-01-01T00:00:00.000Z' }).catch((err: unknown) => {
+    if (!(err instanceof MemoryConflictError)) throw err
+  })
+  await fs.rm('memory')
+}
+
+/** Staged writes are named by a random uuid per call; everything else in a payload is deterministic. */
+function withoutTempNames(ops: MemoryFsPayload[]): unknown {
+  return JSON.parse(
+    JSON.stringify(ops).replace(/\.agentconnect-memory-[0-9a-f-]{36}\.tmp/g, '.agentconnect-memory-TMP.tmp')
+  )
+}

--- a/packages/daemon/test/microsandbox-guest.test.ts
+++ b/packages/daemon/test/microsandbox-guest.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
-import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { MAX_FRAME_BYTES, type MemoryFsPayload } from '@agentconnect.md/protocol'
 import {
   MICROSANDBOX_GUEST_ENTRY,
   MICROSANDBOX_NODE,
@@ -14,7 +14,7 @@ import {
 } from '../src/microsandbox/guest.js'
 import { GitTransportError } from '../src/workspace/git-runner.js'
 import { MicrosandboxWorkspaceFs } from '../src/microsandbox/workspace-fs.js'
-import { applyMemoryFsPayload, type MemoryFsPayload } from '../src/shim/memory-fs-channel.js'
+import { applyMemoryFsPayload } from '../src/shim/memory-fs-channel.js'
 import { ShimChannelLostError } from '../src/shim/channels.js'
 import { pathExecutor } from './fixtures/memory-fs-pod.js'
 


### PR DESCRIPTION
## Why

`docs/designs/memory-evolution.md` §3.2.1 puts a `control-plane` home's live store in the Control Plane and says how the daemon reaches it: "`CpMemoryFs` is the shim client (`ShimMemoryFs`) over a different requester — the daemon's CP connection — so the daemon side is an adapter, not a third implementation." #1865 landed the wire contract (`MemoryStoreReq = { agentId, op }`, `memory/store` → `memory/store/ok`, the two typed refusals as data, `agent-memory-store-v1`); #1866 gave the dream runner `MemoryHomePorts`. This is step ⑤ of the rollout: the adapter, and only the adapter.

## The requester seam

- `MemoryFsRequester = (op: MemoryFsPayload) => Promise<MemoryFsReply>` — the one thing the carriers differ in.
- `settleMemoryFs(requester, payload, schema)` — one op settled: a refusal becomes `MemoryPathError` / `MemoryConflictError`, a value is parsed by the op's schema.
- `MemoryFsClient` (abstract) — the former `ShimMemoryFs` body, moved verbatim: read slicing at `REPLY_BUDGET`, base64 byte chunks, chunked append at `WRITE_CHUNK_BYTES` + commit with `ifMatchMtime`, staging cleanup on failure, `readdir` / `mkdir` / `rename` / `rm` / `utimes`. Only `subdir` is per carrier, because only root composition is.
- `ShimMemoryFs extends MemoryFsClient` over `shimMemoryFsRequester(channel, timeoutMs)`. Constructor, `key` (`sandbox:<agentId>:<root>`), default timeout and `requestMemoryFs` (the workspace seam's `stat`) are unchanged; every existing shim test passes without edits.

## `CpMemoryFs` (`packages/daemon/src/cp/memory-fs.ts`)

- Rides `CpMemoryStoreLink = { connected(), supportsServerFeature(), memoryStore() }`, the slice of `CpClient` it needs (structural). `CpClient` gains `connected()` — the READY | DRAINING gate `requireReady` already applied — and `memoryStore()`, shaped like `knowledgeSearch`: feature-gated so the REQ is never sent to a CP that did not advertise it, unwraps `memory/store/ok`, and an error REP rejects as a `WireError` carrying its code.
- `memoryStore()` sends exactly once, with one 30 s deadline (the shim carrier's per-op timeout), like `requestGitCred`: `memory-append` onto a staged file is not idempotent and the CP does not deduplicate request ids, so the correlator's default retransmission would turn a merely late reply into a chunk written twice. A lost frame is the retryable "no ack" the adapter already reads as `'connection'`.
- `root` is relative to the agent's tree. The wire's `MemoryFsRoot` is `min(1)`, so the tree itself is `'.'` (`CP_MEMORY_TREE_ROOT`) and `subdir` composes below it: `'.'` → `'channels'` → `'channels/c1'`. No pod path is ever formed on this side; the CP resolves the tree from the agent.
- `key` is `control-plane:<agentId>:<root>` — the same in every daemon process for one agent and root, which is what the in-process directory lock and the write ledger key on.
- It does not read the member's disk, cache, retry, or fall back; and it carries nothing above the port — history, retention, index generation, the write ledger and the dream fence stay where they are.

## `MemoryHomeUnavailableError`

Generalizes `MemorySandboxUnavailableError`, which is now its `'sandbox-unavailable'` subclass — every existing `instanceof` and the `reason` the CP maps to a 503 are unchanged. The CP home raises it with a `reason` of:

- `'connection'` — the CP connection is not READY/DRAINING, or a retryable wire error (a drop, no ack) meant the op never got an answer;
- `'feature'` — the CP did not advertise `agent-memory-store-v1`;
- `'scope-denied'` — the CP answered `SCOPE_DENIED` (this member does not serve the agent, or its home is not the CP).

One resolution, no local fallback.

## Nothing selects it yet

`resolveMemoryHomePorts`, the binding's `home`, the capture outbox's reachability predicate, the session boundary and `withMemoryHome` are untouched. That is step ⑦, which will also widen the existing `instanceof MemorySandboxUnavailableError` catches to the base class.

## Also

`test/microsandbox-guest.test.ts` imported `MemoryFsPayload` from the channel module after #1865 moved the type to `protocol`, which has kept `Test / Check` red on `main` since; the import now points at `protocol` (one line).

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — green (red on `main` for the reason above).
- `test/memory-fs.test.ts`, `test/memory-fs-cp.test.ts` (new, 7 cases: the store's own writers over a tree-relative root, one append + one commit for an ordinary write, multi-byte slicing across frames, the two refusals plus staging cleanup, `rename` / `rm` / `readdir` / `utimes`, `subdir` re-rooting, the three unavailability reasons, and the pinned "same op sequence over both carriers"), `test/shim-channels.test.ts`, `test/cp/client-dispatch.test.ts` (+3 client-level cases: org stamping and unwrap, feature refusal before send and an error REP by code, fail-fast off the legal states), `test/dream-runner.test.ts` — all green.
- `test/shim-workspace-files.test.ts` and one `shim-exec-handler` case fail identically on a clean `main` checkout on this macOS machine; both modules are outside this diff.
- prettier and eslint on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
