### PR TITLE
feat(daemon): a control-plane memory home is selected, gated, and served without waking the pod

### DIFF
--- a/packages/daemon/src/cp/control/dream.ts
+++ b/packages/daemon/src/cp/control/dream.ts
@@ -15,7 +15,7 @@ import type {
 } from '@agentconnect.md/protocol'
 import { DreamStateError, DreamViolationError } from '../../dream/runner.js'
 import type { DreamReader } from '../dream-reader.js'
-import { MemorySandboxUnavailableError } from '../memory-reader.js'
+import { MemoryHomeUnavailableError } from '../memory-reader.js'
 import type { ControlHandler, ControlWire } from './context.js'
 
 export interface DreamControlDeps {
@@ -125,8 +125,8 @@ function dreamError(wire: ControlWire, corr: string, op: string, err: unknown): 
     wire.sendError(corr, 'BAD_PAYLOAD', `${op} failed: ${err.message}`, false)
     return
   }
-  // A cluster agent's staging is on its sandbox volume: asleep is transient, and carries the reason.
-  if (err instanceof MemorySandboxUnavailableError) {
+  // The home is out of reach — a cluster agent's staging on a sleeping pod, or a `control-plane` store behind a missing connection: transient, and it carries the reason.
+  if (err instanceof MemoryHomeUnavailableError) {
     wire.sendError(corr, 'BAD_PAYLOAD', `${op} failed: ${err.message}`, false, { reason: err.reason })
     return
   }

--- a/packages/daemon/src/cp/control/memory.ts
+++ b/packages/daemon/src/cp/control/memory.ts
@@ -16,8 +16,9 @@ import type {
 } from '@agentconnect.md/protocol'
 import {
   MemoryConflictError,
+  MemoryHistoryNotLocalError,
+  MemoryHomeUnavailableError,
   MemoryPathError,
-  MemorySandboxUnavailableError,
   MemoryTooLargeError,
   MemoryViolationError,
   type MemoryReader
@@ -129,10 +130,17 @@ function memoryError(wire: ControlWire, corr: string, op: string, err: unknown):
     wire.sendError(corr, 'CONFLICT', `${op} failed: ${err.message}`, false)
     return
   }
-  // The memory tree is on a sandbox that is not running: refused with the workspace reader's
-  // reason, so the CP answers 503 with the code the console wakes on (#1077) — not a 400.
-  if (err instanceof MemorySandboxUnavailableError) {
+  // The home is out of reach — a sleeping sandbox, or a `control-plane` tree behind a missing connection, feature, or
+  // migration copy: every reason is "not now" for the console, so it is refused WITH the reason and the CP answers 503
+  // (for `sandbox-unavailable` with the code the console wakes on, #1077) — never a 400 that would stop the retry.
+  if (err instanceof MemoryHomeUnavailableError) {
     wire.sendError(corr, 'BAD_PAYLOAD', `${op} failed: ${err.message}`, false, { reason: err.reason })
+    return
+  }
+  // A page of a change log the home keeps itself was routed to this daemon: a routing bug that must show as one.
+  if (err instanceof MemoryHistoryNotLocalError) {
+    wire.log.warn(`cp: ${op} failed: ${err.message}`)
+    wire.sendError(corr, 'INTERNAL', `${op} failed: ${err.message}`, false)
     return
   }
   if (err instanceof MemoryViolationError || err instanceof MemoryPathError || err instanceof MemoryTooLargeError) {

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -52,7 +52,7 @@ import { agentSandboxSubject } from '../k8s/sandbox-identity.js'
 import { createSandboxKeepAlive } from './sandbox-keepalive.js'
 import type { SystemMetrics } from '../metrics/system-metrics.js'
 import type { ReadinessGate } from '../readiness.js'
-import type { MemoryFs } from '../memory/store.js'
+import type { MemoryHomePorts } from '../memory/home.js'
 import type { DreamRunner } from '../dream/runner.js'
 import type { CodeHostNoteProjector } from '../gitlab/note-projection.js'
 
@@ -145,7 +145,9 @@ export interface CpClientSeamHost {
   memory(): AgentMemoryAdminResolver
   dreamRunner(): DreamRunner
   runtimeCommands(): RuntimeCommandsCache
-  memoryFsFor(agentId: string): MemoryFs | undefined
+  memoryHomePortsFor(agentId: string): MemoryHomePorts | undefined
+  /** Drain the managed captures deferred while a memory home was out of reach — a READY connection is a reachable `control-plane` home. */
+  wakeMemoryOutbox(): void
   gitCommitIdentity(): GitCommitIdentity | undefined
   sessionThreadUrl(session: SessionRecord): string | undefined
   childSessionStatusProbe(probe: ChildSessionStatusProbe): Promise<ChildSessionStatus>
@@ -264,6 +266,8 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
           host.log().warn(`cp: organization suggestion replay failed (${err instanceof Error ? err.name : 'unknown'})`)
         )
       host.cpClient()?.emitMemoryConnectionFacts(host.memoryConnections()?.facts() ?? [])
+      // A READY connection is a reachable `control-plane` memory home: distill the turns that waited for it.
+      host.wakeMemoryOutbox()
       await host.replayHookTerminalReports()
       await host.replayChannelSnapshots()
       // Only snapshots written to the durable outbox by this build are
@@ -399,7 +403,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
         host.dutyCoordinator().dutyEnforced() && (await host.dutyCoordinator().claimDutyForTrigger(id)).granted,
       log: host.log()
     }),
-    memoryReader: createMemoryReader((id) => host.memoryFsFor(id), host.memory()),
+    memoryReader: createMemoryReader((id) => host.memoryHomePortsFor(id), host.memory()),
     dreamReader: createDreamReader(host.dreamRunner()),
     localSkillsReader: createLocalSkillsReader(
       host.workspaces(),

--- a/packages/daemon/src/cp/memory-fs.ts
+++ b/packages/daemon/src/cp/memory-fs.ts
@@ -1,5 +1,5 @@
-// The `control-plane` memory home: the shim client over the daemon's CP connection (memory-evolution.md §3.2.1).
-// Nothing selects it yet — `resolveMemoryHomePorts` still chooses between the local port and the sandbox port.
+// The `control-plane` memory home: the shim client over the daemon's CP connection (memory-evolution.md §3.2.1), which
+// `resolveMemoryHomePorts` selects as `live` for a managed binding whose `home` is `control-plane`, gated at activation.
 import { AGENT_MEMORY_STORE_V1_FEATURE, type MemoryFsReply, type MemoryStoreReq } from '@agentconnect.md/protocol'
 import { WireError } from '@agentconnect.md/connection'
 import { MemoryHomeUnavailableError, memoryRelSegments, type MemoryFs } from '../memory/fs.js'

--- a/packages/daemon/src/cp/memory-history.ts
+++ b/packages/daemon/src/cp/memory-history.ts
@@ -1,6 +1,6 @@
 // The `control-plane` home's change log (memory-evolution.md §3.2.1): the daemon still composes every record and sends
 // it AFTER the write as a best-effort `memory/history/append` batch — provenance never fails the write — and never
-// reads the log back, since the CP answers the console from its own table. Nothing selects it yet, like `CpMemoryFs`.
+// reads the log back, since the CP answers the console from its own table. `resolveMemoryHomePorts` selects it beside `CpMemoryFs`.
 import {
   AGENT_MEMORY_STORE_V1_FEATURE,
   MEMORY_HISTORY_APPEND_MAX_RECORDS,

--- a/packages/daemon/src/cp/memory-reader.ts
+++ b/packages/daemon/src/cp/memory-reader.ts
@@ -52,10 +52,12 @@ import {
   MemoryPathError,
   MemoryTooLargeError,
   MemoryConflictError,
+  MemoryHistoryNotLocalError,
   MemoryHomeUnavailableError,
   MemorySandboxUnavailableError,
   type MemoryFs
 } from '../memory/store.js'
+import type { MemoryHomePorts } from '../memory/home.js'
 import type { MemoryAdminSurface, MemoryScope } from '../memory/provider.js'
 
 /** Unknown-agent violation → `BAD_PAYLOAD` on the wire (path escapes surface as
@@ -71,6 +73,7 @@ export {
   MemoryPathError,
   MemoryTooLargeError,
   MemoryConflictError,
+  MemoryHistoryNotLocalError,
   MemoryHomeUnavailableError,
   MemorySandboxUnavailableError
 }
@@ -99,25 +102,29 @@ function isErrno(err: unknown, code: string): boolean {
   return (err as NodeJS.ErrnoException | null)?.code === code
 }
 
-/** `memoryFsFor` resolves an agent id → the port over its managed memory tree
- *  (undefined for an unknown agent); it throws `MemorySandboxUnavailableError` for a
- *  cluster agent whose sandbox is not running. */
+// `memoryHomePortsFor` resolves an agent id → the ports over its managed memory home (undefined for an unknown agent);
+// it throws `MemoryHomeUnavailableError` while the home is out of reach — a sleeping sandbox, or a `control-plane` tree
+// whose connection, feature, or migration copy is missing — and that refusal carries its reason to the CP.
 export function createMemoryReader(
-  memoryFsFor: (agentId: string) => MemoryFs | undefined,
+  memoryHomePortsFor: (agentId: string) => MemoryHomePorts | undefined,
   provider?: AgentMemoryAdminResolver
 ): MemoryReader {
-  function dirFor(agentId: string): MemoryFs {
-    const fs = memoryFsFor(agentId)
-    if (!fs) throw new MemoryViolationError(`unknown agent "${agentId}"`)
-    return fs
+  function portsFor(agentId: string): MemoryHomePorts {
+    const ports = memoryHomePortsFor(agentId)
+    if (!ports) throw new MemoryViolationError(`unknown agent "${agentId}"`)
+    return ports
   }
 
-  /** Identity only: a known agent whose sandbox is asleep is still a known agent. */
+  function dirFor(agentId: string): MemoryFs {
+    return portsFor(agentId).live
+  }
+
+  /** Identity only: a known agent whose home is out of reach is still a known agent. */
   function assertKnown(agentId: string): void {
     try {
-      dirFor(agentId)
+      portsFor(agentId)
     } catch (err) {
-      if (!(err instanceof MemorySandboxUnavailableError)) throw err
+      if (!(err instanceof MemoryHomeUnavailableError)) throw err
     }
   }
 
@@ -131,11 +138,22 @@ export function createMemoryReader(
         list: async (scope) => listMemory(dirFor(scope.agentId)),
         read: async (scope, path) => ({ path, content: await readMemoryFile(dirFor(scope.agentId), path) }),
         write: async (scope, path, content, ifMatch, source) => {
-          const result = await writeMemoryFile(dirFor(scope.agentId), path, content, ifMatch, source)
+          const ports = portsFor(scope.agentId)
+          const result = await writeMemoryFile(
+            ports.live,
+            path,
+            content,
+            ifMatch,
+            source ?? 'console',
+            ports.historyFor(ports.live)
+          )
           return { ok: true, path, ...result }
         },
-        // Pages the sidecar; a home whose sink has no `list` (the CP's) answers the console itself — no local history here.
-        history: async (scope, req) => listMemoryHistory(dirFor(scope.agentId), req.path, req.cursor, req.limit)
+        // Pages the store's sink; a home whose sink has no `list` (the CP's) answers the console itself, and a page asked here refuses.
+        history: async (scope, req) => {
+          const ports = portsFor(scope.agentId)
+          return listMemoryHistory(ports.historyFor(ports.live), req.path, req.cursor, req.limit)
+        }
       }
     )
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -401,8 +401,13 @@ import {
   type MemoryScope,
   type PreparedExternalMemoryCapture
 } from './memory/provider.js'
-import { memoryChannelKey, MemorySandboxUnavailableError, type MemoryFs } from './memory/store.js'
-import { resolveMemoryFs, resolveMemoryHomePorts, type MemoryHomePorts } from './memory/home.js'
+import { memoryChannelKey, MemoryHomeUnavailableError, type MemoryFs } from './memory/store.js'
+import {
+  memoryHomeUnavailable,
+  resolveMemoryHomePorts,
+  type MemoryHomeDeps,
+  type MemoryHomePorts
+} from './memory/home.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
 import { DutyRegistry } from './cp/duty-registry.js'
 import { DutyCoordinator, type DutyHost } from './cp/duty-coordinator.js'
@@ -712,7 +717,7 @@ export class Daemon {
   // agent runs in the sandbox). Backs the memory MCP tools, the session-start index
   // injection, and the CP console's memory reads.
   private memory: DispatchingMemoryProvider = createMemoryProvider({
-    memoryFsFor: (id) => this.memoryFsFor(id),
+    memoryHomePortsFor: (id) => this.memoryHomePortsFor(id),
     agentDirByAgent: (id) => {
       const agent = this.agents.get(id)
       if (!agent) return undefined
@@ -2480,7 +2485,11 @@ export class Daemon {
                 (!this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(agent.id))
             )
             .map((agent) => agent.id),
-        reachable: (agentId) => !this.k8sPlane || this.k8sPlane.sandboxBound(agentId),
+        // "The home is reachable", not "the pod is bound": the CP READY with the feature for a `control-plane` tree.
+        reachable: (agentId) => {
+          const agent = this.agents.get(agentId)
+          return agent !== undefined && memoryHomeUnavailable(agent, this.memoryHomeDeps()) === undefined
+        },
         distill: async (agentId, turn) => {
           const agent = this.agents.get(agentId)
           if (!agent) throw new Error(`unknown agent ${agentId}`)
@@ -3055,6 +3064,8 @@ export class Daemon {
         this.log.warn(
           `memory recall degraded for agent ${agentId}: ${error instanceof Error ? error.name : 'unknown'}`
         ),
+      onMemoryHomeUnavailable: (agentId, error) =>
+        this.log.warn(`memory home unreachable for agent ${agentId} (${error.reason}): session starts without memory`),
       onMemoryRecallInjected: (_agentId, bytes) => defaultMemoryPluginMetrics.recallInjected(bytes),
       onMemoryRecallEvent: (agentId, event) =>
         this.evalHooks.emit({
@@ -3790,18 +3801,15 @@ export class Daemon {
     })
   }
 
-  /** The live-store port every memory consumer but the dream runner is built on, decided by placement
-   *  (`resolveMemoryFs`); undefined for an unknown agent, and it throws `MemorySandboxUnavailableError`
-   *  for a cluster agent whose sandbox is not bound. */
-  private memoryFsFor(agentId: string): MemoryFs | undefined {
-    const agent = this.agents.get(agentId)
-    return agent ? resolveMemoryFs(agent, this.k8sPlane) : undefined
+  /** Where a memory home is reached from: this member's sandbox plane (under `--k8s`) and its CP connection. */
+  private memoryHomeDeps(): MemoryHomeDeps {
+    return { sandbox: this.k8sPlane, cp: this.cpClient, log: this.log }
   }
 
-  /** The dream runner's pair — `live` for the store, `staging` for `memory-dreams/` — decided the same way. */
+  /** The ports every managed-memory consumer is built on — `live` for the store, `staging` for `memory-dreams/`, the change-log sink — decided by the agent's `home` and this member's placement; undefined for an unknown agent, and it throws `MemoryHomeUnavailableError` while the home is out of reach. */
   private memoryHomePortsFor(agentId: string): MemoryHomePorts | undefined {
     const agent = this.agents.get(agentId)
-    return agent ? resolveMemoryHomePorts(agent, this.k8sPlane) : undefined
+    return agent ? resolveMemoryHomePorts(agent, this.memoryHomeDeps()) : undefined
   }
 
   /** The one daemon-owned workspace preparation contract used by ordinary
@@ -5069,8 +5077,8 @@ export class Daemon {
           })
         }
       } catch (error) {
-        // A deferred managed capture (sandbox asleep) is not a failure: it completes from the outbox.
-        if (observableCapture && !(error instanceof MemorySandboxUnavailableError)) {
+        // A deferred managed capture (the home out of reach) is not a failure: it completes from the outbox.
+        if (observableCapture && !(error instanceof MemoryHomeUnavailableError)) {
           this.evalHooks.emit({
             type: 'memory.capture.failed',
             agentId,
@@ -5083,7 +5091,9 @@ export class Daemon {
       }
     }
     const logFailure = (err: unknown) =>
-      this.log.warn(`memory post-turn failed for agent ${agentId}: ${err instanceof Error ? err.name : 'unknown'}`)
+      this.log.warn(
+        `memory post-turn failed for agent ${agentId}: ${err instanceof Error ? err.name : 'unknown'}${err instanceof MemoryHomeUnavailableError ? ` (${err.reason})` : ''}`
+      )
 
     // External recordTurn performs only a synchronous SQLite enqueue before it
     // returns its promise. Do it immediately after delivery, rather than placing
@@ -5102,9 +5112,9 @@ export class Daemon {
         await record()
       })
       .catch(async (err: unknown) => {
-        // The tree is on a sandbox that has gone to sleep since the turn: keep the capture durably and
-        // distill it once the pod is bound again, instead of dropping the turn with a warning.
-        if (err instanceof MemorySandboxUnavailableError && this.memoryOutbox) {
+        // The home went out of reach since the turn (the pod asleep, the CP connection down): keep the capture durably
+        // and distill it once the home is reachable again, instead of dropping the turn with a warning.
+        if (err instanceof MemoryHomeUnavailableError && this.memoryOutbox) {
           const result = await this.memoryOutbox.enqueue(
             managedDistillCapture({ agentId, turnId, sessionId, input, output })
           )
@@ -17745,7 +17755,8 @@ export class Daemon {
       memory: () => this.memory,
       dreamRunner: () => this.dreamRunner(),
       runtimeCommands: () => this.runtimeCommands,
-      memoryFsFor: (agentId) => this.memoryFsFor(agentId),
+      memoryHomePortsFor: (agentId) => this.memoryHomePortsFor(agentId),
+      wakeMemoryOutbox: () => this.memoryOutbox?.wake(),
       gitCommitIdentity: () => this.gitCommitIdentity,
       sessionThreadUrl: (session) => this.sessionThreadUrl(session),
       childSessionStatusProbe: (probe) => this.collab.childSessionStatusProbe(probe),

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -30,7 +30,7 @@ import {
   MAX_INDEX_INJECT_BYTES,
   MAX_MEMORY_FILE_BYTES,
   MEMORY_DIRNAME,
-  MemorySandboxUnavailableError,
+  MemoryHomeUnavailableError,
   listMemory,
   memoryHistoryRecord,
   memoryWriteMarks,
@@ -184,8 +184,7 @@ export interface DreamLifecycleEvent {
 export interface DreamRunnerDeps {
   /** The agent's LOCAL root (accepted skills publish under it); undefined for an unknown agent. */
   agentDirByAgent(agentId: string): string | undefined
-  /** The agent's two memory ports — `live` for the store, `staging` for `memory-dreams/` — or undefined for an
-   *  unknown agent. May refuse with `MemorySandboxUnavailableError` for a cluster agent whose sandbox is not running. */
+  /** The agent's two memory ports — `live` for the store, `staging` for `memory-dreams/` — or undefined for an unknown agent. May refuse with `MemoryHomeUnavailableError` while the home is out of reach. */
   memoryHomePortsFor(agentId: string): MemoryHomePorts | undefined
   /** The agent's dreaming policy, or undefined when dreaming is not enabled
    *  (missing binding, non-managed provider, or enabled:false). */
@@ -348,9 +347,8 @@ export class DreamRunner {
       for (const dream of await this.deps.store.supersededDreams()) {
         if (!this.deps.agentDirByAgent(dream.agentId)) continue
         void this.removeStoreStaging(dream.agentId, dream).catch((err) => {
-          // A cluster agent's tree is unreachable while its sandbox sleeps; the staging is a few
-          // files on its own volume, so leaving it is not worth a warning per boot.
-          if (err instanceof MemorySandboxUnavailableError) return
+          // An agent's home may be out of reach at boot (its sandbox asleep, the CP not yet READY); the staging is a few files, so leaving it is not worth a warning per boot.
+          if (err instanceof MemoryHomeUnavailableError) return
           this.deps.log.warn(
             `dream ${dream.dreamId}: could not remove superseded store staging (${err instanceof Error ? err.message : 'unknown'})`
           )

--- a/packages/daemon/src/memory/fs.ts
+++ b/packages/daemon/src/memory/fs.ts
@@ -43,8 +43,9 @@ export class MemoryConflictError extends Error {
   }
 }
 
-/** Why a home is out of reach: no bound pod, or the CP connection, its feature, or this member's duty is missing. */
-export type MemoryHomeUnavailableReason = 'sandbox-unavailable' | 'connection' | 'feature' | 'scope-denied'
+/** Why a home is out of reach: no bound pod; the CP connection, its feature, or this member's duty missing; or a migration copy still pending. */
+export type MemoryHomeUnavailableReason =
+  'sandbox-unavailable' | 'connection' | 'feature' | 'scope-denied' | 'migrating'
 
 /** Raised when an agent's memory home cannot be reached — one resolution, never a fallback to this member's disk. */
 export class MemoryHomeUnavailableError extends Error {

--- a/packages/daemon/src/memory/home.ts
+++ b/packages/daemon/src/memory/home.ts
@@ -1,7 +1,15 @@
 // Where an agent's managed memory lives — the ONE placement decision — as the file ports plus the change-log sink
-// (memory-evolution.md §3.2.1). Today the tree is on this disk or on the bound sandbox volume, and the sidecar inside
-// the store is the sink either way; a `control-plane` home will pick `CpMemoryFs` and `CpMemoryHistorySink` here.
-import { LocalMemoryFs, MemorySandboxUnavailableError, type MemoryFs } from './fs.js'
+// (memory-evolution.md §3.2.1). A `daemon` home is this disk or the bound sandbox volume with the sidecar as its sink; a
+// `control-plane` home is `CpMemoryFs` over the CP connection with `CpMemoryHistorySink`, gated here at activation.
+import {
+  AGENT_MEMORY_STORE_V1_FEATURE,
+  type AgentMemoryBinding,
+  type ManagedMemoryHome
+} from '@agentconnect.md/protocol'
+import { CpMemoryFs, type CpMemoryStoreLink } from '../cp/memory-fs.js'
+import { CpMemoryHistorySink, type CpMemoryHistoryLink } from '../cp/memory-history.js'
+import type { Logger } from '../log.js'
+import { LocalMemoryFs, MemoryHomeUnavailableError, MemorySandboxUnavailableError, type MemoryFs } from './fs.js'
 import { SidecarMemoryHistorySink, type MemoryHistorySink } from './store.js'
 
 /** The sandbox plane as the factory sees it: the port over a bound sandbox volume, or nothing. */
@@ -9,48 +17,109 @@ export interface SandboxMemoryFsSource {
   memoryFsFor(agentId: string): MemoryFs | undefined
 }
 
-/** The ports the dream runner and every managed-memory writer work over; today `live` and `staging` are one tree. */
+/** The CP connection as a memory home: the store and change-log request pairs behind the READY and feature gates. */
+export type CpMemoryHomeLink = CpMemoryStoreLink & CpMemoryHistoryLink
+
+/** What the factory reads off an agent: its root on this disk, and the binding whose `home` places the tree. */
+export interface MemoryHomeAgent {
+  id: string
+  dir: string
+  memory?: AgentMemoryBinding | undefined
+}
+
+/** Where the homes are reached from: the sandbox plane of a `--k8s` member, and the CP connection. */
+export interface MemoryHomeDeps {
+  /** Every agent of a `--k8s` daemon runs in a pod; absent on a self-hosted daemon. */
+  sandbox?: SandboxMemoryFsSource | undefined
+  /** Absent until the daemon has a CP client — a `control-plane` home is then unreachable, never this member's disk. */
+  cp?: CpMemoryHomeLink | undefined
+  log: Pick<Logger, 'warn'>
+}
+
+/** The ports the dream runner and every managed-memory writer work over. */
 export interface MemoryHomePorts {
   /** The live store: `memory/`, `channels/`, `memory-backups/`, and the adoption temp dir beside them. */
   live: MemoryFs
-  /** Dream staging (`memory-dreams/`), on the filesystem the extraction host runs in — its root is the host's cwd. */
+  /** Dream staging (`memory-dreams/`) beside the extraction host; resolved on access, so over a sandbox volume it refuses with `MemorySandboxUnavailableError` while the pod is not bound. */
   staging: MemoryFs
   /** The change-log sink for one store under `live` (the agent's own tree or a channel root), in its coordinates. */
   historyFor(store: MemoryFs): MemoryHistorySink
 }
 
-/** The sidecar inside whichever store is written: the sink every home selects today. */
+/** The sidecar inside whichever store is written: the sink of every `daemon` home, and of every staged store. */
 export function sidecarMemoryHistory(store: MemoryFs): MemoryHistorySink {
   return new SidecarMemoryHistorySink(store)
 }
 
-/**
- * With a sandbox plane (every agent of a `--k8s` daemon runs in a pod) the tree is the port over the agent's sandbox
- * volume, reachable exactly while the pod is bound — no fallback to this member's disk, since a duty move would leave
- * the memory behind; without one, the local port over the agent dir. A later home moves `live` and the sink alone;
- * `staging` stays where the extraction host can see it.
- */
-export function resolveMemoryHomePorts(
-  agent: { id: string; dir: string },
-  sandbox: SandboxMemoryFsSource | undefined
-): MemoryHomePorts {
-  if (!sandbox) {
-    const fs = new LocalMemoryFs(agent.dir)
-    return { live: fs, staging: fs, historyFor: sidecarMemoryHistory }
-  }
-  const fs = sandbox.memoryFsFor(agent.id)
-  if (!fs) {
-    throw new MemorySandboxUnavailableError(
-      `agent "${agent.id}" has no running sandbox, so its memory cannot be reached`
-    )
-  }
+/** The `daemon` home's ports over one tree: both roles on it, the sidecar inside it as the sink. */
+export function localMemoryHome(fs: MemoryFs): MemoryHomePorts {
   return { live: fs, staging: fs, historyFor: sidecarMemoryHistory }
 }
 
+/** The agent's `home`: what a managed binding says, `daemon` for every other binding (`none`/`native` carry none). */
+export function memoryHomeOf(agent: Pick<MemoryHomeAgent, 'memory'>): ManagedMemoryHome {
+  return agent.memory?.provider === 'managed' ? agent.memory.home : 'daemon'
+}
+
+function sandboxAsleep(agentId: string): MemorySandboxUnavailableError {
+  return new MemorySandboxUnavailableError(`agent "${agentId}" has no running sandbox, so its memory cannot be reached`)
+}
+
+/** The tree the agent's pod holds, or this disk without a plane: the `daemon` home's store, and every home's dream staging. */
+function sandboxOrLocalPort(agent: MemoryHomeAgent, sandbox: SandboxMemoryFsSource | undefined): MemoryFs {
+  if (!sandbox) return new LocalMemoryFs(agent.dir)
+  const fs = sandbox.memoryFsFor(agent.id)
+  if (!fs) throw sandboxAsleep(agent.id)
+  return fs
+}
+
+// Why the agent's memory home is out of reach right now, or undefined when it can be served: the activation gate
+// `resolveMemoryHomePorts` refuses on, and the memory capture outbox's reachability predicate. One resolution, never a
+// fallback to this member's disk — a `daemon` home on a pool member needs its pod bound; a `control-plane` home needs
+// the CP connection READY and advertising `agent-memory-store-v1`, and no migration copy still pending against it.
+export function memoryHomeUnavailable(
+  agent: MemoryHomeAgent,
+  deps: MemoryHomeDeps
+): MemoryHomeUnavailableError | undefined {
+  if (memoryHomeOf(agent) !== 'control-plane') {
+    return deps.sandbox && !deps.sandbox.memoryFsFor(agent.id) ? sandboxAsleep(agent.id) : undefined
+  }
+  const home = `agent "${agent.id}" keeps its memory in the Control Plane, which`
+  // Step ④ stamps `homeMigration: 'pending'` on a flipped binding and step ⑧ clears it after the copy: no CP tree is served before the copy exists.
+  if ((agent.memory as { homeMigration?: 'pending' } | undefined)?.homeMigration === 'pending') {
+    return new MemoryHomeUnavailableError('migrating', `${home} is still receiving the copy of its tree`)
+  }
+  if (!deps.cp?.connected()) return new MemoryHomeUnavailableError('connection', `${home} is unreachable`)
+  if (!deps.cp.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+    return new MemoryHomeUnavailableError('feature', `${home} does not serve the memory store`)
+  }
+  return undefined
+}
+
+// The selection. A `daemon` home is one tree for both roles — the local port over the agent dir, or the port over the
+// agent's sandbox volume, reachable exactly while the pod is bound. A `control-plane` home puts `live` and the sink on
+// the CP connection without touching any pod, and leaves `staging` where the extraction host can see it.
+export function resolveMemoryHomePorts(agent: MemoryHomeAgent, deps: MemoryHomeDeps): MemoryHomePorts {
+  if (memoryHomeOf(agent) !== 'control-plane') return localMemoryHome(sandboxOrLocalPort(agent, deps.sandbox))
+  const unavailable = memoryHomeUnavailable(agent, deps)
+  if (unavailable) throw unavailable
+  const cp = deps.cp!
+  const live = new CpMemoryFs(cp, agent.id)
+  return {
+    live,
+    // Looked up on use, not at activation: the store never needs the pod, and a review of a draft on the pool still wakes it.
+    get staging(): MemoryFs {
+      return sandboxOrLocalPort(agent, deps.sandbox)
+    },
+    // A store under `live` logs to the CP table in its own coordinates; a staged store, never in the CP, keeps its sidecar.
+    historyFor: (store) =>
+      store instanceof CpMemoryFs
+        ? new CpMemoryHistorySink(cp, agent.id, store.root, deps.log)
+        : sidecarMemoryHistory(store)
+  }
+}
+
 /** The live store alone, for the consumers that never touch dream staging (the provider, the CP memory reader). */
-export function resolveMemoryFs(
-  agent: { id: string; dir: string },
-  sandbox: SandboxMemoryFsSource | undefined
-): MemoryFs {
-  return resolveMemoryHomePorts(agent, sandbox).live
+export function resolveMemoryFs(agent: MemoryHomeAgent, deps: MemoryHomeDeps): MemoryFs {
+  return resolveMemoryHomePorts(agent, deps).live
 }

--- a/packages/daemon/src/memory/managed-distill-outbox.ts
+++ b/packages/daemon/src/memory/managed-distill-outbox.ts
@@ -1,14 +1,9 @@
-/**
- * Managed distillation as a durable capture: the post-turn distillation of a cluster agent needs its
- * sandbox (the memory tree lives on the volume, and the extraction runs on the warm host in the pod).
- * When the turn's capture arrives after the pod was suspended, the turn is enqueued in the memory
- * capture outbox — the same durable, shared-store-safe pump external plugins use — under a synthetic
- * per-agent connection, and drained once the sandbox is bound again on the member holding the agent.
- *
- * The outbox knows nothing new: this module presents one "connection" per agent through the same
- * registry contract, answering no client while the tree is unreachable (the pump then defers the row
- * without spending an attempt) and a client that runs the distillation once it is.
- */
+// Managed distillation as a durable capture: a post-turn distillation needs the agent's memory home — the sandbox volume
+// (and the warm host in the pod), or the Control Plane for a `control-plane` tree. A turn captured while the home is out
+// of reach is enqueued in the memory capture outbox — the same durable, shared-store-safe pump external plugins use —
+// under a synthetic per-agent connection, and drained once the home is reachable again on the member holding the agent.
+// The outbox knows nothing new: one "connection" per agent through the same registry contract, answering no client while
+// the home is unreachable (the pump then defers the row without spending an attempt) and a distilling one once it is.
 import type { CaptureReceipt, MemoryPluginCaptureInput } from '@agentconnect.md/protocol'
 import type { EnqueueMemoryCapture, MemoryCaptureClient, MemoryCapturePumpRegistry } from '../memory-plugin/outbox.js'
 
@@ -50,7 +45,7 @@ export function managedDistillCapture(input: {
 export interface ManagedDistillDeps {
   /** Agents whose deferred distillations this member may drain: held here, managed memory. */
   agentIds(): readonly string[]
-  /** Whether the agent's memory tree is reachable right now (its sandbox is bound, or it is local). */
+  /** Whether the agent's memory home is reachable right now: this disk always, a sandbox volume while the pod is bound, a `control-plane` tree while the CP is READY with the feature and no migration copy pending. */
   reachable(agentId: string): boolean
   /** Run the distillation for one turn against the live tree; throws when it cannot. */
   distill(agentId: string, turn: MemoryPluginCaptureInput['turn']): Promise<void>

--- a/packages/daemon/src/memory/providers/dispatching.ts
+++ b/packages/daemon/src/memory/providers/dispatching.ts
@@ -2,7 +2,8 @@ import type { AgentMemoryBinding, CaptureReceipt, ExternalMemoryBinding, MemoryE
 import type { RuntimeDef } from '../../config/config-schema.js'
 import type { ToolDescriptor } from '../../tool-schema/descriptor.js'
 import { MEMORY_TOOLS } from '../tools.js'
-import type { MemoryFs, MemoryWriteSource } from '../store.js'
+import type { MemoryWriteSource } from '../store.js'
+import type { MemoryHomePorts } from '../home.js'
 import {
   MemoryProviderUnavailableError,
   type MemoryAdminSurface,
@@ -29,8 +30,8 @@ import {
 
 /** The daemon-side resolvers the dispatcher routes on. */
 export interface MemoryProviderDeps {
-  /** The port over the agent's MANAGED memory tree — the daemon's one placement decision. */
-  memoryFsFor: (agentId: string) => MemoryFs | undefined
+  /** The ports over the agent's MANAGED memory home — the daemon's one placement decision. */
+  memoryHomePortsFor: (agentId: string) => MemoryHomePorts | undefined
   /** The agent's LOCAL root: the runtime's own (native) memory is redirected under it. */
   agentDirByAgent: (agentId: string) => string | undefined
   runtimeFor: (agentId: string) => RuntimeDef | undefined
@@ -65,7 +66,11 @@ export class DispatchingMemoryProvider implements MemoryProvider {
     this.providerKindFor = deps.providerKindFor
     this.externalBindingFor = deps.externalBindingFor ?? (() => undefined)
     this.externalDeps = deps.externalDeps
-    this.managed = new ManagedMemoryProvider(deps.memoryFsFor, deps.autoDistillFor ?? (() => false), deps.extract)
+    this.managed = new ManagedMemoryProvider(
+      deps.memoryHomePortsFor,
+      deps.autoDistillFor ?? (() => false),
+      deps.extract
+    )
     this.native = new NativeMemoryProvider(deps.agentDirByAgent, deps.runtimeFor)
     this.none = new NoMemoryProvider()
   }

--- a/packages/daemon/src/memory/providers/factory.ts
+++ b/packages/daemon/src/memory/providers/factory.ts
@@ -1,5 +1,5 @@
 import type { RuntimeDef } from '../../config/config-schema.js'
-import type { MemoryFs } from '../store.js'
+import type { MemoryHomePorts } from '../home.js'
 import { isNativeRuntimeSupported, nativeRuntimeEnv } from '../runtime/native.js'
 import { describeRuntime } from '../runtime/capabilities.js'
 import { MemoryProviderUnavailableError, type MemoryProvider, type MemoryProviderKind } from '../types.js'
@@ -65,7 +65,9 @@ export function createMemoryProvider(deps: MemoryProviderDeps): DispatchingMemor
   return new DispatchingMemoryProvider(deps)
 }
 
-/** A managed-only provider (used where per-agent dispatch isn't needed, e.g. tests). */
-export function createManagedMemoryProvider(memoryFsFor: (agentId: string) => MemoryFs | undefined): MemoryProvider {
-  return new ManagedMemoryProvider(memoryFsFor)
+/** A managed-only provider over the agents' memory homes (used where per-agent dispatch isn't needed, e.g. tests). */
+export function createManagedMemoryProvider(
+  memoryHomePortsFor: (agentId: string) => MemoryHomePorts | undefined
+): MemoryProvider {
+  return new ManagedMemoryProvider(memoryHomePortsFor)
 }

--- a/packages/daemon/src/memory/providers/managed.ts
+++ b/packages/daemon/src/memory/providers/managed.ts
@@ -15,8 +15,10 @@ import {
   MEMORY_INDEX,
   type MemoryFile,
   type MemoryFs,
+  type MemoryHistorySink,
   type MemoryWriteSource
 } from '../store.js'
+import { sidecarMemoryHistory, type MemoryHomePorts } from '../home.js'
 import { buildDistillationPrompt } from '../distill.js'
 import type {
   FileMemoryAdmin,
@@ -32,50 +34,44 @@ import type {
 } from '../types.js'
 import { disabledRuntimeMemoryEnv } from './runtime-env.js'
 
-/**
- * `managed` memory: our `<root>/memory/` directory. A thin facade over
- * `memory/store.ts` — every method delegates to the existing primitive and lets
- * its error classes (`MemoryPathError` / `MemoryTooLargeError` /
- * `MemoryConflictError`) propagate raw, so the MCP + CP error mappings are unchanged.
- * Where the tree IS (this disk, a sandbox volume) is the factory's answer: it hands
- * back the port and may refuse with `MemorySandboxUnavailableError`.
- */
+// `managed` memory: our `<root>/memory/` directory. A thin facade over `memory/store.ts` — every method delegates to the
+// existing primitive and lets its error classes (`MemoryPathError` / `MemoryTooLargeError` / `MemoryConflictError`)
+// propagate raw, so the MCP + CP error mappings are unchanged. Where the tree IS (this disk, a sandbox volume, the
+// Control Plane) is the home's answer: it hands back the ports and may refuse with `MemoryHomeUnavailableError`.
 export class ManagedMemoryProvider implements MemoryProvider {
   readonly kind = 'managed' as const
 
-  /** `memoryFsFor` resolves an agent id → the port over its memory tree (holds
-   *  `memory/`), or undefined for an unknown agent. */
+  /** `memoryHomePortsFor` resolves an agent id → the ports over its memory home, or undefined for an unknown agent. */
   constructor(
-    private readonly memoryFsFor: (agentId: string) => MemoryFs | undefined,
+    private readonly memoryHomePortsFor: (agentId: string) => MemoryHomePorts | undefined,
     private readonly autoDistillFor: (agentId: string) => boolean = () => false,
     private readonly extract?: MemoryExtractor
   ) {}
 
-  private rootFor(agentId: string): MemoryFs {
-    const fs = this.memoryFsFor(agentId)
-    // Match the pre-provider MCP path's message verbatim (mcp/ops.ts) so the tool
-    // error surface is byte-identical.
-    if (!fs) throw new Error(`unknown agent ${agentId}`)
-    return fs
+  private portsFor(agentId: string): MemoryHomePorts {
+    const ports = this.memoryHomePortsFor(agentId)
+    // Match the pre-provider MCP path's message verbatim (mcp/ops.ts) so the tool error surface is byte-identical.
+    if (!ports) throw new Error(`unknown agent ${agentId}`)
+    return ports
   }
 
-  /** The write/active memory root: the channel folder when channel-scoped, else the
-   *  agent base. All WRITES (tools + distillation) target this so a channel's
-   *  content never lands in another channel or the shared base (#653). */
-  private activeRoot(scope: MemoryScope): MemoryFs {
-    if (scope.root) return scope.root
-    const base = this.rootFor(scope.agentId)
-    return scope.channelKey ? channelMemoryRoot(base, scope.channelKey) : base
+  // The store every WRITE (tools + distillation) targets — the channel folder when channel-scoped, else the agent base,
+  // so a channel's content never lands in another channel or the shared base (#653) — and the sink its change log goes
+  // to. An explicit store is a dream's staging, kept beside the extraction host and never in the CP, so it logs to the
+  // sidecar inside it; otherwise the home decides both.
+  private activeStore(scope: MemoryScope): { store: MemoryFs; history: MemoryHistorySink } {
+    if (scope.root) return { store: scope.root, history: sidecarMemoryHistory(scope.root) }
+    const ports = this.portsFor(scope.agentId)
+    const store = scope.channelKey ? channelMemoryRoot(ports.live, scope.channelKey) : ports.live
+    return { store, history: ports.historyFor(store) }
   }
 
-  /** The read overlay roots, most-specific first — `[channel, base]` when channel-
-   *  scoped so the channel layer shadows the shared base per file; `[base]`
-   *  otherwise. */
+  // The read overlay roots, most-specific first — `[channel, base]` when channel-scoped so the channel layer shadows the
+  // shared base per file; `[base]` otherwise. An explicit store stands alone: a dream's staged proposal must not read
+  // through to the live store, or a reviewer would see files the proposal does not contain.
   private readRoots(scope: MemoryScope): MemoryFs[] {
-    // An explicit store stands alone: a dream's staged proposal must not read through
-    // to the live store, or a reviewer would see files the proposal does not contain.
     if (scope.root) return [scope.root]
-    const base = this.rootFor(scope.agentId)
+    const base = this.portsFor(scope.agentId).live
     return scope.channelKey ? [channelMemoryRoot(base, scope.channelKey), base] : [base]
   }
 
@@ -87,11 +83,11 @@ export class ManagedMemoryProvider implements MemoryProvider {
   }
 
   async ensure(scope: MemoryScope, agentName: string): Promise<void> {
-    await ensureMemory(this.activeRoot(scope), agentName)
+    await ensureMemory(this.activeStore(scope).store, agentName)
     // Record the source identity of a channel folder once, so the console can name
     // it. Best-effort and off the critical path — a failure never blocks memory.
     if (scope.channelKey && scope.channel) {
-      void writeChannelMemoryMeta(this.rootFor(scope.agentId), scope.channelKey, {
+      void writeChannelMemoryMeta(this.portsFor(scope.agentId).live, scope.channelKey, {
         channel: scope.channel,
         ...(scope.transportScope ? { transportScope: scope.transportScope } : {})
       }).catch(() => {})
@@ -122,11 +118,11 @@ export class ManagedMemoryProvider implements MemoryProvider {
     if (!this.autoDistillFor(scope.agentId) || !this.extract) return
     // Per-turn distillation is a WRITE: it goes to the active (channel) folder so a
     // channel's turns never distill into the shared base or another channel (#653).
-    const dir = this.activeRoot(scope)
+    const { store } = this.activeStore(scope)
     // The extraction session holds the same memory tools as any other trigger and
     // writes through them itself (#41), so there is nothing to parse or apply here.
     // Its text answer is not the product; the writes are.
-    await this.extract(scope.agentId, await buildDistillationPrompt(dir, turn), scope)
+    await this.extract(scope.agentId, await buildDistillationPrompt(store, turn), scope)
   }
 
   tools(): ToolDescriptor[] {
@@ -143,8 +139,8 @@ export class ManagedMemoryProvider implements MemoryProvider {
       list: (scope) => this.list(scope),
       read: (scope, path) => this.read(scope, path),
       write: (scope, path, content, ifMatch, source) => this.write(scope, path, content, ifMatch, source),
-      // Pages the sidecar; a home whose sink has no `list` (the CP's) answers the console itself — no local history here.
-      history: (scope, req) => listMemoryHistory(this.activeRoot(scope), req.path, req.cursor, req.limit)
+      // Pages the store's sink; a home whose sink has no `list` (the CP's) answers the console itself, and a page asked here refuses.
+      history: (scope, req) => listMemoryHistory(this.activeStore(scope).history, req.path, req.cursor, req.limit)
     }
   }
 
@@ -188,7 +184,8 @@ export class ManagedMemoryProvider implements MemoryProvider {
     ifMatch?: string,
     source?: MemoryWriteSource
   ): Promise<MemoryWriteResult> {
-    const { size, mtime } = await writeMemoryFile(this.activeRoot(scope), path, content, ifMatch, source)
+    const { store, history } = this.activeStore(scope)
+    const { size, mtime } = await writeMemoryFile(store, path, content, ifMatch, source ?? 'tool', history)
     return { ok: true, path, size, mtime }
   }
 }

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -25,13 +25,7 @@ import {
   MemoryFileHistoryEvent as MemoryFileHistoryEventSchema,
   type MemoryFileHistoryEvent
 } from '@agentconnect.md/protocol'
-import {
-  MemoryConflictError,
-  MemoryPathError,
-  MemoryTooLargeError,
-  type MemoryFs,
-  type MemoryFsFileStat
-} from './fs.js'
+import { MemoryPathError, MemoryTooLargeError, type MemoryFs, type MemoryFsFileStat } from './fs.js'
 
 export {
   MemoryConflictError,
@@ -107,6 +101,14 @@ export interface MemoryHistorySink {
   carryInto(replacement: string): Promise<void>
   /** Page the log back on this daemon; absent when the home answers the console itself (no local history to read). */
   list?(relPath: string, cursor: string | undefined, limit: number): Promise<ManagedMemoryHistoryPage>
+}
+
+/** Raised when this daemon is asked to page a change log its home keeps elsewhere (the CP's table): a routing bug, never an empty page. */
+export class MemoryHistoryNotLocalError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MemoryHistoryNotLocalError'
+  }
 }
 
 export interface MemoryHistoryRetentionLimits {
@@ -405,7 +407,7 @@ export class SidecarMemoryHistorySink implements MemoryHistorySink {
   }
 
   list(relPath: string, cursor: string | undefined, limit: number): Promise<ManagedMemoryHistoryPage> {
-    return listMemoryHistory(this.fs, relPath, cursor, limit)
+    return pageSidecarHistory(this.fs, relPath, cursor, limit)
   }
 }
 
@@ -441,21 +443,32 @@ export function memoryHistoryRecord(
   }
 }
 
-/**
- * Page one file's managed-memory history newest first. The cursor is the stable ID
- * of the next event, so appends and retention cannot shift or duplicate older pages.
- *
- * Invalid/corrupt lines are skipped. History is provenance rather than the source
- * of truth, so one torn or legacy row must not make every valid row unreadable.
- */
+// Page one file's change log through the store's sink, newest first. A home that keeps the log itself (the CP's table)
+// hands out a sink without `list`, and the CP answers the console from its own rows: a daemon-side page of it is a
+// routing bug that must show as one, never as an empty page.
 export async function listMemoryHistory(
+  history: MemoryHistorySink,
+  relPath: string,
+  cursor: string | undefined,
+  limit: number
+): Promise<ManagedMemoryHistoryPage> {
+  if (!history.list) {
+    throw new MemoryHistoryNotLocalError(
+      "this store's change log is kept by its memory home and answered from there, not paged on the daemon"
+    )
+  }
+  return history.list(relPath, cursor, limit)
+}
+
+// The sidecar's page: the cursor is the stable id of the next event, so appends and retention cannot shift or duplicate
+// older pages; invalid or torn lines are skipped, since provenance must not make every valid row unreadable.
+async function pageSidecarHistory(
   fs: MemoryFs,
   relPath: string,
   cursor: string | undefined,
   limit: number
 ): Promise<ManagedMemoryHistoryPage> {
-  // Apply the same containment/flat-path validation as ordinary memory reads,
-  // even though `relPath` is used only as a filter below.
+  // The same containment/flat-path validation as an ordinary memory read, though `relPath` is only a filter below.
   memoryTopicName(relPath)
 
   return withMemoryDirLock(fs, async () => {
@@ -558,43 +571,33 @@ function bumpWriteMarks(fs: MemoryFs, source: MemoryWriteSource): void {
   writeMarks.set(key, marks)
 }
 
-/** Overwrite a memory file with `content` (creating the dir if needed). Atomic
- *  (tmp + rename) so a concurrent read never sees a partial file. Hands `history`
- *  (the sidecar unless a home says otherwise) one record of the add/update, its
- *  bounded `before`/`after` snapshot, and the `source`.
- *
- *  - Rejects content over {@link MAX_MEMORY_FILE_BYTES} ({@link MemoryTooLargeError}).
- *  - `ifMatchMtime` (optimistic concurrency): when given, the current file's mtime
- *    must equal it, else {@link MemoryConflictError} — so a console edit can't
- *    clobber a newer write. A brand-new file (no mtime) matches `ifMatchMtime`
- *    only when the caller passes none (or the empty string). */
+// Overwrite a memory file with `content` (creating the dir if needed), atomically, so a concurrent read never sees a
+// partial file; rejects content over `MAX_MEMORY_FILE_BYTES` (`MemoryTooLargeError`). A non-empty `ifMatchMtime` must
+// equal the current file's mtime, else `MemoryConflictError` (a brand-new file matches only an absent one). The
+// `history` sink — the home's choice, named by every caller so no write can fall back to the sidecar by omission —
+// receives one record of the add/update with its bounded `before`/`after` snapshot and the `source`.
 export function writeMemoryFile(
   fs: MemoryFs,
   relPath: string,
   content: string,
-  ifMatchMtime?: string,
-  source: MemoryWriteSource = 'tool',
-  history: MemoryHistorySink = new SidecarMemoryHistorySink(fs)
+  ifMatchMtime: string | undefined,
+  source: MemoryWriteSource,
+  history: MemoryHistorySink
 ): Promise<{ size: number; mtime: string }> {
   // Serialize every write behind the shared per-dir lock so it can't interleave
   // with a dream adoption's fence-and-swap (nor another write).
   return withMemoryDirLock(fs, () => writeMemoryFileHoldingLock(fs, relPath, content, ifMatchMtime, source, history))
 }
 
-/**
- * The write itself, WITHOUT taking the memory-dir lock — for a caller that
- * already holds it and needs several writes to be one critical section (the
- * distiller's topic+index batch: an adoption slipping between those two writes
- * would be overwritten by the batch's stale index). The lock is not reentrant,
- * so calling {@link writeMemoryFile} from inside it would deadlock.
- */
+// The write itself, WITHOUT taking the memory-dir lock — for a caller that already holds it and needs several writes to
+// be one critical section; the lock is not reentrant, so calling `writeMemoryFile` from inside it would deadlock.
 export async function writeMemoryFileHoldingLock(
   fs: MemoryFs,
   relPath: string,
   content: string,
   ifMatchMtime: string | undefined,
   source: MemoryWriteSource,
-  history: MemoryHistorySink = new SidecarMemoryHistorySink(fs)
+  history: MemoryHistorySink
 ): Promise<{ size: number; mtime: string }> {
   const topic = memoryTopicName(relPath)
   // Keep a written header truthful (`name` from the filename, fresh `modified`).
@@ -681,7 +684,7 @@ export function renderMemoryIndex(entries: MemoryIndexEntry[], heading = '# Memo
 export async function regenerateMemoryIndexHoldingLock(
   fs: MemoryFs,
   source: MemoryWriteSource,
-  opts: { force?: boolean; history?: MemoryHistorySink } = {}
+  opts: { force?: boolean; history: MemoryHistorySink }
 ): Promise<void> {
   const entries: { topic: string; name: string; description: string }[] = []
   for (const file of await listMemory(fs)) {
@@ -710,8 +713,7 @@ export async function regenerateMemoryIndexHoldingLock(
 
   const st = await fs.writeFile(`${MEMORY_DIRNAME}/${MEMORY_INDEX}`, next, {})
   try {
-    const history = opts.history ?? new SidecarMemoryHistorySink(fs)
-    await history.append([memoryHistoryRecord(MEMORY_INDEX, current?.content, next, st.mtime, source)])
+    await opts.history.append([memoryHistoryRecord(MEMORY_INDEX, current?.content, next, st.mtime, source)])
   } catch {
     // Provenance is best-effort, exactly as in the topic write above.
   }

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -5,6 +5,7 @@ import { monotonicTs } from '../store/monotonic-ts.js'
 import { effectiveSessionIsolation, WorkspaceManager } from '../workspace/workspace-manager.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
 import { memoryKindOf, type MemoryProvider, type MemoryScope } from '../memory/provider.js'
+import { MemoryHomeUnavailableError } from '../memory/fs.js'
 import { agentChildEnv } from '../agents/agent-env.js'
 import { planConfigFiles } from '../shim/config-file-env.js'
 import { recallQueryFromBlocks } from '../memory/recall.js'
@@ -207,6 +208,8 @@ export class SessionManager {
       memoryScopeFor?: (agentId: string, msg: NormalizedMessage, integrationId?: string) => MemoryScope
       /** Fail-open recall diagnostics. Must never include query/record/plugin body text. */
       onMemoryRecallError?: (agentId: string, error: unknown) => void
+      /** The agent's memory home was out of reach at session start: the session opened without standing context, and this is the warning. */
+      onMemoryHomeUnavailable?: (agentId: string, error: MemoryHomeUnavailableError) => void
       /** Exact final reference bytes after provider-neutral validation/rendering. */
       onMemoryRecallInjected?: (agentId: string, bytes: number) => void
       /** Metadata-only evaluation/telemetry seam for recall. Observer failures
@@ -545,10 +548,19 @@ export class SessionManager {
     // Seeded HERE, after the host is up: a cluster agent's memory home is its sandbox
     // volume, reachable only once the pod is bound. Idempotent, so a resumed session pays
     // one cheap check.
-    if (memoryEnabled) await abortable(() => this.deps.memory.ensure(memScope, agent.name), signal)
-    const memoryIndex = memoryEnabled
-      ? (await abortable(() => this.deps.memory.standingContextAtSessionStart(memScope), signal)).trim()
-      : ''
+    // A home out of reach (memory-evolution.md §3.2.1, degradation) — the CP connection down under a `control-plane`
+    // home, a suspended sandbox — starts the session with no standing context and a warning; the memory tools answer
+    // the same error, and the post-turn distillation waits in the capture outbox. Anything else still fails the turn.
+    let memoryIndex = ''
+    if (memoryEnabled) {
+      try {
+        await abortable(() => this.deps.memory.ensure(memScope, agent.name), signal)
+        memoryIndex = (await abortable(() => this.deps.memory.standingContextAtSessionStart(memScope), signal)).trim()
+      } catch (err) {
+        if (!(err instanceof MemoryHomeUnavailableError)) throw err
+        this.deps.onMemoryHomeUnavailable?.(agentId, err)
+      }
+    }
     // The channel's human display name, if the daemon has resolved one (Slack bulk refresh /
     // ChannelNameResolver, cached in `display_names`). Stored bare for a group/channel,
     // `@name` for a DM (same value the console labels with), surfaced as-is.

--- a/packages/daemon/test/channel-memory.test.ts
+++ b/packages/daemon/test/channel-memory.test.ts
@@ -18,12 +18,13 @@ import {
   MemoryPathError
 } from '../src/memory/store.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
+import { localMemoryHome } from '../src/memory/home.js'
 
 const local = (dir: string) => new LocalMemoryFs(dir)
 
 function provider() {
   const dir = mkdtempSync(join(tmpdir(), 'ac-chan-mem-'))
-  return { dir, mem: createManagedMemoryProvider(() => local(dir)) }
+  return { dir, mem: createManagedMemoryProvider(() => localMemoryHome(local(dir))) }
 }
 
 const chan = (channel: string, transportScope?: string) => ({
@@ -121,8 +122,10 @@ describe('channel-scoped memory overlay', () => {
 
   it('the CP memory reader lists channel folders and routes reads to the selected channel', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-chan-reader-'))
-    const mem = createManagedMemoryProvider(() => local(dir))
-    const reader = createMemoryReader(() => local(dir), { adminSurfaceForAgent: () => mem.adminSurface() })
+    const mem = createManagedMemoryProvider(() => localMemoryHome(local(dir)))
+    const reader = createMemoryReader(() => localMemoryHome(local(dir)), {
+      adminSurfaceForAgent: () => mem.adminSurface()
+    })
     const a = chan('C1')
     await mem.ensure(a, 'bot')
     await mem.write(a, 'notes.md', '- channel A note', undefined, 'tool')

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi } from 'vitest'
 import { buildEnvelope, decodeEnvelope, MAX_FRAME_BYTES, SESSION_LIVE_TAIL_FEATURE } from '@agentconnect.md/protocol'
 import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
 import { WorkspaceConflictError, WorkspaceViolationError } from '../../src/cp/workspace-reader.js'
-import { MemorySandboxUnavailableError } from '../../src/cp/memory-reader.js'
+import {
+  MemoryHistoryNotLocalError,
+  MemoryHomeUnavailableError,
+  MemorySandboxUnavailableError
+} from '../../src/cp/memory-reader.js'
 import { TaskViolationError } from '../../src/cp/task-reader.js'
 import { AgentWakeViolationError } from '../../src/cp/agent-wake.js'
 import { createRuntimeCommandsReader } from '../../src/cp/runtime-commands-reader.js'
@@ -890,6 +894,45 @@ describe('CpClient dispatch', () => {
     expect(err.corr).toBe(f.id)
     expect(err.payload.code).toBe('BAD_PAYLOAD')
     expect(err.payload.details).toEqual({ reason: 'sandbox-unavailable' })
+  })
+
+  it('refuses a control-plane home that is out of reach with its own reason, and shows a misrouted change-log page as a bug', async () => {
+    // Every home reason is "not now" for the console and rides the same shape, so the CP answers 503 with it; a page
+    // of a change log the home keeps itself was routed to the wrong side — that is INTERNAL, with the message, not an empty page.
+    const warn = vi.fn()
+    const { t } = await readyClient({
+      log: { ...silent, warn },
+      memoryReader: {
+        list: async () => {
+          throw new MemoryHomeUnavailableError(
+            'migrating',
+            'agent "a1" keeps its memory in the Control Plane, which is still receiving the copy of its tree'
+          )
+        },
+        history: async () => {
+          throw new MemoryHistoryNotLocalError("this store's change log is kept by its memory home")
+        }
+      } as any
+    })
+    const list = JSON.parse(frame('memory/list', { agentId: 'a1' }, { epoch: 5 }))
+    t.pushInbound(JSON.stringify(list))
+    await tick()
+    const refused = JSON.parse(t.sent[0]!)
+    expect(refused.type).toBe('error')
+    expect(refused.corr).toBe(list.id)
+    expect(refused.payload.code).toBe('BAD_PAYLOAD')
+    expect(refused.payload.details).toEqual({ reason: 'migrating' })
+    expect(refused.payload.message).toContain('still receiving the copy')
+
+    const history = JSON.parse(frame('memory/history', { agentId: 'a1', path: 'notes.md', limit: 5 }, { epoch: 5 }))
+    t.pushInbound(JSON.stringify(history))
+    await tick()
+    const bug = JSON.parse(t.sent[1]!)
+    expect(bug.type).toBe('error')
+    expect(bug.corr).toBe(history.id)
+    expect(bug.payload.code).toBe('INTERNAL')
+    expect(bug.payload.message).toContain('change log is kept by its memory home')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('memory/history failed'))
   })
 
   it('maps an unknown-agent workspace git violation to BAD_PAYLOAD', async () => {

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -35,6 +35,7 @@ import type { MemoryFs } from '../src/memory/fs.js'
 import { sidecarMemoryHistory, type MemoryHomePorts } from '../src/memory/home.js'
 import { pod } from './fixtures/memory-fs-pod.js'
 import { WAIT } from './wait-support.js'
+import { writeWithSidecar } from './fixtures/memory-sidecar.js'
 
 const local = (dir: string) => new LocalMemoryFs(dir)
 /** One tree for both roles and the sidecar sink, the way the daemon resolves a home today. */
@@ -339,7 +340,7 @@ describe('DreamRunner pipeline', () => {
     // topic the model never rewrote is simply gone, because staging replaces the store.
     const { dir, store, runner } = await setup({
       stagedWrite: async (stagedStore) => {
-        await writeMemoryFile(
+        await writeWithSidecar(
           stagedStore,
           'deploys.md',
           '---\ndescription: how we ship\n---\n\n- ship from main\n',
@@ -385,7 +386,7 @@ describe('DreamRunner pipeline', () => {
     // the proposal is refused rather than reviewed.
     const { dir, store, runner } = await setup({
       stagedWrite: async (stagedStore) => {
-        await writeMemoryFile(stagedStore, 'smuggled.md', 'written with the runtime file tool\n', undefined, 'dream')
+        await writeWithSidecar(stagedStore, 'smuggled.md', 'written with the runtime file tool\n', undefined, 'dream')
         return [] // ...and reported by nobody: no bound tool call happened
       }
     })
@@ -576,7 +577,7 @@ describe('DreamRunner pipeline', () => {
     // forward self-reference is safe.
     const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
     await ensureMemory(local(dir), 'bot')
-    await writeMemoryFile(local(dir), 'prefs.md', '- seed\n', undefined, 'tool')
+    await writeWithSidecar(local(dir), 'prefs.md', '- seed\n', undefined, 'tool')
     const store = new FakeStore()
     const runner = new DreamRunner({
       agentDirByAgent: () => dir,
@@ -740,7 +741,7 @@ describe('DreamRunner adoption', () => {
     const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
     const { fs, root } = pod()
     await ensureMemory(fs, 'bot')
-    await writeMemoryFile(fs, 'prefs.md', '- uses tabs\n', undefined, 'tool')
+    await writeWithSidecar(fs, 'prefs.md', '- uses tabs\n', undefined, 'tool')
     let bound = false
     let holds = 0
     let maxHolds = 0
@@ -947,7 +948,7 @@ describe('DreamRunner adoption', () => {
       historyFor: sidecarMemoryHistory
     }
     await ensureMemory(ports.live, 'bot')
-    await writeMemoryFile(ports.live, 'prefs.md', '- uses tabs\n- uses tabs again\n', undefined, 'tool')
+    await writeWithSidecar(ports.live, 'prefs.md', '- uses tabs\n- uses tabs again\n', undefined, 'tool')
     const store = new FakeStore()
     const inputDirs: string[] = []
     const runner = new DreamRunner({
@@ -1052,7 +1053,7 @@ describe('DreamRunner adoption', () => {
     // A dream stages into a real memory store now, so its files live under `memory/`.
     const out = join(dir, 'memory-dreams', started.dreamId, 'memory')
     const stagedKeep = await readFile(join(out, 'keep.md'), 'utf8')
-    await writeMemoryFile(local(dir), 'keep.md', stagedKeep, undefined, 'tool')
+    await writeWithSidecar(local(dir), 'keep.md', stagedKeep, undefined, 'tool')
     const OLD = new Date('2020-01-01T00:00:00.000Z')
     for (const name of ['keep.md', 'prefs.md', MEMORY_INDEX]) {
       await utimes(join(memoryDir(dir), name), OLD, OLD).catch(() => {})
@@ -1110,7 +1111,7 @@ describe('DreamRunner adoption', () => {
         { path: 'fresh.md', content: '- newly learned fact' }
       ]
     })
-    await writeMemoryFile(local(dir), 'obsolete.md', '- no longer relevant\n', undefined, 'tool')
+    await writeWithSidecar(local(dir), 'obsolete.md', '- no longer relevant\n', undefined, 'tool')
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
 
@@ -1192,7 +1193,7 @@ describe('DreamRunner adoption', () => {
     // the new store. The marker must be present in the final live store.
     await Promise.allSettled([
       runner.adopt('a1', started.dreamId, false),
-      writeMemoryFile(local(dir), 'marker.md', '- concurrent write\n', undefined, 'console')
+      writeWithSidecar(local(dir), 'marker.md', '- concurrent write\n', undefined, 'console')
     ])
     expect(await readMemoryFile(local(dir), 'marker.md')).toContain('concurrent write')
   })
@@ -1202,7 +1203,7 @@ describe('DreamRunner adoption', () => {
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
 
-    await writeMemoryFile(local(dir), 'prefs.md', '- console edit after snapshot\n', undefined, 'console')
+    await writeWithSidecar(local(dir), 'prefs.md', '- console edit after snapshot\n', undefined, 'console')
     await expect(runner.adopt('a1', started.dreamId, false)).rejects.toThrow(/changed since/)
 
     const adopted = await runner.adopt('a1', started.dreamId, true)
@@ -1244,7 +1245,7 @@ describe('DreamRunner adoption', () => {
       policy: { enabled: true, autoAdopt: true },
       // Hold the extraction open so a console write lands inside the dream window.
       extract: async () => {
-        await writeMemoryFile(local(dir), 'notes.md', '- human note mid-dream\n', undefined, 'console')
+        await writeWithSidecar(local(dir), 'notes.md', '- human note mid-dream\n', undefined, 'console')
         return PROPOSAL
       }
     })
@@ -1267,7 +1268,7 @@ describe('DreamRunner adoption', () => {
     const { dir, store, runner } = await setup({})
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
-    await writeMemoryFile(local(dir), 'prefs.md', '- uses tabs\n- distilled after\n', undefined, 'distill')
+    await writeWithSidecar(local(dir), 'prefs.md', '- uses tabs\n- distilled after\n', undefined, 'distill')
 
     const dream = store.dreams.get(started.dreamId)!
     // Same counts (so the count checks still pass), different daemon process.
@@ -1290,7 +1291,7 @@ describe('DreamRunner adoption', () => {
     await settle(store, b.dreamId)
 
     await runner.adopt('a1', a.dreamId, false)
-    await writeMemoryFile(
+    await writeWithSidecar(
       local(dir),
       'prefs.md',
       '- Uses tabs, not spaces (2026-07-24).\n- later distilled\n',
@@ -1311,7 +1312,7 @@ describe('DreamRunner adoption', () => {
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
 
-    await writeMemoryFile(local(dir), 'notes.md', '- human note\n', undefined, 'console')
+    await writeWithSidecar(local(dir), 'notes.md', '- human note\n', undefined, 'console')
     // Erase the console row from the log, leaving only the distill one.
     const historyPath = join(memoryDir(dir), MEMORY_HISTORY_FILENAME)
     const kept = (await readFile(historyPath, 'utf8'))
@@ -1319,7 +1320,7 @@ describe('DreamRunner adoption', () => {
       .filter((line) => !line.includes('"source":"console"'))
       .join('\n')
     await writeFile(historyPath, kept, 'utf8')
-    await writeMemoryFile(local(dir), 'prefs.md', '- uses tabs\n- distilled later\n', undefined, 'distill')
+    await writeWithSidecar(local(dir), 'prefs.md', '- uses tabs\n- distilled later\n', undefined, 'distill')
 
     await expect(runner.adopt('a1', started.dreamId, false)).rejects.toThrow(/changed since/)
     expect(await readMemoryFile(local(dir), 'notes.md')).toContain('human note')
@@ -1333,7 +1334,7 @@ describe('DreamRunner adoption', () => {
     const started = await runner.start('a1', { trigger: 'manual' })
     await settle(store, started.dreamId)
 
-    await writeMemoryFile(local(dir), 'prefs.md', '- uses tabs\n- one more distilled line\n', undefined, 'distill')
+    await writeWithSidecar(local(dir), 'prefs.md', '- uses tabs\n- one more distilled line\n', undefined, 'distill')
     await expect(runner.adopt('a1', started.dreamId, false)).rejects.toThrow(/changed since/)
   })
 
@@ -1345,7 +1346,7 @@ describe('DreamRunner adoption', () => {
     // Per-turn capture landed a NEW fact while the dream ran. The digest now
     // differs, but every post-snapshot .history row is distill-sourced, so the
     // fence must rebase rather than refuse.
-    await writeMemoryFile(local(dir), 'prefs.md', '- uses tabs\n- prefers pnpm over npm\n', undefined, 'distill')
+    await writeWithSidecar(local(dir), 'prefs.md', '- uses tabs\n- prefers pnpm over npm\n', undefined, 'distill')
 
     const adopted = await runner.adopt('a1', started.dreamId, false)
     expect(adopted.status).toBe('adopted')
@@ -1363,8 +1364,8 @@ describe('DreamRunner adoption', () => {
 
     // A distill write is rebasable, but the console write in the same window is
     // not — a mixed window must refuse rather than silently drop the edit.
-    await writeMemoryFile(local(dir), 'prefs.md', '- uses tabs\n- distilled\n', undefined, 'distill')
-    await writeMemoryFile(local(dir), 'notes.md', '- a human wrote this\n', undefined, 'console')
+    await writeWithSidecar(local(dir), 'prefs.md', '- uses tabs\n- distilled\n', undefined, 'distill')
+    await writeWithSidecar(local(dir), 'notes.md', '- a human wrote this\n', undefined, 'console')
 
     await expect(runner.adopt('a1', started.dreamId, false)).rejects.toThrow(/changed since/)
     expect(await readMemoryFile(local(dir), 'notes.md')).toContain('a human wrote this')
@@ -1376,7 +1377,7 @@ describe('DreamRunner adoption', () => {
     await settle(store, started.dreamId)
 
     // The distiller re-states, in its own words, the very fact the dream wrote.
-    await writeMemoryFile(
+    await writeWithSidecar(
       local(dir),
       'prefs.md',
       '- uses tabs\n- Uses tabs, not spaces (2026-07-24).\n',
@@ -1567,7 +1568,7 @@ describe('DreamRunner production security hold', () => {
   it('blocks every staged-content operation without changing files or metadata', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'ac-dream-held-'))
     await ensureMemory(local(dir), 'bot')
-    await writeMemoryFile(local(dir), 'prefs.md', '- live value\n', undefined, 'tool')
+    await writeWithSidecar(local(dir), 'prefs.md', '- live value\n', undefined, 'tool')
 
     const dreamId = 'drm-held'
     const candidateId = '11111111-1111-4111-8111-111111111111'
@@ -1782,7 +1783,7 @@ describe('DreamRunner store persistence', () => {
   it('the real runner persists snapshotWrites end to end', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
     await ensureMemory(local(dir), 'bot')
-    await writeMemoryFile(local(dir), 'prefs.md', '- uses tabs\n', undefined, 'tool')
+    await writeWithSidecar(local(dir), 'prefs.md', '- uses tabs\n', undefined, 'tool')
     const store = await LocalStore.open(join(await mkdtemp(join(tmpdir(), 'ac-dream-store-')), 'local.sqlite'))
     const runner = new DreamRunner({
       agentDirByAgent: () => dir,
@@ -2038,7 +2039,7 @@ describe('capture/adoption serialization', () => {
 
     // Fire capture and adoption concurrently at the same store.
     const [, adoptResult] = await Promise.allSettled([
-      writeMemoryFile(local(dir), 'captured.md', '- a captured fact\n', undefined, 'distill'),
+      writeWithSidecar(local(dir), 'captured.md', '- a captured fact\n', undefined, 'distill'),
       runner.adopt('a1', started.dreamId, false)
     ])
 

--- a/packages/daemon/test/external-memory-provider.test.ts
+++ b/packages/daemon/test/external-memory-provider.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/memory-plugin/client.js'
 import { MemoryConflictError, MemoryTooLargeError } from '../src/memory/store.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
+import { localMemoryHome } from '../src/memory/home.js'
 
 const connectionA = '11111111-1111-4111-8111-111111111111'
 const connectionB = '22222222-2222-4222-8222-222222222222'
@@ -179,7 +180,7 @@ describe('ExternalMemoryProvider', () => {
     const h = harness()
     let current = binding(connectionB)
     const dispatcher = createMemoryProvider({
-      memoryFsFor: () => new LocalMemoryFs('/tmp/agent'),
+      memoryHomePortsFor: () => localMemoryHome(new LocalMemoryFs('/tmp/agent')),
       agentDirByAgent: () => '/tmp/agent',
       runtimeFor: () => undefined,
       providerKindFor: () => 'external',

--- a/packages/daemon/test/fixtures/memory-sidecar.ts
+++ b/packages/daemon/test/fixtures/memory-sidecar.ts
@@ -1,0 +1,32 @@
+// Test convenience over ONE local tree: the sidecar inside it is the sink, named here once instead of at every call.
+// Production callers name their sink through `resolveMemoryHomePorts` (memory-evolution.md §3.2.1); a test that is
+// about the sink itself calls the store's functions directly with the sink it means.
+import { sidecarMemoryHistory } from '../../src/memory/home.js'
+import {
+  listMemoryHistory,
+  writeMemoryFile,
+  type ManagedMemoryHistoryPage,
+  type MemoryFs,
+  type MemoryWriteSource
+} from '../../src/memory/store.js'
+
+/** `writeMemoryFile` on a local tree, its change log in the sidecar beside the store. */
+export function writeWithSidecar(
+  fs: MemoryFs,
+  relPath: string,
+  content: string,
+  ifMatchMtime?: string,
+  source: MemoryWriteSource = 'tool'
+): Promise<{ size: number; mtime: string }> {
+  return writeMemoryFile(fs, relPath, content, ifMatchMtime, source, sidecarMemoryHistory(fs))
+}
+
+/** `listMemoryHistory` over the sidecar inside a local tree. */
+export function listSidecarHistory(
+  fs: MemoryFs,
+  relPath: string,
+  cursor: string | undefined,
+  limit: number
+): Promise<ManagedMemoryHistoryPage> {
+  return listMemoryHistory(sidecarMemoryHistory(fs), relPath, cursor, limit)
+}

--- a/packages/daemon/test/memory-distiller.test.ts
+++ b/packages/daemon/test/memory-distiller.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { ensureMemory, readMemoryFile } from '../src/memory/store.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
+import { localMemoryHome } from '../src/memory/home.js'
 import {
   buildDistillationPrompt,
   MEMORY_DISTILLATION_SYSTEM_PROMPT,
@@ -51,7 +52,7 @@ describe('managed memory auto-distillation', () => {
     await ensureMemory(local(dir), 'bot')
     let calls = 0
     const provider = new ManagedMemoryProvider(
-      () => local(dir),
+      () => localMemoryHome(local(dir)),
       (id) => id === 'enabled',
       async () => {
         calls++

--- a/packages/daemon/test/memory-frontmatter.test.ts
+++ b/packages/daemon/test/memory-frontmatter.test.ts
@@ -25,11 +25,12 @@ import {
   readMemoryFile,
   regenerateMemoryIndexHoldingLock,
   renderMemoryIndex,
-  writeMemoryFile,
   memoryChannelKey
 } from '../src/memory/store.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT } from '../src/memory/distill.js'
 import { createMemoryProvider } from '../src/memory/providers/factory.js'
+import { localMemoryHome, sidecarMemoryHistory } from '../src/memory/home.js'
+import { writeWithSidecar } from './fixtures/memory-sidecar.js'
 
 const fs = () => new LocalMemoryFs(mkdtempSync(join(tmpdir(), 'ac-fm-')))
 
@@ -125,8 +126,8 @@ describe('generated memory index', () => {
   it('rebuilds MEMORY.md from topic descriptions, sorted, and refreshes on change', async () => {
     const f = fs()
     await ensureMemory(f, 'bot')
-    await writeMemoryFile(f, 'zeta.md', '---\ndescription: last one\n---\nz\n', undefined, 'tool')
-    await writeMemoryFile(f, 'alpha.md', '---\ndescription: first one\n---\na\n', undefined, 'tool')
+    await writeWithSidecar(f, 'zeta.md', '---\ndescription: last one\n---\nz\n', undefined, 'tool')
+    await writeWithSidecar(f, 'alpha.md', '---\ndescription: first one\n---\na\n', undefined, 'tool')
 
     const index = await readMemoryFile(f, 'MEMORY.md')
     expect(index).toContain('- [alpha](alpha.md) — first one')
@@ -135,7 +136,7 @@ describe('generated memory index', () => {
     expect(index).toContain('generated')
 
     // Editing a description re-renders the entry rather than duplicating it.
-    await writeMemoryFile(f, 'alpha.md', '---\ndescription: renamed\n---\na\n', undefined, 'tool')
+    await writeWithSidecar(f, 'alpha.md', '---\ndescription: renamed\n---\na\n', undefined, 'tool')
     const updated = await readMemoryFile(f, 'MEMORY.md')
     expect(updated).toContain('- [alpha](alpha.md) — renamed')
     expect(updated).not.toContain('first one')
@@ -144,13 +145,13 @@ describe('generated memory index', () => {
   it('leaves a legacy hand-written index alone until a described topic exists', async () => {
     const f = fs()
     await ensureMemory(f, 'bot')
-    await writeMemoryFile(f, 'MEMORY.md', '# bot memory\n\nmy own notes\n', undefined, 'tool')
+    await writeWithSidecar(f, 'MEMORY.md', '# bot memory\n\nmy own notes\n', undefined, 'tool')
     // A headerless topic gives nothing to generate from, so the index is untouched.
-    await writeMemoryFile(f, 'plain.md', 'no header here\n', undefined, 'tool')
+    await writeWithSidecar(f, 'plain.md', 'no header here\n', undefined, 'tool')
     expect(await readMemoryFile(f, 'MEMORY.md')).toContain('my own notes')
 
     // The first described topic migrates it to the generated form.
-    await writeMemoryFile(f, 'described.md', '---\ndescription: has one\n---\nx\n', undefined, 'tool')
+    await writeWithSidecar(f, 'described.md', '---\ndescription: has one\n---\nx\n', undefined, 'tool')
     const index = await readMemoryFile(f, 'MEMORY.md')
     expect(index).toContain('- [described](described.md) — has one')
     expect(index).toContain('# bot memory') // the agent's own heading is preserved
@@ -160,11 +161,11 @@ describe('generated memory index', () => {
   it('clears an entry when its description is removed, instead of freezing stale text', async () => {
     const f = fs()
     await ensureMemory(f, 'bot')
-    await writeMemoryFile(f, 'a.md', '---\ndescription: original text\n---\na\n', undefined, 'tool')
+    await writeWithSidecar(f, 'a.md', '---\ndescription: original text\n---\na\n', undefined, 'tool')
     expect(await readMemoryFile(f, 'MEMORY.md')).toContain('original text')
 
     // Dropping the last description must not leave the index frozen with it.
-    await writeMemoryFile(f, 'a.md', '---\ntype: project\n---\na\n', undefined, 'tool')
+    await writeWithSidecar(f, 'a.md', '---\ntype: project\n---\na\n', undefined, 'tool')
     const index = await readMemoryFile(f, 'MEMORY.md')
     expect(index).not.toContain('original text')
     expect(index).toContain('- [a](a.md)')
@@ -176,7 +177,7 @@ describe('generated memory index', () => {
     const description = 'x'.repeat(4_000)
     // Enough described topics that the naive index would blow past the write cap.
     for (let i = 0; i < 80; i++) {
-      await writeMemoryFile(f, `topic-${i}.md`, `---\ndescription: ${description}\n---\nbody\n`, undefined, 'tool')
+      await writeWithSidecar(f, `topic-${i}.md`, `---\ndescription: ${description}\n---\nbody\n`, undefined, 'tool')
     }
     const index = await readMemoryFile(f, 'MEMORY.md')
     expect(Buffer.byteLength(index)).toBeLessThanOrEqual(MAX_MEMORY_FILE_BYTES)
@@ -186,7 +187,7 @@ describe('generated memory index', () => {
   it('readMemory accepts the [[link]] form the agent sees in a body', async () => {
     const f = fs()
     await ensureMemory(f, 'bot')
-    await writeMemoryFile(f, 'deploys.md', '---\ndescription: d\n---\nport 4242\n', undefined, 'tool')
+    await writeWithSidecar(f, 'deploys.md', '---\ndescription: d\n---\nport 4242\n', undefined, 'tool')
     expect(await readMemoryFile(f, '[[deploys]]')).toContain('port 4242')
     expect(await readMemoryFile(f, 'deploys')).toContain('port 4242')
   })
@@ -194,7 +195,7 @@ describe('generated memory index', () => {
 
 describe('memory graph (one hop)', () => {
   const write = (f: ReturnType<typeof fs>, topic: string, description: string, body: string) =>
-    writeMemoryFile(f, topic, `---\ndescription: ${description}\n---\n${body}\n`, undefined, 'tool')
+    writeWithSidecar(f, topic, `---\ndescription: ${description}\n---\n${body}\n`, undefined, 'tool')
 
   it('reports outgoing links and backlinks, each with its description', async () => {
     const f = fs()
@@ -241,7 +242,7 @@ describe('memory graph through the live provider path', () => {
   // directly is not enough: this is the path production actually takes.
   const dispatcher = (dir: string) =>
     createMemoryProvider({
-      memoryFsFor: () => new LocalMemoryFs(dir),
+      memoryHomePortsFor: () => localMemoryHome(new LocalMemoryFs(dir)),
       providerKindFor: () => 'managed' as const
     } as never)
 
@@ -295,7 +296,7 @@ describe('dream adoption and index ownership', () => {
     await f.writeFile('memory/MEMORY.md', '# bot memory\n\nthe dream wrote this by hand\n', {})
     await f.writeFile('memory/a.md', '---\ndescription: from the dream\n---\na\n', {})
 
-    await regenerateMemoryIndexHoldingLock(f, 'dream')
+    await regenerateMemoryIndexHoldingLock(f, 'dream', { history: sidecarMemoryHistory(f) })
     const index = await readMemoryFile(f, 'MEMORY.md')
     expect(index).toContain('- [a](a.md) — from the dream')
     expect(index).not.toContain('the dream wrote this by hand')
@@ -308,7 +309,7 @@ describe('dream adoption and index ownership', () => {
     await f.writeFile('memory/MEMORY.md', '# bot memory\n\ncurated by the dream\n', {})
     await f.writeFile('memory/a.md', 'no header here\n', {})
 
-    await regenerateMemoryIndexHoldingLock(f, 'dream')
+    await regenerateMemoryIndexHoldingLock(f, 'dream', { history: sidecarMemoryHistory(f) })
     expect(await readMemoryFile(f, 'MEMORY.md')).toContain('curated by the dream')
   })
 })
@@ -380,7 +381,7 @@ describe('a description survives the real write path', () => {
     const nasty = 'he said "ship it", path C:\\tmp — see #2'
     // Exactly what a model writes through the shared tool surface: a header it wrote,
     // stored by the ordinary write path.
-    await writeMemoryFile(f, 'quoted.md', `${buildMemoryHeader({ description: nasty })}fact\n`, undefined, 'distill')
+    await writeWithSidecar(f, 'quoted.md', `${buildMemoryHeader({ description: nasty })}fact\n`, undefined, 'distill')
 
     const created = await readMemoryFile(f, 'quoted.md')
     expect(parseMemoryFrontmatter(created).header.description).toBe(nasty)
@@ -429,7 +430,7 @@ describe('the reviewed index is the adopted index', () => {
     const f = fs()
     await ensureMemory(f, 'bot')
     for (const e of entries) {
-      await writeMemoryFile(f, e.topic, `---\ndescription: ${e.description}\n---\nbody\n`, undefined, 'dream')
+      await writeWithSidecar(f, e.topic, `---\ndescription: ${e.description}\n---\nbody\n`, undefined, 'dream')
     }
     const liveIndex = await readMemoryFile(f, 'MEMORY.md')
 
@@ -453,7 +454,7 @@ describe('every writer stores safe frontmatter', () => {
     for (const source of ['tool', 'distill', 'dream', 'console'] as const) {
       const f = fs()
       await ensureMemory(f, 'bot')
-      await writeMemoryFile(f, 'topic.md', `---\ndescription: ${nasty}\n---\nbody\n`, undefined, source)
+      await writeWithSidecar(f, 'topic.md', `---\ndescription: ${nasty}\n---\nbody\n`, undefined, source)
 
       const stored = await readMemoryFile(f, 'topic.md')
       expect(stored).toContain(`description: ${JSON.stringify(nasty)}`)
@@ -464,11 +465,11 @@ describe('every writer stores safe frontmatter', () => {
   it('is a no-op for a header that is already safe, so rewrites do not churn', async () => {
     const f = fs()
     await ensureMemory(f, 'bot')
-    await writeMemoryFile(f, 'plain.md', '---\ndescription: how we ship\n---\nbody\n', undefined, 'tool')
+    await writeWithSidecar(f, 'plain.md', '---\ndescription: how we ship\n---\nbody\n', undefined, 'tool')
     const first = await readMemoryFile(f, 'plain.md')
     expect(first).toContain('description: how we ship') // still unquoted
 
-    await writeMemoryFile(f, 'plain.md', first, undefined, 'tool')
+    await writeWithSidecar(f, 'plain.md', first, undefined, 'tool')
     const second = await readMemoryFile(f, 'plain.md')
     // Only `modified` may differ; the description must not gain quoting or escapes.
     expect(second).toContain('description: how we ship')
@@ -519,7 +520,7 @@ describe('values that only stay strings while quoted', () => {
   it('survives a write/read cycle for a numeric-looking description', async () => {
     const f = fs()
     await ensureMemory(f, 'bot')
-    await writeMemoryFile(f, 'n.md', '---\ndescription: "2026"\n---\nbody\n', undefined, 'dream')
+    await writeWithSidecar(f, 'n.md', '---\ndescription: "2026"\n---\nbody\n', undefined, 'dream')
     expect(parseMemoryFrontmatter(await readMemoryFile(f, 'n.md')).header.description).toBe('2026')
   })
 })
@@ -542,7 +543,7 @@ describe('values whose BYTES change when emitted bare', () => {
     const f = fs()
     await ensureMemory(f, 'bot')
     const value = 'first\nsecond'
-    await writeMemoryFile(f, 'multi.md', `---\ndescription: ${JSON.stringify(value)}\n---\nbody\n`, undefined, 'dream')
+    await writeWithSidecar(f, 'multi.md', `---\ndescription: ${JSON.stringify(value)}\n---\nbody\n`, undefined, 'dream')
     const stored = await readMemoryFile(f, 'multi.md')
     expect(stored.match(/^description:/gm)).toHaveLength(1)
     expect(parseMemoryFrontmatter(stored).header.description).toBe(value)

--- a/packages/daemon/test/memory-fs-cp.test.ts
+++ b/packages/daemon/test/memory-fs-cp.test.ts
@@ -14,7 +14,14 @@ import {
   MemorySandboxUnavailableError,
   type MemoryFs
 } from '../src/memory/fs.js'
-import { MEMORY_INDEX, ensureMemory, listMemory, readMemoryFile, writeMemoryFile } from '../src/memory/store.js'
+import {
+  MEMORY_INDEX,
+  ensureMemory,
+  listMemory,
+  readMemoryFile,
+  writeMemoryFile,
+  type MemoryHistorySink
+} from '../src/memory/store.js'
 import { ShimMemoryFs, applyMemoryFsPayload } from '../src/shim/memory-fs-channel.js'
 import { REPLY_BUDGET } from '../src/wire-slice.js'
 import { pathExecutor } from './fixtures/memory-fs-pod.js'
@@ -63,9 +70,12 @@ describe('CpMemoryFs (the port over the CP connection)', () => {
     expect(fs.key).toBe(`control-plane:${AGENT}:.`)
     await ensureMemory(fs, 'bot-a')
     expect(await fsp.readFile(join(link.tree, 'memory', MEMORY_INDEX), 'utf8')).toContain('# bot-a memory')
-    await writeMemoryFile(fs, 'deploys.md', '- region sea\n', undefined, 'tool')
+    // The change log is not this port's business: a CP-homed store's sink is the CP table, never a file in the tree.
+    const elsewhere: MemoryHistorySink = { append: async () => {}, carryInto: async () => {} }
+    await writeMemoryFile(fs, 'deploys.md', '- region sea\n', undefined, 'tool', elsewhere)
     expect(await readMemoryFile(fs, 'deploys.md')).toBe('- region sea\n')
     expect((await listMemory(fs)).map((f) => f.name)).toEqual([MEMORY_INDEX, 'deploys.md'])
+    expect(await fsp.readdir(join(link.tree, 'memory'))).not.toContain('.history')
     expect(link.requests.every((r) => r.agentId === AGENT && r.op.root === '.')).toBe(true)
     expect(link.requests.map((r) => r.op.op)).toContain('memory-commit')
   })

--- a/packages/daemon/test/memory-fs.test.ts
+++ b/packages/daemon/test/memory-fs.test.ts
@@ -9,16 +9,8 @@ import {
   MemorySandboxUnavailableError,
   type MemoryFs
 } from '../src/memory/fs.js'
-import { resolveMemoryFs } from '../src/memory/home.js'
-import {
-  MEMORY_HISTORY_FILENAME,
-  MEMORY_INDEX,
-  ensureMemory,
-  listMemory,
-  listMemoryHistory,
-  readMemoryFile,
-  writeMemoryFile
-} from '../src/memory/store.js'
+import { localMemoryHome, resolveMemoryFs } from '../src/memory/home.js'
+import { MEMORY_HISTORY_FILENAME, MEMORY_INDEX, ensureMemory, listMemory, readMemoryFile } from '../src/memory/store.js'
 import { ManagedMemoryProvider } from '../src/memory/provider.js'
 import { createMemoryReader } from '../src/cp/memory-reader.js'
 import { MemoryFsPayloadSchema } from '@agentconnect.md/protocol'
@@ -27,6 +19,7 @@ import { createFdMemoryFsExecutor } from '../src/shim/fd-memory-fs.js'
 import { createExecHandler } from '../src/shim/exec-handler.js'
 import { REPLY_BUDGET } from '../src/wire-slice.js'
 import { pod, shimRequester } from './fixtures/memory-fs-pod.js'
+import { listSidecarHistory, writeWithSidecar } from './fixtures/memory-sidecar.js'
 
 const roots: string[] = []
 afterAll(() => {
@@ -121,10 +114,10 @@ describe('ShimMemoryFs over the read capability (the port over a sandbox volume)
     const { root, fs, requester } = pod()
     await ensureMemory(fs, 'bot-a')
     expect(await fsp.readFile(join(root, 'memory', MEMORY_INDEX), 'utf8')).toContain('# bot-a memory')
-    await writeMemoryFile(fs, 'deploys.md', '- region sea\n', undefined, 'tool')
+    await writeWithSidecar(fs, 'deploys.md', '- region sea\n', undefined, 'tool')
     expect(await readMemoryFile(fs, 'deploys.md')).toBe('- region sea\n')
     expect((await listMemory(fs)).map((f) => f.name)).toEqual([MEMORY_INDEX, 'deploys.md'])
-    const history = await listMemoryHistory(fs, 'deploys.md', undefined, 10)
+    const history = await listSidecarHistory(fs, 'deploys.md', undefined, 10)
     expect(history.events.map((e) => e.event)).toEqual(['add'])
     expect(await fsp.readFile(join(root, 'memory', MEMORY_HISTORY_FILENAME), 'utf8')).toContain('"source":"tool"')
     // Every touch crossed the channel as a memory-fs frame; nothing landed on this side's disk.
@@ -188,7 +181,7 @@ describe('ShimMemoryFs over the read capability (the port over a sandbox volume)
     let bound: MemoryFs | undefined = fs
     const rootFor = () => {
       if (!bound) throw new MemorySandboxUnavailableError('agent "bot-a" has no running sandbox')
-      return bound
+      return localMemoryHome(bound)
     }
     const provider = new ManagedMemoryProvider(rootFor)
     await provider.ensure({ agentId: 'bot-a' }, 'bot-a')
@@ -211,12 +204,15 @@ describe('ShimMemoryFs over the read capability (the port over a sandbox volume)
 describe('resolveMemoryFs (the one placement decision)', () => {
   it('gives a local agent the local port, a bound cluster agent the shim port, and refuses an unbound one', () => {
     const agent = { id: 'bot-a', dir: tempRoot() }
-    const local = resolveMemoryFs(agent, undefined)
+    const log = { warn: () => {} }
+    const local = resolveMemoryFs(agent, { log })
     expect(local).toBeInstanceOf(LocalMemoryFs)
     expect(local.root).toBe(agent.dir)
     const { fs } = pod()
-    expect(resolveMemoryFs(agent, { memoryFsFor: () => fs })).toBe(fs)
-    expect(() => resolveMemoryFs(agent, { memoryFsFor: () => undefined })).toThrow(MemorySandboxUnavailableError)
+    expect(resolveMemoryFs(agent, { sandbox: { memoryFsFor: () => fs }, log })).toBe(fs)
+    expect(() => resolveMemoryFs(agent, { sandbox: { memoryFsFor: () => undefined }, log })).toThrow(
+      MemorySandboxUnavailableError
+    )
   })
 })
 
@@ -227,7 +223,7 @@ describe.skipIf(process.platform !== 'linux')('the descriptor-bound executor (po
     const requester = shimRequester(mount, createFdMemoryFsExecutor(mount))
     const fs = new ShimMemoryFs(requester, root)
     await ensureMemory(fs, 'bot-a')
-    const st = await writeMemoryFile(fs, 'deploys.md', 'é'.repeat(120_000), undefined, 'tool')
+    const st = await writeWithSidecar(fs, 'deploys.md', 'é'.repeat(120_000), undefined, 'tool')
     expect(await readMemoryFile(fs, 'deploys.md')).toBe('é'.repeat(120_000))
     await fs.writeFile('memory/big.md', 'é'.repeat(300_000))
     expect((await fs.readFile('memory/big.md'))?.content).toBe('é'.repeat(300_000))

--- a/packages/daemon/test/memory-history-sink.test.ts
+++ b/packages/daemon/test/memory-history-sink.test.ts
@@ -106,13 +106,12 @@ describe('the sink seam in the write path', () => {
     expect(readFileSync(join(memoryDir(dir), 'notes.md'), 'utf8')).toBe('kept')
   })
 
-  it('selects the sidecar by default, the same one every home resolves today, and pages it back', async () => {
+  it('a `daemon` home selects the sidecar inside the store, and pages it back', async () => {
     const dir = newDir()
-    const fs = new LocalMemoryFs(dir)
-    await writeMemoryFile(fs, 'notes.md', 'v1')
-    const ports = resolveMemoryHomePorts({ id: 'bot-a', dir }, undefined)
+    const ports = resolveMemoryHomePorts({ id: 'bot-a', dir }, { log: { warn: () => {} } })
     const sink = ports.historyFor(ports.live)
     expect(sink).toBeInstanceOf(SidecarMemoryHistorySink)
+    await writeMemoryFile(ports.live, 'notes.md', 'v1', undefined, 'tool', sink)
     await sink.append([record('notes.md', 'v2', 'v1')])
     expect(readSidecar(dir).map((event) => event.after)).toEqual(['v1', 'v2'])
     const page = await sink.list!('notes.md', undefined, 5)

--- a/packages/daemon/test/memory-home.test.ts
+++ b/packages/daemon/test/memory-home.test.ts
@@ -1,0 +1,378 @@
+// The memory home selection (memory-evolution.md §3.2.1): a `daemon` home is unchanged on every placement, a
+// `control-plane` home puts the store and its change log on the CP connection behind three activation gates, every
+// writer and reader goes through the ports, and the console reads a CP-homed tree without asking for the pod.
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, promises as fsp, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  AGENT_MEMORY_STORE_V1_FEATURE,
+  MemoryHistoryAppendReq,
+  MemoryStoreReq,
+  type AgentMemoryBinding,
+  type MemoryFsPayload,
+  type MemoryHistoryAppendOk
+} from '@agentconnect.md/protocol'
+import { CpMemoryFs } from '../src/cp/memory-fs.js'
+import { CpMemoryHistorySink } from '../src/cp/memory-history.js'
+import { createMemoryReader } from '../src/cp/memory-reader.js'
+import {
+  LocalMemoryFs,
+  MemoryHomeUnavailableError,
+  MemorySandboxUnavailableError,
+  type MemoryFs
+} from '../src/memory/fs.js'
+import {
+  memoryHomeUnavailable,
+  resolveMemoryHomePorts,
+  type CpMemoryHomeLink,
+  type MemoryHomeAgent
+} from '../src/memory/home.js'
+import { managedDistillCapture, withManagedDistill } from '../src/memory/managed-distill-outbox.js'
+import { ManagedMemoryProvider } from '../src/memory/provider.js'
+import {
+  MEMORY_HISTORY_FILENAME,
+  MEMORY_INDEX,
+  MemoryHistoryNotLocalError,
+  SidecarMemoryHistorySink,
+  channelMemoryRoot,
+  listMemoryHistory
+} from '../src/memory/store.js'
+import type { MemoryPluginMetrics } from '../src/memory-plugin/metrics.js'
+import { MemoryCaptureOutbox, type MemoryCapturePumpRegistry } from '../src/memory-plugin/outbox.js'
+import { applyMemoryFsPayload } from '../src/shim/memory-fs-channel.js'
+import { LocalStore } from '../src/store/local-store.js'
+import { pathExecutor, pod } from './fixtures/memory-fs-pod.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const log = { warn: vi.fn() }
+
+const dirs: string[] = []
+afterAll(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function newDir(prefix = 'ac-home-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+
+const managed = (home: 'daemon' | 'control-plane'): AgentMemoryBinding => ({ provider: 'managed', home })
+/** Step ④ stamps the migration marker on the binding; until the protocol carries it, the daemon reads it as an extra field. */
+const migrating = (): AgentMemoryBinding =>
+  ({ ...managed('control-plane'), homeMigration: 'pending' }) as unknown as AgentMemoryBinding
+
+const agentWith = (memory: AgentMemoryBinding | undefined, dir = newDir()): MemoryHomeAgent => ({
+  id: AGENT,
+  dir,
+  ...(memory ? { memory } : {})
+})
+
+type FakeCp = CpMemoryHomeLink & {
+  tree: string
+  ops: MemoryFsPayload[]
+  appends: MemoryHistoryAppendReq[]
+  up: boolean
+  feature: boolean
+}
+
+/** The CP connection as the home sees it: a tree directory behind the store pair, a recorder behind the change-log pair. */
+function fakeCp(): FakeCp {
+  const tree = newDir('ac-home-tree-')
+  const executor = pathExecutor()
+  const link: FakeCp = {
+    tree,
+    ops: [],
+    appends: [],
+    up: true,
+    feature: true,
+    connected: () => link.up,
+    supportsServerFeature: (feature) => link.feature && feature === AGENT_MEMORY_STORE_V1_FEATURE,
+    async memoryStore(req) {
+      const parsed = MemoryStoreReq.parse(req)
+      link.ops.push(parsed.op)
+      return applyMemoryFsPayload({ ...parsed.op, root: join(tree, parsed.op.root) }, tree, executor)
+    },
+    async memoryHistoryAppend(req): Promise<MemoryHistoryAppendOk> {
+      link.appends.push(MemoryHistoryAppendReq.parse(req))
+      return { accepted: true }
+    }
+  }
+  return link
+}
+
+const reasonOf = (fn: () => unknown): string | undefined => {
+  try {
+    fn()
+    return undefined
+  } catch (err) {
+    return err instanceof MemoryHomeUnavailableError ? err.reason : `not a home refusal: ${String(err)}`
+  }
+}
+
+describe('resolveMemoryHomePorts — the one selection', () => {
+  it('leaves a daemon home as it was: the local tree here, the sandbox volume on a pool member, refused while unbound', () => {
+    const cp = fakeCp()
+    cp.up = false
+    for (const memory of [managed('daemon'), { provider: 'none' } as AgentMemoryBinding, undefined]) {
+      // A `daemon` home never consults the CP connection, down or not.
+      const agent = agentWith(memory)
+      const ports = resolveMemoryHomePorts(agent, { cp, log })
+      expect(ports.live).toBeInstanceOf(LocalMemoryFs)
+      expect(ports.live.root).toBe(agent.dir)
+      expect(ports.staging).toBe(ports.live)
+      expect(ports.historyFor(ports.live)).toBeInstanceOf(SidecarMemoryHistorySink)
+      expect(memoryHomeUnavailable(agent, { cp, log })).toBeUndefined()
+    }
+
+    const { fs } = pod()
+    const agent = agentWith(managed('daemon'))
+    const bound = resolveMemoryHomePorts(agent, { sandbox: { memoryFsFor: () => fs }, cp, log })
+    expect(bound.live).toBe(fs)
+    expect(bound.staging).toBe(fs)
+    expect(bound.historyFor(fs)).toBeInstanceOf(SidecarMemoryHistorySink)
+    const asleep = { sandbox: { memoryFsFor: () => undefined }, cp, log }
+    expect(() => resolveMemoryHomePorts(agent, asleep)).toThrow(MemorySandboxUnavailableError)
+    expect(memoryHomeUnavailable(agent, asleep)?.reason).toBe('sandbox-unavailable')
+  })
+
+  it('puts a control-plane home on the CP connection and leaves staging beside the extraction host', () => {
+    const cp = fakeCp()
+    const agent = agentWith(managed('control-plane'))
+    const ports = resolveMemoryHomePorts(agent, { cp, log })
+    expect(ports.live).toBeInstanceOf(CpMemoryFs)
+    expect(ports.live.key).toBe(`control-plane:${AGENT}:.`)
+    // Self-hosted: the dream host runs on this disk, so its staging root is the agent dir.
+    expect(ports.staging).toBeInstanceOf(LocalMemoryFs)
+    expect(ports.staging.root).toBe(agent.dir)
+    const sink = ports.historyFor(ports.live)
+    expect(sink).toBeInstanceOf(CpMemoryHistorySink)
+    expect((sink as CpMemoryHistorySink).root).toBe('.')
+    expect(sink.list).toBeUndefined()
+    // A channel store under `live` names its own root; a staged store, never in the CP, keeps its sidecar.
+    expect((ports.historyFor(channelMemoryRoot(ports.live, 'c1')) as CpMemoryHistorySink).root).toBe('channels/c1')
+    expect(ports.historyFor(ports.staging)).toBeInstanceOf(SidecarMemoryHistorySink)
+    expect(memoryHomeUnavailable(agent, { cp, log })).toBeUndefined()
+
+    // A pool member: the store resolves without the pod; staging is the pod's volume, looked up on use.
+    const sandbox = { memoryFsFor: vi.fn((): MemoryFs | undefined => undefined) }
+    const onPool = resolveMemoryHomePorts(agent, { sandbox, cp, log })
+    expect(onPool.live).toBeInstanceOf(CpMemoryFs)
+    expect(sandbox.memoryFsFor).not.toHaveBeenCalled()
+    expect(() => onPool.staging).toThrow(MemorySandboxUnavailableError)
+    expect(sandbox.memoryFsFor).toHaveBeenCalledWith(AGENT)
+    const { fs } = pod()
+    sandbox.memoryFsFor.mockReturnValue(fs)
+    expect(onPool.staging).toBe(fs)
+    expect(memoryHomeUnavailable(agent, { sandbox, cp, log })).toBeUndefined()
+  })
+
+  it('refuses a control-plane activation with its reason — no connection, no feature, a pending copy — and never this disk', () => {
+    const agent = agentWith(managed('control-plane'))
+    const gates: [string, () => Parameters<typeof resolveMemoryHomePorts>[1]][] = [
+      ['connection', () => ({ log })],
+      [
+        'connection',
+        () => {
+          const cp = fakeCp()
+          cp.up = false
+          return { cp, log }
+        }
+      ],
+      [
+        'feature',
+        () => {
+          const cp = fakeCp()
+          cp.feature = false
+          return { cp, log }
+        }
+      ]
+    ]
+    for (const [reason, deps] of gates) {
+      expect(reasonOf(() => resolveMemoryHomePorts(agent, deps()))).toBe(reason)
+      expect(memoryHomeUnavailable(agent, deps())?.reason).toBe(reason)
+    }
+    // The copy step ④ starts and step ⑧ finishes: the binding says so, and the tree is served to nobody meanwhile.
+    const pending = agentWith(migrating(), agent.dir)
+    const cp = fakeCp()
+    expect(reasonOf(() => resolveMemoryHomePorts(pending, { cp, log }))).toBe('migrating')
+    expect(memoryHomeUnavailable(pending, { cp, log })?.message).toContain('still receiving the copy')
+    cp.up = false
+    expect(memoryHomeUnavailable(pending, { cp, log })?.reason).toBe('migrating')
+    // One resolution: nothing was created on this member's disk, and no op reached the CP.
+    expect(existsSync(join(agent.dir, 'memory'))).toBe(false)
+    expect(cp.ops).toEqual([])
+  })
+})
+
+describe('every writer and reader goes through the ports', () => {
+  it('routes a topic write under a control-plane home to the CP tree and its change log to the CP sink, with no sidecar anywhere', async () => {
+    const cp = fakeCp()
+    const agent = agentWith(managed('control-plane'))
+    const deps = { cp, log }
+    const provider = new ManagedMemoryProvider(() => resolveMemoryHomePorts(agent, deps))
+    await provider.ensure({ agentId: AGENT }, 'bot-a')
+    await provider.write(
+      { agentId: AGENT },
+      'deploys.md',
+      '---\ndescription: how we ship\n---\n- region sea\n',
+      undefined,
+      'tool'
+    )
+    expect(await fsp.readFile(join(cp.tree, 'memory', 'deploys.md'), 'utf8')).toContain('- region sea')
+    expect((await provider.read({ agentId: AGENT }, 'deploys.md')).content).toContain('- region sea')
+    expect(cp.ops.some((op) => op.op === 'memory-commit')).toBe(true)
+    // The topic record, then the regenerated index's — both to the CP, in the store's own coordinates.
+    expect(cp.appends.flatMap((req) => req.records.map((r) => [req.root, r.path, r.event, r.source]))).toEqual([
+      ['.', 'deploys.md', 'add', 'tool'],
+      ['.', MEMORY_INDEX, 'update', 'tool']
+    ])
+    expect(await fsp.readdir(join(cp.tree, 'memory'))).not.toContain(MEMORY_HISTORY_FILENAME)
+    expect(existsSync(join(agent.dir, 'memory'))).toBe(false)
+
+    // A channel store: the same tree, its own root on every record.
+    await provider.write({ agentId: AGENT, channelKey: 'general-abc' }, 'notes.md', '- pinned\n', undefined, 'console')
+    expect(await fsp.readFile(join(cp.tree, 'channels', 'general-abc', 'memory', 'notes.md'), 'utf8')).toContain(
+      'pinned'
+    )
+    expect(cp.appends.at(-1)).toMatchObject({ agentId: AGENT, root: 'channels/general-abc' })
+    expect(cp.appends.at(-1)!.records.map((r) => [r.path, r.source])).toEqual([['notes.md', 'console']])
+    expect(await fsp.readdir(join(cp.tree, 'channels', 'general-abc', 'memory'))).not.toContain(MEMORY_HISTORY_FILENAME)
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('logs a staged store bound explicitly to the sidecar inside it, whatever the home', async () => {
+    const cp = fakeCp()
+    const agent = agentWith(managed('control-plane'))
+    const provider = new ManagedMemoryProvider(() => resolveMemoryHomePorts(agent, { cp, log }))
+    const staged = new LocalMemoryFs(join(agent.dir, 'memory-dreams', 'drm-1', 'store'))
+    await provider.write({ agentId: AGENT, root: staged }, 'prefs.md', '- tabs\n', undefined, 'dream')
+    expect(existsSync(join(staged.root, 'memory', MEMORY_HISTORY_FILENAME))).toBe(true)
+    expect(cp.appends).toEqual([])
+    expect(cp.ops).toEqual([])
+  })
+
+  it('refuses a daemon-side page of a control-plane change log as a routing bug, never an empty page', async () => {
+    const cp = fakeCp()
+    const agent = agentWith(managed('control-plane'))
+    const provider = new ManagedMemoryProvider(() => resolveMemoryHomePorts(agent, { cp, log }))
+    await expect(
+      listMemoryHistory(new CpMemoryHistorySink(cp, AGENT, '.', log), 'notes.md', undefined, 5)
+    ).rejects.toBeInstanceOf(MemoryHistoryNotLocalError)
+    await expect(
+      provider.adminSurface().history!({ agentId: AGENT }, { path: 'notes.md', limit: 5 })
+    ).rejects.toBeInstanceOf(MemoryHistoryNotLocalError)
+    // The sidecar still pages, through the same entry point.
+    const local = new LocalMemoryFs(newDir())
+    await new ManagedMemoryProvider(() => resolveMemoryHomePorts({ id: AGENT, dir: local.root }, { log })).write(
+      { agentId: AGENT },
+      'notes.md',
+      'v1',
+      undefined,
+      'tool'
+    )
+    const page = await listMemoryHistory(new SidecarMemoryHistorySink(local), 'notes.md', undefined, 5)
+    expect(page.events.map((event) => event.after)).toEqual(['v1'])
+  })
+})
+
+describe('the console reads a control-plane home without waking the pod', () => {
+  it('answers list, read, channels, and write from the CP port while the pod sleeps, and only a staging read asks for it', async () => {
+    const cp = fakeCp()
+    const agent = agentWith(managed('control-plane'))
+    // A pool member whose agent pod is not bound: nothing here may ask for it.
+    const sandbox = { memoryFsFor: vi.fn((): MemoryFs | undefined => undefined) }
+    const deps = { sandbox, cp, log }
+    const provider = new ManagedMemoryProvider(() => resolveMemoryHomePorts(agent, deps))
+    const reader = createMemoryReader(() => resolveMemoryHomePorts(agent, deps), {
+      adminSurfaceForAgent: () => provider.adminSurface()
+    })
+    await provider.ensure({ agentId: AGENT, channelKey: 'c1', channel: 'C1' }, 'bot-a')
+    await reader.write({ agentId: AGENT, path: 'notes.md', content: '- from the console\n' })
+    expect((await reader.list({ agentId: AGENT })).entries.map((entry) => entry.name)).toContain('notes.md')
+    expect((await reader.read({ agentId: AGENT, path: 'notes.md', offset: 0, limit: 100 })).content).toContain(
+      'from the console'
+    )
+    expect((await reader.channels({ agentId: AGENT })).channels.map((channel) => channel.channelKey)).toEqual(['c1'])
+    expect(sandbox.memoryFsFor).not.toHaveBeenCalled()
+    expect(cp.appends.at(-1)!.records[0]).toMatchObject({ path: 'notes.md', source: 'console' })
+
+    // #1077's wake survives where staging lives: a review of a draft on the pool still refuses as asleep.
+    expect(() => resolveMemoryHomePorts(agent, deps).staging).toThrow(MemorySandboxUnavailableError)
+  })
+
+  it('carries the reason of an unreachable home to the reader, and still knows the agent', async () => {
+    const cp = fakeCp()
+    const agent = agentWith(managed('control-plane'))
+    const provider = new ManagedMemoryProvider(() => resolveMemoryHomePorts(agent, { cp, log }))
+    const reader = createMemoryReader(() => resolveMemoryHomePorts(agent, { cp, log }), {
+      adminSurfaceForAgent: () => provider.adminSurface()
+    })
+    cp.up = false
+    const refusal = await reader.list({ agentId: AGENT }).then(
+      () => undefined,
+      (err: unknown) => err
+    )
+    expect(refusal).toBeInstanceOf(MemoryHomeUnavailableError)
+    expect((refusal as MemoryHomeUnavailableError).reason).toBe('connection')
+    await expect(provider.standingContextAtSessionStart({ agentId: AGENT })).rejects.toBeInstanceOf(
+      MemoryHomeUnavailableError
+    )
+    // The shape query is config, not files: a known agent whose home is out of reach still answers it.
+    expect((await reader.surface({ agentId: AGENT })).shape).toBe('files')
+  })
+})
+
+describe('degradation: the capture outbox waits for the home', () => {
+  const metrics: MemoryPluginMetrics = {
+    recall: vi.fn(),
+    recallInjected: vi.fn(),
+    captureState: vi.fn(),
+    outbox: vi.fn()
+  }
+  const noPlugins: MemoryCapturePumpRegistry = {
+    connectionIds: () => [],
+    clientFor: () => undefined,
+    specFor: () => undefined,
+    markDegraded: vi.fn(),
+    markRecovered: vi.fn()
+  }
+
+  it('defers a distillation while the CP connection is down and drains it once the home is reachable', async () => {
+    const cp = fakeCp()
+    cp.up = false
+    const agent = agentWith(managed('control-plane'))
+    const distill = vi.fn(async () => {})
+    const db = await LocalStore.open(join(newDir('ac-home-outbox-'), 'local.sqlite'))
+    const outbox = new MemoryCaptureOutbox(
+      db,
+      withManagedDistill(noPlugins, {
+        agentIds: () => [AGENT],
+        // "The home is reachable", the same predicate the daemon wires — not "the pod is bound".
+        reachable: () => memoryHomeUnavailable(agent, { cp, log }) === undefined,
+        distill
+      }),
+      { metrics, unavailableRetryMs: 5 }
+    )
+    outbox.start()
+    const queued = await outbox.enqueue(
+      managedDistillCapture({ agentId: AGENT, turnId: 'turn-1', sessionId: 'sess-1', input: 'hi', output: 'hello' })
+    )
+    expect(queued.status).toBe('inserted')
+    await vi.waitFor(async () =>
+      expect((await db.getMemoryCapture(queued.operationId))?.reasonCode).toBe('connection_unavailable')
+    )
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(distill).not.toHaveBeenCalled()
+    expect(await db.getMemoryCapture(queued.operationId)).toMatchObject({ state: 'pending', attempts: 0 })
+
+    // READY again: the daemon wakes the pump from `onReady`, and the deferred turn is distilled exactly once.
+    cp.up = true
+    outbox.wake()
+    await vi.waitFor(async () => expect((await db.getMemoryCapture(queued.operationId))?.state).toBe('completed'))
+    expect(distill).toHaveBeenCalledTimes(1)
+    await outbox.stop()
+    await db.close()
+  })
+})

--- a/packages/daemon/test/memory-provider-dispatch.test.ts
+++ b/packages/daemon/test/memory-provider-dispatch.test.ts
@@ -13,6 +13,7 @@ import {
 import { MEMORY_INDEX, MemoryConflictError, MemoryPathError } from '../src/memory/store.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
 import { isNativeRuntimeSupported, nativeRuntimeEnv } from '../src/memory/runtime/native.js'
+import { localMemoryHome } from '../src/memory/home.js'
 
 function newDir(): string {
   return mkdtempSync(join(tmpdir(), 'ac-m2-'))
@@ -130,7 +131,8 @@ describe('DispatchingMemoryProvider (per-agent routing)', () => {
   const runtimes: Record<string, RuntimeDef> = { 'bot-m': claude, 'bot-n': claude, 'bot-0': claude }
   function provider() {
     return createMemoryProvider({
-      memoryFsFor: (id) => (roots[id] === undefined ? undefined : new LocalMemoryFs(roots[id]!)),
+      memoryHomePortsFor: (id) =>
+        roots[id] === undefined ? undefined : localMemoryHome(new LocalMemoryFs(roots[id]!)),
       agentDirByAgent: (id) => roots[id],
       runtimeFor: (id) => runtimes[id],
       providerKindFor: (id) => kinds[id] ?? 'managed'

--- a/packages/daemon/test/memory.test.ts
+++ b/packages/daemon/test/memory.test.ts
@@ -7,10 +7,8 @@ import {
   ensureMemory,
   readIndex,
   readMemoryFile,
-  writeMemoryFile,
   appendHistory,
   listMemory,
-  listMemoryHistory,
   memoryDir,
   memoryTopicName,
   withMemoryDirLock,
@@ -31,6 +29,8 @@ import { createMemoryReader, MemoryViolationError } from '../src/cp/memory-reade
 import { createManagedMemoryProvider } from '../src/memory/provider.js'
 import { MEMORY_TOOLS } from '../src/memory/tools.js'
 import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+import { listSidecarHistory, writeWithSidecar } from './fixtures/memory-sidecar.js'
+import { localMemoryHome } from '../src/memory/home.js'
 
 const local = (dir: string) => new LocalMemoryFs(dir)
 
@@ -46,7 +46,7 @@ describe('memory/store (directory model)', () => {
     expect(existsSync(indexPath(dir))).toBe(true)
     expect(readFileSync(indexPath(dir), 'utf8')).toContain('# bot-a memory')
     // second call must not overwrite existing content
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'kept')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'kept')
     await ensureMemory(local(dir), 'bot-a')
     expect(readFileSync(indexPath(dir), 'utf8')).toBe('kept')
   })
@@ -54,8 +54,8 @@ describe('memory/store (directory model)', () => {
   it('reads/writes the index and topic files', async () => {
     const dir = newDir()
     expect(await readMemoryFile(local(dir), MEMORY_INDEX)).toBe('') // missing ⇒ ''
-    await writeMemoryFile(local(dir), MEMORY_INDEX, '# index\n- [deploys](deploys.md)')
-    await writeMemoryFile(local(dir), 'deploys.md', '# deploys\nrun make ship')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, '# index\n- [deploys](deploys.md)')
+    await writeWithSidecar(local(dir), 'deploys.md', '# deploys\nrun make ship')
     expect(await readMemoryFile(local(dir), MEMORY_INDEX)).toContain('deploys.md')
     expect(await readMemoryFile(local(dir), 'deploys.md')).toBe('# deploys\nrun make ship')
   })
@@ -63,16 +63,16 @@ describe('memory/store (directory model)', () => {
   it('listMemory returns the index first, then topics; skips .tmp', async () => {
     const dir = newDir()
     expect(await listMemory(local(dir))).toEqual([]) // missing dir ⇒ []
-    await writeMemoryFile(local(dir), 'zeta.md', 'z')
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'i')
-    await writeMemoryFile(local(dir), 'alpha.md', 'a')
+    await writeWithSidecar(local(dir), 'zeta.md', 'z')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'i')
+    await writeWithSidecar(local(dir), 'alpha.md', 'a')
     const names = (await listMemory(local(dir))).map((f) => f.name)
     expect(names).toEqual([MEMORY_INDEX, 'alpha.md', 'zeta.md']) // index first, then alphabetical
   })
 
   it('readIndex truncates a huge index to the inject cap', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'x'.repeat(MAX_INDEX_INJECT_BYTES + 5000))
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'x'.repeat(MAX_INDEX_INJECT_BYTES + 5000))
     const injected = await readIndex(local(dir))
     expect(Buffer.byteLength(injected)).toBeLessThanOrEqual(MAX_INDEX_INJECT_BYTES)
     expect(injected).toContain('truncated')
@@ -80,7 +80,7 @@ describe('memory/store (directory model)', () => {
 
   it('readIndex truncates before a complete UTF-8 code point', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, '🚀'.repeat(MAX_INDEX_INJECT_BYTES))
+    await writeWithSidecar(local(dir), MEMORY_INDEX, '🚀'.repeat(MAX_INDEX_INJECT_BYTES))
     const injected = await readIndex(local(dir))
     expect(Buffer.byteLength(injected)).toBeLessThanOrEqual(MAX_INDEX_INJECT_BYTES)
     expect(injected).not.toContain('\uFFFD')
@@ -100,32 +100,34 @@ describe('memory/store (directory model)', () => {
   it('reserves .history from ordinary managed-memory reads and writes', async () => {
     const dir = newDir()
     await expect(readMemoryFile(local(dir), MEMORY_HISTORY_FILENAME)).rejects.toBeInstanceOf(MemoryPathError)
-    await expect(writeMemoryFile(local(dir), MEMORY_HISTORY_FILENAME, 'forged provenance')).rejects.toBeInstanceOf(
+    await expect(writeWithSidecar(local(dir), MEMORY_HISTORY_FILENAME, 'forged provenance')).rejects.toBeInstanceOf(
       MemoryPathError
     )
   })
 
   it('rejects a write over the size budget (MemoryTooLargeError)', async () => {
     const dir = newDir()
-    await expect(writeMemoryFile(local(dir), 'big.md', 'x'.repeat(MAX_MEMORY_FILE_BYTES + 1))).rejects.toBeInstanceOf(
+    await expect(writeWithSidecar(local(dir), 'big.md', 'x'.repeat(MAX_MEMORY_FILE_BYTES + 1))).rejects.toBeInstanceOf(
       MemoryTooLargeError
     )
     // at the limit is fine
-    await expect(writeMemoryFile(local(dir), 'ok.md', 'x'.repeat(MAX_MEMORY_FILE_BYTES))).resolves.toBeTruthy()
+    await expect(writeWithSidecar(local(dir), 'ok.md', 'x'.repeat(MAX_MEMORY_FILE_BYTES))).resolves.toBeTruthy()
   })
 
   it('enforces the ifMatchMtime precondition (optimistic concurrency)', async () => {
     const dir = newDir()
-    const first = await writeMemoryFile(local(dir), 'notes.md', 'v1')
+    const first = await writeWithSidecar(local(dir), 'notes.md', 'v1')
     // a stale mtime is rejected
-    await expect(writeMemoryFile(local(dir), 'notes.md', 'v2', '1999-01-01T00:00:00.000Z')).rejects.toBeInstanceOf(
+    await expect(writeWithSidecar(local(dir), 'notes.md', 'v2', '1999-01-01T00:00:00.000Z')).rejects.toBeInstanceOf(
       MemoryConflictError
     )
     // the current mtime succeeds
-    await expect(writeMemoryFile(local(dir), 'notes.md', 'v2', first.mtime)).resolves.toBeTruthy()
+    await expect(writeWithSidecar(local(dir), 'notes.md', 'v2', first.mtime)).resolves.toBeTruthy()
     expect(await readMemoryFile(local(dir), 'notes.md')).toBe('v2')
     // a precondition on a brand-new (absent) file with a non-empty mtime is a conflict
-    await expect(writeMemoryFile(local(dir), 'fresh.md', 'x', 'some-mtime')).rejects.toBeInstanceOf(MemoryConflictError)
+    await expect(writeWithSidecar(local(dir), 'fresh.md', 'x', 'some-mtime')).rejects.toBeInstanceOf(
+      MemoryConflictError
+    )
   })
 
   it('does not follow a pre-planted predictable temp symlink', async () => {
@@ -138,7 +140,7 @@ describe('memory/store (directory model)', () => {
     symlinkSync(outside, join(memoryDir(dir), 'notes.md.tmp'))
     symlinkSync(outsideHistory, join(memoryDir(dir), MEMORY_HISTORY_FILENAME))
 
-    await writeMemoryFile(local(dir), 'notes.md', 'updated')
+    await writeWithSidecar(local(dir), 'notes.md', 'updated')
 
     expect(readFileSync(outside, 'utf8')).toBe('keep')
     expect(readFileSync(outsideHistory, 'utf8')).toBe('keep-history')
@@ -174,8 +176,8 @@ describe('memory/store (.history change log)', () => {
 
   it('records add then update in order, with before absent on add and present on update', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), 'notes.md', 'v1')
-    await writeMemoryFile(local(dir), 'notes.md', 'v2')
+    await writeWithSidecar(local(dir), 'notes.md', 'v1')
+    await writeWithSidecar(local(dir), 'notes.md', 'v2')
     const log = readHistory(dir)
     expect(log).toHaveLength(2)
     expect(log[0]).toMatchObject({ path: 'notes.md', event: 'add', after: 'v1', scope: 'agent', source: 'tool' })
@@ -185,8 +187,8 @@ describe('memory/store (.history change log)', () => {
 
   it('attributes the source (tool default vs console)', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), 'a.md', 'x') // default source
-    await writeMemoryFile(local(dir), 'b.md', 'y', undefined, 'console')
+    await writeWithSidecar(local(dir), 'a.md', 'x') // default source
+    await writeWithSidecar(local(dir), 'b.md', 'y', undefined, 'console')
     const log = readHistory(dir)
     expect(log.find((r) => r.path === 'a.md')?.source).toBe('tool')
     expect(log.find((r) => r.path === 'b.md')?.source).toBe('console')
@@ -195,7 +197,7 @@ describe('memory/store (.history change log)', () => {
   it('truncates an over-cap before/after snapshot (flagged), keeping the line bounded', async () => {
     const dir = newDir()
     const big = 'x'.repeat(MAX_HISTORY_VALUE_BYTES + 500)
-    await writeMemoryFile(local(dir), 'big.md', big)
+    await writeWithSidecar(local(dir), 'big.md', big)
     const rec = readHistory(dir)[0]!
     expect(rec.truncated).toBe(true)
     expect(rec.after.endsWith('…')).toBe(true)
@@ -204,8 +206,8 @@ describe('memory/store (.history change log)', () => {
 
   it('does not surface .history as a topic in listMemory', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'i')
-    await writeMemoryFile(local(dir), 'topic.md', 't')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'i')
+    await writeWithSidecar(local(dir), 'topic.md', 't')
     const names = (await listMemory(local(dir))).map((f) => f.name)
     expect(names).toEqual([MEMORY_INDEX, 'topic.md']) // .history excluded
     expect(existsSync(join(memoryDir(dir), MEMORY_HISTORY_FILENAME))).toBe(true) // but it exists
@@ -267,7 +269,7 @@ describe('memory/store (.history change log)', () => {
       })
     )
 
-    await expect(listMemoryHistory(local(dir), 'notes.md', undefined, 5)).resolves.toMatchObject({
+    await expect(listSidecarHistory(local(dir), 'notes.md', undefined, 5)).resolves.toMatchObject({
       events: [{ after: 'v1' }]
     })
     expect(readFileSync(outside, 'utf8')).toBe('keep')
@@ -275,18 +277,18 @@ describe('memory/store (.history change log)', () => {
 
   it('pages one file newest first without interleaved topic changes', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), 'notes.md', 'v1')
-    await writeMemoryFile(local(dir), 'other.md', 'unrelated')
+    await writeWithSidecar(local(dir), 'notes.md', 'v1')
+    await writeWithSidecar(local(dir), 'other.md', 'unrelated')
     for (let version = 2; version <= 7; version += 1) {
-      await writeMemoryFile(local(dir), 'notes.md', `v${version}`)
+      await writeWithSidecar(local(dir), 'notes.md', `v${version}`)
     }
 
-    const newest = await listMemoryHistory(local(dir), 'notes.md', undefined, 5)
+    const newest = await listSidecarHistory(local(dir), 'notes.md', undefined, 5)
     expect(newest.events.map((event) => event.after)).toEqual(['v7', 'v6', 'v5', 'v4', 'v3'])
     expect(newest.nextCursor).toBeDefined()
     expect(newest.events.every((event) => event.path === 'notes.md')).toBe(true)
 
-    const older = await listMemoryHistory(local(dir), 'notes.md', newest.nextCursor, 5)
+    const older = await listSidecarHistory(local(dir), 'notes.md', newest.nextCursor, 5)
     expect(older.events.map((event) => event.after)).toEqual(['v2', 'v1'])
     expect(older.nextCursor).toBeUndefined()
   })
@@ -294,7 +296,7 @@ describe('memory/store (.history change log)', () => {
   it('retains the newest 100 changes for each memory file by default', async () => {
     const dir = newDir()
     for (let version = 0; version < MAX_HISTORY_VERSIONS_PER_FILE + 3; version += 1) {
-      await writeMemoryFile(local(dir), 'notes.md', `v${version}`)
+      await writeWithSidecar(local(dir), 'notes.md', `v${version}`)
     }
 
     const log = readHistory(dir)
@@ -321,7 +323,7 @@ describe('memory/store (.history change log)', () => {
     expect(Buffer.byteLength(oversized)).toBeGreaterThan(MAX_HISTORY_FILE_BYTES)
     writeFileSync(historyPath, oversized)
 
-    const page = await listMemoryHistory(local(dir), 'topic-549.md', undefined, 5)
+    const page = await listSidecarHistory(local(dir), 'topic-549.md', undefined, 5)
     const compacted = readFileSync(historyPath, 'utf8')
     const retained = readHistory(dir)
     expect(page.events).toHaveLength(1)
@@ -353,7 +355,7 @@ describe('memory/store (.history change log)', () => {
 
   it('serializes history reads behind a dream-style directory mutation', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), 'notes.md', 'v1')
+    await writeWithSidecar(local(dir), 'notes.md', 'v1')
     let entered!: () => void
     let release!: () => void
     const enteredLock = new Promise<void>((resolve) => (entered = resolve))
@@ -376,7 +378,7 @@ describe('memory/store (.history change log)', () => {
     await enteredLock
 
     let settled = false
-    const read = listMemoryHistory(local(dir), 'notes.md', undefined, 5).then((page) => {
+    const read = listSidecarHistory(local(dir), 'notes.md', undefined, 5).then((page) => {
       settled = true
       return page
     })
@@ -390,7 +392,8 @@ describe('memory/store (.history change log)', () => {
 })
 
 describe('cp/memory-reader', () => {
-  const reader = (dir: string | undefined) => createMemoryReader(() => (dir === undefined ? undefined : local(dir)))
+  const reader = (dir: string | undefined) =>
+    createMemoryReader(() => (dir === undefined ? undefined : localMemoryHome(local(dir))))
 
   it('list returns exists:false for an empty/missing memory dir', async () => {
     const rep = await reader(newDir()).list({ agentId: 'bot-a' })
@@ -399,8 +402,8 @@ describe('cp/memory-reader', () => {
 
   it('list returns the files once written', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'i')
-    await writeMemoryFile(local(dir), 'deploys.md', 'd')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'i')
+    await writeWithSidecar(local(dir), 'deploys.md', 'd')
     const rep = await reader(dir).list({ agentId: 'bot-a' })
     expect(rep.exists).toBe(true)
     expect(rep.entries.map((e) => e.name)).toEqual([MEMORY_INDEX, 'deploys.md'])
@@ -413,7 +416,7 @@ describe('cp/memory-reader', () => {
 
   it('read returns a topic file slice with size/mtime/nextOffset', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), 'deploys.md', '# mem\nhello')
+    await writeWithSidecar(local(dir), 'deploys.md', '# mem\nhello')
     const rep = await reader(dir).read({ agentId: 'bot-a', path: 'deploys.md', offset: 0, limit: 65536 })
     expect(rep.exists).toBe(true)
     expect(rep.content).toBe('# mem\nhello')
@@ -431,8 +434,8 @@ describe('cp/memory-reader', () => {
 
   it('returns bounded managed history pages through the dedicated reader method', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), 'deploys.md', 'v1')
-    await writeMemoryFile(local(dir), 'deploys.md', 'v2', undefined, 'console')
+    await writeWithSidecar(local(dir), 'deploys.md', 'v1')
+    await writeWithSidecar(local(dir), 'deploys.md', 'v2', undefined, 'console')
 
     const page = await reader(dir).history({ agentId: 'bot-a', path: 'deploys.md', limit: 5 })
     expect(page).toMatchObject({
@@ -459,7 +462,7 @@ describe('cp/memory-reader', () => {
 
   it('surfaces a stale ifMatchMtime as MemoryConflictError on write', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'v1')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'v1')
     await expect(
       reader(dir).write({ agentId: 'bot-a', path: MEMORY_INDEX, content: 'v2', ifMatchMtime: 'stale' })
     ).rejects.toBeInstanceOf(MemoryConflictError)
@@ -467,9 +470,9 @@ describe('cp/memory-reader', () => {
 
   it('routes legacy file frames through the selected file provider', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'managed content must stay hidden')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'managed content must stay hidden')
     const writes: Array<{ path: string; content: string; ifMatch?: string; source?: string }> = []
-    const files = createMemoryReader(() => local(dir), {
+    const files = createMemoryReader(() => localMemoryHome(local(dir)), {
       adminSurfaceForAgent: () => ({
         shape: 'files',
         list: async () => [
@@ -513,7 +516,7 @@ describe('cp/memory-reader', () => {
 
   it('routes an external provider through records and blocks the underlying file surface', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'must stay hidden')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'must stay hidden')
     const record = {
       id: 'record-1',
       text: 'deploy in sea',
@@ -521,7 +524,7 @@ describe('cp/memory-reader', () => {
       version: 'v1'
     }
     let updatedVersion: string | undefined
-    const records = createMemoryReader(() => local(dir), {
+    const records = createMemoryReader(() => localMemoryHome(local(dir)), {
       adminSurfaceForAgent: () => ({
         shape: 'records',
         capabilities: new Set(['recall', 'list', 'get', 'create', 'update', 'delete', 'history'] as const),
@@ -564,7 +567,7 @@ describe('cp/memory-reader', () => {
   })
 
   it('hides unsupported record actions at the router boundary', async () => {
-    const records = createMemoryReader(() => local(newDir()), {
+    const records = createMemoryReader(() => localMemoryHome(local(newDir())), {
       adminSurfaceForAgent: () => ({
         shape: 'records',
         capabilities: new Set(['recall', 'capture'] as const),
@@ -599,7 +602,7 @@ describe('memory MCP tools (executeTool)', () => {
     ({
       // gatewayFor returns undefined — a memory-only agent has no Slack connection.
       gatewayFor: () => undefined,
-      memory: createManagedMemoryProvider(() => local(dir)),
+      memory: createManagedMemoryProvider(() => localMemoryHome(local(dir))),
       recordOutbound: () => {},
       now: () => 0
     }) as unknown as OpsDeps
@@ -671,7 +674,7 @@ describe('memory MCP tools (executeTool)', () => {
 
   it('readMemory defaults to the index', async () => {
     const dir = newDir()
-    await writeMemoryFile(local(dir), MEMORY_INDEX, 'the index')
+    await writeWithSidecar(local(dir), MEMORY_INDEX, 'the index')
     const read = (await executeTool(ctx, 'readMemory', {}, depsFor(dir))) as { path: string; content: string }
     expect(read.path).toBe('MEMORY.md')
     expect(read.content).toBe('the index')
@@ -745,7 +748,7 @@ describe('memory MCP tools (executeTool)', () => {
 
 describe('memory/provider (ManagedMemoryProvider)', () => {
   const provider = (dir: string | undefined) =>
-    createManagedMemoryProvider(() => (dir === undefined ? undefined : local(dir)))
+    createManagedMemoryProvider(() => (dir === undefined ? undefined : localMemoryHome(local(dir))))
   const scope = { agentId: 'bot-a' }
 
   it('kind is managed', () => {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -9,11 +9,13 @@ import { buildHookMessage } from '../src/messages/hook-message.js'
 import { hookSubjectSessionKey, type RdMsgHook } from '@agentconnect.md/protocol'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 import { createManagedMemoryProvider } from '../src/memory/provider.js'
-import { writeMemoryFile, MEMORY_INDEX, MAX_INDEX_INJECT_BYTES } from '../src/memory/store.js'
-import { LocalMemoryFs } from '../src/memory/fs.js'
+import { MEMORY_INDEX, MAX_INDEX_INJECT_BYTES } from '../src/memory/store.js'
+import { LocalMemoryFs, MemoryHomeUnavailableError } from '../src/memory/fs.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
 import type { McpServer } from '@agentclientprotocol/sdk'
+import { writeWithSidecar } from './fixtures/memory-sidecar.js'
+import { localMemoryHome } from '../src/memory/home.js'
 
 const local = (dir: string) => new LocalMemoryFs(dir)
 
@@ -45,7 +47,7 @@ const fakeHost = () => ({ newSession: vi.fn(async () => 'acp-1') }) as any
 
 // The managed memory provider over the shared agent's root dir — SessionManager
 // now seeds/injects memory through it.
-const memory = createManagedMemoryProvider(() => local(agent.dir))
+const memory = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
 
 const msg = (over: Partial<NormalizedMessage> & { ts?: string; channel?: string }): NormalizedMessage => {
   const channel = over.channel ?? 'C1'
@@ -442,7 +444,7 @@ describe('SessionManager', () => {
       hasSession: () => true,
       usesMetaSystemPrompt: () => true
     } as any
-    const recalling = createManagedMemoryProvider(() => local(agent.dir))
+    const recalling = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
     recalling.recallForTurn = vi.fn(async (_scope, req) => [
       {
         id: `memory-${req.turnId}`,
@@ -501,7 +503,7 @@ describe('SessionManager', () => {
   it('fails open when recall errors and never exposes a plugin error body in the prompt', async () => {
     const store = await newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
-    const broken = createManagedMemoryProvider(() => local(agent.dir))
+    const broken = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
     broken.recallForTurn = vi.fn(async () => {
       throw new Error('upstream body must stay private')
     })
@@ -527,10 +529,54 @@ describe('SessionManager', () => {
     await (await store).close()
   })
 
+  it('starts a session without standing context, and warns, when the memory home is out of reach', async () => {
+    // memory-evolution.md §3.2.1 degradation: a `control-plane` home behind a down CP connection (or a suspended
+    // sandbox) is one resolution, not a fallback to this disk — the turn proceeds, the memory index is simply absent.
+    const store = await newStore()
+    await writeWithSidecar(local(agent.dir), MEMORY_INDEX, '# idx\n- SENTINEL_MEMORY_LINE')
+    const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
+    const unreachable = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
+    const down = new MemoryHomeUnavailableError(
+      'connection',
+      'agent "bot-a" keeps its memory in the Control Plane, which is unreachable'
+    )
+    unreachable.ensure = vi.fn(async () => {
+      throw down
+    })
+    const onMemoryHomeUnavailable = vi.fn()
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => host,
+      agentById: () => agent,
+      memory: unreachable,
+      onMemoryHomeUnavailable
+    })
+    const turn = await sm.handle('bot-a', msg({ ts: '100.1', text: 'still here' }))
+    expect(turn.blocks.at(-1)).toEqual({ type: 'text', text: '[U1] still here' })
+    expect(onMemoryHomeUnavailable).toHaveBeenCalledWith('bot-a', down)
+    const metaArg = host.newSession.mock.calls[0][3] as string
+    expect(metaArg).toMatch(/^# Agent/)
+    expect(metaArg).not.toContain('SENTINEL_MEMORY_LINE')
+
+    // Only an unreachable home degrades; any other failure of the seeding still fails the turn.
+    const broken = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
+    broken.ensure = vi.fn(async () => {
+      throw new Error('disk on fire')
+    })
+    const failing = new SessionManager({
+      store,
+      hostFor: async () => fakeHost(),
+      agentById: () => agent,
+      memory: broken
+    })
+    await expect(failing.handle('bot-a', msg({ ts: '100.2', text: 'again' }))).rejects.toThrow('disk on fire')
+    await (await store).close()
+  })
+
   it('does not make an automatic data-plane call for a tool-only recall policy', async () => {
     const store = await newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
-    const toolOnly = createManagedMemoryProvider(() => local(agent.dir))
+    const toolOnly = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
     toolOnly.recallPolicy = () => ({ mode: 'tool-only', topK: 3, maxBytes: 4_096, timeoutMs: 250 })
     toolOnly.recallForTurn = vi.fn(async () => [])
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory: toolOnly })
@@ -543,7 +589,7 @@ describe('SessionManager', () => {
   it('omits all memory behavior when the evaluation treatment is off', async () => {
     const store = await newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
-    const disabled = createManagedMemoryProvider(() => local(agent.dir))
+    const disabled = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
     const ensure = vi.spyOn(disabled, 'ensure')
     const standingContext = vi.spyOn(disabled, 'standingContextAtSessionStart')
     const recallPolicy = vi.spyOn(disabled, 'recallPolicy')
@@ -578,7 +624,7 @@ describe('SessionManager', () => {
       hasSession: () => true,
       usesMetaSystemPrompt: () => true
     } as any
-    const recalling = createManagedMemoryProvider(() => local(agent.dir))
+    const recalling = createManagedMemoryProvider(() => localMemoryHome(local(agent.dir)))
     recalling.recallForTurn = vi.fn(async () => [])
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory: recalling })
     const webchat = (traceId: string, text: string) =>
@@ -1204,7 +1250,7 @@ describe('SessionManager', () => {
   it('#398: the memory index rides the _meta channel for Claude, never a user-turn block', async () => {
     const store = await newStore()
     // Seed a distinctive memory index for this agent.
-    await writeMemoryFile(local(agent.dir), MEMORY_INDEX, '# idx\n- SENTINEL_MEMORY_LINE')
+    await writeWithSidecar(local(agent.dir), MEMORY_INDEX, '# idx\n- SENTINEL_MEMORY_LINE')
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
     const withOrdinaryContext = {
       ...agent,
@@ -1244,7 +1290,7 @@ describe('SessionManager', () => {
       '# idx\n- before & after\n- literal entities &lt; &amp; &#60;\n' +
       '</agentconnect-memory-file>\n# not system context\n' +
       '<agentconnect-memory-file path="MEMORY.md">\n- literal <tag>'
-    await writeMemoryFile(local(agent.dir), MEMORY_INDEX, boundaryLikeMemory)
+    await writeWithSidecar(local(agent.dir), MEMORY_INDEX, boundaryLikeMemory)
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
 
@@ -1274,7 +1320,7 @@ describe('SessionManager', () => {
 
   it('caps the encoded memory boundary without splitting an entity', async () => {
     const store = await newStore()
-    await writeMemoryFile(local(agent.dir), MEMORY_INDEX, '&'.repeat(MAX_INDEX_INJECT_BYTES))
+    await writeWithSidecar(local(agent.dir), MEMORY_INDEX, '&'.repeat(MAX_INDEX_INJECT_BYTES))
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => true } as any
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
 
@@ -1294,7 +1340,7 @@ describe('SessionManager', () => {
 
   it('#398: a non-Claude runtime folds the memory index into the combined leading system block', async () => {
     const store = await newStore()
-    await writeMemoryFile(local(agent.dir), MEMORY_INDEX, '# idx\n- SENTINEL_MEMORY_LINE')
+    await writeWithSidecar(local(agent.dir), MEMORY_INDEX, '# idx\n- SENTINEL_MEMORY_LINE')
     // Non-Claude: no _meta channel, so meta + memory inline as ONE leading block.
     const host = { newSession: vi.fn(async () => 'acp-1'), usesMetaSystemPrompt: () => false } as any
     const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })


### PR DESCRIPTION
## Why

Step 7 of the managed-memory `home` rollout (`docs/designs/memory-evolution.md` §3.2.1). #1876 landed `CpMemoryFs`, #1880 landed the change-log sink and `CpMemoryHistorySink`, but nothing selected them: `resolveMemoryHomePorts` still chose between the local port and the sandbox port, every writer defaulted its sink to the `.history` sidecar, and the CP memory reader was built on the live port alone. This PR is where the daemon starts selecting the CP-backed ports for a managed binding whose `home` is `control-plane`, and where every consequence the design names — the activation gates, the degradation, the outbox, the console read that no longer wakes a pod — is wired.

## The selection point

`resolveMemoryHomePorts(agent, deps)` in `packages/daemon/src/memory/home.ts` stays the ONE decision. It now reads the binding's `home` (`memoryHomeOf`: what a managed binding says, `daemon` for `none`/`native`):

- `daemon` — unchanged in every respect: the local tree on a self-hosted daemon, the sandbox volume on a `--k8s` member (refused with `MemorySandboxUnavailableError` while the pod is unbound), the sidecar as the sink. The design's "refuse `daemon` on the pool" is deliberately NOT here (step 10, together with the CP flipping existing pool agents — a daemon that refused first would break every pool agent in between).
- `control-plane` — `live` is `CpMemoryFs(cp, agent.id)`, `historyFor(store)` is `CpMemoryHistorySink(cp, agent.id, store.root, log)` for any store under `live` (the agent tree at `.`, a channel store at `channels/<key>`) and the sidecar for a staged store, and `staging` is exactly what it is today (this disk, or the pod's volume) — resolved on access as a getter, so the store never needs the pod while a review of a draft on the pool still refuses as asleep.

`deps` is `{ sandbox?, cp?, log }`: the daemon passes its `K8sRuntimePlane`, its `CpClient` (which structurally satisfies `CpMemoryStoreLink & CpMemoryHistoryLink`) and its logger from one `memoryHomeDeps()`.

## The three gates and the `migrating` reason

`memoryHomeUnavailable(agent, deps)` is the activation gate `resolveMemoryHomePorts` refuses on and the outbox's reachability predicate. For a `control-plane` home, in this order:

1. `homeMigration: 'pending'` on the binding → `MemoryHomeUnavailableError('migrating', …)` — new member of `MemoryHomeUnavailableReason`. Step 4 stamps it when the home flips; step 8 copies the tree and clears it. Until then the CP tree is served to nobody, whatever the connection's state. Read defensively as an optional field on the parsed binding until step 4's protocol change lands.
2. CP connection not READY (or no CP client) → `'connection'`.
3. `agent-memory-store-v1` not advertised → `'feature'`.

One resolution, never a fallback to this member's disk: nothing is created locally, no op reaches the CP.

## The sink is a required argument

Under a CP home the old default (`history = new SidecarMemoryHistorySink(fs)`) would have silently written `.history` as a file into the CP tree. So `writeMemoryFile`, `writeMemoryFileHoldingLock` and `regenerateMemoryIndexHoldingLock` now REQUIRE their sink — no caller can fall back to the sidecar by omission — and `listMemoryHistory` takes the sink instead of the port and refuses with `MemoryHistoryNotLocalError` when it has no `list`: a CP-homed agent's history is answered by the CP from its own table, and a daemon-side page of it is a routing bug that must show, never an empty page. The managed provider and the CP memory reader are rebuilt on `MemoryHomePorts` (`live` + `historyFor(store)`); an explicit `scope.root` (a dream's staged store, beside the extraction host and never in the CP) logs to the sidecar inside it. Tests over one local tree use a small fixture (`test/fixtures/memory-sidecar.ts`) that names the sidecar once instead of at every call.

## Unavailability everywhere, and the 503 mapping

The five `instanceof MemorySandboxUnavailableError` catches (`daemon.ts` ×2, `cp/memory-reader.ts`, `cp/control/memory.ts`, `cp/control/dream.ts`, `dream/runner.ts`) widen to `MemoryHomeUnavailableError`, and the daemon logs `err.reason` wherever it logs the miss. In `cp/control/memory.ts` every reason is "not now" for the console and rides one shape — `BAD_PAYLOAD` with `{ reason }` in the details — so the CP answers 503: for `sandbox-unavailable` byte-for-byte today's coded 503 the console wakes on (#1077); for `connection` / `feature` / `scope-denied` / `migrating` the 503 the CP already gives every daemon-side error REP, carrying the reason in the body. `MemoryHistoryNotLocalError` maps to `INTERNAL` with its message, after a warn.

## Degradation and the outbox predicate

With the CP connection down, a `control-plane` agent starts a new session with no standing context and a warning (`SessionManager` catches `MemoryHomeUnavailableError` around the seed + index read and calls the new `onMemoryHomeUnavailable` dep; the daemon logs the reason — the way a suspended sandbox's session now degrades too, instead of failing the turn), memory tools answer the unavailable error through the existing MCP path, and the post-turn distillation waits in the memory capture outbox. The outbox's `reachable` predicate becomes "the home is reachable" (`memoryHomeUnavailable(...) === undefined`: CP READY + feature for a CP tree, pod bound for a sandbox volume, always for this disk), and `onReady` wakes the outbox the way a sandbox bind does. Established sessions are unaffected. No local cache.

## No pod wake for the store

#1077's wake was never a call the daemon made: the memory reader refused with `sandbox-unavailable`, the CP mapped it to a coded 503, and the console pressed `agent/wake`. Under a `control-plane` home the `memory/*` C→D frames (list / read / write / channels) are answered from `CpMemoryFs` without ever consulting the sandbox plane, so that refusal — and the wake — never happens for the store. The wake survives exactly where staging lives: dream files/review/adopt go through `ports.staging`, whose getter still refuses `MemorySandboxUnavailableError` on an unbound pool member, and the dream runner's `withMemoryHome` still binds the pod for the extraction host and the staging root.

## Deliberately not here

- No migration copy, no forced-return archiving (step 8). The `migrating` gate is the hook it clears: `memoryHomeUnavailable` in `home.ts` reads the binding field, so the copy only has to report completion and the CP only has to drop the field.
- No CP changes (step 4 in flight): the CP maps the new reasons to a coded 503 in its own step; today they arrive as the uncoded 503 every daemon error REP gets.
- No web.
- No refusal of `daemon` on the pool (step 10).

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean (covers tests).
- `vitest run` over `test/memory*.test.ts`, `test/cp/client-dispatch.test.ts`, `test/dream-runner.test.ts`, `test/daemon-k8s-mode.test.ts`, `test/session-manager.test.ts`, `test/channel-memory.test.ts`, `test/managed-distill-outbox.test.ts`, `test/memory-capture-outbox.test.ts`, `test/memory-provider-dispatch.test.ts`, `test/external-memory-provider.test.ts`, `test/memory-distiller.test.ts`, `test/standing-context.test.ts` — 17 files, 452 passed, 1 skipped (pre-existing platform skip).
- New `test/memory-home.test.ts`: selection returns CP ports for a `control-plane` binding and unchanged ports for `daemon` (self-hosted and `--k8s`); the three gates each refuse with their reason and touch neither disk nor wire; a topic write through the managed provider under a CP home goes to `CpMemoryFs` and its history (topic, then regenerated index) to the CP sink in the store's own root, with no `.history` anywhere; a staged store logs to its sidecar; `listMemoryHistory` refuses for a sink without `list`; the console list/read/channels/write under a CP home never call the sandbox plane while a staging read still refuses as asleep; the outbox defers while the CP is down and drains once it is READY. `client-dispatch.test.ts` covers the wire mapping of a non-sandbox reason and of the misrouted-page error; `session-manager.test.ts` covers the degraded session start.
- eslint and prettier on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
