### PR TITLE
feat(control-plane): the memory home is resolved on create, migrates one way, and returns only by force

### DIFF
--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -321,7 +321,10 @@ and `channels/` once through the two ports (`copyMemoryTree(from, to)`, under th
 directory lock), the change log with them — sidecar lines become rows, one batch,
 bounded by the sidecar cap — and reports completion on a frame of its own,
 `memory/home/migrated` → `memory/home/migrated/ok`, which the CP records on the
-binding; it is not an op in the store set, because it is not a file operation. Until that record exists the agent's memory is unavailable the way an
+binding; it is not an op in the store set, because it is not a file operation. The
+record is the CP-owned `homeMigration: 'pending'` the binding carries from the flip
+until that report clears it (a report for a home that moved on since is `CONFLICT`;
+a repeated report is the same success). Until that record exists the agent's memory is unavailable the way an
 unreachable home is (no standing context, tools answer unavailable, distillation waits
 in the outbox), so nothing writes the target while the copy runs. That is what makes
 the copy restartable by doing nothing clever: the source is frozen from the moment the
@@ -332,7 +335,8 @@ marker file, no partial-tree question. Staging and the pre-adoption backup stay 
 each belonging to the host or the adoption that made it; the source tree is never
 deleted. The daemon then rebuilds the session boundary as any memory change does. The
 reverse, `control-plane` → `daemon`, is not a migration: the CP refuses it as a plain
-binding change and accepts it only as a forced one, which keeps nothing — the CP drops
+binding change (409) and accepts it only as a forced one (`force: true` on the agent
+edit), which keeps nothing — the CP drops
 the agent's rows and its change log, and the daemon starts from an empty tree, the
 pre-switch local tree archived aside rather than resurrected (a snapshot from before
 the switch is not the memory the agent has been using since). The console offers the
@@ -848,7 +852,7 @@ Agent configuration uses a discriminated shape across protocol `AgentSpec`, CP
 type MemoryConfig =
   | { provider: 'none' }
   | { provider: 'native' }
-  | { provider: 'managed'; autoDistill?: boolean; home?: 'daemon' | 'control-plane' }
+  | { provider: 'managed'; autoDistill?: boolean; home?: 'daemon' | 'control-plane'; homeMigration?: 'pending' }
   | {
       provider: 'external'
       connectionId: string
@@ -861,7 +865,10 @@ type MemoryConfig =
   a later placement change never flips it implicitly; an agent placed on the
   install-wide pool must carry `control-plane`, and the console fixes the selector
   there. `home` migrates one way only, `daemon` → `control-plane` (§3.2.1); the
-  reverse is accepted only as a forced change and keeps no memory.
+  reverse is accepted only as a forced change (`force: true` on the edit, 409 without
+  it) and keeps no memory. An edit that omits `home` keeps the current one, and
+  `homeMigration` is CP-owned and read-only: set by the forward switch, cleared by the
+  daemon's completion report, never accepted from a client.
 - `connectionId` must belong to the agent's organization, and the caller must
   be authorized to use it. The CP does not accept per-agent
   `endpoint/apiKey/command`.

--- a/packages/control-plane/src/agent-memory/history.ts
+++ b/packages/control-plane/src/agent-memory/history.ts
@@ -1,6 +1,32 @@
 // A wire change-log record as a row, and the byte count its retention is measured in (memory-evolution.md §3.2.1).
 import type { MemoryFileHistoryEvent } from '@agentconnect.md/protocol'
-import type { AgentMemoryHistoryInput } from '../persistence/ports.js'
+import type { AgentMemoryHistoryInput, AgentMemoryHistoryRecord } from '../persistence/ports.js'
+import { memoryPathSegments } from './paths.js'
+
+/** The store a change log belongs to, as the daemon names it in `root`: the agent's `memory/`, or one channel's. */
+export function memoryHistoryRoot(channelKey?: string): string {
+  return channelKey ? `channels/${channelKey}/memory` : 'memory'
+}
+
+/** `root` as stored: the same string for `memory`, `./memory` and `memory/`, so a read filter finds what a batch wrote. */
+export function normalizeMemoryHistoryRoot(root: string): string {
+  return memoryPathSegments(root).join('/')
+}
+
+/** A stored record back on the wire, in the shape the daemon's sidecar page carries. */
+export function toHistoryEvent(record: AgentMemoryHistoryRecord): MemoryFileHistoryEvent {
+  return {
+    id: record.id,
+    path: record.path,
+    event: record.event,
+    ...(record.before !== undefined ? { before: record.before } : {}),
+    after: record.after,
+    at: record.at.toISOString(),
+    scope: 'agent',
+    source: record.source,
+    ...(record.truncated !== undefined ? { truncated: record.truncated } : {})
+  }
+}
 
 /** The bytes one record costs the cap: its sidecar line, `JSON.stringify(record) + '\n'`, as the daemon counts it. */
 export function historyRecordBytes(record: MemoryFileHistoryEvent): number {

--- a/packages/control-plane/src/agent-memory/home.test.ts
+++ b/packages/control-plane/src/agent-memory/home.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  managedMemoryHomeOf,
+  memoryHomedInControlPlane,
+  resolveMemoryBindingOnCreate,
+  resolveMemoryBindingOnUpdate
+} from './home.js'
+
+const cp = { provider: 'managed', home: 'control-plane' } as const
+const pendingCp = { ...cp, homeMigration: 'pending' } as const
+const daemon = { provider: 'managed', home: 'daemon' } as const
+
+describe('managedMemoryHomeOf', () => {
+  it('reads no binding and a binding older than the field as the daemon home; other providers have none', () => {
+    expect(managedMemoryHomeOf(null)).toBe('daemon')
+    expect(managedMemoryHomeOf({ provider: 'managed' } as never)).toBe('daemon')
+    expect(managedMemoryHomeOf(cp)).toBe('control-plane')
+    expect(managedMemoryHomeOf({ provider: 'native' })).toBeNull()
+    expect(memoryHomedInControlPlane(pendingCp)).toBe(true)
+    expect(memoryHomedInControlPlane(daemon)).toBe(false)
+  })
+})
+
+describe('resolveMemoryBindingOnCreate', () => {
+  it('resolves the pool to the Control Plane, everything else to the given value or daemon', () => {
+    expect(resolveMemoryBindingOnCreate(undefined, true)).toEqual({ memory: cp })
+    expect(resolveMemoryBindingOnCreate({ provider: 'managed', autoDistill: false }, true)).toEqual({
+      memory: { provider: 'managed', autoDistill: false, home: 'control-plane' }
+    })
+    expect(resolveMemoryBindingOnCreate(undefined, false)).toEqual({ memory: undefined })
+    expect(resolveMemoryBindingOnCreate({ provider: 'managed' }, false)).toEqual({ memory: daemon })
+    expect(resolveMemoryBindingOnCreate({ provider: 'managed', home: 'control-plane' }, false)).toEqual({ memory: cp })
+    expect(resolveMemoryBindingOnCreate({ provider: 'native' }, true)).toEqual({ memory: { provider: 'native' } })
+  })
+
+  it('refuses an explicit daemon home on the pool', () => {
+    expect(resolveMemoryBindingOnCreate(daemon, true)).toMatchObject({ refused: 'pool-daemon-home' })
+  })
+})
+
+describe('resolveMemoryBindingOnUpdate', () => {
+  it('leaves an absent patch alone, and an absent home keeps the current one — the migration flag included', () => {
+    expect(resolveMemoryBindingOnUpdate(pendingCp, undefined, false, false)).toEqual({ kind: 'unchanged' })
+    expect(resolveMemoryBindingOnUpdate(pendingCp, { provider: 'managed', autoDistill: true }, false, false)).toEqual({
+      kind: 'write',
+      memory: { provider: 'managed', autoDistill: true, home: 'control-plane', homeMigration: 'pending' },
+      dropHome: false
+    })
+    expect(resolveMemoryBindingOnUpdate(daemon, { provider: 'managed', scope: 'channel' }, false, false)).toEqual({
+      kind: 'write',
+      memory: { provider: 'managed', scope: 'channel', home: 'daemon' },
+      dropHome: false
+    })
+    // The managed default on a daemon-home agent stays the bare default; on a CP-home agent it must carry the home.
+    expect(resolveMemoryBindingOnUpdate(null, null, false, false)).toEqual({
+      kind: 'write',
+      memory: null,
+      dropHome: false
+    })
+    expect(resolveMemoryBindingOnUpdate(pendingCp, null, false, false)).toEqual({
+      kind: 'write',
+      memory: pendingCp,
+      dropHome: false
+    })
+  })
+
+  it('flags the forward switch and never re-flags a home that already is the Control Plane', () => {
+    expect(resolveMemoryBindingOnUpdate(null, { provider: 'managed', home: 'control-plane' }, false, false)).toEqual({
+      kind: 'write',
+      memory: pendingCp,
+      dropHome: false
+    })
+    expect(resolveMemoryBindingOnUpdate(cp, { provider: 'managed', home: 'control-plane' }, false, false)).toEqual({
+      kind: 'write',
+      memory: cp,
+      dropHome: false
+    })
+  })
+
+  it('refuses the reverse without force, and drops the tree with it', () => {
+    expect(resolveMemoryBindingOnUpdate(pendingCp, daemon, false, false)).toMatchObject({
+      kind: 'refused',
+      refused: 'reverse-needs-force'
+    })
+    expect(resolveMemoryBindingOnUpdate(pendingCp, daemon, false, true)).toEqual({
+      kind: 'write',
+      memory: daemon,
+      dropHome: true
+    })
+    // `force` alone names no home: the managed default on a CP-home agent keeps the home, and nothing is dropped.
+    expect(resolveMemoryBindingOnUpdate(cp, null, false, true)).toEqual({ kind: 'write', memory: cp, dropHome: false })
+  })
+
+  it('never lets a pool agent name the daemon home, force or not', () => {
+    expect(resolveMemoryBindingOnUpdate(cp, daemon, true, true)).toMatchObject({ refused: 'pool-daemon-home' })
+    expect(resolveMemoryBindingOnUpdate({ provider: 'native' }, daemon, true, false)).toMatchObject({
+      refused: 'pool-daemon-home'
+    })
+    expect(resolveMemoryBindingOnUpdate({ provider: 'native' }, null, true, false)).toEqual({
+      kind: 'write',
+      memory: cp,
+      dropHome: false
+    })
+  })
+
+  it('a provider switch never migrates: away drops the home, back resolves as on create with no flag', () => {
+    expect(resolveMemoryBindingOnUpdate(pendingCp, { provider: 'native' }, false, false)).toEqual({
+      kind: 'write',
+      memory: { provider: 'native' },
+      dropHome: false
+    })
+    expect(
+      resolveMemoryBindingOnUpdate({ provider: 'native' }, { provider: 'managed', home: 'control-plane' }, false, false)
+    ).toEqual({ kind: 'write', memory: cp, dropHome: false })
+    expect(resolveMemoryBindingOnUpdate({ provider: 'native' }, { provider: 'managed' }, false, false)).toEqual({
+      kind: 'write',
+      memory: daemon,
+      dropHome: false
+    })
+  })
+})

--- a/packages/control-plane/src/agent-memory/home.ts
+++ b/packages/control-plane/src/agent-memory/home.ts
@@ -1,0 +1,96 @@
+// The CP's rules for a managed binding's `home` (memory-evolution.md §3.2.1, §6): resolved on create, one way on
+// update (`daemon` → `control-plane` flags a migration), back only by force, and mandated on the install-wide pool.
+import type {
+  AgentMemoryBinding,
+  ExternalMemoryBinding,
+  ManagedMemoryBinding,
+  ManagedMemoryHome,
+  RuntimeMemoryBinding
+} from '@agentconnect.md/protocol'
+
+/** A binding as a client submits it: `home` optional with NO default (absent ⇒ keep), `homeMigration` never accepted. */
+export type ManagedMemoryBindingInput = Omit<ManagedMemoryBinding, 'home' | 'homeMigration'> & {
+  home?: ManagedMemoryHome
+}
+export type MemoryBindingInput = ManagedMemoryBindingInput | RuntimeMemoryBinding | ExternalMemoryBinding
+
+/** The home a stored binding means: no binding is the managed default, and a binding older than the field is `daemon`. */
+export function managedMemoryHomeOf(memory: AgentMemoryBinding | null | undefined): ManagedMemoryHome | null {
+  if (memory && memory.provider !== 'managed') return null
+  return (memory as { home?: ManagedMemoryHome } | null | undefined)?.home ?? 'daemon'
+}
+
+/** Whether the agent's memory is served by the Control Plane — the only binding the store family answers for. */
+export function memoryHomedInControlPlane(memory: AgentMemoryBinding | null | undefined): boolean {
+  return managedMemoryHomeOf(memory) === 'control-plane'
+}
+
+export const POOL_REFUSES_DAEMON_HOME =
+  'the managed pool keeps agent memory in the Control Plane; set memory.home to control-plane or leave it unset'
+export const REVERSE_NEEDS_FORCE =
+  'moving memory back from the Control Plane to the daemon keeps nothing; send force: true to confirm'
+export const POOL_MOVE_NEEDS_CP_HOME =
+  'this agent keeps its memory on the daemon; switch memory.home to control-plane before placing it on the managed pool'
+
+export type MemoryBindingRefusal = { refused: 'pool-daemon-home' | 'reverse-needs-force'; message: string }
+
+/** The binding to store for a new agent, or why it is refused. `onPool` ⇒ the placement is the install-wide pool. */
+export function resolveMemoryBindingOnCreate(
+  input: MemoryBindingInput | undefined,
+  onPool: boolean
+): { memory: AgentMemoryBinding | undefined } | MemoryBindingRefusal {
+  if (input === undefined) {
+    return { memory: onPool ? { provider: 'managed', home: 'control-plane' } : undefined }
+  }
+  if (input.provider !== 'managed') return { memory: input }
+  if (onPool) {
+    if (input.home === 'daemon') return { refused: 'pool-daemon-home', message: POOL_REFUSES_DAEMON_HOME }
+    return { memory: { ...input, home: 'control-plane' } }
+  }
+  return { memory: { ...input, home: input.home ?? 'daemon' } }
+}
+
+export type MemoryBindingUpdate =
+  | { kind: 'unchanged' }
+  // `dropHome` is the forced return: every row of the agent's CP tree and change log goes with the write.
+  | { kind: 'write'; memory: AgentMemoryBinding | null; dropHome: boolean }
+  | ({ kind: 'refused' } & MemoryBindingRefusal)
+
+/** The binding to store for an edit. A patch of `null` is the managed default; an absent `home` keeps the current one. */
+export function resolveMemoryBindingOnUpdate(
+  current: AgentMemoryBinding | null,
+  patch: MemoryBindingInput | null | undefined,
+  onPool: boolean,
+  force: boolean
+): MemoryBindingUpdate {
+  if (patch === undefined) return { kind: 'unchanged' }
+  // A provider without a managed tree drops `home` with the binding; its rows, if any, stay where they are (§6).
+  if (patch !== null && patch.provider !== 'managed') return { kind: 'write', memory: patch, dropHome: false }
+  const currentHome = managedMemoryHomeOf(current)
+  const base: Omit<ManagedMemoryBinding, 'home' | 'homeMigration'> = patch ?? { provider: 'managed' }
+  const requested = patch?.home
+  // Switching back to managed resolves as on create and never migrates; so does the managed default on the pool.
+  if (currentHome === null) {
+    const resolved = resolveMemoryBindingOnCreate(patch ?? undefined, onPool)
+    if ('refused' in resolved) return { kind: 'refused', ...resolved }
+    return { kind: 'write', memory: resolved.memory ?? null, dropHome: false }
+  }
+  const target = requested ?? currentHome
+  if (onPool && target === 'daemon') {
+    return { kind: 'refused', refused: 'pool-daemon-home', message: POOL_REFUSES_DAEMON_HOME }
+  }
+  if (target === currentHome) {
+    const pending = current?.provider === 'managed' && current.homeMigration === 'pending'
+    if (patch === null && target === 'daemon') return { kind: 'write', memory: null, dropHome: false }
+    return {
+      kind: 'write',
+      memory: { ...base, home: target, ...(pending ? { homeMigration: 'pending' as const } : {}) },
+      dropHome: false
+    }
+  }
+  if (target === 'control-plane') {
+    return { kind: 'write', memory: { ...base, home: 'control-plane', homeMigration: 'pending' }, dropHome: false }
+  }
+  if (!force) return { kind: 'refused', refused: 'reverse-needs-force', message: REVERSE_NEEDS_FORCE }
+  return { kind: 'write', memory: patch === null ? null : { ...base, home: 'daemon' }, dropHome: true }
+}

--- a/packages/control-plane/src/agent-memory/home.ts
+++ b/packages/control-plane/src/agent-memory/home.ts
@@ -34,6 +34,24 @@ export const POOL_MOVE_NEEDS_CP_HOME =
 
 export type MemoryBindingRefusal = { refused: 'pool-daemon-home' | 'reverse-needs-force'; message: string }
 
+/** A refusal raised from inside the row-locked write, where the resolution is authoritative; routes answer 409. */
+export class MemoryHomeRefusedError extends Error {
+  constructor(
+    readonly refused: MemoryBindingRefusal['refused'],
+    message: string
+  ) {
+    super(message)
+    this.name = 'MemoryHomeRefusedError'
+  }
+}
+
+/** What a caller hands the row-locked write: the submitted binding and the two facts the resolution needs. */
+export interface MemoryHomeUpdate {
+  input: MemoryBindingInput | null
+  onPool: boolean
+  force: boolean
+}
+
 /** The binding to store for a new agent, or why it is refused. `onPool` ⇒ the placement is the install-wide pool. */
 export function resolveMemoryBindingOnCreate(
   input: MemoryBindingInput | undefined,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1504,6 +1504,7 @@ export function buildContainer(
       externalMemoryConnectionSecret: repos.externalMemoryConnectionSecret,
       externalMemoryGrant: repos.externalMemoryGrant,
       memoryConnectionWriter: repos.memoryConnectionWriter,
+      agentMemoryHistory: repos.agentMemoryHistory,
       slackInstall: repos.slackInstall,
       slackPlatformInstall: repos.slackPlatformInstall,
       feishuAppRegistration: repos.feishuAppRegistration,

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -5,6 +5,7 @@
  * `buildHttpServer`.
  */
 import type {
+  AgentMemoryHistoryRepo,
   AgentRepo,
   AssignmentRepo,
   AuditRepo,
@@ -229,6 +230,8 @@ export interface HttpDeps {
     /** Transactional check-then-write pairs for external-memory mutations,
      *  serialized cross-instance via advisory mutation scopes ('busy' ⇒ 409). */
     memoryConnectionWriter: MemoryConnectionWriter
+    /** The change log of a `control-plane` memory home — `memory/history` is answered from it, never proxied. */
+    agentMemoryHistory: Pick<AgentMemoryHistoryRepo, 'page'>
     /** Pending config-token auto-install sessions (§Tier B); holds secret material, never DTO'd. */
     slackInstall: SlackInstallStore
     /** Pending platform-app installs (preset-agents.md §5.3): OAuth state → tenancy, no secrets. */

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -10,6 +10,10 @@ import { RESERVED_AGENT_SLUGS } from '../../domain/reserved-agent-slugs.js'
 import {
   AgentMemoryBinding,
   AgentPermissionRequestRecord,
+  ExternalMemoryBinding,
+  ManagedMemoryBinding,
+  ManagedMemoryHome,
+  RuntimeMemoryBinding,
   CanonicalMemoryRecord,
   DecimalAmount,
   FeishuRegion,
@@ -582,6 +586,14 @@ const ManagedSkillEnableBody = z
 // carries only a connection reference + product policy; credentials and plugin
 // transport stay on the daemon-private connection data plane.
 const MemoryConfigBody = AgentMemoryBinding
+// The INPUT shape (memory-evolution.md §3.2.1/§6): `home` has no default here — absent means "keep the current home"
+// on an edit and "resolve it" on create — and the CP-owned `homeMigration` is never accepted from a client. Reusing
+// the wire binding would turn every console save from a Control-Plane-homed agent into a forbidden reverse change.
+const ManagedMemoryConfigInput = ManagedMemoryBinding.omit({ home: true, homeMigration: true })
+  .extend({ home: ManagedMemoryHome.optional() })
+  .strict()
+export const MemoryConfigInputBody = z.union([ManagedMemoryConfigInput, RuntimeMemoryBinding, ExternalMemoryBinding])
+export type MemoryConfigInputBodyT = z.infer<typeof MemoryConfigInputBody>
 
 // Console avatar (docs: the "Agent Avatar" picker), INPUT shape (create/update body).
 // Only `runtime` and `glyph` are settable via a JSON body — the glyph color is
@@ -626,7 +638,9 @@ export const CreateAgentBody = z.object({
   mcpServers: McpServerNamesBody.optional(),
   skills: SkillEnableBody.optional(),
   managedSkills: ManagedSkillEnableBody.optional(),
-  memory: MemoryConfigBody.optional(), // memory backend; absent ⇒ managed default
+  // Memory backend; absent ⇒ managed default. The CP resolves `home`: the managed pool gets `control-plane`
+  // (an explicit `daemon` there is refused), anywhere else the given value or `daemon`.
+  memory: MemoryConfigInputBody.optional(),
   // Placement at create. `set` uses `setId`; `daemon` (the default) uses `daemonId`. `pool` is
   // accepted API sugar for "the org-less set" and is resolved to it at the edge.
   placementKind: z.enum(['daemon', 'pool', 'set']).optional(),
@@ -682,10 +696,16 @@ export const UpdateAgentBody = z
     mcpServers: McpServerNamesBody.nullable().optional(), // replaced wholesale; null clears
     skills: SkillEnableBody.nullable().optional(), // enabled skills; replaced wholesale; null clears
     managedSkills: ManagedSkillEnableBody.nullable().optional(), // accepted managed-skill ids; null clears
-    memory: MemoryConfigBody.nullable().optional() // memory backend; null clears (revert to managed)
+    // Memory backend; null clears (revert to managed). A managed `home` moves one way, `daemon` → `control-plane`;
+    // the reverse is refused unless `force` is set, and never accepted on the managed pool.
+    memory: MemoryConfigInputBody.nullable().optional(),
+    // Confirms the one destructive edit: returning a memory home from the Control Plane to the daemon keeps nothing.
+    force: z.boolean().optional()
   })
   .strict()
-  .refine((b) => Object.values(b).some((v) => v !== undefined), { message: 'no fields to update' })
+  .refine((b) => Object.entries(b).some(([key, v]) => key !== 'force' && v !== undefined), {
+    message: 'no fields to update'
+  })
 
 /** Explicit cold placement move. Kept separate from spec PATCH because it
  * drains one daemon, reprovisions another, and does not migrate local state.
@@ -779,7 +799,9 @@ export const AgentDto = z.object({
   mcpServers: z.array(z.string()), // enabled daemon-configured MCP server names ([] ⇒ none)
   skills: z.array(z.string()), // enabled shared-skills "<source>/<skill>" / "<source>/*" ([] ⇒ none)
   managedSkills: z.array(z.string().uuid()), // explicitly enabled accepted managed-skill ids
-  memory: MemoryConfigBody.nullable(), // memory backend (null ⇒ managed default)
+  // Memory backend (null ⇒ managed default). A managed binding carries its resolved `home` and, while a
+  // `daemon` → `control-plane` copy is under way, the read-only `homeMigration: 'pending'`.
+  memory: MemoryConfigBody.nullable(),
   status: z.string(),
   // What the placement NAMES. `set` carries a null `daemonId` on purpose: no member id is
   // durable, so the console must read readiness from `placementReady` rather than from a machine.

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -91,6 +91,7 @@ class SkillEnableDenied extends Error {}
 import { parseSkillRef, redactSourceCredentials } from '../../orchestrator/skillSource.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from '../../orchestrator/memoryConnection.js'
 import {
+  MemoryHomeRefusedError,
   POOL_MOVE_NEEDS_CP_HOME,
   managedMemoryHomeOf,
   memoryHomedInControlPlane,
@@ -2216,12 +2217,12 @@ export function agentRoutes(deps: HttpDeps) {
           }
           // The memory home rules (memory-evolution.md §3.2.1): an absent home keeps the current one, the forward
           // switch flags the migration, the reverse needs `force` and drops the CP tree, the pool refuses `daemon`.
-          const memoryChange = resolveMemoryBindingOnUpdate(
-            existing.memory,
-            req.body.memory,
-            await placedOnInstallPool(deps, { setId: existing.setId, daemonId: existing.daemonId }),
-            req.body.force === true
-          )
+          // This pass is the friendly refusal and names the target for the external check; the authoritative
+          // resolution runs again inside the row-locked write (`opts.memoryHome`), against the binding as it is then.
+          const onPool = await placedOnInstallPool(deps, { setId: existing.setId, daemonId: existing.daemonId })
+          const force = req.body.force === true
+          const memoryHome = req.body.memory !== undefined ? { input: req.body.memory, onPool, force } : undefined
+          const memoryChange = resolveMemoryBindingOnUpdate(existing.memory, req.body.memory, onPool, force)
           if (memoryChange.kind === 'refused') {
             return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: memoryChange.message })
           }
@@ -2261,13 +2262,17 @@ export function agentRoutes(deps: HttpDeps) {
                   {
                     authorizeMcpServers,
                     ...(skillsFence ? { skillSources: skillsFence } : {}),
-                    ...(memoryChange.kind === 'write' && memoryChange.dropHome ? { dropManagedMemoryHome: true } : {})
+                    ...(memoryHome ? { memoryHome } : {})
                   }
                 )
             )
           } catch (e) {
             if (e instanceof McpEnableDenied || e instanceof SkillEnableDenied) {
               return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: e.message })
+            }
+            // The binding changed under the edit (a forced return, a completion) and the locked resolution refused.
+            if (e instanceof MemoryHomeRefusedError) {
+              return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: e.message })
             }
             throw e
           }

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -90,6 +90,14 @@ class McpEnableDenied extends Error {}
 class SkillEnableDenied extends Error {}
 import { parseSkillRef, redactSourceCredentials } from '../../orchestrator/skillSource.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from '../../orchestrator/memoryConnection.js'
+import {
+  POOL_MOVE_NEEDS_CP_HOME,
+  managedMemoryHomeOf,
+  memoryHomedInControlPlane,
+  resolveMemoryBindingOnCreate,
+  resolveMemoryBindingOnUpdate
+} from '../../agent-memory/home.js'
+import { memoryHistoryRoot, toHistoryEvent } from '../../agent-memory/history.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { refreshMutationAgent as refreshAgentUnderMutation } from '../mutation-agent.js'
 import { canView, canViewSession, canEdit, canManageSharing, type ViewCtx } from '../../authorization/policy.js'
@@ -400,6 +408,19 @@ async function resolveTargetSetId(
   if (body.placementKind !== 'set' || body.setId === undefined) return null
   const set = await deps.repos.memberSet.get(body.setId)
   return set && (set.orgId === null || set.orgId === orgId) ? set.id : null
+}
+
+/** Whether a placement lands on the install-wide pool: the org-less set itself, or a machine that is a member of it.
+ *  The pool keeps agent memory in the Control Plane (memory-evolution.md §3.2.1), so the memory rules read this. */
+async function placedOnInstallPool(
+  deps: HttpDeps,
+  target: { setId?: string | null; daemonId?: string | null }
+): Promise<boolean> {
+  const pool = await deps.repos.memberSet.crossOrgSetId()
+  if (!pool) return false
+  if (target.setId) return target.setId === pool
+  if (target.daemonId) return (await deps.repos.memberSet.setIdOf(DaemonId(target.daemonId))) === pool
+  return false
 }
 
 /** The members of a set that could serve an agent right now. One read; reuse it for a page.
@@ -1456,7 +1477,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Create an agent',
           description:
-            'Mint a new agent definition scoped to the caller’s org; the CP assigns its UUID. With ?connect=true, also provisions a daemon connect token and start command for onboarding.',
+            'Mint a new agent definition scoped to the caller’s org; the CP assigns its UUID. With ?connect=true, also provisions a daemon connect token and start command for onboarding. A managed memory binding is stored with its resolved home: an agent placed on the managed pool keeps its memory in the Control Plane (an explicit daemon home there is refused with 409); anywhere else the given home or daemon.',
           operationId: 'createAgent',
           body: CreateAgentBody,
           querystring: z.object({ connect: z.stringbool().default(false) }),
@@ -1583,12 +1604,19 @@ export function agentRoutes(deps: HttpDeps) {
         if (managedSkillError) {
           return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: managedSkillError })
         }
+        // The memory home is resolved here, once, so a later placement change never flips it (§3.2.1).
+        const resolvedMemory = resolveMemoryBindingOnCreate(
+          req.body.memory,
+          await placedOnInstallPool(deps, { setId: targetSetId, daemonId: wantsSet ? undefined : req.body.daemonId })
+        )
+        if ('refused' in resolvedMemory) return conflict(resolvedMemory.message)
+        const memory = resolvedMemory.memory
         // The friendly external-memory validation runs here; the authoritative
         // fence (connection advisory try-lock + in-transaction existence
         // re-check) lives inside the create transaction (PgAgentRepo) and
         // surfaces as MemoryConnectionBusy/Missing in the catch below.
         try {
-          const memoryError = await validateExternalMemoryBinding(req.body.memory, orgOf(req))
+          const memoryError = await validateExternalMemoryBinding(memory, orgOf(req))
           if (memoryError) {
             return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: memoryError })
           }
@@ -1653,7 +1681,7 @@ export function agentRoutes(deps: HttpDeps) {
                   ...(req.body.mcpServers !== undefined ? { mcpServers: req.body.mcpServers } : {}),
                   ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
                   ...(req.body.managedSkills !== undefined ? { managedSkills: req.body.managedSkills } : {}),
-                  ...(req.body.memory !== undefined ? { memory: req.body.memory } : {}),
+                  ...(memory !== undefined ? { memory } : {}),
                   ...(targetSetId !== null
                     ? { placementKind: 'set' as const, setId: targetSetId }
                     : req.body.daemonId !== undefined
@@ -2036,7 +2064,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Update an agent',
           description:
-            'Edit the agent spec or widen an existing GitHub workspace from read to write access; the change hot-syncs the owning daemon’s replica and rides the next register/launch.',
+            'Edit the agent spec or widen an existing GitHub workspace from read to write access; the change hot-syncs the owning daemon’s replica and rides the next register/launch. A managed memory binding without a home keeps the current one. Switching the home from daemon to control-plane is accepted and flags a migration the owning daemon completes; the reverse is refused with 409 unless force is set, and then drops every memory file and change-log record the Control Plane holds for the agent. An agent on the managed pool cannot name the daemon home.',
           operationId: 'updateAgent',
           params: IdParam,
           body: UpdateAgentBody,
@@ -2080,7 +2108,6 @@ export function agentRoutes(deps: HttpDeps) {
         // connections and the in-transaction existence re-check) happens inside
         // the update transaction (PgAgentRepo); MemoryConnectionBusy/Missing
         // surface in the catch below.
-        const targetMemory = req.body.memory === undefined ? existing.memory : req.body.memory
         try {
           if (!(await refreshMutationAgent(existing))) {
             return reply
@@ -2187,6 +2214,18 @@ export function agentRoutes(deps: HttpDeps) {
               })
             }
           }
+          // The memory home rules (memory-evolution.md §3.2.1): an absent home keeps the current one, the forward
+          // switch flags the migration, the reverse needs `force` and drops the CP tree, the pool refuses `daemon`.
+          const memoryChange = resolveMemoryBindingOnUpdate(
+            existing.memory,
+            req.body.memory,
+            await placedOnInstallPool(deps, { setId: existing.setId, daemonId: existing.daemonId }),
+            req.body.force === true
+          )
+          if (memoryChange.kind === 'refused') {
+            return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: memoryChange.message })
+          }
+          const targetMemory = memoryChange.kind === 'write' ? memoryChange.memory : existing.memory
           const memoryError = await validateExternalMemoryBinding(targetMemory ?? undefined, orgOf(req))
           if (memoryError) {
             return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: memoryError })
@@ -2198,7 +2237,8 @@ export function agentRoutes(deps: HttpDeps) {
           // transaction) and fenced per submitted skill-ref source name INSIDE
           // that transaction (the skillSources opts), so the row can't commit
           // inside a concurrent registry-delete's check→drop window.
-          const { secrets: secretsPatch, ...bodyPatch } = req.body
+          // `force` and the submitted binding are consumed above; the row gets the resolved binding.
+          const { secrets: secretsPatch, force: _force, memory: _memory, ...bodyPatch } = req.body
           const skillsFence = skillSourceFenceFor(orgOf(req), ctxOf(req), req.body.skills)
           let agent: AgentRecord
           try {
@@ -2212,12 +2252,17 @@ export function agentRoutes(deps: HttpDeps) {
                   AgentId(req.params.id),
                   {
                     ...bodyPatch,
+                    ...(memoryChange.kind === 'write' ? { memory: memoryChange.memory } : {}),
                     ...(req.principal ? { lastModifiedByUserId: req.principal.userId } : {})
                   },
                   secretsPatch,
                   // Evaluated inside the row-locked transaction, against the same
                   // committed lists this write merges onto (see the fence helpers).
-                  { authorizeMcpServers, ...(skillsFence ? { skillSources: skillsFence } : {}) }
+                  {
+                    authorizeMcpServers,
+                    ...(skillsFence ? { skillSources: skillsFence } : {}),
+                    ...(memoryChange.kind === 'write' && memoryChange.dropHome ? { dropManagedMemoryHome: true } : {})
+                  }
                 )
             )
           } catch (e) {
@@ -2509,7 +2554,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Move an agent to another daemon',
           description:
-            'Hard-cut an agent over to another READY daemon. Active source turns are cancelled without a final reply, and subsequent messages start fresh on the target; force is an explicit disaster-recovery option when the source is unavailable. Daemon-local workspace, memory, and transcript data are not migrated or replayed.',
+            'Hard-cut an agent over to another READY daemon. Active source turns are cancelled without a final reply, and subsequent messages start fresh on the target; force is an explicit disaster-recovery option when the source is unavailable. Daemon-local workspace, memory, and transcript data are not migrated or replayed; managed memory follows the agent only when its home is the Control Plane, and an agent whose memory home is the daemon is refused a move onto the managed pool (409) until the home is switched.',
           operationId: 'moveAgentDaemon',
           params: IdParam,
           body: SetAgentDaemonBody,
@@ -2573,6 +2618,19 @@ export function agentRoutes(deps: HttpDeps) {
         const samePlacementTarget = targetSetId
           ? placement.kind === 'set' && placement.setId === targetSetId
           : placement.kind === 'daemon' && placement.daemonId === req.body.daemonId
+
+        // A daemon-home tree stays in the source archive; the pool has nowhere to keep one (memory-evolution.md §3.2.1).
+        // A same-target repair is not a move onto the pool, so an agent already there is not refused its retry.
+        if (
+          !samePlacementTarget &&
+          managedMemoryHomeOf(existing.memory) === 'daemon' &&
+          (await placedOnInstallPool(deps, {
+            setId: targetSetId,
+            daemonId: targetSetId ? undefined : req.body.daemonId
+          }))
+        ) {
+          return conflict(POOL_MOVE_NEEDS_CP_HOME)
+        }
 
         // The org registry rows the agent enables — read once for every candidate's facts check
         // below, then staged on the target.
@@ -3718,7 +3776,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'List memory file history',
           description:
-            'Return one newest-first page of add/update/delete provenance for a managed memory file. History bodies are proxied live from the owning daemon and are not persisted here.',
+            'Return one newest-first page of add/update/delete provenance for a managed memory file. For a memory home on the daemon the page is proxied live from the owning daemon and not persisted here; for a home in the Control Plane it is answered from the change log the Control Plane keeps, with no daemon involved.',
           operationId: 'listAgentMemoryFileHistory',
           params: IdParam,
           querystring: MemoryHistoryQueryDto,
@@ -3740,6 +3798,17 @@ export function agentRoutes(deps: HttpDeps) {
             statusCode: 400,
             message: 'file change history is available only for managed memory'
           })
+        }
+        // A Control-Plane home keeps its change log here, so the read needs no daemon at all (§3.2.1).
+        if (memoryHomedInControlPlane(agent.memory)) {
+          const page = await deps.repos.agentMemoryHistory.page(
+            AgentId(agent.id),
+            memoryHistoryRoot(req.query.channelKey),
+            req.query.path,
+            req.query.cursor,
+            req.query.limit ?? 5
+          )
+          return { events: page.records.map(toHistoryEvent), nextCursor: page.nextCursor ?? null }
         }
         if (!agent.daemonId) {
           return reply

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -815,6 +815,8 @@ export interface AgentSkillSourceFence {
 export interface AgentUpdateOpts {
   authorizeMcpServers?: (currentlyHeld: readonly string[]) => void
   skillSources?: AgentSkillSourceFence
+  /** The forced return of a memory home to the daemon: the agent's CP tree and change log go in the same transaction. */
+  dropManagedMemoryHome?: true
 }
 
 export interface AgentCreateOpts {
@@ -852,6 +854,9 @@ export interface AgentRepo {
    *  Org-fenced: throws {@link AgentMissing} when `agentId` does not exist in
    *  `orgId` — a cross-org id is indistinguishable from a missing row. */
   update(orgId: OrgId, agentId: AgentId, patch: UpdateAgentInput, opts?: AgentUpdateOpts): Promise<AgentRecord>
+  /** Clear `homeMigration` once the daemon reports the copy done (memory-evolution.md §3.2.1), atomically against the
+   *  binding it reads: `conflict` when the home is no longer the Control Plane; an already-clear flag is `cleared`. */
+  settleMemoryHomeMigration(orgId: OrgId, agentId: AgentId): Promise<'cleared' | 'conflict' | 'missing'>
   /** Compare-and-set a workspace edit. The caller has already drained/proved
    *  an owning daemon when one exists. Org-fenced: a cross-org id misses the
    *  CAS exactly like a stale expectation (null). */
@@ -5879,6 +5884,8 @@ export interface AgentMemoryFileRepo {
   utimes(agentId: AgentId, path: string, mtime: Date): Promise<void>
   /** Delete up to `limit` staged rows older than `before` — what an abandoned append sequence left. */
   sweepStaged(before: Date, limit: number): Promise<number>
+  /** Every row of the agent — the forced return to a daemon home; the store service refuses `rm` of the root on purpose. */
+  deleteTree(agentId: AgentId): Promise<void>
 }
 
 /** One change-log record as stored: the wire event plus the store `root` it belongs to. */
@@ -5900,6 +5907,15 @@ export interface AgentMemoryHistoryRetention {
   maxBytesPerRoot: number
 }
 
+/** One stored change-log record, as the console's `memory/history` page carries it. */
+export type AgentMemoryHistoryRecord = AgentMemoryHistoryInput
+
+/** One newest-first page of a file's change log; `nextCursor` is the id of the next not-yet-returned record. */
+export interface AgentMemoryHistoryPage {
+  records: AgentMemoryHistoryRecord[]
+  nextCursor?: string
+}
+
 /** The `agent_memory_history` table: insert a batch, then retain by deleting — newest N per file, then a byte cap per store. */
 export interface AgentMemoryHistoryRepo {
   append(
@@ -5909,6 +5925,16 @@ export interface AgentMemoryHistoryRepo {
     records: AgentMemoryHistoryInput[],
     retention: AgentMemoryHistoryRetention
   ): Promise<void>
+  /** Page one file's records newest first; `cursor` names the record the page starts at, and an evicted one is an empty page. */
+  page(
+    agentId: AgentId,
+    root: string,
+    path: string,
+    cursor: string | undefined,
+    limit: number
+  ): Promise<AgentMemoryHistoryPage>
+  /** Every record of the agent — the forced return to a daemon home. */
+  deleteTree(agentId: AgentId): Promise<void>
 }
 
 // ── External-memory plugin control plane (memory-evolution M-5A) ──

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -9,6 +9,7 @@
  * Record types are lightweight, domain-facing shapes (NOT raw Prisma models) so
  * nothing above this layer imports `@prisma/client`.
  */
+import type { MemoryHomeUpdate } from '../agent-memory/home.js'
 import type {
   AuthReq,
   RegisterReq,
@@ -815,8 +816,11 @@ export interface AgentSkillSourceFence {
 export interface AgentUpdateOpts {
   authorizeMcpServers?: (currentlyHeld: readonly string[]) => void
   skillSources?: AgentSkillSourceFence
-  /** The forced return of a memory home to the daemon: the agent's CP tree and change log go in the same transaction. */
-  dropManagedMemoryHome?: true
+  /** Resolve the managed memory `home` against the binding under the row lock, not the caller's earlier read — so an
+   *  ordinary save cannot restore a flag `memory/home/migrated` cleared in between. It decides the stored binding
+   *  (`patch.memory` still names the target for the external-connection fence), throws `MemoryHomeRefusedError`,
+   *  and on the forced return drops the agent's CP tree and change log in the same transaction. */
+  memoryHome?: MemoryHomeUpdate
 }
 
 export interface AgentCreateOpts {

--- a/packages/control-plane/src/persistence/preset-agents.ts
+++ b/packages/control-plane/src/persistence/preset-agents.ts
@@ -149,7 +149,9 @@ export async function provisionPresetAgents(
           placementKind: 'set' as const,
           setId: pool.setId,
           runtime: pool.runtime,
-          ...(pool.model ? { model: pool.model } : {})
+          ...(pool.model ? { model: pool.model } : {}),
+          // The pool keeps agent memory in the Control Plane (memory-evolution.md §3.2.1), resolved at birth as on create.
+          memory: { provider: 'managed' as const, home: 'control-plane' as const }
         }
       : {}),
     ...(skills.length > 0 ? { skills } : {}),

--- a/packages/control-plane/src/persistence/repositories/agent-config.writer.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-config.writer.ts
@@ -42,6 +42,7 @@ import type {
 import type { SecretCipher } from '../../secrets/cipher.js'
 import type { AgentId, OrgId } from '../../domain/ids.js'
 import { PgAgentRepo } from './agent.repo.js'
+import { PgAgentMemoryFileRepo, PgAgentMemoryHistoryRepo } from './agent-memory.repo.js'
 import { applySealedSecretPatch, sealSecretPatch } from './agent-secret.repo.js'
 import { assertEnvironmentAdmissible, snapshotAgentEnvironments } from './organization-environment-fence.js'
 
@@ -98,6 +99,11 @@ export class PgAgentConfigWriter implements AgentConfigWriter {
       // later re-read sees its entry and refuses — or it queues behind, and then sees
       // these rows committed and refuses itself. Either way exactly one survives.
       if (sealed) await applySealedSecretPatch(tx, orgId, agentId, sealed)
+      // The forced return of a memory home: the CP tree and its change log go with the binding, or neither does.
+      if (opts?.dropManagedMemoryHome) {
+        await new PgAgentMemoryFileRepo(tx).deleteTree(agentId)
+        await new PgAgentMemoryHistoryRepo(tx).deleteTree(agentId)
+      }
       // The row update last: it stamps lastModifiedAt, advances configRevision, and
       // runs the fence over the definition INCLUDING the secrets above — so the
       // audit advance, the secret rows, and the validation commit (or roll back) as

--- a/packages/control-plane/src/persistence/repositories/agent-config.writer.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-config.writer.ts
@@ -42,7 +42,6 @@ import type {
 import type { SecretCipher } from '../../secrets/cipher.js'
 import type { AgentId, OrgId } from '../../domain/ids.js'
 import { PgAgentRepo } from './agent.repo.js'
-import { PgAgentMemoryFileRepo, PgAgentMemoryHistoryRepo } from './agent-memory.repo.js'
 import { applySealedSecretPatch, sealSecretPatch } from './agent-secret.repo.js'
 import { assertEnvironmentAdmissible, snapshotAgentEnvironments } from './organization-environment-fence.js'
 
@@ -99,11 +98,6 @@ export class PgAgentConfigWriter implements AgentConfigWriter {
       // later re-read sees its entry and refuses — or it queues behind, and then sees
       // these rows committed and refuses itself. Either way exactly one survives.
       if (sealed) await applySealedSecretPatch(tx, orgId, agentId, sealed)
-      // The forced return of a memory home: the CP tree and its change log go with the binding, or neither does.
-      if (opts?.dropManagedMemoryHome) {
-        await new PgAgentMemoryFileRepo(tx).deleteTree(agentId)
-        await new PgAgentMemoryHistoryRepo(tx).deleteTree(agentId)
-      }
       // The row update last: it stamps lastModifiedAt, advances configRevision, and
       // runs the fence over the definition INCLUDING the secrets above — so the
       // audit advance, the secret rows, and the validation commit (or roll back) as

--- a/packages/control-plane/src/persistence/repositories/agent-memory.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-memory.repo.ts
@@ -11,6 +11,8 @@ import type {
   AgentMemoryFileRepo,
   AgentMemoryFileSlice,
   AgentMemoryHistoryInput,
+  AgentMemoryHistoryPage,
+  AgentMemoryHistoryRecord,
   AgentMemoryHistoryRepo,
   AgentMemoryHistoryRetention,
   AgentMemoryRenameOutcome
@@ -210,6 +212,39 @@ export class PgAgentMemoryFileRepo implements AgentMemoryFileRepo {
       )
     `)
   }
+
+  async deleteTree(agentId: AgentId): Promise<void> {
+    await withAmbientTx(this.db, async (tx) => {
+      await lockTree(tx, `agent-memory:${agentId}`)
+      await tx.$executeRaw(Prisma.sql`DELETE FROM "agent_memory_file" WHERE "agentId" = ${agentId}::uuid`)
+    })
+  }
+}
+
+type HistoryRow = {
+  id: string
+  path: string
+  event: 'add' | 'update' | 'delete'
+  before: string | null
+  after: string
+  at: Date
+  source: 'tool' | 'console' | 'distill' | 'dream'
+  truncated: boolean | null
+  bytes: number
+}
+
+function toRecord(row: HistoryRow): AgentMemoryHistoryRecord {
+  return {
+    id: row.id,
+    path: row.path,
+    event: row.event,
+    ...(row.before !== null ? { before: row.before } : {}),
+    after: row.after,
+    at: row.at,
+    source: row.source,
+    ...(row.truncated !== null ? { truncated: row.truncated } : {}),
+    bytes: row.bytes
+  }
 }
 
 export class PgAgentMemoryHistoryRepo implements AgentMemoryHistoryRepo {
@@ -259,6 +294,41 @@ export class PgAgentMemoryHistoryRepo implements AgentMemoryHistoryRepo {
           ) summed WHERE "running" > ${retention.maxBytesPerRoot}::bigint
         )
       `)
+    })
+  }
+
+  async page(
+    agentId: AgentId,
+    root: string,
+    path: string,
+    cursor: string | undefined,
+    limit: number
+  ): Promise<AgentMemoryHistoryPage> {
+    // The cursor is the record the page starts at (the daemon's sidecar semantics); one extra row tells whether more follow.
+    const anchor = cursor
+      ? await this.db.$queryRaw<{ at: Date; seq: bigint }[]>(Prisma.sql`
+          SELECT "at", "seq" FROM "agent_memory_history"
+          WHERE "id" = ${cursor}::uuid AND "agentId" = ${agentId}::uuid AND "root" = ${root} AND "path" = ${path}
+        `)
+      : undefined
+    if (anchor && !anchor[0]) return { records: [] }
+    const bound = anchor?.[0]
+      ? Prisma.sql`AND ("at", "seq") <= (${anchor[0].at}::timestamptz, ${anchor[0].seq}::bigint)`
+      : Prisma.empty
+    const rows = await this.db.$queryRaw<HistoryRow[]>(Prisma.sql`
+      SELECT "id", "path", "event", "before", "after", "at", "source", "truncated", "bytes"
+      FROM "agent_memory_history"
+      WHERE "agentId" = ${agentId}::uuid AND "root" = ${root} AND "path" = ${path} ${bound}
+      ORDER BY "at" DESC, "seq" DESC LIMIT ${limit + 1}::int
+    `)
+    const next = rows[limit]
+    return { records: rows.slice(0, limit).map(toRecord), ...(next ? { nextCursor: next.id } : {}) }
+  }
+
+  async deleteTree(agentId: AgentId): Promise<void> {
+    await withAmbientTx(this.db, async (tx) => {
+      await lockTree(tx, `agent-memory-history:${agentId}`)
+      await tx.$executeRaw(Prisma.sql`DELETE FROM "agent_memory_history" WHERE "agentId" = ${agentId}::uuid`)
     })
   }
 }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -39,6 +39,8 @@ import {
 import { lockResourceWriteMemberships } from '../resource-membership-lock.js'
 import { lockSkillSourceNameScopes } from '../skill-source-lock.js'
 import { tryLockMemoryConnectionScopes } from '../memory-connection-lock.js'
+import { MemoryHomeRefusedError, resolveMemoryBindingOnUpdate } from '../../agent-memory/home.js'
+import { PgAgentMemoryFileRepo, PgAgentMemoryHistoryRepo } from './agent-memory.repo.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockAgentPlacement, settlePlacementChange } from './agent-placement.js'
 import { assertAgentMayUseSet, assertDaemonNotInSet } from './member-set.repo.js'
@@ -523,7 +525,8 @@ export class PgAgentRepo implements AgentRepo {
       patch.env !== undefined ||
       patch.mcpServers !== undefined ||
       patch.skills !== undefined ||
-      patch.memory !== undefined
+      patch.memory !== undefined ||
+      opts?.memoryHome !== undefined
     ) {
       // Row-lock the read: overrides are ONE JsonB bag, so the read-merge-write
       // below replaces keys this patch OMITS with whatever it read. Unlocked,
@@ -602,6 +605,22 @@ export class PgAgentRepo implements AgentRepo {
       if (patch.memory !== undefined) {
         if (patch.memory === null) delete next.memory
         else next.memory = patch.memory
+      }
+      // The managed home is decided here, against the locked binding (memory-evolution.md §3.2.1): a completion
+      // `memory/home/migrated` recorded since the caller read the agent is what this write sees, not the caller's copy.
+      if (opts?.memoryHome) {
+        const { input, onPool, force } = opts.memoryHome
+        const change = resolveMemoryBindingOnUpdate(cur?.memory ?? null, input, onPool, force)
+        if (change.kind === 'refused') throw new MemoryHomeRefusedError(change.refused, change.message)
+        if (change.kind === 'write') {
+          if (change.memory === null) delete next.memory
+          else next.memory = change.memory
+          // The forced return keeps nothing: the CP tree and its change log go with the binding, or neither does.
+          if (change.dropHome) {
+            await new PgAgentMemoryFileRepo(tx).deleteTree(agentId)
+            await new PgAgentMemoryHistoryRepo(tx).deleteTree(agentId)
+          }
+        }
       }
       overrides = next
     }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -454,6 +454,22 @@ export class PgAgentRepo implements AgentRepo {
     return this.transaction(async (tx) => this.updateInTx(tx, orgId, agentId, patch, opts))
   }
 
+  settleMemoryHomeMigration(orgId: OrgId, agentId: AgentId): Promise<'cleared' | 'conflict' | 'missing'> {
+    return this.transaction(async (tx) => {
+      // The row lock makes the read and the clear one step, so a concurrent edit cannot slip between them.
+      const rows = await tx.$queryRaw<Array<{ runtimeOverrides: unknown; orgId: string }>>(
+        Prisma.sql`SELECT "runtimeOverrides", "orgId" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
+      )
+      if (!rows[0] || rows[0].orgId !== orgId) return 'missing'
+      const memory = (rows[0].runtimeOverrides as RuntimeOverrides | null)?.memory
+      if (memory?.provider !== 'managed' || memory.home !== 'control-plane') return 'conflict'
+      if (memory.homeMigration === undefined) return 'cleared'
+      const { homeMigration: _done, ...settled } = memory
+      await this.updateInTx(tx, orgId, agentId, { memory: settled })
+      return 'cleared'
+    })
+  }
+
   private async updateInTx(
     tx: Prisma.TransactionClient,
     orgId: OrgId,

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -63,7 +63,7 @@ import {
   handleManagedSkillRead,
   handleOrganizationSuggestionsSync
 } from './organization-knowledge.js'
-import { handleMemoryHistoryAppend, handleMemoryStore } from './memory-store.js'
+import { handleMemoryHistoryAppend, handleMemoryHomeMigrated, handleMemoryStore } from './memory-store.js'
 
 export type Handler = (frame: AnyFrame, conn: DaemonConnection, deps: DaemonWsDeps) => Promise<void>
 
@@ -116,6 +116,7 @@ export class FrameRouter {
       'managed-skill/read': handleManagedSkillRead,
       'memory/store': handleMemoryStore,
       'memory/history/append': handleMemoryHistoryAppend,
+      'memory/home/migrated': handleMemoryHomeMigrated,
       ...overrides
     }
   }
@@ -163,5 +164,6 @@ export {
   handleOrganizationSuggestionsSync,
   handleManagedSkillRead,
   handleMemoryStore,
-  handleMemoryHistoryAppend
+  handleMemoryHistoryAppend,
+  handleMemoryHomeMigrated
 }

--- a/packages/control-plane/src/ws/handlers/memory-store.test.ts
+++ b/packages/control-plane/src/ws/handlers/memory-store.test.ts
@@ -6,7 +6,7 @@ import { PlacementResolver } from '../../orchestrator/placementResolver.js'
 import { systemClock } from '../../domain/clock.js'
 import type { DaemonId } from '../../domain/ids.js'
 import { MemoryStoreTooLargeError } from '../../agent-memory/paths.js'
-import { handleMemoryHistoryAppend, handleMemoryStore } from './memory-store.js'
+import { handleMemoryHistoryAppend, handleMemoryHomeMigrated, handleMemoryStore } from './memory-store.js'
 
 const DAEMON = 'd0d0d0d0-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -37,7 +37,10 @@ const cpHome = { provider: 'managed', home: 'control-plane' }
 function deps(overrides: Partial<Record<keyof DaemonWsDeps, unknown>> = {}): DaemonWsDeps {
   return {
     log: { error: vi.fn() },
-    agent: { get: async () => ({ id: AGENT, orgId: ORG, placementKind: 'daemon', daemonId: DAEMON, memory: cpHome }) },
+    agent: {
+      get: async () => ({ id: AGENT, orgId: ORG, placementKind: 'daemon', daemonId: DAEMON, memory: cpHome }),
+      settleMemoryHomeMigration: vi.fn(async () => 'cleared')
+    },
     agentMemoryStore: { apply: vi.fn(async () => ({ ok: true, value: { exists: false } })) },
     agentMemoryHistory: { append: vi.fn(async () => undefined) },
     ...overrides
@@ -208,5 +211,80 @@ describe('handleMemoryHistoryAppend', () => {
       d
     )
     expect(c.sendError).toHaveBeenCalledWith(expect.any(String), 'SCOPE_DENIED', expect.any(String), false)
+  })
+
+  it('stores the root normalized and answers an escaping root as BAD_PAYLOAD', async () => {
+    const d = deps()
+    const c = conn()
+    await handleMemoryHistoryAppend(
+      frame('memory/history/append', { agentId: AGENT, root: './memory/', records: [record] }),
+      c,
+      d
+    )
+    const append = (d.agentMemoryHistory as { append: ReturnType<typeof vi.fn> }).append
+    expect(append.mock.calls[0]![2]).toBe('memory')
+
+    const bad = conn()
+    await handleMemoryHistoryAppend(
+      frame('memory/history/append', { agentId: AGENT, root: '../elsewhere', records: [record] }),
+      bad,
+      deps()
+    )
+    expect(bad.sendError).toHaveBeenCalledWith(expect.any(String), 'BAD_PAYLOAD', expect.any(String), false)
+  })
+})
+
+describe('handleMemoryHomeMigrated', () => {
+  const migrated = () => frame('memory/home/migrated', { agentId: AGENT })
+  type Settle = { settleMemoryHomeMigration: ReturnType<typeof vi.fn> }
+
+  it('clears the flag under the store fence and answers accepted; a second report is the same success', async () => {
+    const d = deps()
+    const c = conn()
+    await handleMemoryHomeMigrated(migrated(), c, d)
+    expect((d.agent as unknown as Settle).settleMemoryHomeMigration).toHaveBeenCalledWith(ORG, AGENT)
+    expect(c.replyTo).toHaveBeenCalledWith(expect.anything(), 'memory/home/migrated/ok', { accepted: true })
+  })
+
+  it('refuses a daemon that does not serve the agent, and one whose home is not the Control Plane', async () => {
+    const other = conn()
+    const pool = { id: AGENT, orgId: ORG, placementKind: 'set', daemonId: null, setId: POOL_SET, memory: cpHome }
+    await handleMemoryHomeMigrated(
+      migrated(),
+      other,
+      deps({ agent: { get: async () => pool }, placementResolver: holderOf({ [AGENT]: ['other-daemon'] }) })
+    )
+    expect(other.sendError).toHaveBeenCalledWith(expect.any(String), 'SCOPE_DENIED', expect.any(String), false)
+
+    const daemonHome = conn()
+    await handleMemoryHomeMigrated(
+      migrated(),
+      daemonHome,
+      deps({
+        agent: { get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, memory: { provider: 'managed' } }) }
+      })
+    )
+    expect(daemonHome.sendError).toHaveBeenCalledWith(
+      expect.any(String),
+      'SCOPE_DENIED',
+      'the agent memory home is not the Control Plane',
+      false
+    )
+  })
+
+  it('answers CONFLICT when the home moved on between the read and the atomic clear', async () => {
+    const c = conn()
+    await handleMemoryHomeMigrated(
+      migrated(),
+      c,
+      deps({
+        agent: {
+          get: async () => ({ id: AGENT, orgId: ORG, daemonId: DAEMON, memory: cpHome }),
+          settleMemoryHomeMigration: async () => 'conflict'
+        }
+      })
+    )
+    expect(c.sendError).toHaveBeenCalledWith(expect.any(String), 'CONFLICT', expect.any(String), false)
+    expect(c.replyTo).not.toHaveBeenCalled()
   })
 })

--- a/packages/control-plane/src/ws/handlers/memory-store.ts
+++ b/packages/control-plane/src/ws/handlers/memory-store.ts
@@ -1,4 +1,5 @@
-// The `control-plane` memory home's two D→C pairs (memory-evolution.md §3.2.1): one memory-fs op, and one change-log batch.
+// The `control-plane` memory home's D→C pairs (memory-evolution.md §3.2.1): a memory-fs op, a change-log batch, and the
+// one-way migration's completion.
 // Authorization mirrors `knowledge/search` (org from the frame or connection, agent served by THIS daemon), which is what makes
 // the CP the write fence across daemons: a member that lost the duty gets `SCOPE_DENIED` instead of racing its successor.
 import { randomUUID } from 'node:crypto'
@@ -7,8 +8,9 @@ import { AgentId } from '../../domain/ids.js'
 import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
 import type { AgentRecord } from '../../persistence/ports.js'
 import { HISTORY_RETENTION } from '../../agent-memory/limits.js'
-import { toHistoryInput } from '../../agent-memory/history.js'
-import { MemoryStoreTooLargeError } from '../../agent-memory/paths.js'
+import { normalizeMemoryHistoryRoot, toHistoryInput } from '../../agent-memory/history.js'
+import { memoryHomedInControlPlane } from '../../agent-memory/home.js'
+import { MemoryStorePathError, MemoryStoreTooLargeError } from '../../agent-memory/paths.js'
 import { frameOrgId } from './frame-org.js'
 import type { Handler } from './index.js'
 
@@ -27,9 +29,7 @@ async function homedAgent(
   const resolver = deps.placementResolver ?? PLACEMENT_ONLY
   if (!(await resolver.mayAct(agent, conn.daemonId))) return { denied: 'agent is not served by this daemon' }
   // An older binding carries no `home`, which is `daemon`; only a resolved `control-plane` is served here.
-  if (agent.memory?.provider !== 'managed' || agent.memory.home !== 'control-plane') {
-    return { denied: 'the agent memory home is not the Control Plane' }
-  }
+  if (!memoryHomedInControlPlane(agent.memory)) return { denied: 'the agent memory home is not the Control Plane' }
   return { agent }
 }
 
@@ -72,11 +72,41 @@ export const handleMemoryHistoryAppend: Handler = async (frame, conn, deps) => {
   }
   const { agent } = verdict
   try {
+    // The root is stored normalized (`./memory` is `memory`), so the console's read filter finds what the batch wrote.
+    const root = normalizeMemoryHistoryRoot(frame.payload.root)
     const records = frame.payload.records.map((record) => toHistoryInput(record, record.id ?? randomUUID()))
-    await history.append(agent.id, agent.orgId, frame.payload.root, records, HISTORY_RETENTION)
+    await history.append(agent.id, agent.orgId, root, records, HISTORY_RETENTION)
     conn.replyTo(frame, 'memory/history/append/ok', { accepted: true })
   } catch (err) {
+    if (err instanceof MemoryStorePathError) {
+      conn.sendError(frame.id, 'BAD_PAYLOAD', err.message, false)
+      return
+    }
     deps.log.error({ err, agentId: agent.id }, 'memory/history/append: batch failed')
     conn.sendError(frame.id, 'INTERNAL', 'memory history append failed', true)
+  }
+}
+
+// The owning daemon finished the one-way `daemon` → `control-plane` copy: clear the flag the binding change set. The
+// clear is atomic against the binding (`settleMemoryHomeMigration`), a home that moved on since is `CONFLICT`, and a
+// report after the flag is already clear is the same success — a retried copy simply reports twice.
+export const handleMemoryHomeMigrated: Handler = async (frame, conn, deps) => {
+  if (!isFrame('memory/home/migrated')(frame)) return
+  const verdict = await homedAgent(frame, frame.payload.agentId, conn, deps)
+  if ('denied' in verdict) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', verdict.denied, false)
+    return
+  }
+  const { agent } = verdict
+  try {
+    const outcome = await deps.agent.settleMemoryHomeMigration(agent.orgId, agent.id)
+    if (outcome === 'cleared') {
+      conn.replyTo(frame, 'memory/home/migrated/ok', { accepted: true })
+      return
+    }
+    conn.sendError(frame.id, 'CONFLICT', 'the agent memory home is no longer the Control Plane', false)
+  } catch (err) {
+    deps.log.error({ err, agentId: agent.id }, 'memory/home/migrated: settle failed')
+    conn.sendError(frame.id, 'INTERNAL', 'memory home migration could not be recorded', true)
   }
 }

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -13,6 +13,7 @@
 import {
   isFrame,
   AGENT_EXISTS_FEATURE,
+  AGENT_MEMORY_STORE_V1_FEATURE,
   APPROVAL_DM_ROUTE_V1_FEATURE,
   CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   CODEHOST_REVIEW_V1_FEATURE,
@@ -115,7 +116,9 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
       ORGANIZATION_KNOWLEDGE_FEATURE,
       AGENT_EXISTS_FEATURE,
       // slack-approval-dm.md §4.2: this CP resolves and revalidates approval-DM recipients.
-      APPROVAL_DM_ROUTE_V1_FEATURE
+      APPROVAL_DM_ROUTE_V1_FEATURE,
+      // memory-evolution.md §3.2.1: this CP serves the whole `memory/store` family, the migration completion included.
+      AGENT_MEMORY_STORE_V1_FEATURE
     ]
   })
   deps.connReg.markReady(conn.daemonId, conn)

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -74,6 +74,7 @@ import {
   PgDutyGroupRepo
 } from '../../src/persistence/index.js'
 import { PgMemberSetRepo } from '../../src/persistence/repositories/member-set.repo.js'
+import { PgAgentMemoryHistoryRepo } from '../../src/persistence/repositories/agent-memory.repo.js'
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { runWithSharedTx, withSharedTxRouting } from '../../src/persistence/ambient-tx.js'
 import { AgentSpecAssembler } from '../../src/orchestrator/agentSpecAssembler.js'
@@ -507,6 +508,7 @@ export function buildHttpApp(
       externalMemoryConnectionSecret: new PgExternalMemoryConnectionSecretStore(prisma, cipher),
       externalMemoryGrant: new PgExternalMemoryGrantRepo(prisma, cipher),
       memoryConnectionWriter: new PgMemoryConnectionWriter(prisma, cipher),
+      agentMemoryHistory: new PgAgentMemoryHistoryRepo(prisma),
       slackInstall: new PgSlackInstallStore(prisma, cipher),
       slackPlatformInstall: new PgSlackPlatformInstallStore(prisma),
       feishuAppRegistration: feishuAppRegistrationStore,

--- a/packages/control-plane/test/integration/agents.memory-home.route.test.ts
+++ b/packages/control-plane/test/integration/agents.memory-home.route.test.ts
@@ -1,0 +1,369 @@
+/**
+ * The CP's rules for a managed memory binding's `home` (memory-evolution.md §3.2.1, §6), at the REST surface:
+ *
+ *  - create stores a RESOLVED home: the install-wide pool gets `control-plane` (an explicit `daemon` there is 409),
+ *    anywhere else the given value or `daemon`;
+ *  - an edit without `home` keeps the current one, the migration flag included — the console's wholesale save
+ *    from a Control-Plane-homed agent is not a reverse change;
+ *  - `daemon` → `control-plane` is accepted and flags `homeMigration: pending`; the reverse is 409 unless `force`
+ *    is set, and then the agent's CP tree and change log are dropped with the write;
+ *  - a provider switch never migrates; a move onto the pool is refused while the home is the daemon;
+ *  - `memory/history` for a Control-Plane home is answered from the table, daemon or no daemon.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type {
+  Ack,
+  AgentActivate,
+  AgentDetach,
+  AgentUpsert,
+  McpServerSpec,
+  MemoryConnectionSpec
+} from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { DEF_ORG, seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { joinPool, poolSetId } from '../fakes/member-set.js'
+import type { DaemonLiveness } from '../../src/ports.js'
+import type { ControlSender } from '../../src/orchestrator/outbound.js'
+import {
+  PgAgentMemoryFileRepo,
+  PgAgentMemoryHistoryRepo
+} from '../../src/persistence/repositories/agent-memory.repo.js'
+import { AgentId } from '../../src/domain/ids.js'
+import type { AgentMemoryHistoryInput } from '../../src/persistence/ports.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const SOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const MEMBER = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const CAPS = { platforms: ['slack'], runtimes: ['Claude Code'], acp: true, features: ['agent-move-v1'] }
+
+const CP = { provider: 'managed', home: 'control-plane' }
+const PENDING = { ...CP, homeMigration: 'pending' }
+const DAEMON_HOME = { provider: 'managed', home: 'daemon' }
+
+let running: HttpApp | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+/** The daemon-side seam, answering every push with an ack and refusing the one read the CP must answer itself. */
+class ControlSpy {
+  readonly calls: string[] = []
+  async agentDetach(daemonId: string, _value: AgentDetach): Promise<Ack> {
+    this.calls.push(`detach:${daemonId}`)
+    return { ok: true }
+  }
+  async agentActivate(daemonId: string, _value: AgentActivate): Promise<Ack> {
+    this.calls.push(`activate:${daemonId}`)
+    return { ok: true }
+  }
+  async agentUpsert(daemonId: string, _value: AgentUpsert): Promise<void> {
+    this.calls.push(`upsert:${daemonId}`)
+  }
+  async memoryConnectionUpsert(_daemonId: string, _spec: MemoryConnectionSpec): Promise<void> {}
+  async memoryConnectionRemove(_daemonId: string, _connectionId: string): Promise<void> {}
+  async mcpServerUpsert(_daemonId: string, _spec: McpServerSpec): Promise<void> {}
+  async mcpServerRemove(_daemonId: string, _orgId: string, _name: string): Promise<void> {}
+  async memoryHistory(): Promise<never> {
+    throw new Error('memory/history must not reach the daemon for a Control-Plane home')
+  }
+}
+
+const live: DaemonLiveness = {
+  get: (id) => ([SOURCE, MEMBER].includes(id) ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
+}
+
+/** One install-wide pool member: org-less, Pod-bound, enrolled — what `upsertOnAuth` writes for a real Pod. */
+async function seedPoolMember(): Promise<void> {
+  await prisma.daemon.create({
+    data: {
+      id: MEMBER,
+      orgId: null,
+      clusterIdentity: 'system:serviceaccount:ac-example:ac-cloud-daemon',
+      clusterPodUid: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      maxAgents: 8,
+      status: 'ready',
+      capabilities: CAPS
+    }
+  })
+  await joinPool(prisma, MEMBER)
+}
+
+function app(): HttpApp {
+  running = buildHttpApp(prisma, undefined, live, new ControlSpy() as unknown as ControlSender)
+  return running
+}
+
+const storedMemory = async (agentId: string) =>
+  ((await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).runtimeOverrides as { memory?: unknown } | null)
+    ?.memory ?? null
+
+const create = (payload: Record<string, unknown>) => app().app.inject({ method: 'POST', url: `${ORG}/agents`, payload })
+const patch = (agentId: string, payload: Record<string, unknown>) =>
+  app().app.inject({ method: 'PATCH', url: `${ORG}/agents/${agentId}`, payload })
+
+async function seedHomed(memory: Record<string, unknown> | null, opts: { pool?: boolean } = {}): Promise<string> {
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, {
+    ...(opts.pool ? { setId: await poolSetId(prisma) } : { daemonId: SOURCE }),
+    ...(memory ? { runtimeOverrides: { memory } } : {})
+  })
+  return agentId
+}
+
+describe('POST /agents — the memory home is resolved on create', () => {
+  it('an agent placed on the pool keeps its memory in the Control Plane, with or without a binding', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    await seedPoolMember()
+    const bare = await create({ name: 'pooled-bare', runtime: 'Claude Code', placementKind: 'pool' })
+    expect(bare.statusCode).toBe(201)
+    expect(bare.json().memory).toEqual(CP)
+    expect(await storedMemory(bare.json().id)).toEqual(CP)
+
+    const bound = await create({
+      name: 'pooled-bound',
+      runtime: 'Claude Code',
+      placementKind: 'pool',
+      memory: { provider: 'managed', autoDistill: false }
+    })
+    expect(bound.statusCode).toBe(201)
+    expect(bound.json().memory).toEqual({ provider: 'managed', autoDistill: false, home: 'control-plane' })
+    // (A create pinned to a member directly is refused by the repo itself — `DaemonPlacementInSet` — so the
+    // member-pinned shape only exists on legacy rows, which the edit and move rules below still cover.)
+  })
+
+  it('refuses an explicit daemon home on the pool, and never accepts the CP-owned flag from a client', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    await seedPoolMember()
+    const res = await create({
+      name: 'pooled-daemon',
+      runtime: 'Claude Code',
+      placementKind: 'pool',
+      memory: DAEMON_HOME
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json().message).toContain('control-plane')
+    expect(await prisma.agent.findFirst({ where: { name: 'pooled-daemon' } })).toBeNull()
+
+    const flagged = await create({ name: 'flagged', runtime: 'Claude Code', memory: PENDING })
+    expect(flagged.statusCode).toBe(400)
+  })
+
+  it('a self-hosted agent stores the given home or daemon, and no binding stays the managed default', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const bare = await create({ name: 'local-bare', runtime: 'Claude Code', daemonId: SOURCE })
+    expect(bare.statusCode).toBe(201)
+    expect(bare.json().memory).toBeNull()
+
+    const managed = await create({
+      name: 'local-managed',
+      runtime: 'Claude Code',
+      daemonId: SOURCE,
+      memory: { provider: 'managed' }
+    })
+    expect(managed.json().memory).toEqual(DAEMON_HOME)
+
+    const cp = await create({ name: 'local-cp', runtime: 'Claude Code', daemonId: SOURCE, memory: CP })
+    // Created straight into the Control Plane: there is no tree to copy, so nothing is flagged.
+    expect(cp.json().memory).toEqual(CP)
+  })
+})
+
+describe('PATCH /agents/:id — the home moves one way and comes back only by force', () => {
+  it('an absent home keeps the current one, the pending flag included; the same value re-sent is a no-op', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const agentId = await seedHomed(PENDING)
+    const saved = await patch(agentId, { memory: { provider: 'managed', autoDistill: true } })
+    expect(saved.statusCode).toBe(200)
+    expect(saved.json().memory).toEqual({
+      provider: 'managed',
+      autoDistill: true,
+      home: 'control-plane',
+      homeMigration: 'pending'
+    })
+
+    const settled = await seedHomed(CP)
+    const same = await patch(settled, { memory: CP })
+    expect(same.statusCode).toBe(200)
+    expect(same.json().memory).toEqual(CP)
+    // The managed default on a Control-Plane-homed agent keeps the home rather than silently reversing it.
+    const cleared = await patch(settled, { memory: null })
+    expect(cleared.json().memory).toEqual(CP)
+  })
+
+  it('daemon → control-plane persists the home and the pending flag in one write', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const agentId = await seedHomed(null)
+    const res = await patch(agentId, { memory: { provider: 'managed', home: 'control-plane' } })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().memory).toEqual(PENDING)
+    expect(await storedMemory(agentId)).toEqual(PENDING)
+  })
+
+  it('control-plane → daemon is refused without force, and with force drops the CP tree and change log', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const agentId = await seedHomed(PENDING)
+    const other = await seedHomed(CP)
+    const files = new PgAgentMemoryFileRepo(prisma)
+    const history = new PgAgentMemoryHistoryRepo(prisma)
+    const record = (): AgentMemoryHistoryInput => ({
+      id: randomUUID(),
+      path: 'MEMORY.md',
+      event: 'add',
+      after: 'x',
+      at: new Date(),
+      source: 'tool',
+      bytes: 10
+    })
+    for (const id of [agentId, other]) {
+      const temp = `memory/.tmp-${randomUUID()}`
+      await files.append(AgentId(id), DEF_ORG, temp, Buffer.from('hello'), true, new Date())
+      await files.commit(AgentId(id), 'memory/MEMORY.md', temp, undefined, new Date())
+      await history.append(AgentId(id), DEF_ORG, 'memory', [record()], {
+        maxVersionsPerFile: 10,
+        maxBytesPerRoot: 1000
+      })
+    }
+
+    const refused = await patch(agentId, { memory: DAEMON_HOME })
+    expect(refused.statusCode).toBe(409)
+    expect(refused.json().message).toContain('force')
+    expect(await storedMemory(agentId)).toEqual(PENDING)
+    expect(await prisma.agentMemoryFile.count({ where: { agentId } })).toBe(1)
+
+    const forced = await patch(agentId, { memory: DAEMON_HOME, force: true })
+    expect(forced.statusCode).toBe(200)
+    expect(forced.json().memory).toEqual(DAEMON_HOME)
+    expect(await storedMemory(agentId)).toEqual(DAEMON_HOME)
+    expect(await prisma.agentMemoryFile.count({ where: { agentId } })).toBe(0)
+    expect(await prisma.agentMemoryHistory.count({ where: { agentId } })).toBe(0)
+    // Only this agent's rows went.
+    expect(await prisma.agentMemoryFile.count({ where: { agentId: other } })).toBe(1)
+    expect(await prisma.agentMemoryHistory.count({ where: { agentId: other } })).toBe(1)
+    // `force` alone is not an edit.
+    expect((await patch(agentId, { force: true })).statusCode).toBe(400)
+  })
+
+  it('a provider round trip never migrates: away drops the home, back resolves as on create with no flag', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const agentId = await seedHomed(PENDING)
+    const away = await patch(agentId, { memory: { provider: 'native' } })
+    expect(away.json().memory).toEqual({ provider: 'native' })
+    const back = await patch(agentId, { memory: { provider: 'managed', home: 'control-plane' } })
+    expect(back.json().memory).toEqual(CP)
+    // Once back in the Control Plane the ordinary rules apply again: a bare save keeps it, naming daemon needs force.
+    expect((await patch(agentId, { memory: { provider: 'managed' } })).json().memory).toEqual(CP)
+    const reverse = await patch(agentId, { memory: DAEMON_HOME })
+    expect(reverse.statusCode).toBe(409)
+    expect(reverse.json().message).toContain('force')
+    const local = await patch(agentId, { memory: { provider: 'none' } })
+    expect(local.json().memory).toEqual({ provider: 'none' })
+    expect((await patch(agentId, { memory: { provider: 'managed' } })).json().memory).toEqual(DAEMON_HOME)
+  })
+
+  it('an agent on the pool can never name the daemon home, force or not', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    await seedPoolMember()
+    const agentId = await seedHomed(CP, { pool: true })
+    expect((await patch(agentId, { memory: DAEMON_HOME })).statusCode).toBe(409)
+    expect((await patch(agentId, { memory: DAEMON_HOME, force: true })).statusCode).toBe(409)
+    expect((await patch(agentId, { memory: null })).json().memory).toEqual(CP)
+    expect((await patch(agentId, { memory: { provider: 'managed', scope: 'channel' } })).json().memory).toEqual({
+      ...CP,
+      scope: 'channel'
+    })
+  })
+})
+
+describe('PUT /agents/:id/daemon — a daemon-home agent may not move onto the pool', () => {
+  it('refuses the move until the home is switched, for the set and for a member alike', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    await seedPoolMember()
+    const agentId = await seedHomed(null)
+    const onto = await app().app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { placementKind: 'pool' }
+    })
+    expect(onto.statusCode).toBe(409)
+    expect(onto.json().message).toContain('control-plane')
+    const pinned = await running!.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/daemon`,
+      payload: { daemonId: MEMBER }
+    })
+    expect(pinned.statusCode).toBe(409)
+    expect(pinned.json().message).toContain('control-plane')
+    expect(await prisma.agent.findUnique({ where: { id: agentId } })).toMatchObject({
+      placementKind: 'daemon',
+      daemonId: SOURCE
+    })
+  })
+})
+
+describe('GET /agents/:id/memory/history — a Control-Plane home is answered from the table', () => {
+  it('pages newest first by cursor, per store, and needs no daemon', async () => {
+    const agentId = randomUUID()
+    // Unplaced on purpose: the daemon-home path would answer 503 here.
+    await seedAgent(prisma, agentId, { runtimeOverrides: { memory: CP } })
+    const history = new PgAgentMemoryHistoryRepo(prisma)
+    const t = Date.parse('2026-09-08T12:00:00.000Z')
+    const record = (path: string, atMs: number, after: string): AgentMemoryHistoryInput => ({
+      id: randomUUID(),
+      path,
+      event: 'update',
+      before: 'old',
+      after,
+      at: new Date(atMs),
+      source: 'console',
+      bytes: 10
+    })
+    const keep = { maxVersionsPerFile: 100, maxBytesPerRoot: 10_000 }
+    await history.append(
+      AgentId(agentId),
+      DEF_ORG,
+      'memory',
+      [
+        record('a.md', t + 1, 'v1'),
+        record('a.md', t + 2, 'v2'),
+        record('a.md', t + 3, 'v3'),
+        record('b.md', t + 4, 'b')
+      ],
+      keep
+    )
+    await history.append(AgentId(agentId), DEF_ORG, 'channels/c1/memory', [record('a.md', t + 5, 'c')], keep)
+
+    const first = await app().app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${agentId}/memory/history?path=a.md&limit=2`
+    })
+    expect(first.statusCode).toBe(200)
+    expect(first.json().events.map((e: { after: string }) => e.after)).toEqual(['v3', 'v2'])
+    expect(first.json().events[0]).toMatchObject({
+      path: 'a.md',
+      event: 'update',
+      before: 'old',
+      at: new Date(t + 3).toISOString(),
+      scope: 'agent',
+      source: 'console'
+    })
+    const cursor = first.json().nextCursor as string
+    expect(cursor).toMatch(/^[0-9a-f-]{36}$/)
+
+    const second = await running!.app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${agentId}/memory/history?path=a.md&limit=2&cursor=${cursor}`
+    })
+    expect(second.json()).toMatchObject({ nextCursor: null })
+    expect(second.json().events.map((e: { after: string }) => e.after)).toEqual(['v1'])
+
+    const channel = await running!.app.inject({
+      method: 'GET',
+      url: `${ORG}/agents/${agentId}/memory/history?path=a.md&channelKey=c1`
+    })
+    expect(channel.json().events.map((e: { after: string }) => e.after)).toEqual(['c'])
+  })
+})

--- a/packages/control-plane/test/integration/agents.memory-home.route.test.ts
+++ b/packages/control-plane/test/integration/agents.memory-home.route.test.ts
@@ -32,6 +32,10 @@ import {
 } from '../../src/persistence/repositories/agent-memory.repo.js'
 import { AgentId } from '../../src/domain/ids.js'
 import type { AgentMemoryHistoryInput } from '../../src/persistence/ports.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgAgentConfigWriter } from '../../src/persistence/repositories/agent-config.writer.js'
+import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
+import { MemoryHomeRefusedError } from '../../src/agent-memory/home.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -275,6 +279,41 @@ describe('PATCH /agents/:id — the home moves one way and comes back only by fo
       ...CP,
       scope: 'channel'
     })
+  })
+})
+
+describe('the home is resolved against the locked binding, not the caller’s earlier read', () => {
+  const repo = () => new PgAgentRepo(prisma)
+  const writer = () => new PgAgentConfigWriter(prisma, new PlaintextSecretCipher())
+
+  it('a save that read a pending binding cannot restore the flag memory/home/migrated cleared meanwhile', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const agentId = AgentId(await seedHomed(PENDING))
+    // The console read `PENDING`; the daemon's completion lands before its save commits.
+    expect(await repo().settleMemoryHomeMigration(DEF_ORG, agentId)).toBe('cleared')
+    // The save carries no flag of its own — it is resolved under the row lock, where the binding is already settled.
+    const saved = await writer().update(
+      DEF_ORG,
+      agentId,
+      { memory: { provider: 'managed', autoDistill: false, home: 'control-plane' } },
+      undefined,
+      { memoryHome: { input: { provider: 'managed', autoDistill: false }, onPool: false, force: false } }
+    )
+    expect(saved.memory).toEqual({ provider: 'managed', autoDistill: false, home: 'control-plane' })
+    expect(await storedMemory(agentId)).toEqual({ provider: 'managed', autoDistill: false, home: 'control-plane' })
+  })
+
+  it('a reverse that was fine against the caller’s read is refused once the locked binding is the Control Plane', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    const agentId = AgentId(await seedHomed(DAEMON_HOME))
+    // Another edit switched the home after the caller read `daemon`.
+    await repo().update(DEF_ORG, agentId, { memory: { provider: 'managed', home: 'control-plane' } })
+    await expect(
+      writer().update(DEF_ORG, agentId, { memory: DAEMON_HOME as never }, undefined, {
+        memoryHome: { input: DAEMON_HOME as never, onPool: false, force: false }
+      })
+    ).rejects.toBeInstanceOf(MemoryHomeRefusedError)
+    expect(await storedMemory(agentId)).toEqual(CP)
   })
 })
 

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -691,7 +691,11 @@ describe('PUT /agents/:id/daemon — the pool as a placement target', () => {
     await seedMoveDaemons()
     await seedPoolMember()
     const agentId = randomUUID()
-    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    // The pool keeps memory in the Control Plane; a daemon-home agent is refused the move (agents.memory-home tests).
+    await seedAgent(prisma, agentId, {
+      daemonId: SOURCE,
+      runtimeOverrides: { memory: { provider: 'managed', home: 'control-plane' } }
+    })
     const control = new MoveControlSpy()
     running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
 
@@ -840,7 +844,7 @@ describe('PUT /agents/:id/daemon — converting a member-pinned agent to the poo
     await seedMoveDaemons()
     await seedPoolMember()
     const agentId = randomUUID()
-    await seedAgent(prisma, agentId)
+    await seedAgent(prisma, agentId, { runtimeOverrides: { memory: { provider: 'managed', home: 'control-plane' } } })
     // Pinned to the MEMBER, which is the shape today's pool agents actually have.
     await prisma.agent.update({ where: { id: agentId }, data: { daemonId: MEMBER } })
     const control = new MoveControlSpy()
@@ -870,7 +874,10 @@ describe('PUT /agents/:id/daemon — converting a member-pinned agent to the poo
     await seedMoveDaemons()
     await seedPoolMember()
     const agentId = randomUUID()
-    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    await seedAgent(prisma, agentId, {
+      daemonId: SOURCE,
+      runtimeOverrides: { memory: { provider: 'managed', home: 'control-plane' } }
+    })
     const control = new MoveControlSpy()
     running = buildHttpApp(prisma, undefined, poolLive, control as unknown as ControlSender)
 
@@ -895,7 +902,7 @@ describe('PUT /agents/:id/daemon — a two-hop move back onto the pool (#1093)',
     await seedMoveDaemons()
     await seedPoolMember()
     const agentId = randomUUID()
-    await seedAgent(prisma, agentId)
+    await seedAgent(prisma, agentId, { runtimeOverrides: { memory: { provider: 'managed', home: 'control-plane' } } })
     await prisma.agent.update({
       where: { id: agentId },
       data: { placementKind: 'set', setId: await poolSetId(prisma), daemonId: null }

--- a/packages/control-plane/test/integration/memory-store.test.ts
+++ b/packages/control-plane/test/integration/memory-store.test.ts
@@ -25,7 +25,7 @@ import {
 import { AgentMemoryStoreService } from '../../src/agent-memory/store.service.js'
 import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
 import { systemClock } from '../../src/domain/clock.js'
-import { handleMemoryHistoryAppend, handleMemoryStore } from '../../src/ws/handlers/index.js'
+import { handleMemoryHistoryAppend, handleMemoryHomeMigrated, handleMemoryStore } from '../../src/ws/handlers/index.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -538,5 +538,79 @@ describe('memory/history/append', () => {
       [false, 'memory', 'topics/a.md', 'update', 'a', 'b', 'tool', DEFAULT_ORG_ID]
     ])
     expect(rows[0]!.bytes).toBe(Buffer.byteLength(JSON.stringify({ ...batch[0], id }) + '\n'))
+  })
+})
+
+describe('memory/home/migrated', () => {
+  const PENDING = { memory: { provider: 'managed', home: 'control-plane', homeMigration: 'pending' } }
+
+  async function migrated(daemonId: string, agentId: string, over: Partial<DaemonWsDeps> = {}): Promise<Answer> {
+    const frame = {
+      v: 1,
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      type: 'memory/home/migrated',
+      orgId: DEFAULT_ORG_ID,
+      payload: { agentId }
+    } as AnyFrame
+    const replyTo = vi.fn()
+    const sendError = vi.fn()
+    await handleMemoryHomeMigrated(
+      frame,
+      { daemonId, orgId: null, replyTo, sendError } as unknown as DaemonConnection,
+      {
+        ...deps(),
+        ...over
+      }
+    )
+    if (sendError.mock.calls.length > 0) {
+      const [, code, message] = sendError.mock.calls[0] as [string, string, string]
+      return { error: { code, message } }
+    }
+    return { reply: replyTo.mock.calls[0]![2] as MemoryFsReply }
+  }
+
+  const binding = async (agentId: string) =>
+    ((await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).runtimeOverrides as { memory: unknown }).memory
+
+  it('clears the pending flag on the binding, idempotently, under the store fence', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON, runtimeOverrides: PENDING })
+    expect(await migrated(OTHER_DAEMON, agentId)).toMatchObject({ error: { code: 'SCOPE_DENIED' } })
+    expect(await binding(agentId)).toEqual(PENDING.memory)
+
+    expect(await migrated(DAEMON, agentId)).toEqual({ reply: { accepted: true } })
+    expect(await binding(agentId)).toEqual({ provider: 'managed', home: 'control-plane' })
+    // A retried copy reports twice; the second report finds nothing to clear and is the same success.
+    expect(await migrated(DAEMON, agentId)).toEqual({ reply: { accepted: true } })
+    expect(await binding(agentId)).toEqual({ provider: 'managed', home: 'control-plane' })
+  })
+
+  it('SCOPE_DENIED for a daemon home, and CONFLICT when the home moved on under the report', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, {
+      daemonId: DAEMON,
+      runtimeOverrides: { memory: { provider: 'managed', home: 'daemon' } }
+    })
+    expect(await migrated(DAEMON, agentId)).toEqual({
+      error: { code: 'SCOPE_DENIED', message: 'the agent memory home is not the Control Plane' }
+    })
+    // The verdict read saw the Control Plane, the row says the daemon: the atomic clear is what decides.
+    const repo = new PgAgentRepo(prisma)
+    const stale = {
+      ...repo,
+      get: async (orgId: string, id: string) => {
+        const agent = await repo.get(orgId as never, id as never)
+        return agent ? { ...agent, memory: PENDING.memory } : null
+      },
+      settleMemoryHomeMigration: repo.settleMemoryHomeMigration.bind(repo)
+    }
+    expect(await migrated(DAEMON, agentId, { agent: stale as unknown as DaemonWsDeps['agent'] })).toEqual({
+      error: { code: 'CONFLICT', message: 'the agent memory home is no longer the Control Plane' }
+    })
+    expect(await binding(agentId)).toEqual({ provider: 'managed', home: 'daemon' })
   })
 })

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import {
+  AGENT_MEMORY_STORE_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
   GITLAB_DEFAULT_BASE_URL,
   GITLAB_INSTANCE_V1_FEATURE,
@@ -171,6 +172,9 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
 
     // routingEpoch re-issued as-is (convergence, not bump).
     expect(snap.routingEpoch).toBe(7)
+
+    // memory-evolution.md §3.2.1: the whole `memory/store` family is served, so a `control-plane` home may activate.
+    expect(snap.serverFeatures).toContain(AGENT_MEMORY_STORE_V1_FEATURE)
 
     // assignments: exactly the one active row for this daemon, as a RouteAssign.
     expect(snap.assignments).toHaveLength(1)

--- a/packages/control-plane/test/repo/agent-memory.repo.test.ts
+++ b/packages/control-plane/test/repo/agent-memory.repo.test.ts
@@ -162,4 +162,48 @@ describe('agent_memory_history (real Postgres)', () => {
     })
     expect(await prisma.agentMemoryHistory.count({ where: { agentId } })).toBe(4)
   })
+
+  it('pages one file newest first from an inclusive cursor, per store; an evicted cursor is an empty page', async () => {
+    const repo = new PgAgentMemoryHistoryRepo(prisma)
+    const agentId = await agent()
+    const t = NOW.getTime()
+    const a = [record('a.md', t + 1), record('a.md', t + 2), record('a.md', t + 3), record('a.md', t + 4)]
+    const keep = { maxVersionsPerFile: 100, maxBytesPerRoot: 10_000 }
+    await repo.append(agentId, DEF_ORG, 'memory', [...a, record('b.md', t + 5)], keep)
+    await repo.append(agentId, DEF_ORG, 'channels/x/memory', [record('a.md', t + 6)], keep)
+
+    const first = await repo.page(agentId, 'memory', 'a.md', undefined, 2)
+    expect(first.records.map((r) => r.id)).toEqual([a[3]!.id, a[2]!.id])
+    expect(first.nextCursor).toBe(a[1]!.id)
+    const second = await repo.page(agentId, 'memory', 'a.md', first.nextCursor, 2)
+    expect(second.records.map((r) => r.id)).toEqual([a[1]!.id, a[0]!.id])
+    expect(second.nextCursor).toBeUndefined()
+    expect((await repo.page(agentId, 'memory', 'b.md', undefined, 5)).records.map((r) => r.path)).toEqual(['b.md'])
+    expect((await repo.page(agentId, 'channels/x/memory', 'a.md', undefined, 5)).records).toHaveLength(1)
+    // A cursor that retention evicted (or that names another file) starts no page: the daemon's sidecar rule.
+    expect(await repo.page(agentId, 'memory', 'a.md', randomUUID(), 2)).toEqual({ records: [] })
+    expect(await repo.page(agentId, 'memory', 'b.md', a[0]!.id, 2)).toEqual({ records: [] })
+    expect(first.records[0]).toMatchObject({ event: 'update', after: 'x', source: 'tool', at: new Date(t + 4) })
+  })
+
+  it('deleteTree drops every row of the agent in both tables and nothing of another agent', async () => {
+    const files = new PgAgentMemoryFileRepo(prisma)
+    const history = new PgAgentMemoryHistoryRepo(prisma)
+    const gone = await agent()
+    const kept = AgentId(randomUUID())
+    await seedAgent(prisma, kept, { daemonId: DAEMON })
+    for (const id of [gone, kept]) {
+      await publish(files, id, 'memory/MEMORY.md', 'x', NOW)
+      await history.append(id, DEF_ORG, 'memory', [record('MEMORY.md', NOW.getTime())], {
+        maxVersionsPerFile: 100,
+        maxBytesPerRoot: 10_000
+      })
+    }
+    await files.deleteTree(gone)
+    await history.deleteTree(gone)
+    expect(await prisma.agentMemoryFile.count({ where: { agentId: gone } })).toBe(0)
+    expect(await prisma.agentMemoryHistory.count({ where: { agentId: gone } })).toBe(0)
+    expect(await prisma.agentMemoryFile.count({ where: { agentId: kept } })).toBe(1)
+    expect(await prisma.agentMemoryHistory.count({ where: { agentId: kept } })).toBe(1)
+  })
 })

--- a/packages/protocol/src/frames/memory-connection.test.ts
+++ b/packages/protocol/src/frames/memory-connection.test.ts
@@ -160,6 +160,20 @@ describe('managed memory home', () => {
     }
   })
 
+  it('carries the CP-owned migration flag only as `pending`, and only on a managed binding', () => {
+    expect(AgentMemoryBinding.parse({ provider: 'managed', home: 'control-plane', homeMigration: 'pending' })).toEqual({
+      provider: 'managed',
+      home: 'control-plane',
+      homeMigration: 'pending'
+    })
+    for (const bad of [
+      { provider: 'managed', home: 'control-plane', homeMigration: 'done' },
+      { provider: 'native', homeMigration: 'pending' }
+    ]) {
+      expect(AgentMemoryBinding.safeParse(bad).success).toBe(false)
+    }
+  })
+
   it('resolves the home on the AgentSpec a daemon receives', () => {
     expect(AgentSpec.parse({ name: 'bot', memory: { provider: 'managed' } }).memory).toEqual({
       provider: 'managed',

--- a/packages/protocol/src/frames/memory-connection.ts
+++ b/packages/protocol/src/frames/memory-connection.ts
@@ -110,15 +110,18 @@ export const ManagedMemoryBinding = z
     dreaming: MemoryDreamingPolicy.optional(),
     scope: ManagedMemoryScope.optional(),
     // Absent on a binding older than the field ⇒ `daemon`, the historical home; the CP stores the resolved value.
-    home: ManagedMemoryHome.default('daemon')
+    home: ManagedMemoryHome.default('daemon'),
+    // CP-owned: set with a `daemon` → `control-plane` change, cleared by `memory/home/migrated`; never accepted from a client.
+    homeMigration: z.literal('pending').optional()
   })
   .strict()
 export type ManagedMemoryBinding = z.infer<typeof ManagedMemoryBinding>
 
 // `none` and `native` carry no managed policy; `autoDistill` stays accepted because stored bindings have carried it.
-const RuntimeMemoryBinding = z
+export const RuntimeMemoryBinding = z
   .object({ provider: z.enum(['none', 'native']), autoDistill: z.boolean().optional() })
   .strict()
+export type RuntimeMemoryBinding = z.infer<typeof RuntimeMemoryBinding>
 
 export const ExternalMemoryBinding = z
   .object({


### PR DESCRIPTION
## Why

Step ④ of the managed-memory `home` rollout (`docs/designs/memory-evolution.md` §3.2.1 "Changing `home` is one way…", "Moves", "Rollout"; §6 `home` bullet; `docs/product-conventions.md` move convention). Steps ①③⑤ landed the wire contract, the two tables and the `memory/store` / `memory/history/append` handlers. This is the Control Plane's half of the rules those paragraphs state: the home is resolved once on create, moves one way, comes back only by force, and is mandated on the install-wide pool.

## The rules

1. **A migration flag on the binding.** `ManagedMemoryBinding` gains `homeMigration: z.literal('pending').optional()`. It is CP-owned: set by a `daemon` → `control-plane` edit, cleared by `memory/home/migrated`, never accepted from a client (the input DTO does not know it; a body carrying it is 400). It reaches the daemon on `agent/upsert` as read-only state.
2. **Create.** The CP stores a resolved home. An agent placed on the install-wide pool gets `control-plane` whether or not a binding was sent (no binding ⇒ `{ provider: 'managed', home: 'control-plane' }`); an explicit `daemon` there is **409**. Anywhere else the given value or `daemon`; no binding stays the managed default. The preset agent born on the pool carries the same binding.
3. **Update — the edit body is NOT the wire binding.** `MemoryConfigInputBody` is the binding with `home` optional and **no default**. Reusing the wire schema, whose `home` defaults to `daemon`, would have turned every console save from a Control-Plane-homed agent (the console rebuilds the managed binding without `home`) into a forbidden reverse change. So: absent `home` keeps the current one, the pending flag included; `memory: null` on a Control-Plane-homed agent keeps the home too.
   - `daemon` → `control-plane`: accepted; `home` and `homeMigration: 'pending'` are written together.
   - `control-plane` → `daemon`: **409** naming `force` unless the body carries `force: true` (a top-level request field, not part of the binding; `force` alone is not an edit). With it, every `agent_memory_file` and `agent_memory_history` row of the agent is deleted in the same transaction as the binding write, the flag is cleared and `home: 'daemon'` is stored. Nothing else is archived here.
   - **The resolution is authoritative under the row lock.** The route's pass over `existing.memory` is the friendly refusal and names the target for the external-connection check; the binding that is stored is resolved again inside `PgAgentRepo.updateInTx` (`AgentUpdateOpts.memoryHome`) against the row as it is *then*, so a save that read a pending flag cannot restore it after `memory/home/migrated` cleared it, and a reverse that raced a forward switch is refused (`MemoryHomeRefusedError` → 409) instead of silently un-switching. The forced drop runs in that same transaction.
   - Same value ⇒ no flag change. A provider switch away from `managed` drops `home` with the binding (the rows stay); switching back resolves as on create and sets no flag — provider switches never migrate.
   - On the pool `daemon` is refused, force or not.
4. **Moves / placement.** In `PUT /agents/:id/daemon`, right after the same-target check and before any admission or detach: an agent whose managed home is the daemon (an absent binding included) is refused a move onto the pool — the org-less set or one of its members — with **409** telling the caller to switch the home first. A same-target repair of an agent already on the pool is not a move and passes. `placedOnInstallPool()` next to `resolveTargetSetId()` is the shared predicate.
5. **`memory/home/migrated`.** Authorized exactly as `memory/store` (org, served by this daemon, home is the Control Plane). `PgAgentRepo.settleMemoryHomeMigration()` clears the flag under the row lock, atomically against the binding it reads: `accepted: true` on success and on a repeated report (idempotent), `CONFLICT` when the home moved on between the verdict and the clear.
6. **`register/ok` advertises `agent-memory-store-v1`** now that the whole family is served.
7. **`memory/history` for a Control-Plane home is answered by the CP.** The route reads `agent_memory_history` through `AgentMemoryHistoryRepo.page()` — newest first, filtered by `path`, cursor-paged with the daemon's sidecar semantics (the cursor names the record the page starts at; an evicted cursor is an empty page) — and never contacts the daemon, so it works for an unplaced agent. `daemon`-home agents keep the proxy. The store `root` convention is the one the existing tests use: `memory` for the agent store, `channels/<channelKey>/memory` for a channel store; the append handler normalizes the root it stores (`./memory` ⇒ `memory`) and answers an escaping root as `BAD_PAYLOAD`.
8. **DTO / OpenAPI.** `home` on create and update, `force` on update, `homeMigration` read-only on the agent DTO; the create, update, move and history route descriptions say what changed.

## What the CP now answers itself

`memory/history` for a Control-Plane home, and the `memory/home/migrated` completion. The daemon still owns everything above the port.

## Deliberately not here

- No daemon changes: reading `homeMigration`, selecting `CpMemoryFs`, the one-time copy, `--k8s` refusing a `daemon` home, local-tree archiving on the forced return (steps ⑦⑧).
- No web changes (step ⑨). Until the console offers the selector, switching a home is an API edit; a console move of a daemon-home agent onto the pool is refused with the message above.
- No reconciler flipping existing pool agents (step ⑩). Existing pool agents keep whatever binding they have; a same-target repair still passes.
- The design doc got one sentence each in §3.2.1 and §6 naming `homeMigration: 'pending'` and `force`.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck test:unit test:int` — green locally with Docker (integration suite included).
- `pnpm --filter @agentconnect.md/protocol typecheck test`, `pnpm --filter @agentconnect.md/daemon typecheck`, `pnpm --filter @agentconnect.md/web typecheck` — green.
- New tests: `agent-memory/home.test.ts` (the pure resolver), writer-level cases proving the resolution reads the locked row (a cleared flag stays cleared; a raced reverse is refused), handler unit cases for `memory/home/migrated` and root normalization, `test/integration/agents.memory-home.route.test.ts` (create resolution on pool vs self-hosted, absent home keeps, forward flags, reverse refused / forced drop of both tables, provider round trip, pool refusals, move-to-pool refusal, history served from the table with paging and channel roots), `memory-store.test.ts` (migrated: clears / idempotent / `SCOPE_DENIED` / `CONFLICT`), repo tests for `page()` and `deleteTree()`, and the `register/ok` feature assertion.
- Four existing pool-move tests now seed a Control-Plane home, since a daemon-home move onto the pool is what this change refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
