### PR TITLE
feat(daemon): the change log gets a sink, and the Control Plane sink sends it after the write

### DIFF
--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -60,6 +60,8 @@ import type {
   KnowledgeListOk,
   MemoryStoreReq,
   MemoryFsReply,
+  MemoryHistoryAppendReq,
+  MemoryHistoryAppendOk,
   OrgSkillsReq,
   OrgSkillsOk,
   OrganizationSuggestionsSyncReq,
@@ -1144,6 +1146,25 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected memory/store/ok, got ${rep.type}`, false)
     }
     return rep.payload as MemoryFsReply
+  }
+
+  // `memory/history/append` (D→C REQ): one best-effort batch of change-log records for a CP-homed store, sent like
+  // `memoryStore` — one send on one deadline. Every record carries its own id, so the CP could take a resend, but the
+  // sender holds the store's memory-dir lock while it waits, and one deadline keeps that wait bounded.
+  async memoryHistoryAppend(payload: MemoryHistoryAppendReq): Promise<MemoryHistoryAppendOk> {
+    this.requireReady('memory/history/append')
+    if (!this.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+      throw new WireError('INTERNAL', 'control plane does not serve the memory store', false)
+    }
+    const frame = this.scopedFrame('memory/history/append', payload)
+    const rep = await this.correlator.request(frame, (e) => this.transport!.send(e), {
+      maxTries: 1,
+      ackTimeoutMs: MEMORY_STORE_TIMEOUT_MS
+    })
+    if (rep.type !== 'memory/history/append/ok') {
+      throw new WireError('INTERNAL', `expected memory/history/append/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as MemoryHistoryAppendOk
   }
 
   async knowledgeList(payload: KnowledgeListReq): Promise<KnowledgeListOk> {

--- a/packages/daemon/src/cp/memory-history.ts
+++ b/packages/daemon/src/cp/memory-history.ts
@@ -1,0 +1,95 @@
+// The `control-plane` home's change log (memory-evolution.md §3.2.1): the daemon still composes every record and sends
+// it AFTER the write as a best-effort `memory/history/append` batch — provenance never fails the write — and never
+// reads the log back, since the CP answers the console from its own table. Nothing selects it yet, like `CpMemoryFs`.
+import {
+  AGENT_MEMORY_STORE_V1_FEATURE,
+  MEMORY_HISTORY_APPEND_MAX_RECORDS,
+  REPLY_BUDGET,
+  type MemoryHistoryAppendOk,
+  type MemoryHistoryAppendReq
+} from '@agentconnect.md/protocol'
+import { WireError } from '@agentconnect.md/connection'
+import type { Logger } from '../log.js'
+import type { MemoryHistoryRecord, MemoryHistorySink } from '../memory/store.js'
+import { CP_MEMORY_TREE_ROOT, joinTreeRoot } from './memory-fs.js'
+
+/** The slice of the CP connection the sink rides: the gates `CpMemoryStoreLink` has, and the one request pair. */
+export interface CpMemoryHistoryLink {
+  connected(): boolean
+  supportsServerFeature(feature: string): boolean
+  memoryHistoryAppend(req: MemoryHistoryAppendReq): Promise<MemoryHistoryAppendOk>
+}
+
+/** Pack records, in order, into requests the wire accepts: `MEMORY_HISTORY_APPEND_MAX_RECORDS` at most, under `REPLY_BUDGET`. */
+export function packMemoryHistoryBatches(
+  agentId: string,
+  root: string,
+  records: readonly MemoryHistoryRecord[]
+): MemoryHistoryAppendReq[] {
+  const envelope = Buffer.byteLength(JSON.stringify({ agentId, root, records: [] }))
+  const batches: MemoryHistoryAppendReq[] = []
+  let batch: MemoryHistoryRecord[] = []
+  let bytes = envelope
+  for (const record of records) {
+    const size = Buffer.byteLength(JSON.stringify(record))
+    // A comma precedes every record but a batch's first; a record no batch can hold still goes alone, for the CP to refuse.
+    if (batch.length > 0 && (batch.length === MEMORY_HISTORY_APPEND_MAX_RECORDS || bytes + 1 + size > REPLY_BUDGET)) {
+      batches.push({ agentId, root, records: batch })
+      batch = []
+      bytes = envelope
+    }
+    bytes += size + (batch.length > 0 ? 1 : 0)
+    batch.push(record)
+  }
+  if (batch.length > 0) batches.push({ agentId, root, records: batch })
+  return batches
+}
+
+function failureReason(err: unknown): string {
+  if (err instanceof WireError) return `${err.code}: ${err.message}`
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+}
+
+// The sink over the CP. `root` is the store's tree-relative root, the coordinates `CpMemoryFs` names on every op — `.`
+// for the agent's own tree, `channels/<key>` for a channel store — so one table row lines up with one store.
+export class CpMemoryHistorySink implements MemoryHistorySink {
+  readonly root: string
+
+  constructor(
+    private readonly link: CpMemoryHistoryLink,
+    private readonly agentId: string,
+    root: string = CP_MEMORY_TREE_ROOT,
+    private readonly log: Pick<Logger, 'warn'>
+  ) {
+    this.root = joinTreeRoot(CP_MEMORY_TREE_ROOT, root)
+  }
+
+  /** Best-effort: the write already happened, so any failure is one warn line naming what went unrecorded, never a rejection. */
+  async append(records: MemoryHistoryRecord[]): Promise<void> {
+    if (records.length === 0) return
+    let unsent = records.length
+    let reason: string | undefined
+    if (!this.link.connected()) reason = 'the connection is down'
+    else if (!this.link.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+      reason = 'the Control Plane does not serve the memory store'
+    } else {
+      // One failure ends the batch run: what refused or dropped this request will do the same to the next one.
+      for (const batch of packMemoryHistoryBatches(this.agentId, this.root, records)) {
+        try {
+          await this.link.memoryHistoryAppend(batch)
+        } catch (err) {
+          reason = failureReason(err)
+          break
+        }
+        unsent -= batch.records.length
+      }
+    }
+    if (reason === undefined) return
+    this.log.warn(
+      `agent "${this.agentId}": ${unsent} memory change-log record(s) for ${this.root} not recorded in the Control Plane (${reason})`
+    )
+  }
+
+  /** Nothing lives inside a CP-homed store to carry: the table outlives the swap on its own. */
+  async carryInto(): Promise<void> {}
+}

--- a/packages/daemon/src/cp/memory-reader.ts
+++ b/packages/daemon/src/cp/memory-reader.ts
@@ -134,6 +134,7 @@ export function createMemoryReader(
           const result = await writeMemoryFile(dirFor(scope.agentId), path, content, ifMatch, source)
           return { ok: true, path, ...result }
         },
+        // Pages the sidecar; a home whose sink has no `list` (the CP's) answers the console itself — no local history here.
         history: async (scope, req) => listMemoryHistory(dirFor(scope.agentId), req.path, req.cursor, req.limit)
       }
     )

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -402,7 +402,7 @@ import {
   type PreparedExternalMemoryCapture
 } from './memory/provider.js'
 import { memoryChannelKey, MemorySandboxUnavailableError, type MemoryFs } from './memory/store.js'
-import { resolveMemoryFs, resolveMemoryHomePorts, type MemoryHomePorts } from './memory/fs.js'
+import { resolveMemoryFs, resolveMemoryHomePorts, type MemoryHomePorts } from './memory/home.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
 import { DutyRegistry } from './cp/duty-registry.js'
 import { DutyCoordinator, type DutyHost } from './cp/duty-coordinator.js'

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -21,24 +21,21 @@ import {
   organizationSuggestionCanonical
 } from '@agentconnect.md/protocol'
 import { memoryNameForTopic, parseMemoryFrontmatter } from '../memory/frontmatter.js'
-import type { MemoryHomePorts } from '../memory/fs.js'
+import type { MemoryHomePorts } from '../memory/home.js'
 import {
   MEMORY_INDEX,
   renderMemoryIndex,
   regenerateMemoryIndexHoldingLock,
   type MemoryIndexEntry,
-  MEMORY_HISTORY_FILENAME,
   MAX_INDEX_INJECT_BYTES,
   MAX_MEMORY_FILE_BYTES,
   MEMORY_DIRNAME,
   MemorySandboxUnavailableError,
-  clampMemoryHistoryValue,
-  enforceMemoryHistoryRetentionHoldingLock,
   listMemory,
+  memoryHistoryRecord,
   memoryWriteMarks,
   recordExternalMemoryMutation,
   readMemoryFile,
-  snapshotMemoryHistoryHoldingLock,
   type MemoryFs,
   type MemoryHistoryRecord,
   withMemoryDirLock
@@ -1150,12 +1147,13 @@ export class DreamRunner {
 
   /**
    * Adopt a completed dream (design §6). Serialized per agent (the lock) against
-   * concurrent starts, adopts, and discards. The replacement store — including
-   * the carried-over `.history` plus one `source:"dream"` provenance row per
-   * changed file — is built entirely in a sibling temp directory FIRST, so `memory/` is
-   * never a half-written tree: the visible window is a single rename, and a
-   * failure rolls the previous store back. Fenced against post-snapshot writes
-   * unless `force`.
+   * concurrent starts, adopts, and discards. The replacement store is built
+   * entirely in a sibling temp directory FIRST, so `memory/` is never a
+   * half-written tree: the visible window is a single rename, and a failure rolls
+   * the previous store back. The change log follows the store's sink: a sidecar
+   * is carried into the replacement before the swap, and one `source:"dream"`
+   * row per changed file is appended after it. Fenced against post-snapshot
+   * writes unless `force`.
    *
    * The non-force fence is authoritative *under the shared memory-dir lock*: the
    * replacement is built first (no touch to `memory/`), then the digest is
@@ -1171,6 +1169,7 @@ export class DreamRunner {
     this.assertStagedContentAllowed()
     const ports = this.portsFor(agentId)
     const { live, staging } = ports
+    const history = ports.historyFor(live)
     return this.withLock(agentId, async () => {
       this.assertNotAbandoned(dreamId)
       const dream = await this.getDream(agentId, dreamId)
@@ -1207,7 +1206,7 @@ export class DreamRunner {
       const at = this.nowIso()
 
       // 1) Build the proposed files in a temp sibling dir. `memory/` is
-      //    untouched. History is added later under the shared lock so every
+      //    untouched. The change set is taken later under the shared lock so every
       //    `before` snapshot describes the exact store the swap replaces.
       const replacement = `.memory.adopting-${dreamId}`
       await live.rm(replacement)
@@ -1244,11 +1243,9 @@ export class DreamRunner {
             }
           }
 
-          // Canonicalize the exact live history before adding adoption rows. A
-          // legacy final row without a newline (or a torn tail) must not absorb
-          // the first dream row. Build a full add/update/delete change set from
-          // the store that is about to be replaced, skipping unchanged files.
-          let history = await snapshotMemoryHistoryHoldingLock(live)
+          // The full add/update/delete change set of the store about to be replaced, unchanged files skipped; it
+          // reaches the sink only once the swap has happened (provenance follows the write, never precedes it).
+          const records: MemoryHistoryRecord[] = []
           const beforeByPath = new Map(liveFiles.map((file) => [file.name, file.content]))
           const afterFiles = (await live.readdir(replacement))
             .filter((entry) => entry.kind === 'file' && stagedPathOk(entry.name))
@@ -1262,23 +1259,10 @@ export class DreamRunner {
             const before = beforeByPath.get(path)
             const after = afterByPath.get(path)
             if (before === after) continue
-
-            const beforeClamped = before === undefined ? undefined : clampMemoryHistoryValue(before)
-            const afterClamped = clampMemoryHistoryValue(after ?? '')
-            const record: MemoryHistoryRecord = {
-              id: randomUUID(),
-              path,
-              event: before === undefined ? 'add' : after === undefined ? 'delete' : 'update',
-              ...(beforeClamped ? { before: beforeClamped.value } : {}),
-              after: afterClamped.value,
-              at,
-              scope: 'agent',
-              source: 'dream',
-              ...(beforeClamped?.truncated || afterClamped.truncated ? { truncated: true } : {})
-            }
-            history += JSON.stringify(record) + '\n'
+            records.push(memoryHistoryRecord(path, before, after, at, 'dream'))
           }
-          await live.writeFile(join(replacement, MEMORY_HISTORY_FILENAME), history, { mode: 0o600 })
+          // A log kept inside the store (the sidecar) would go with the swap: the sink copies it into the replacement first.
+          await history.carryInto(replacement)
 
           // Preserve the "last meaningfully changed" time of files the dream left
           // byte-for-byte unchanged. The whole store is rebuilt into `replacement`
@@ -1313,15 +1297,14 @@ export class DreamRunner {
           // snapshot must fence on this adoption rather than classify it as
           // distill-only drift and roll over it.
           recordExternalMemoryMutation(live, 'dream')
+          // Provenance after the write, never failing it: one `dream` row per changed file, still under the lock.
+          await history.append(records).catch(() => {})
           // The adopted store has a hand-authored MEMORY.md while ordinary writes
           // regenerate it from the topic descriptions — two writers with no defined
           // precedence. Settle it here, inside the same lock: if the adopted topics
           // give the generator anything to work with, it owns the index from now on
           // instead of silently replacing the dream's copy at some later write.
-          await regenerateMemoryIndexHoldingLock(live, 'dream').catch(() => {})
-          // Dream adoption copies history as part of the atomic store swap, so
-          // tighten that copied/appended sidecar before releasing the same lock.
-          await enforceMemoryHistoryRetentionHoldingLock(live).catch(() => {})
+          await regenerateMemoryIndexHoldingLock(live, 'dream', { history }).catch(() => {})
 
           // The backup is the undo path for THIS adoption; older ones superseded.
           if (hadLiveStore) {

--- a/packages/daemon/src/memory/fs.ts
+++ b/packages/daemon/src/memory/fs.ts
@@ -3,7 +3,7 @@
  *
  * Every managed-memory writer and reader (`memory/store.ts`, the memory provider, the dream
  * runner, the CP memory reader) is a DIRECTORY abstraction over this port, so where the tree lives
- * is a placement decision, not a policy one: a local agent's home is `<agent.dir>` on this daemon's
+ * is a placement decision (`memory/home.ts`), not a policy one: a local agent's home is `<agent.dir>` on this daemon's
  * disk (`LocalMemoryFs`), a cluster agent's is one root on its sandbox volume reached through the
  * shim (`shim/memory-fs-channel.ts`), and a `control-plane` home is that same client over the CP
  * connection (`cp/memory-fs.ts`). Paths are relative to the root; the root itself is in the
@@ -413,49 +413,4 @@ export class LocalMemoryFs implements MemoryFs {
       // best-effort: a vanished file keeps whatever mtime it has
     }
   }
-}
-
-/** The sandbox plane as the factory sees it: the port over a bound sandbox volume, or nothing. */
-export interface SandboxMemoryFsSource {
-  memoryFsFor(agentId: string): MemoryFs | undefined
-}
-
-/** The two ports the dream runner works over; today both are the same instance (memory-evolution.md §3.2.1). */
-export interface MemoryHomePorts {
-  /** The live store: `memory/`, `channels/`, `memory-backups/`, and the adoption temp dir beside them. */
-  live: MemoryFs
-  /** Dream staging (`memory-dreams/`), on the filesystem the extraction host runs in — its root is the host's cwd. */
-  staging: MemoryFs
-}
-
-/**
- * The ONE decision about where an agent's managed memory tree lives. With a sandbox plane (every
- * agent of a `--k8s` daemon runs in a pod) it is the port over the agent's sandbox volume, reachable
- * exactly while the pod is bound — no fallback to this member's disk, since a duty move would leave
- * the memory behind; without one, the local port over the agent dir. A later home moves `live`
- * alone; `staging` stays where the extraction host can see it.
- */
-export function resolveMemoryHomePorts(
-  agent: { id: string; dir: string },
-  sandbox: SandboxMemoryFsSource | undefined
-): MemoryHomePorts {
-  if (!sandbox) {
-    const fs = new LocalMemoryFs(agent.dir)
-    return { live: fs, staging: fs }
-  }
-  const fs = sandbox.memoryFsFor(agent.id)
-  if (!fs) {
-    throw new MemorySandboxUnavailableError(
-      `agent "${agent.id}" has no running sandbox, so its memory cannot be reached`
-    )
-  }
-  return { live: fs, staging: fs }
-}
-
-/** The live store alone, for the consumers that never touch dream staging (the provider, the CP memory reader). */
-export function resolveMemoryFs(
-  agent: { id: string; dir: string },
-  sandbox: SandboxMemoryFsSource | undefined
-): MemoryFs {
-  return resolveMemoryHomePorts(agent, sandbox).live
 }

--- a/packages/daemon/src/memory/home.ts
+++ b/packages/daemon/src/memory/home.ts
@@ -1,0 +1,56 @@
+// Where an agent's managed memory lives — the ONE placement decision — as the file ports plus the change-log sink
+// (memory-evolution.md §3.2.1). Today the tree is on this disk or on the bound sandbox volume, and the sidecar inside
+// the store is the sink either way; a `control-plane` home will pick `CpMemoryFs` and `CpMemoryHistorySink` here.
+import { LocalMemoryFs, MemorySandboxUnavailableError, type MemoryFs } from './fs.js'
+import { SidecarMemoryHistorySink, type MemoryHistorySink } from './store.js'
+
+/** The sandbox plane as the factory sees it: the port over a bound sandbox volume, or nothing. */
+export interface SandboxMemoryFsSource {
+  memoryFsFor(agentId: string): MemoryFs | undefined
+}
+
+/** The ports the dream runner and every managed-memory writer work over; today `live` and `staging` are one tree. */
+export interface MemoryHomePorts {
+  /** The live store: `memory/`, `channels/`, `memory-backups/`, and the adoption temp dir beside them. */
+  live: MemoryFs
+  /** Dream staging (`memory-dreams/`), on the filesystem the extraction host runs in — its root is the host's cwd. */
+  staging: MemoryFs
+  /** The change-log sink for one store under `live` (the agent's own tree or a channel root), in its coordinates. */
+  historyFor(store: MemoryFs): MemoryHistorySink
+}
+
+/** The sidecar inside whichever store is written: the sink every home selects today. */
+export function sidecarMemoryHistory(store: MemoryFs): MemoryHistorySink {
+  return new SidecarMemoryHistorySink(store)
+}
+
+/**
+ * With a sandbox plane (every agent of a `--k8s` daemon runs in a pod) the tree is the port over the agent's sandbox
+ * volume, reachable exactly while the pod is bound — no fallback to this member's disk, since a duty move would leave
+ * the memory behind; without one, the local port over the agent dir. A later home moves `live` and the sink alone;
+ * `staging` stays where the extraction host can see it.
+ */
+export function resolveMemoryHomePorts(
+  agent: { id: string; dir: string },
+  sandbox: SandboxMemoryFsSource | undefined
+): MemoryHomePorts {
+  if (!sandbox) {
+    const fs = new LocalMemoryFs(agent.dir)
+    return { live: fs, staging: fs, historyFor: sidecarMemoryHistory }
+  }
+  const fs = sandbox.memoryFsFor(agent.id)
+  if (!fs) {
+    throw new MemorySandboxUnavailableError(
+      `agent "${agent.id}" has no running sandbox, so its memory cannot be reached`
+    )
+  }
+  return { live: fs, staging: fs, historyFor: sidecarMemoryHistory }
+}
+
+/** The live store alone, for the consumers that never touch dream staging (the provider, the CP memory reader). */
+export function resolveMemoryFs(
+  agent: { id: string; dir: string },
+  sandbox: SandboxMemoryFsSource | undefined
+): MemoryFs {
+  return resolveMemoryHomePorts(agent, sandbox).live
+}

--- a/packages/daemon/src/memory/providers/managed.ts
+++ b/packages/daemon/src/memory/providers/managed.ts
@@ -143,6 +143,7 @@ export class ManagedMemoryProvider implements MemoryProvider {
       list: (scope) => this.list(scope),
       read: (scope, path) => this.read(scope, path),
       write: (scope, path, content, ifMatch, source) => this.write(scope, path, content, ifMatch, source),
+      // Pages the sidecar; a home whose sink has no `list` (the CP's) answers the console itself — no local history here.
       history: (scope, req) => listMemoryHistory(this.activeRoot(scope), req.path, req.cursor, req.limit)
     }
   }

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -97,6 +97,18 @@ export interface ManagedMemoryHistoryPage {
   nextCursor?: string
 }
 
+// Where one store's change log goes (memory-evolution.md §3.2.1): the `.history` sidecar inside the store, or the
+// CP's event table under a `control-plane` home. A writer calls it after its write, holding the memory-dir lock, and
+// swallows a failure itself — provenance never fails the write. `memory/home.ts` picks the sink beside the store's port.
+export interface MemoryHistorySink {
+  /** Record writes already made, oldest first; every record carries the id the daemon minted. */
+  append(records: MemoryHistoryRecord[]): Promise<void>
+  /** Adoption is about to swap `memory/` for the tree at `replacement`: a log kept inside the store copies itself there. */
+  carryInto(replacement: string): Promise<void>
+  /** Page the log back on this daemon; absent when the home answers the console itself (no local history to read). */
+  list?(relPath: string, cursor: string | undefined, limit: number): Promise<ManagedMemoryHistoryPage>
+}
+
 export interface MemoryHistoryRetentionLimits {
   maxBytes: number
   maxVersionsPerFile: number
@@ -364,20 +376,6 @@ async function readHistoryRaw(fs: MemoryFs): Promise<string> {
   return (await fs.readFile(HISTORY_PATH))?.content ?? ''
 }
 
-/** Take a canonical history snapshot while the caller already holds the memory-dir
- * lock. Dream adoption uses this in the same critical section as its final live-store
- * snapshot and directory swap. */
-export async function snapshotMemoryHistoryHoldingLock(fs: MemoryFs): Promise<string> {
-  const raw = await readHistoryRaw(fs)
-  return raw ? canonicalizeMemoryHistory(raw) : ''
-}
-
-/** Take a canonical snapshot for a replacement store. The brief shared lock makes the
- * copied sidecar line up with ordinary appends. */
-export function snapshotMemoryHistory(fs: MemoryFs): Promise<string> {
-  return withMemoryDirLock(fs, () => snapshotMemoryHistoryHoldingLock(fs))
-}
-
 /** Compact one sidecar atomically. Invalid legacy/torn rows are discarded and
  * rows written before stable event IDs existed are upgraded during the rewrite. */
 async function compactHistoryFile(fs: MemoryFs): Promise<void> {
@@ -388,34 +386,58 @@ async function compactHistoryFile(fs: MemoryFs): Promise<void> {
   await fs.writeFile(HISTORY_PATH, canonical, { mode: 0o600 })
 }
 
-/** Apply system retention while the caller already holds the memory-dir lock.
- * Exported for dream adoption, whose directory swap is one larger critical
- * section. Calling this without the shared lock would race ordinary writes. */
-export async function enforceMemoryHistoryRetentionHoldingLock(fs: MemoryFs): Promise<void> {
-  await compactHistoryFile(fs)
+/** The sidecar sink: `<root>/memory/.history`, rewritten once per append, the fixed retention applied in the same pass. */
+export class SidecarMemoryHistorySink implements MemoryHistorySink {
+  constructor(private readonly fs: MemoryFs) {}
+
+  // Canonicalize the current file first: a torn tail, or a legacy row without its newline, would swallow the append.
+  async append(records: MemoryHistoryRecord[]): Promise<void> {
+    if (records.length === 0) return
+    const canonical = canonicalizeMemoryHistory(await readHistoryRaw(this.fs))
+    const lines = records.map((record) => historyLine({ ...record, id: record.id ?? randomUUID() })).join('')
+    await this.fs.writeFile(HISTORY_PATH, canonicalizeMemoryHistory(canonical + lines), { mode: 0o600 })
+  }
+
+  /** The canonical log copied into the replacement store, so the swap keeps it and the adoption rows append to it. */
+  async carryInto(replacement: string): Promise<void> {
+    const canonical = canonicalizeMemoryHistory(await readHistoryRaw(this.fs))
+    await this.fs.writeFile(join(replacement, MEMORY_HISTORY_FILENAME), canonical, { mode: 0o600 })
+  }
+
+  list(relPath: string, cursor: string | undefined, limit: number): Promise<ManagedMemoryHistoryPage> {
+    return listMemoryHistory(this.fs, relPath, cursor, limit)
+  }
 }
 
-/** Apply system retention to an existing sidecar (including legacy files).
- * Callers decide whether failure is best-effort. */
-export function enforceMemoryHistoryRetention(fs: MemoryFs): Promise<void> {
-  return withMemoryDirLock(fs, () => enforceMemoryHistoryRetentionHoldingLock(fs))
-}
-
-/** Append one line to the memory change log and enforce fixed retention: the current
- * sidecar is canonicalized first (a legacy row without its final newline, or a torn
- * tail, would otherwise absorb this append into one invalid row), then rewritten once
- * with the new row retained. Best-effort: provenance failure never fails the write. */
-async function appendHistoryHoldingLock(fs: MemoryFs, record: MemoryHistoryRecord): Promise<void> {
-  const canonical = canonicalizeMemoryHistory(await readHistoryRaw(fs))
-  const next = canonicalizeMemoryHistory(canonical + historyLine({ ...record, id: record.id ?? randomUUID() }))
-  await fs.writeFile(HISTORY_PATH, next, { mode: 0o600 })
-}
-
+/** One sidecar append under the memory-dir lock; best-effort, as every writer treats its sink. */
 export async function appendHistory(fs: MemoryFs, record: MemoryHistoryRecord): Promise<void> {
   try {
-    await withMemoryDirLock(fs, () => appendHistoryHoldingLock(fs, record))
+    await withMemoryDirLock(fs, () => new SidecarMemoryHistorySink(fs).append([record]))
   } catch {
     // Provenance is best-effort — retry compaction on the next append/read.
+  }
+}
+
+/** The change-log record for a write that just landed: snapshots clamped, the id minted here so every sink sees it. */
+export function memoryHistoryRecord(
+  path: string,
+  before: string | undefined,
+  after: string | undefined,
+  at: string,
+  source: MemoryWriteSource
+): MemoryHistoryRecord {
+  const beforeClamped = before === undefined ? undefined : clampMemoryHistoryValue(before)
+  const afterClamped = clampMemoryHistoryValue(after ?? '')
+  return {
+    id: randomUUID(),
+    path,
+    event: before === undefined ? 'add' : after === undefined ? 'delete' : 'update',
+    ...(beforeClamped ? { before: beforeClamped.value } : {}),
+    after: afterClamped.value,
+    at,
+    scope: 'agent',
+    source,
+    ...(beforeClamped?.truncated || afterClamped.truncated ? { truncated: true } : {})
   }
 }
 
@@ -537,9 +559,9 @@ function bumpWriteMarks(fs: MemoryFs, source: MemoryWriteSource): void {
 }
 
 /** Overwrite a memory file with `content` (creating the dir if needed). Atomic
- *  (tmp + rename) so a concurrent read never sees a partial file. Appends a line to
- *  the change log (`.history`) recording the add/update, its `before`/`after`
- *  snapshot (bounded), and the `source`.
+ *  (tmp + rename) so a concurrent read never sees a partial file. Hands `history`
+ *  (the sidecar unless a home says otherwise) one record of the add/update, its
+ *  bounded `before`/`after` snapshot, and the `source`.
  *
  *  - Rejects content over {@link MAX_MEMORY_FILE_BYTES} ({@link MemoryTooLargeError}).
  *  - `ifMatchMtime` (optimistic concurrency): when given, the current file's mtime
@@ -551,11 +573,12 @@ export function writeMemoryFile(
   relPath: string,
   content: string,
   ifMatchMtime?: string,
-  source: MemoryWriteSource = 'tool'
+  source: MemoryWriteSource = 'tool',
+  history: MemoryHistorySink = new SidecarMemoryHistorySink(fs)
 ): Promise<{ size: number; mtime: string }> {
   // Serialize every write behind the shared per-dir lock so it can't interleave
   // with a dream adoption's fence-and-swap (nor another write).
-  return withMemoryDirLock(fs, () => writeMemoryFileHoldingLock(fs, relPath, content, ifMatchMtime, source))
+  return withMemoryDirLock(fs, () => writeMemoryFileHoldingLock(fs, relPath, content, ifMatchMtime, source, history))
 }
 
 /**
@@ -570,7 +593,8 @@ export async function writeMemoryFileHoldingLock(
   relPath: string,
   content: string,
   ifMatchMtime: string | undefined,
-  source: MemoryWriteSource
+  source: MemoryWriteSource,
+  history: MemoryHistorySink = new SidecarMemoryHistorySink(fs)
 ): Promise<{ size: number; mtime: string }> {
   const topic = memoryTopicName(relPath)
   // Keep a written header truthful (`name` from the filename, fresh `modified`).
@@ -594,24 +618,12 @@ export async function writeMemoryFileHoldingLock(
   // adoption fence authorizes from these counters, never from `.history`.
   bumpWriteMarks(fs, source)
 
-  const existed = current !== null
-  const beforeClamped = existed ? clampMemoryHistoryValue(current.content) : undefined
-  const afterClamped = clampMemoryHistoryValue(content)
   try {
-    await appendHistoryHoldingLock(fs, {
-      path: relPath,
-      event: existed ? 'update' : 'add',
-      ...(beforeClamped ? { before: beforeClamped.value } : {}),
-      after: afterClamped.value,
-      at: st.mtime,
-      scope: 'agent',
-      source,
-      ...(afterClamped.truncated || beforeClamped?.truncated ? { truncated: true } : {})
-    })
+    await history.append([memoryHistoryRecord(relPath, current?.content, content, st.mtime, source)])
   } catch {
     // Provenance is best-effort — retry compaction on the next append/read.
   }
-  if (topic !== MEMORY_INDEX) await regenerateMemoryIndexHoldingLock(fs, source)
+  if (topic !== MEMORY_INDEX) await regenerateMemoryIndexHoldingLock(fs, source, { history })
   return { size: st.size, mtime: st.mtime }
 }
 
@@ -669,7 +681,7 @@ export function renderMemoryIndex(entries: MemoryIndexEntry[], heading = '# Memo
 export async function regenerateMemoryIndexHoldingLock(
   fs: MemoryFs,
   source: MemoryWriteSource,
-  opts: { force?: boolean } = {}
+  opts: { force?: boolean; history?: MemoryHistorySink } = {}
 ): Promise<void> {
   const entries: { topic: string; name: string; description: string }[] = []
   for (const file of await listMemory(fs)) {
@@ -698,18 +710,8 @@ export async function regenerateMemoryIndexHoldingLock(
 
   const st = await fs.writeFile(`${MEMORY_DIRNAME}/${MEMORY_INDEX}`, next, {})
   try {
-    const before = current ? clampMemoryHistoryValue(current.content) : undefined
-    const after = clampMemoryHistoryValue(next)
-    await appendHistoryHoldingLock(fs, {
-      path: MEMORY_INDEX,
-      event: current ? 'update' : 'add',
-      ...(before ? { before: before.value } : {}),
-      after: after.value,
-      at: st.mtime,
-      scope: 'agent',
-      source,
-      ...(after.truncated || before?.truncated ? { truncated: true } : {})
-    })
+    const history = opts.history ?? new SidecarMemoryHistorySink(fs)
+    await history.append([memoryHistoryRecord(MEMORY_INDEX, current?.content, next, st.mtime, source)])
   } catch {
     // Provenance is best-effort, exactly as in the topic write above.
   }

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -1166,3 +1166,48 @@ describe('CpClient memory/store (D→C REQ)', () => {
     expect(t.sent).toHaveLength(0)
   })
 })
+
+describe('CpClient memory/history/append (D→C REQ)', () => {
+  const record = {
+    id: '99999999-9999-4999-8999-999999999999',
+    path: 'notes.md',
+    event: 'add',
+    after: 'v1',
+    at: '2026-01-01T00:00:00.000Z',
+    scope: 'agent',
+    source: 'tool'
+  } as const
+  const batch = { agentId: CRON_AGENT_ID, root: '.', records: [record] }
+
+  it('names the agent, stamps its org, and unwraps memory/history/append/ok', async () => {
+    const { client, t } = await readyClient(
+      { orgForAgent: (agentId) => (agentId === CRON_AGENT_ID ? 'org-1' : undefined) },
+      ['agent-memory-store-v1'],
+      'frame'
+    )
+    const pending = client.memoryHistoryAppend(batch)
+    await tick()
+    const req = JSON.parse(t.sent[0]!)
+    expect(req).toMatchObject({ type: 'memory/history/append', orgId: 'org-1', payload: batch })
+    t.pushInbound(
+      JSON.stringify(buildEnvelope('memory/history/append/ok', { accepted: true }, { corr: req.id, orgId: 'org-1' }))
+    )
+    await expect(pending).resolves.toEqual({ accepted: true })
+  })
+
+  it('refuses before sending without the feature, sends exactly once, and fails on one deadline', async () => {
+    const older = await readyClient({}, [])
+    await expect(older.client.memoryHistoryAppend(batch)).rejects.toMatchObject({ code: 'INTERNAL', retryable: false })
+    expect(older.t.sent).toHaveLength(0)
+
+    const { client, t, clock } = await readyClient({}, ['agent-memory-store-v1'])
+    const appends = () => t.sent.filter((raw) => JSON.parse(raw).type === 'memory/history/append')
+    const pending = client.memoryHistoryAppend(batch)
+    await tick()
+    clock.advance(29_000)
+    expect(appends()).toHaveLength(1)
+    clock.advance(1_000)
+    await expect(pending).rejects.toMatchObject({ code: 'INTERNAL', retryable: true })
+    expect(appends()).toHaveLength(1)
+  })
+})

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -24,19 +24,25 @@ import {
   MAX_MEMORY_FILE_BYTES,
   listMemory,
   memoryDir,
-  type MemoryHistoryRecord
+  type MemoryHistoryRecord,
+  type MemoryHistorySink
 } from '../src/memory/store.js'
 import { LocalMemoryFs, MemorySandboxUnavailableError } from '../src/memory/fs.js'
 import { acceptedDreamSkillSources } from '../src/skills/dream-skills.js'
 import { storeDigest } from '../src/dream/dreamer.js'
 import { inspectLocalSkillSource } from '../src/skills/skill-source-snapshot.js'
-import type { MemoryFs, MemoryHomePorts } from '../src/memory/fs.js'
+import type { MemoryFs } from '../src/memory/fs.js'
+import { sidecarMemoryHistory, type MemoryHomePorts } from '../src/memory/home.js'
 import { pod } from './fixtures/memory-fs-pod.js'
 import { WAIT } from './wait-support.js'
 
 const local = (dir: string) => new LocalMemoryFs(dir)
-/** One tree for both roles, the way the daemon resolves a home today. */
-const home = (fs: MemoryFs): MemoryHomePorts => ({ live: fs, staging: fs })
+/** One tree for both roles and the sidecar sink, the way the daemon resolves a home today. */
+const home = (fs: MemoryFs, historyFor = sidecarMemoryHistory): MemoryHomePorts => ({
+  live: fs,
+  staging: fs,
+  historyFor
+})
 
 /** The same port, noting every root-relative path it is asked for, `/`-separated on every platform (a subdir's paths are prefixed). */
 function recording(fs: MemoryFs, touched: string[], prefix = ''): MemoryFs {
@@ -179,17 +185,20 @@ async function setup(opts: {
   now?: () => Date
   /** Put the agent's memory tree on a sandbox volume reached through the shim channel. */
   sandbox?: boolean
+  /** The change-log sink for the store, instead of the sidecar inside it. */
+  historyFor?: MemoryHomePorts['historyFor']
 }) {
   const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
   const sandbox = opts.sandbox ? pod() : undefined
   const root: MemoryFs = sandbox?.fs ?? local(dir)
+  const historyFor = opts.historyFor ?? sidecarMemoryHistory
   await ensureMemory(root, 'bot')
-  await writeMemoryFile(root, 'prefs.md', '- uses tabs\n- uses tabs again\n', undefined, 'tool')
+  await writeMemoryFile(root, 'prefs.md', '- uses tabs\n- uses tabs again\n', undefined, 'tool', historyFor(root))
   const store = new FakeStore()
   const prompts: { systemPrompt: string; prompt: string; inputDir: string }[] = []
   const runner = new DreamRunner({
     agentDirByAgent: (id) => (id === 'a1' ? dir : undefined),
-    memoryHomePortsFor: (id) => (id === 'a1' ? home(root) : undefined),
+    memoryHomePortsFor: (id) => (id === 'a1' ? home(root, historyFor) : undefined),
     dreamingPolicyFor: () => opts.policy ?? { enabled: true },
     operationPolicy: opts.operationPolicy ?? 'test-only',
     store,
@@ -934,7 +943,8 @@ describe('DreamRunner adoption', () => {
     const stagingTouched: string[] = []
     const ports: MemoryHomePorts = {
       live: recording(local(liveDir), liveTouched),
-      staging: recording(local(stagingDir), stagingTouched)
+      staging: recording(local(stagingDir), stagingTouched),
+      historyFor: sidecarMemoryHistory
     }
     await ensureMemory(ports.live, 'bot')
     await writeMemoryFile(ports.live, 'prefs.md', '- uses tabs\n- uses tabs again\n', undefined, 'tool')
@@ -979,6 +989,48 @@ describe('DreamRunner adoption', () => {
       }))
     )
     expect(storeDigest(adoptedFiles)).toBe(token)
+  })
+
+  it("sends one dream row per changed file through the store's sink and carries no sidecar when the sink is not one", async () => {
+    // The shape a `control-plane` home has: the log is a table beside the store, so nothing inside `memory/` moves.
+    const batches: MemoryHistoryRecord[][] = []
+    const carried: string[] = []
+    const sink: MemoryHistorySink = {
+      append: async (records) => void batches.push(records),
+      carryInto: async (replacement) => void carried.push(replacement)
+    }
+    const { dir, store, runner } = await setup({
+      stagedFiles: [
+        { path: 'prefs.md', content: '- consolidated preference' },
+        { path: 'fresh.md', content: '- newly learned fact' }
+      ],
+      historyFor: () => sink
+    })
+    await writeMemoryFile(local(dir), 'obsolete.md', '- no longer relevant\n', undefined, 'tool', sink)
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+    batches.length = 0
+
+    await runner.adopt('a1', started.dreamId, false)
+
+    expect(carried).toEqual([`.memory.adopting-${started.dreamId}`])
+    // The first batch after the swap is the change set — one row per changed file, the rendered index among them —
+    // sorted by path and all dream-sourced.
+    const adoption = batches[0]!
+    expect(adoption.map((record) => [record.path, record.event])).toEqual([
+      ['fresh.md', 'add'],
+      [MEMORY_INDEX, 'update'],
+      ['obsolete.md', 'delete'],
+      ['prefs.md', 'update']
+    ])
+    expect(adoption.every((record) => record.source === 'dream' && record.id)).toBe(true)
+    expect(adoption.find((record) => record.path === 'prefs.md')).toMatchObject({
+      before: '- uses tabs\n- uses tabs again\n',
+      after: '- consolidated preference\n'
+    })
+    // No sidecar anywhere on the tree: not in the adopted store, and none was ever written to carry.
+    expect(await readdir(memoryDir(dir))).not.toContain(MEMORY_HISTORY_FILENAME)
+    expect(await readMemoryFile(local(dir), 'prefs.md')).toBe('- consolidated preference\n')
   })
 
   it('preserves the mtime of files the dream left unchanged, refreshing only changed ones', async () => {

--- a/packages/daemon/test/memory-fs.test.ts
+++ b/packages/daemon/test/memory-fs.test.ts
@@ -7,9 +7,9 @@ import {
   MemoryConflictError,
   MemoryPathError,
   MemorySandboxUnavailableError,
-  resolveMemoryFs,
   type MemoryFs
 } from '../src/memory/fs.js'
+import { resolveMemoryFs } from '../src/memory/home.js'
 import {
   MEMORY_HISTORY_FILENAME,
   MEMORY_INDEX,

--- a/packages/daemon/test/memory-history-sink.test.ts
+++ b/packages/daemon/test/memory-history-sink.test.ts
@@ -1,0 +1,264 @@
+// The change-log sink (memory-evolution.md §3.2.1): the seam every managed-memory writer hands its records to, the
+// sidecar behind it today, and `CpMemoryHistorySink` — batches under the wire's two limits, tree-relative roots, and
+// best-effort delivery that warns once and never rejects.
+import { afterAll, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { WireError } from '@agentconnect.md/connection'
+import {
+  MEMORY_HISTORY_APPEND_MAX_RECORDS,
+  MemoryHistoryAppendReq,
+  REPLY_BUDGET,
+  type MemoryHistoryAppendOk
+} from '@agentconnect.md/protocol'
+import { CpMemoryFs } from '../src/cp/memory-fs.js'
+import { CpMemoryHistorySink, packMemoryHistoryBatches, type CpMemoryHistoryLink } from '../src/cp/memory-history.js'
+import { LocalMemoryFs } from '../src/memory/fs.js'
+import { resolveMemoryHomePorts } from '../src/memory/home.js'
+import {
+  MEMORY_HISTORY_FILENAME,
+  MEMORY_INDEX,
+  SidecarMemoryHistorySink,
+  channelMemoryRoot,
+  memoryDir,
+  memoryHistoryRecord,
+  writeMemoryFile,
+  type MemoryHistoryRecord,
+  type MemoryHistorySink
+} from '../src/memory/store.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+
+const dirs: string[] = []
+afterAll(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function newDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'ac-history-sink-'))
+  dirs.push(dir)
+  return dir
+}
+
+function readSidecar(dir: string): MemoryHistoryRecord[] {
+  return readFileSync(join(memoryDir(dir), MEMORY_HISTORY_FILENAME), 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as MemoryHistoryRecord)
+}
+
+/** A sink that only remembers what it was handed, the way a home other than the sidecar receives records. */
+function recordingSink(): MemoryHistorySink & { batches: MemoryHistoryRecord[][]; carried: string[] } {
+  const batches: MemoryHistoryRecord[][] = []
+  const carried: string[] = []
+  return {
+    batches,
+    carried,
+    append: async (records) => void batches.push(records),
+    carryInto: async (replacement) => void carried.push(replacement)
+  }
+}
+
+function record(path: string, after: string, before?: string): MemoryHistoryRecord {
+  return memoryHistoryRecord(path, before, after, '2026-01-01T00:00:00.000Z', 'tool')
+}
+
+describe('the sink seam in the write path', () => {
+  it('hands every write one record with the id the daemon minted, and writes no sidecar when the sink is not one', async () => {
+    const dir = newDir()
+    const fs = new LocalMemoryFs(dir)
+    const sink = recordingSink()
+    await writeMemoryFile(fs, 'notes.md', 'v1', undefined, 'console', sink)
+    await writeMemoryFile(fs, 'notes.md', 'v2', undefined, 'tool', sink)
+    expect(sink.batches.map((batch) => batch.length)).toEqual([1, 1])
+    const [add, update] = sink.batches.map((batch) => batch[0]!)
+    expect(add).toMatchObject({ path: 'notes.md', event: 'add', after: 'v1', scope: 'agent', source: 'console' })
+    expect(add!.before).toBeUndefined()
+    expect(update).toMatchObject({ path: 'notes.md', event: 'update', before: 'v1', after: 'v2', source: 'tool' })
+    expect(add!.id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(update!.id).not.toBe(add!.id)
+    expect(existsSync(join(memoryDir(dir), MEMORY_HISTORY_FILENAME))).toBe(false)
+  })
+
+  it('routes the regenerated index through the same sink as the topic write that caused it', async () => {
+    const fs = new LocalMemoryFs(newDir())
+    const sink = recordingSink()
+    await writeMemoryFile(fs, 'deploys.md', '---\ndescription: how we ship\n---\nbody\n', undefined, 'tool', sink)
+    expect(sink.batches.flat().map((event) => [event.path, event.source])).toEqual([
+      ['deploys.md', 'tool'],
+      [MEMORY_INDEX, 'tool']
+    ])
+  })
+
+  it('never fails the write it describes when the sink rejects', async () => {
+    const dir = newDir()
+    const fs = new LocalMemoryFs(dir)
+    const failing: MemoryHistorySink = {
+      append: async () => {
+        throw new Error('table unavailable')
+      },
+      carryInto: async () => {}
+    }
+    await expect(writeMemoryFile(fs, 'notes.md', 'kept', undefined, 'tool', failing)).resolves.toMatchObject({
+      size: 4
+    })
+    expect(readFileSync(join(memoryDir(dir), 'notes.md'), 'utf8')).toBe('kept')
+  })
+
+  it('selects the sidecar by default, the same one every home resolves today, and pages it back', async () => {
+    const dir = newDir()
+    const fs = new LocalMemoryFs(dir)
+    await writeMemoryFile(fs, 'notes.md', 'v1')
+    const ports = resolveMemoryHomePorts({ id: 'bot-a', dir }, undefined)
+    const sink = ports.historyFor(ports.live)
+    expect(sink).toBeInstanceOf(SidecarMemoryHistorySink)
+    await sink.append([record('notes.md', 'v2', 'v1')])
+    expect(readSidecar(dir).map((event) => event.after)).toEqual(['v1', 'v2'])
+    const page = await sink.list!('notes.md', undefined, 5)
+    expect(page.events.map((event) => event.after)).toEqual(['v2', 'v1'])
+    // A store swap keeps a log that lives inside the store: the carry is the canonical log, ready to append to.
+    await sink.carryInto('.memory.adopting-x')
+    expect(readFileSync(join(dir, '.memory.adopting-x', MEMORY_HISTORY_FILENAME), 'utf8')).toBe(
+      readFileSync(join(memoryDir(dir), MEMORY_HISTORY_FILENAME), 'utf8')
+    )
+  })
+})
+
+type FakeLink = CpMemoryHistoryLink & { requests: MemoryHistoryAppendReq[]; warnings: string[] }
+
+/** The CP connection as the sink sees it: the wire's own strict parse on every request, and a log that remembers. */
+function fakeLink(over: Partial<CpMemoryHistoryLink> = {}): FakeLink {
+  const requests: MemoryHistoryAppendReq[] = []
+  return {
+    requests,
+    warnings: [],
+    connected: () => true,
+    supportsServerFeature: (feature) => feature === 'agent-memory-store-v1',
+    async memoryHistoryAppend(req): Promise<MemoryHistoryAppendOk> {
+      requests.push(MemoryHistoryAppendReq.parse(req))
+      return { accepted: true }
+    },
+    ...over
+  }
+}
+
+const neverOp = (): never => {
+  throw new Error('no store op belongs in this test')
+}
+
+const sinkOver = (link: FakeLink, root?: string) =>
+  new CpMemoryHistorySink(link, AGENT, root, { warn: (msg) => link.warnings.push(msg) })
+
+describe('CpMemoryHistorySink (the sink over the CP connection)', () => {
+  it('names the agent and the tree-relative root — the agent tree, or a channel store in CpMemoryFs coordinates', async () => {
+    const link = fakeLink()
+    await sinkOver(link).append([record('notes.md', 'v1')])
+    // The store's own port names the root the sink must name; its ops never run here.
+    const storeLink = { connected: () => true, supportsServerFeature: () => true, memoryStore: async () => neverOp() }
+    const channelStore = channelMemoryRoot(new CpMemoryFs(storeLink, AGENT), 'general-abc123')
+    await sinkOver(link, channelStore.root).append([record('notes.md', 'v1')])
+    expect(link.requests.map((req) => [req.agentId, req.root])).toEqual([
+      [AGENT, '.'],
+      [AGENT, 'channels/general-abc123']
+    ])
+    expect(link.warnings).toEqual([])
+  })
+
+  it('carries the ids the daemon minted, so a resend is the same rows, and carries nothing into a store swap', async () => {
+    const link = fakeLink()
+    // Seen as the port the writers hold: the swap hook is a no-op, and there is no local page to read back.
+    const sink: MemoryHistorySink = sinkOver(link)
+    const rows = [record('a.md', 'x'), record('b.md', 'y')]
+    await sink.append(rows)
+    await sink.append(rows)
+    expect(link.requests.map((req) => req.records.map((event) => event.id))).toEqual([
+      rows.map((event) => event.id),
+      rows.map((event) => event.id)
+    ])
+    await sink.carryInto('.memory.adopting-x')
+    expect(sink.list).toBeUndefined()
+    expect(link.requests).toHaveLength(2)
+  })
+
+  it('splits a large set at the record cap, in order', async () => {
+    const link = fakeLink()
+    const rows = Array.from({ length: 150 }, (_, index) => record(`t${index}.md`, String(index)))
+    await sinkOver(link).append(rows)
+    expect(link.requests.map((req) => req.records.length)).toEqual([MEMORY_HISTORY_APPEND_MAX_RECORDS, 64, 22])
+    expect(link.requests.flatMap((req) => req.records.map((event) => event.path))).toEqual(rows.map((r) => r.path))
+    expect(link.warnings).toEqual([])
+  })
+
+  it('splits at the frame budget with multi-byte snapshots, each batch as full as the wire allows', async () => {
+    // Every row carries two clamped snapshots of multi-byte text, so the byte bound trips long before the record cap.
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      record(`t${index}.md`, 'é'.repeat(1_900) + index, '🚀'.repeat(950) + index)
+    )
+    const batches = packMemoryHistoryBatches(AGENT, '.', rows)
+    expect(batches.length).toBeGreaterThan(1)
+    expect(batches.flatMap((batch) => batch.records)).toEqual(rows)
+    for (const [index, batch] of batches.entries()) {
+      expect(batch.records.length).toBeLessThan(MEMORY_HISTORY_APPEND_MAX_RECORDS)
+      // The wire's own refinement accepts the batch as packed...
+      expect(MemoryHistoryAppendReq.safeParse(batch).success).toBe(true)
+      // ...and would refuse it with the next batch's first record added, so no batch was cut short.
+      const next = batches[index + 1]?.records[0]
+      if (!next) continue
+      const overfull = { ...batch, records: [...batch.records, next] }
+      expect(Buffer.byteLength(JSON.stringify(overfull))).toBeGreaterThan(REPLY_BUDGET)
+      expect(MemoryHistoryAppendReq.safeParse(overfull).success).toBe(false)
+    }
+    const link = fakeLink()
+    await sinkOver(link).append(rows)
+    expect(link.requests.map((req) => req.records.length)).toEqual(batches.map((batch) => batch.records.length))
+  })
+
+  it('warns once with the reason and returns normally whatever fails — the write already happened', async () => {
+    const rows = [record('a.md', 'x')]
+    const closed = fakeLink({ connected: () => false })
+    await sinkOver(closed).append(rows)
+    expect(closed.requests).toEqual([])
+    expect(closed.warnings).toEqual([expect.stringContaining('1 memory change-log record(s) for . not recorded')])
+    expect(closed.warnings[0]).toContain('the connection is down')
+
+    const older = fakeLink({ supportsServerFeature: () => false })
+    await sinkOver(older).append(rows)
+    expect(older.requests).toEqual([])
+    expect(older.warnings).toEqual([expect.stringContaining('does not serve the memory store')])
+
+    const rejecting = (err: Error) =>
+      fakeLink({
+        memoryHistoryAppend: async () => {
+          throw err
+        }
+      })
+    const denied = rejecting(new WireError('SCOPE_DENIED', 'agent is not served here', false))
+    await sinkOver(denied).append(rows)
+    expect(denied.warnings).toEqual([expect.stringContaining('SCOPE_DENIED: agent is not served here')])
+    const timedOut = rejecting(new WireError('INTERNAL', 'no ack after 1 try', true))
+    await sinkOver(timedOut).append(rows)
+    expect(timedOut.warnings).toEqual([expect.stringContaining('INTERNAL: no ack after 1 try')])
+    const broken = rejecting(new TypeError('boom'))
+    await sinkOver(broken).append(rows)
+    expect(broken.warnings).toEqual([expect.stringContaining('TypeError: boom')])
+
+    // A failure mid-run ends the run, and the warning counts what never reached the table.
+    const flaky = fakeLink()
+    const delivered: number[] = []
+    flaky.memoryHistoryAppend = async (req) => {
+      if (delivered.length === 1) throw new WireError('INTERNAL', 'dropped', true)
+      delivered.push(req.records.length)
+      return { accepted: true }
+    }
+    await sinkOver(flaky).append(Array.from({ length: 150 }, (_, index) => record(`t${index}.md`, String(index))))
+    expect(delivered).toEqual([64])
+    expect(flaky.warnings).toEqual([expect.stringContaining('86 memory change-log record(s)')])
+
+    // Nothing to send is nothing to warn about.
+    const idle = fakeLink()
+    await sinkOver(idle).append([])
+    expect(idle.requests).toEqual([])
+    expect(idle.warnings).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

Step ⑥ of the managed-memory `home` rollout (`docs/designs/memory-evolution.md` §3.2.1, "`.history` becomes an event table, not a file"). Under a `control-plane` home the change log is a table in the Control Plane, not a sidecar inside the store: the daemon still composes every record — it holds `before`, `after`, and `source` — and sends it **after** the write as a best-effort `memory/history/append` batch, the same provenance-never-fails-the-write rule the sidecar has today. The daemon never reads that log back; the CP answers the console itself. A `daemon` home keeps the sidecar file.

The wire contract (`MemoryHistoryAppendReq`, #1865), the CP tables and store handler (#1877), and `CpMemoryFs` (#1876) have landed. This change gives the daemon the write side: a sink seam in the store, the sidecar behind it, and the Control Plane implementation. **Nothing selects the CP sink yet.**

## The sink seam

`MemoryHistorySink` (`packages/daemon/src/memory/store.ts`) is what every managed-memory writer hands its records to, under the memory-dir lock, after its write:

- `append(records)` — writes already made, oldest first, each carrying the id the daemon minted (`memoryHistoryRecord` builds the row for the topic write, the index regeneration, and dream adoption alike, so one shape reaches every sink).
- `carryInto(replacement)` — dream adoption is about to swap `memory/` for the replacement tree; a log kept inside the store copies itself there first.
- `list?` — optional: the sidecar pages itself back; a sink without it means the home answers the console itself, which is the "no local history" answer step ⑦ hands the CP memory reader (the two `listMemoryHistory` call sites carry a one-line note).

`SidecarMemoryHistorySink` is the one implementation any code path selects — `writeMemoryFile` / `writeMemoryFileHoldingLock` / `regenerateMemoryIndexHoldingLock` default to it — and it is byte-for-byte what the inline `appendHistoryHoldingLock` did: one canonical rewrite per append with the fixed retention applied in the same pass. Every existing history test passes unedited. Retention stays exactly where it was (in the sidecar's append and the read-side compaction); the CP enforces its own.

`MemoryHomePorts` gains `historyFor(store)` — the sink for any store under `live`, the agent's own tree or a channel root, in that store's coordinates — and moves with `resolveMemoryHomePorts` / `resolveMemoryFs` to `packages/daemon/src/memory/home.ts`: the ports bag now carries the store's default sink, and keeping the resolver in `memory/fs.ts` would have made the port module import the store module built over it. `resolveMemoryHomePorts` still returns the local/shim ports and the sidecar sink.

## The Control Plane sink

`CpMemoryHistorySink` (`packages/daemon/src/cp/memory-history.ts`) over a `CpMemoryHistoryLink` — the same gates `CpMemoryStoreLink` has plus `memoryHistoryAppend`, which `CpClient` now exposes exactly like `memoryStore()`: feature-gated on `agent-memory-store-v1`, one send on one deadline (the sender holds the store's memory-dir lock while it waits, so the wait stays bounded).

- **Batching** — `packMemoryHistoryBatches` splits a record set, in order, into requests satisfying the schema: at most `MEMORY_HISTORY_APPEND_MAX_RECORDS` (64) and under `REPLY_BUDGET` encoded bytes, measured exactly as the schema's refinement measures.
- **Coordinates** — `root` is the store's tree-relative root, the coordinates `CpMemoryFs` names on every op: `.` for the agent's own tree, `channels/<key>` for a channel store (`channelMemoryRoot(cpFs, key).root`).
- **Best-effort** — the write already happened, so any failure (connection down, feature missing, `SCOPE_DENIED`, timeout, anything else) is one warn line naming how many records for which root went unrecorded and why; it never rejects the caller. One failure ends the batch run, since what refused this request will refuse the next.
- **Idempotent** — every record carries the daemon-minted id, so a resent batch is the same rows on the CP.
- `carryInto` is a no-op (nothing inside a CP-homed store to carry) and there is no `list`.

## Dream adoption through the sink

Adoption builds its add/update/delete change set under the lock as before, then: `carryInto(replacement)` (the sidecar copies its canonical log into the replacement; the CP sink copies nothing), the atomic swap, `append(rows)` with one `source: 'dream'` row per changed file, then the index settles through the same sink. The post-swap retention pass is gone: the sidecar's append already applies retention, so the log is canonical the moment the rows land. Under a non-sidecar sink no `.history` ever enters `memory/`.

## Not wired

`resolveMemoryHomePorts` returns the sidecar sink for both homes it knows; nothing reads the binding's `home`; `withMemoryHome`, the outbox, and the session boundary are untouched. Step ⑦ selects `CpMemoryFs` and `CpMemoryHistorySink` together in `memory/home.ts`.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean (tests included).
- `test/memory-history-sink.test.ts` (new): the seam hands each write one record with a minted id and writes no sidecar through a fake sink; index regeneration goes through the same sink; a rejecting sink never fails the write; the sidecar is the default and the one every home resolves, and pages/carries itself. `CpMemoryHistorySink`: agent and channel `root`s, ids preserved across a resend, splitting at 64 records and at the byte budget with multi-byte snapshots (each batch parses under the wire schema and would fail it with the next record added), and every failure mode returns normally after one warn.
- `test/dream-runner.test.ts`: new case — adoption through a fake sink sends one `dream` row per changed file (the rendered index among them) and carries no sidecar into the replacement; the 77 existing cases pass, the history-reading ones unedited.
- `test/cp/client-dispatch.test.ts`: `memoryHistoryAppend` stamps the org and unwraps `memory/history/append/ok`; refuses without the feature; sends exactly once and fails on one deadline.
- `test/memory*.test.ts`, `test/channel-memory.test.ts`, `test/dream-skills.test.ts`, `test/memory-dreamer.test.ts`, `test/memory-distiller.test.ts`, `test/memory-capture-outbox.test.ts` — all green, unedited (298 tests across the run).
- Prettier and ESLint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
