### PR TITLE
fix(relay): preserve webchat subscriptions across tabs

### DIFF
--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -486,9 +486,11 @@ block at the daemon, and is never persisted by the relay or Control Plane.
   the normal daemon path.
 - Direct Slack integrations retain their daemon-owned socket transport.
 - Webchat output is returned through `rd/chat` to the relay holding the browser
-  session. The daemon assigns monotonically increasing output indexes, retains
-  the bounded replay window, and can rebind an accepted turn to a replacement
-  relay connection.
+  session. That relay delivers output, completion, and canonical posts to every
+  verified browser connection for the conversation; opening or closing another
+  tab preserves existing subscriptions. The daemon assigns monotonically
+  increasing output indexes, retains the bounded replay window, and can rebind
+  an accepted turn to a replacement relay connection.
 
 Slack rate limits are global to a bot while send queues are local to member
 daemons. Each daemon respects `429` and `Retry-After`; conversation ownership reduces

--- a/packages/relay/src/relay-browser-server.test.ts
+++ b/packages/relay/src/relay-browser-server.test.ts
@@ -11,7 +11,13 @@ import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { WebSocket } from 'ws'
 import type { FastifyInstance } from 'fastify'
-import type { RcVerifyResult, RdAck, RdMsgWebchat, WebchatRemoteMcpEntitlement } from '@agentconnect.md/protocol'
+import type {
+  RcVerifyResult,
+  RdAck,
+  RdChat,
+  RdMsgWebchat,
+  WebchatRemoteMcpEntitlement
+} from '@agentconnect.md/protocol'
 import { createRelayBrowserServer, RELAY_WEBCHAT_WS_PATH } from './relay-browser-server.js'
 import { WebchatRouter } from './webchat-router.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
@@ -196,6 +202,77 @@ describe('createRelayBrowserServer (browser webchat edge)', () => {
     expect((await nextFrame(ws, 'done')).done).toMatchObject({ conversationId: RESUME })
     ws.close()
   })
+
+  it.each(['sender', 'viewer'] as const)(
+    'streams to both conversation tabs and keeps the other subscribed when the %s closes',
+    async (closing) => {
+      const { base, router, sent } = await start()
+      const sender = await dial(base, '?token=sender')
+      await nextFrame(sender, 'ready')
+      const viewer = await dial(base, '?token=viewer')
+      await nextFrame(viewer, 'ready')
+      const tabs = { sender, viewer }
+      sender.send(JSON.stringify({ text: 'hello agent', turnId: AGENT }))
+      await nextFrame(sender, 'ack')
+
+      const frames: RdChat[] = ['Hello', ' from', ' the agent'].map((text, index) => ({
+        chatId: RESUME,
+        seq: index,
+        event: {
+          kind: 'output',
+          output: {
+            conversationId: RESUME,
+            turnId: AGENT,
+            agentId: AGENT,
+            index,
+            event: { kind: 'message', text }
+          }
+        }
+      }))
+      frames.push({
+        chatId: RESUME,
+        seq: frames.length,
+        event: {
+          kind: 'done',
+          done: { conversationId: RESUME, turnId: AGENT, agentId: AGENT, lastIndex: frames.length - 1 }
+        }
+      })
+      for (const frame of frames) router.deliver(frame)
+      for (const tab of [sender, viewer]) {
+        expect(await nextFrame(tab, 'done')).toEqual({
+          type: 'done',
+          done: { conversationId: RESUME, turnId: AGENT, agentId: AGENT, lastIndex: 2 }
+        })
+        expect(tab.frames).toEqual(
+          frames.slice(0, -1).map((frame) => ({
+            type: 'output',
+            output: frame.event.kind === 'output' ? frame.event.output : undefined
+          }))
+        )
+        tab.frames.length = 0
+      }
+
+      const post = {
+        postId: DAEMON,
+        conversationId: RESUME,
+        author: { kind: 'agent' as const, agentId: AGENT },
+        text: 'Hello from the agent',
+        at: 1_000
+      }
+      router.deliverPost({ conversationId: RESUME, agentId: AGENT, post })
+      expect(await nextFrame(sender, 'post')).toEqual({ type: 'post', post })
+      expect(await nextFrame(viewer, 'post')).toEqual({ type: 'post', post })
+
+      tabs[closing].close()
+      await vi.waitFor(() => expect(sent.some((message) => message.payload.op === 'close')).toBe(true))
+      const remaining = closing === 'sender' ? viewer : sender
+      expect(router.size()).toBe(1)
+      router.deliver(frames.at(-1)!)
+      expect((await nextFrame(remaining, 'done')).done).toMatchObject({ turnId: AGENT, lastIndex: 2 })
+      remaining.close()
+      await vi.waitFor(() => expect(router.size()).toBe(0))
+    }
+  )
 
   it('uses only the CP-verified entitlement even when browser fields try to override it', async () => {
     const forged = {

--- a/packages/relay/src/webchat-router.test.ts
+++ b/packages/relay/src/webchat-router.test.ts
@@ -50,15 +50,15 @@ describe('WebchatRouter', () => {
     expect(r.size()).toBe(0)
   })
 
-  it('unregister is only-if-still-ours — a stale close must not evict a resumed socket', () => {
+  it('a stale close removes only its own subscription', () => {
     const r = new WebchatRouter()
     const first = sink()
     const second = sink()
     r.register(CHAT_A, first)
-    r.register(CHAT_A, second) // a resume reclaims the same chatId
-    r.unregister(CHAT_A, first) // the OLD socket's late close fires — must be a no-op
+    r.register(CHAT_A, second)
+    r.unregister(CHAT_A, first)
     r.deliver(chat(CHAT_A))
-    expect(second.onChat).toHaveBeenCalledOnce() // resumed socket still attached
+    expect(second.onChat).toHaveBeenCalledOnce()
     expect(first.onChat).not.toHaveBeenCalled()
   })
 })

--- a/packages/relay/src/webchat-router.ts
+++ b/packages/relay/src/webchat-router.ts
@@ -1,13 +1,4 @@
-/**
- * `WebchatRouter` — the relay's `chatId → browser connection` index (shared-bot-relay.md
- * §7.2). A daemon streams a turn's reply back as `rd/chat { chatId, seq, event }` over
- * its rd/* socket; the relay looks the chatId up here and forwards each chunk to the
- * browser that owns that conversation. Registered when a browser socket opens, removed
- * (only-if-still-ours) on close. A completed reply post (`rd/webchat-post`) resolves
- * through the same index: the browser connection holds the conversation's verified
- * roster, so it both renders the post and fans the context copies out
- * (webchat-multi-agents.md §5.2).
- */
+// Fan conversation output to its verified browser connections; cache rosters separately for peer-daemon context.
 import type { RdChat, RdWebchatPost } from '@agentconnect.md/protocol'
 
 /** The browser sink the router delivers a reply chunk to. */
@@ -71,11 +62,13 @@ export function bindWebchatPostAuthor(
 }
 
 export class WebchatRouter {
-  private byChatId = new Map<string, ChatSink>()
+  private byChatId = new Map<string, Set<ChatSink>>()
   private rosterByChatId = new Map<string, CachedParticipant[]>()
 
   register(chatId: string, sink: ChatSink): void {
-    this.byChatId.set(chatId, sink)
+    let sinks = this.byChatId.get(chatId)
+    if (!sinks) this.byChatId.set(chatId, (sinks = new Set()))
+    sinks.add(sink)
   }
 
   /** Cache a conversation's CP-verified roster (called on every browser connect,
@@ -97,22 +90,22 @@ export class WebchatRouter {
     return this.rosterByChatId.get(chatId) ?? []
   }
 
-  /** Remove only if `sink` is still the registered one (a stale close must not evict a resume). */
+  /** Remove only this connection; sibling tabs and reconnects remain subscribed. */
   unregister(chatId: string, sink: ChatSink): void {
-    if (this.byChatId.get(chatId) === sink) this.byChatId.delete(chatId)
+    const sinks = this.byChatId.get(chatId)
+    if (!sinks) return
+    sinks.delete(sink)
+    if (sinks.size === 0) this.byChatId.delete(chatId)
   }
 
-  /** Route one `rd/chat` to the browser owning its chatId (dropped if none is attached). */
+  /** Route output and completion to every browser subscribed to this conversation. */
   deliver(chat: RdChat): void {
-    this.byChatId.get(chat.chatId)?.onChat(chat)
+    for (const sink of this.byChatId.get(chat.chatId) ?? []) sink.onChat(chat)
   }
 
-  /** Render one `rd/webchat-post` to the browser owning its conversation, when one is
-   *  attached (the live stream already showed the text; this is the canonical record).
-   *  Peer-daemon context fan-out happens SEPARATELY from the roster cache — never
-   *  through the browser sink, which may be gone mid-turn. */
+  /** Render the canonical post to every subscriber; peer-daemon context uses the independent roster cache. */
   deliverPost(post: RdWebchatPost): void {
-    this.byChatId.get(post.conversationId)?.onPost?.(post)
+    for (const sink of this.byChatId.get(post.conversationId) ?? []) sink.onPost?.(post)
   }
 
   size(): number {


### PR DESCRIPTION
Opening another tab for a running webchat conversation replaced the original tab's relay subscription. The original tab could miss output and completion, leaving its reply unfinished until reload.

Keep all verified browser subscriptions for each conversation and remove only the closing connection. Deliver indexed output, completion, and canonical posts to every subscriber on that relay.

Validation: 65 focused relay tests passed, including real WebSocket regressions that failed before the fix and verify delivery to both tabs and continued delivery after either closes. Relay typecheck, ESLint, Prettier, and diff checks passed. This addresses subscriptions on the same relay; it does not change cross-relay routing or idle-viewer UI synchronization.

Created by Codex . GPT-6
