### PR TITLE
fix(control-plane): a stored memory binding older than `home` reads with the default filled in

### DIFF
--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -3,7 +3,7 @@
  */
 import { Prisma } from '../../generated/prisma/client.js'
 import type { Agent, PrismaClient, User } from '../../generated/prisma/client.js'
-import { redactGitUrlSecrets, type AgentMemoryBinding } from '@agentconnect.md/protocol'
+import { AgentMemoryBinding, redactGitUrlSecrets } from '@agentconnect.md/protocol'
 import type { PrismaLike } from '../prisma.js'
 import type {
   AgentCallPolicy,
@@ -189,6 +189,13 @@ function overridesOf(a: Agent): RuntimeOverrides {
   return (a.runtimeOverrides as RuntimeOverrides | null) ?? {}
 }
 
+// A stored binding predates the fields the schema now defaults (`home`): fill on read what the input path fills on write.
+function storedMemoryBinding(memory: AgentMemoryBinding | undefined): AgentMemoryBinding | null {
+  if (!memory) return null
+  const parsed = AgentMemoryBinding.safeParse(memory)
+  return parsed.success ? parsed.data : memory
+}
+
 // Preset one-shot settle (preset-agents.md §3.2): the FIRST placement of any
 // kind — and an explicit delete — permanently stamps `placementSettledAt`, so
 // M1 auto-placement never fights a user who placed, moved, or removed the
@@ -273,7 +280,7 @@ function toRecord(a: AgentWithUsers): AgentRecord {
     mcpServers: ov.mcpServers ?? [],
     skills: ov.skills ?? [],
     managedSkills: a.managedSkills,
-    memory: ov.memory ?? null,
+    memory: storedMemoryBinding(ov.memory),
     status: a.status as AgentRecord['status'],
     placementKind: a.placementKind,
     daemonId: a.daemonId ? DaemonId(a.daemonId) : null,

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -1242,3 +1242,22 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(res.json()).toEqual({ status: 'ok' })
   })
 })
+
+describe('agent rows written before the memory binding carried `home`', () => {
+  it('GET /agents fills the default on read instead of failing the response schema', async () => {
+    const app = build()
+    const id = 'c3c3c3c3-cccc-4ccc-8ccc-cccccccccccc'
+    // Written by a CP older than the field: a managed binding with no `home`, as every pre-#1865 row is.
+    await seedAgent(prisma, id, { runtimeOverrides: { memory: { provider: 'managed', autoDistill: true } } })
+
+    type Row = { id: string; memory?: { provider: string; autoDistill?: boolean; home?: string } }
+    const list = await app.app.inject({ method: 'GET', url: `${ORG}/agents` })
+    expect(list.statusCode).toBe(200)
+    const listed = (list.json() as Row[]).find((a) => a.id === id)
+    expect(listed?.memory).toEqual({ provider: 'managed', autoDistill: true, home: 'daemon' })
+
+    const one = await app.app.inject({ method: 'GET', url: `${ORG}/agents/${id}` })
+    expect(one.statusCode).toBe(200)
+    expect((one.json() as Row).memory).toEqual({ provider: 'managed', autoDistill: true, home: 'daemon' })
+  })
+})


### PR DESCRIPTION
## What broke

#1865 gave the managed memory binding a `home` field with `.default('daemon')`. A zod default fills the value when INPUT is parsed; it does nothing when a stored row is handed to the response serializer, which validates against the output type where `home` is required. Every agent row written before that release has a managed binding without `home`, so `GET /agents` (and `GET /agents/:id`) failed the response schema with a 500 and the console showed no agents. Reproduced locally.

## Fix

Fill the defaults on read, at the one place a row becomes an `AgentRecord` (`toRecord` in `agent.repo.ts`): a stored binding is run through `AgentMemoryBinding.safeParse`, so `home` — and any other default the schema carries — is present exactly as it would be after the input path. A shape the schema refuses is passed through as stored rather than hidden. No data migration; old rows stay as they are.

Because every read of an agent goes through `toRecord`, this also covers the daemon-facing frames that carry the binding.

## Verification

- New integration case: an agent seeded with `runtimeOverrides.memory = { provider: 'managed', autoDistill: true }` (no `home`) lists and reads with `home: 'daemon'`, 200 on both routes. It fails on `main` with the 500 this PR fixes and passes with it.
- `agents.route.test.ts`: 29/29 against a real Postgres. Control-plane typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
