### PR TITLE
fix(daemon): clear microsandbox runtime state on restart

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -256,6 +256,12 @@ sparse copying on the host filesystem. Measure both image preparation and clonin
 Flat disks do not provide native snapshots or rootfs patches; generated launch
 files are written after boot through the guest file API.
 
+Each VM mounts `/run` as tmpfs so process IDs and service sockets cannot survive
+a stop/start while application data remains on the persistent disk. Operator
+mounts cannot replace `/run`. The local guest helper creates its private socket
+directory at `/tmp/agentconnect` as the image's ordinary user; the pool keeps its
+existing `/run/agentconnect` paths.
+
 In pinned version `0.6.17`, starting a retained flat-disk VM still validates the
 OCI image's VMDK cache. The manager therefore runs the official
 `msb pull <image> --materialize all --quiet` before its VM probe, preparing both

--- a/packages/daemon/scripts/smoke-microsandbox-docker.mts
+++ b/packages/daemon/scripts/smoke-microsandbox-docker.mts
@@ -17,13 +17,18 @@ const home = join(root, 'home')
 await mkdir(home)
 await mkdir(join(root, 'microsandbox'))
 if (cacheDir) await symlink(resolve(cacheDir), join(root, 'microsandbox', 'cache'))
-process.env = {
+const sandboxEnv = {
   PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
   HOME: home,
   MSB_HOME: join(root, 'microsandbox'),
   MSB_BACKEND: 'local',
   XDG_CACHE_HOME: join(root, 'cache')
 }
+// Preserve Node's environment proxy so native SDK calls see the same values as child processes.
+for (const key of Object.keys(process.env)) {
+  if (!Object.hasOwn(sandboxEnv, key)) delete process.env[key]
+}
+Object.assign(process.env, sandboxEnv)
 const sdk: typeof import('microsandbox') = await import(
   sdkModule ? pathToFileURL(resolve(sdkModule)).href : 'microsandbox'
 )

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join, relative, sep } from 'node:path'
 import { installMicrosandbox, microsandboxGuestEntry } from './microsandbox/install.js'
 import { prepareMicrosandboxLaunch } from './microsandbox/launch.js'
 import type { MicrosandboxManager, MicrosandboxEnvironment } from './microsandbox/driver.js'
-import { microsandboxGitRunner, microsandboxWorkspaceFs } from './microsandbox/guest.js'
+import { MICROSANDBOX_TUNNEL_PATHS, microsandboxGitRunner, microsandboxWorkspaceFs } from './microsandbox/guest.js'
 import { MicrosandboxWorkspaceFs } from './microsandbox/workspace-fs.js'
 import { microsandboxSupportMounts } from './microsandbox/support.js'
 import { GITCRED_SOCKET_ENV } from './gitcred/env.js'
@@ -4000,7 +4000,7 @@ export class Daemon {
     if (agent && this.usesMicrosandbox(agent)) {
       const bridge = this.microsandboxTable?.mcpBridge
       if (!bridge) throw new Error('microsandbox image does not provide the AgentConnect MCP bridge')
-      return buildSandboxMcpServers({ bridge, token })
+      return buildSandboxMcpServers({ bridge, token, socketPath: MICROSANDBOX_TUNNEL_PATHS.mcp })
     }
     if (!this.k8sPlane) {
       return buildMcpServers({

--- a/packages/daemon/src/mcp/inject.ts
+++ b/packages/daemon/src/mcp/inject.ts
@@ -42,19 +42,11 @@ export function buildMcpServers(opts: {
   ]
 }
 
-/**
- * The same bridge for a runtime that lives in a SANDBOX POD, in that pod's coordinates.
- *
- * Nothing of this daemon's filesystem survives the trip. The launch is the one the image reported
- * for itself — interpreter included, so nothing here depends on what the harness leaves on the
- * pod's PATH — and the endpoint is the `mcp` tunnel's in-pod socket, which the shim serves and
- * proxies back to this daemon's control server. Sending the daemon-side pair instead is not a
- * degraded spec but an unspawnable one: the pod's runtime retried a module it has no filesystem
- * for until it gave up, and the agent lost every AgentConnect tool without saying so.
- */
+/** Use the image's bridge command with the local guest socket; pool paths remain the default. */
 export function buildSandboxMcpServers(opts: {
   bridge: { command: string; args: string[] }
   token: string
+  socketPath?: string
 }): McpStdioServer[] {
   return [
     {
@@ -62,7 +54,7 @@ export function buildSandboxMcpServers(opts: {
       command: opts.bridge.command,
       args: [...opts.bridge.args],
       env: [
-        { name: 'AC_MCP_ENDPOINT', value: SANDBOX_TUNNEL_PATHS.mcp },
+        { name: 'AC_MCP_ENDPOINT', value: opts.socketPath ?? SANDBOX_TUNNEL_PATHS.mcp },
         { name: 'AC_MCP_TOKEN', value: opts.token }
       ]
     }

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -185,7 +185,7 @@ export class MicrosandboxManager {
 
   private spec(environment: MicrosandboxEnvironment): string {
     return stableJson({
-      version: 1,
+      version: 2,
       config: this.options.config,
       environment: { ...environment, mounts: [...environment.mounts].sort((a, b) => a.target.localeCompare(b.target)) },
       sockets: this.options.sockets
@@ -206,6 +206,7 @@ export class MicrosandboxManager {
       .deploymentProfile('single-tenant')
       .detached(true)
       .ephemeral(false)
+      .volume('/run', (volume) => volume.tmpfs())
       .quietLogs()
     for (const mount of mounts) {
       builder.volume(mount.target, (volume) => {

--- a/packages/daemon/src/microsandbox/guest.ts
+++ b/packages/daemon/src/microsandbox/guest.ts
@@ -7,9 +7,13 @@ import type { WorkspaceFs } from '../workspace/workspace-fs.js'
 
 export const MICROSANDBOX_NODE = '/usr/local/bin/node'
 export const MICROSANDBOX_GUEST_ENTRY = '/opt/agentconnect-local/guest.js'
+export const MICROSANDBOX_TUNNEL_PATHS = {
+  mcp: '/tmp/agentconnect/mcp.sock',
+  gitcred: '/tmp/agentconnect/gitcred.sock'
+} as const
 export const MICROSANDBOX_SOCKET_BRIDGES = [
-  { path: '/run/agentconnect/mcp.sock', port: 5000 },
-  { path: '/run/agentconnect/gitcred.sock', port: 5001 }
+  { path: MICROSANDBOX_TUNNEL_PATHS.mcp, port: 5000 },
+  { path: MICROSANDBOX_TUNNEL_PATHS.gitcred, port: 5001 }
 ] as const
 
 export interface MicrosandboxExecuteOptions {

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -9,9 +9,8 @@ import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
 import { compactReadRoots, normalizeSandboxMounts } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials } from '../runtimes/runtime-credentials.js'
 import { prepareRuntimeHome, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
-import { SANDBOX_TUNNEL_PATHS } from '../shim/sandbox-paths.js'
 import { SESSIONS_DIR } from '../workspace/session-layout.js'
-import { MICROSANDBOX_GUEST_ENTRY, MICROSANDBOX_SOCKET_BRIDGES } from './guest.js'
+import { MICROSANDBOX_GUEST_ENTRY, MICROSANDBOX_SOCKET_BRIDGES, MICROSANDBOX_TUNNEL_PATHS } from './guest.js'
 
 const IMAGE_PATH = '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 const HOST_IPC_ENV = [
@@ -125,6 +124,8 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   automatic.push({ source: guestEntry, target: MICROSANDBOX_GUEST_ENTRY, readOnly: true })
   const configured = normalizeSandboxMounts(opts.mounts, hostEnv, 'microsandbox')
   const ownedTargets = [
+    '/run',
+    '/var/run',
     ...automatic.map((mount) => mount.target),
     ...MICROSANDBOX_SOCKET_BRIDGES.map((bridge) => bridge.path)
   ]
@@ -158,7 +159,7 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
     throw new Error('microsandbox private XDG runtime path must be a real directory')
   }
   mkdirSync(env.XDG_RUNTIME_DIR, { recursive: true, mode: 0o700 })
-  env[GITCRED_SOCKET_ENV] = SANDBOX_TUNNEL_PATHS.gitcred
+  env[GITCRED_SOCKET_ENV] = MICROSANDBOX_TUNNEL_PATHS.gitcred
   return {
     env,
     inheritProcessEnv: false,

--- a/packages/daemon/test/mcp-inject.test.ts
+++ b/packages/daemon/test/mcp-inject.test.ts
@@ -45,8 +45,7 @@ describe('buildSandboxMcpServers', () => {
     const bridge = { command: '/usr/local/bin/node', args: ['/opt/agentconnect/shim/mcp-bridge.js'] }
     const [server] = buildSandboxMcpServers({ bridge, token: 'tok-1' })
     expect(server!.name).toBe('agentconnect')
-    // Not process.execPath and not the daemon's CLI entry: both name files the pod does not have,
-    // and a runtime handed them retries a missing module instead of serving tools.
+    // Both the interpreter and bridge must exist in the image.
     expect(server!.command).toBe(bridge.command)
     expect(server!.args).toEqual(bridge.args)
     expect(server!.env).toEqual([
@@ -54,5 +53,7 @@ describe('buildSandboxMcpServers', () => {
       { name: 'AC_MCP_TOKEN', value: 'tok-1' }
     ])
     expect(server!.args).not.toContain('tok-1')
+    const [localVm] = buildSandboxMcpServers({ bridge, token: 'tok-1', socketPath: '/tmp/agentconnect/mcp.sock' })
+    expect(localVm!.env).toContainEqual({ name: 'AC_MCP_ENDPOINT', value: '/tmp/agentconnect/mcp.sock' })
   })
 })

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -103,7 +103,7 @@ describe('prepareMicrosandboxLaunch', () => {
       expect(launch.env[name]).toBeUndefined()
     }
     expect(launch.env.TMPDIR).toBe('/tmp')
-    expect(launch.env.AC_GITCRED_SOCKET).toBe('/run/agentconnect/gitcred.sock')
+    expect(launch.env.AC_GITCRED_SOCKET).toBe('/tmp/agentconnect/gitcred.sock')
     const dockerConfig = join(opts.scopeDir, 'run', 'config-files', 'docker')
     const explicit = prepareMicrosandboxLaunch({
       ...opts,
@@ -209,7 +209,11 @@ describe('prepareMicrosandboxLaunch', () => {
       opts.scopeDir,
       join(opts.scopeDir, 'home', 'replacement'),
       dirname(MICROSANDBOX_GUEST_ENTRY),
-      '/run/agentconnect'
+      '/run',
+      '/var/run',
+      '/run/docker',
+      '/tmp/agentconnect',
+      '/tmp'
     ]) {
       expect(() =>
         prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: opts.hostHome, target, readOnly: false }] })


### PR DESCRIPTION
Restarting a retained microsandbox VM can leave stale containerd PID files in `/run`. A reused PID then prevents the agent from starting Docker again, despite its images and volumes remaining intact. Mount `/run` as tmpfs and move the microsandbox tool sockets to the guest user's private `/tmp/agentconnect` directory. Docker still starts only when the agent requests it; SRT and the pool's default socket paths are unchanged.

Reserve `/run` and its `/var/run` alias against configured mounts. Bump the effective VM specification so old retained environments are explicitly rejected rather than silently resumed without the new mount. No retained disks are automatically deleted or migrated.

The Docker smoke also preserves Node's native environment object: replacing `process.env` made native SDK calls and CLI child processes use different cache directories.

Validation:
- Daemon typecheck, repository lint, formatting, build, and 22 focused tests pass.
- Linux KVM smoke against published `runtime-sandbox:v1.55.0-rc.37` passes manual Docker startup, Compose build/DNS, workspace bind writes, independent Docker image/volume state, stop/start persistence, same and random guest ports, Testcontainers/Ryuk cleanup, and VM removal.
- Two-VM network probes pass public npm/GitHub access and rejection of peer VM, host gateway, and host private-address connections. Host public-address and full IPv6 coverage remain pending.

Follow-up validation is tracked in #1874.

Created by Codex . GPT-6
