### PR TITLE
fix(daemon): allow existing Console Git operations in sandboxes

### DIFF
--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -11,25 +11,22 @@ import type { ShimCapability } from './protocol.js'
 import { applyWorkspaceFilesPayload } from './workspace-files-channel.js'
 import { applyMemoryFsPayload, isMemoryFsPayload } from './memory-fs-channel.js'
 
-/**
- * The git subcommands a sandbox will run, enforced HERE.
- *
- * The daemon declares a closed inventory, but a declaration on the sending side is not a
- * control: this process is the one that spawns git, so this is where the list has to be
- * checked. Anything else and a compromised daemon — or a bug in one — reaches arbitrary git,
- * which through `-c`, hooks and `--upload-pack` reaches arbitrary execution.
- */
+// Enforce the daemon's workspace Git command inventory where Git actually runs.
 export const ALLOWED_GIT_SUBCOMMANDS = new Set([
+  'add',
   'branch',
   'check-ref-format',
   'clean',
   'clone',
+  'commit',
   'config',
   'diff',
   'fetch',
   'log',
+  'ls-files',
   'ls-remote',
   'pull',
+  'push',
   'remote',
   'reset',
   'rev-list',

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -7,6 +7,7 @@ import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import { ALLOWED_GIT_SUBCOMMANDS, ExecRefusedError, createExecHandler } from '../src/shim/exec-handler.js'
 import { configFilesDir } from '../src/shim/config-file-env.js'
 import type { GitExecResult } from '../src/shim/git-exec.js'
+import { workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
 
 /**
  * The sandbox side of the exec channel, which is where the declared git inventory is actually
@@ -71,11 +72,11 @@ describe('sandbox exec handler', () => {
 
   it('refuses a subcommand outside the declared inventory', async () => {
     const root = repository()
-    for (const subcommand of ['push', 'submodule', 'daemon', 'gc', 'apply', 'checkout', 'for-each-ref']) {
+    for (const subcommand of ['submodule', 'daemon', 'gc', 'apply', 'checkout', 'for-each-ref']) {
       await expect(handler(root)('exec', { tool: 'git', args: [subcommand] })).rejects.toBeInstanceOf(ExecRefusedError)
     }
     // And the inventory is the daemon's declared list, not a superset invented here.
-    expect(ALLOWED_GIT_SUBCOMMANDS.has('push')).toBe(false)
+    expect(ALLOWED_GIT_SUBCOMMANDS.has('submodule')).toBe(false)
     expect(ALLOWED_GIT_SUBCOMMANDS.has('status')).toBe(true)
   })
 
@@ -87,11 +88,36 @@ describe('sandbox exec handler', () => {
       ['status', '-c', 'protocol.ext.allow=always'],
       ['--exec-path=/tmp/evil', 'status'],
       ['fetch', '--upload-pack=sh -c "id"', 'origin'],
+      ['push', '--receive-pack=sh -c "id"', 'origin'],
       ['--config-env=core.pager=EVIL', 'status']
     ]
     for (const args of attacks) {
       await expect(handler(root)('exec', { tool: 'git', args })).rejects.toBeInstanceOf(ExecRefusedError)
     }
+  })
+
+  it('pushes the explicit Console refspec to a local bare repository', async () => {
+    const root = repository()
+    const remote = mkdtempSync(join(tmpdir(), 'ac-execguard-remote-'))
+    roots.push(remote)
+    execFileSync('git', ['init', '--bare', '--initial-branch=main'], { cwd: remote })
+    const env = workspaceGitLocalEnv()
+    const configCount = Number(env.GIT_CONFIG_COUNT)
+    const result = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['push', '--porcelain', 'agentconnect-test', 'refs/heads/main:refs/heads/main'],
+      env: {
+        ...env,
+        GIT_ALLOW_PROTOCOL: 'file',
+        GIT_CONFIG_COUNT: String(configCount + 1),
+        [`GIT_CONFIG_KEY_${configCount}`]: 'remote.agentconnect-test.url',
+        [`GIT_CONFIG_VALUE_${configCount}`]: remote
+      }
+    })) as GitExecResult
+    expect(result.code).toBe(0)
+    expect(execFileSync('git', ['rev-parse', 'refs/heads/main'], { cwd: remote, encoding: 'utf8' })).toBe(
+      execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' })
+    )
   })
 
   it('serves the worktree inventory the pod-side session paths need', async () => {
@@ -250,9 +276,7 @@ describe('sandbox exec handler', () => {
   })
 
   it('applies the request env as given rather than merging the sandbox environment', async () => {
-    // Verified through `config`, which IS in the inventory. An earlier version of this test used
-    // `commit` — and the guard refused it, correctly: the daemon never commits, so `commit` is
-    // not on the list. The test reaching for a convenient command it does not use was the bug.
+    // Read config to verify that the request replaces the sandbox's environment.
     const root = repository()
     const globalConfig = join(root, 'from-request.gitconfig')
     writeFileSync(globalConfig, '[user]\n\tname = Only From Request\n')

--- a/packages/daemon/test/workspace-git-write.test.ts
+++ b/packages/daemon/test/workspace-git-write.test.ts
@@ -12,7 +12,8 @@ import {
   gitFor
 } from '../src/workspace/git-injection.js'
 import type { GitRunner } from '../src/workspace/git-runner.js'
-import { parsePorcelainV2 } from '../src/shim/git-exec.js'
+import { parsePorcelainV2, ShimGitRunner } from '../src/shim/git-exec.js'
+import { createExecHandler } from '../src/shim/exec-handler.js'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 
 // One plane per test file — the isolation Vitest's per-file module registry used to give.
@@ -185,11 +186,57 @@ const githubTarget = (branch = 'main') => ({
 })
 
 afterEach(() => {
+  workspaces.setSandboxMode(false)
   workspaces.setGitRunnerResolver(undefined)
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
 describe('workspace git stage / unstage (real repo, real index)', () => {
+  it('reads a diff, stages and commits through the real sandbox handler with the existing guards', async () => {
+    const dir = repo()
+    const handle = createExecHandler({ workspaceRoot: dir })
+    workspaces.setSandboxMode(true)
+    workspaces.setGitRunnerResolver(
+      () =>
+        new ShimGitRunner(
+          { request: (capability, payload, options) => handle(capability, payload, options?.abort) },
+          dir
+        )
+    )
+    const seam = createWorkspaceGit(
+      workspaces,
+      async () => dir,
+      () => undefined,
+      async () => githubTarget(),
+      () => IDENTITY
+    )
+    writeFileSync(join(dir, 'tracked.txt'), 'two\n')
+    const diff = await seam.diff({ agentId: 'a', path: 'tracked.txt', staged: false })
+    expect(diff.exists).toBe(true)
+    expect(diff.diff).toContain('+two')
+
+    await expect(seam.stage({ agentId: 'a', paths: ['../outside.txt'] })).rejects.toMatchObject({
+      reason: 'path-escape'
+    })
+    git(dir, ['config', 'filter.refused.clean', 'false'])
+    await expect(seam.stage({ agentId: 'a', paths: ['tracked.txt'] })).rejects.toThrow(/disallowed/)
+    expect(git(dir, ['diff', '--cached', '--name-only'])).toBe('')
+    git(dir, ['config', '--unset', 'filter.refused.clean'])
+
+    const staged = await seam.stage({ agentId: 'a', paths: ['tracked.txt'] })
+    expect(staged.files).toContainEqual({
+      path: 'tracked.txt',
+      index: 'M',
+      workingDir: ' ',
+      additions: 1,
+      deletions: 1
+    })
+    expect(await seam.commit({ agentId: 'a', message: 'fix: sandbox change' })).toMatchObject({ ok: true })
+    expect(git(dir, ['show', 'HEAD:tracked.txt'])).toBe('two\n')
+    expect(git(dir, ['log', '-1', '--format=%an <%ae>'])).toBe(`${IDENTITY.name} <${IDENTITY.email}>\n`)
+    expect((await seam.status('a')).clean).toBe(true)
+  })
+
   it('stages a modified and an untracked path, and answers with the FRESH status', async () => {
     const dir = repo()
     writeFileSync(join(dir, 'tracked.txt'), 'two\n')

--- a/packages/web/src/components/console/dock/FilesPanel.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.tsx
@@ -269,7 +269,7 @@ export function FilesPanel({
     outcome === 'none'
       ? 'Not a git checkout — no branch or file status'
       : outcome === 'asleep'
-        ? 'Git status not available — this agent’s sandbox is not running'
+        ? 'Git status unavailable — this agent’s sandbox could not answer'
         : outcome === 'unavailable'
           ? 'Git status unavailable — the daemon may be offline'
           : null


### PR DESCRIPTION
Console Git operations already issue `ls-files`, `add`, `commit`, and `push`, but the sandbox guest rejected those commands because its inventory was incomplete. Include them so sandbox workspaces can use the existing diff, stage, commit, and push handlers.

The existing path validation, Git configuration audit, argument restrictions, replacement environment, and authorized-remote checks remain in force. Update the Files panel error to describe an unanswered request, since an unavailable Git transport does not prove that the VM stopped.

Validation: 58 daemon tests and 52 Files panel tests passed, along with daemon/web typechecks, ESLint, Prettier, and diff checks. New real-repository coverage executes Console diff/stage/commit through the guest handler, verifies the existing path/filter refusals, and pushes an explicit refspec to a local bare repository. Daemon tests used `TMPDIR=/private/tmp` to avoid an existing macOS temporary-path alias mismatch.

Related: #1874. The microsandbox SDK connection reclamation issue remains tracked separately in #1884.

Created by Codex . GPT-6
