### PR TITLE
fix(daemon): the CP change-log sink files rows under the store's memory/ directory

### DIFF
--- a/packages/daemon/src/cp/memory-history.ts
+++ b/packages/daemon/src/cp/memory-history.ts
@@ -10,7 +10,7 @@ import {
 } from '@agentconnect.md/protocol'
 import { WireError } from '@agentconnect.md/connection'
 import type { Logger } from '../log.js'
-import type { MemoryHistoryRecord, MemoryHistorySink } from '../memory/store.js'
+import { MEMORY_DIRNAME, type MemoryHistoryRecord, type MemoryHistorySink } from '../memory/store.js'
 import { CP_MEMORY_TREE_ROOT, joinTreeRoot } from './memory-fs.js'
 
 /** The slice of the CP connection the sink rides: the gates `CpMemoryStoreLink` has, and the one request pair. */
@@ -50,8 +50,9 @@ function failureReason(err: unknown): string {
   return err instanceof Error ? `${err.name}: ${err.message}` : String(err)
 }
 
-// The sink over the CP. `root` is the store's tree-relative root, the coordinates `CpMemoryFs` names on every op — `.`
-// for the agent's own tree, `channels/<key>` for a channel store — so one table row lines up with one store.
+// The sink over the CP. `root` is the store's port root in `CpMemoryFs` coordinates (`.` for the agent's tree,
+// `channels/<key>` for a channel store); the log is filed under the directory that holds the store's files — `memory`,
+// `channels/<key>/memory` — which is the root the CP's `memory/history` read filters on, so a page finds what a batch wrote.
 export class CpMemoryHistorySink implements MemoryHistorySink {
   readonly root: string
 
@@ -61,7 +62,7 @@ export class CpMemoryHistorySink implements MemoryHistorySink {
     root: string = CP_MEMORY_TREE_ROOT,
     private readonly log: Pick<Logger, 'warn'>
   ) {
-    this.root = joinTreeRoot(CP_MEMORY_TREE_ROOT, root)
+    this.root = joinTreeRoot(joinTreeRoot(CP_MEMORY_TREE_ROOT, root), MEMORY_DIRNAME)
   }
 
   /** Best-effort: the write already happened, so any failure is one warn line naming what went unrecorded, never a rejection. */

--- a/packages/daemon/test/memory-history-sink.test.ts
+++ b/packages/daemon/test/memory-history-sink.test.ts
@@ -150,16 +150,16 @@ const sinkOver = (link: FakeLink, root?: string) =>
   new CpMemoryHistorySink(link, AGENT, root, { warn: (msg) => link.warnings.push(msg) })
 
 describe('CpMemoryHistorySink (the sink over the CP connection)', () => {
-  it('names the agent and the tree-relative root — the agent tree, or a channel store in CpMemoryFs coordinates', async () => {
+  it('names the agent and the directory holding the store — memory/ under the agent tree, or under a channel store', async () => {
     const link = fakeLink()
     await sinkOver(link).append([record('notes.md', 'v1')])
-    // The store's own port names the root the sink must name; its ops never run here.
+    // The store's port root is what the sink is given; it files the log under that root's memory/ dir. No ops run here.
     const storeLink = { connected: () => true, supportsServerFeature: () => true, memoryStore: async () => neverOp() }
     const channelStore = channelMemoryRoot(new CpMemoryFs(storeLink, AGENT), 'general-abc123')
     await sinkOver(link, channelStore.root).append([record('notes.md', 'v1')])
     expect(link.requests.map((req) => [req.agentId, req.root])).toEqual([
-      [AGENT, '.'],
-      [AGENT, 'channels/general-abc123']
+      [AGENT, 'memory'],
+      [AGENT, 'channels/general-abc123/memory']
     ])
     expect(link.warnings).toEqual([])
   })
@@ -218,7 +218,7 @@ describe('CpMemoryHistorySink (the sink over the CP connection)', () => {
     const closed = fakeLink({ connected: () => false })
     await sinkOver(closed).append(rows)
     expect(closed.requests).toEqual([])
-    expect(closed.warnings).toEqual([expect.stringContaining('1 memory change-log record(s) for . not recorded')])
+    expect(closed.warnings).toEqual([expect.stringContaining('1 memory change-log record(s) for memory not recorded')])
     expect(closed.warnings[0]).toContain('the connection is down')
 
     const older = fakeLink({ supportsServerFeature: () => false })

--- a/packages/daemon/test/memory-home.test.ts
+++ b/packages/daemon/test/memory-home.test.ts
@@ -148,10 +148,12 @@ describe('resolveMemoryHomePorts — the one selection', () => {
     expect(ports.staging.root).toBe(agent.dir)
     const sink = ports.historyFor(ports.live)
     expect(sink).toBeInstanceOf(CpMemoryHistorySink)
-    expect((sink as CpMemoryHistorySink).root).toBe('.')
+    expect((sink as CpMemoryHistorySink).root).toBe('memory')
     expect(sink.list).toBeUndefined()
-    // A channel store under `live` names its own root; a staged store, never in the CP, keeps its sidecar.
-    expect((ports.historyFor(channelMemoryRoot(ports.live, 'c1')) as CpMemoryHistorySink).root).toBe('channels/c1')
+    // A channel store under `live` files its log under its own memory/ dir; a staged store, never in the CP, keeps its sidecar.
+    expect((ports.historyFor(channelMemoryRoot(ports.live, 'c1')) as CpMemoryHistorySink).root).toBe(
+      'channels/c1/memory'
+    )
     expect(ports.historyFor(ports.staging)).toBeInstanceOf(SidecarMemoryHistorySink)
     expect(memoryHomeUnavailable(agent, { cp, log })).toBeUndefined()
 
@@ -223,10 +225,10 @@ describe('every writer and reader goes through the ports', () => {
     expect(await fsp.readFile(join(cp.tree, 'memory', 'deploys.md'), 'utf8')).toContain('- region sea')
     expect((await provider.read({ agentId: AGENT }, 'deploys.md')).content).toContain('- region sea')
     expect(cp.ops.some((op) => op.op === 'memory-commit')).toBe(true)
-    // The topic record, then the regenerated index's — both to the CP, in the store's own coordinates.
+    // The topic record, then the regenerated index's — both to the CP, filed under the store's memory/ dir, the root the CP's read filters on.
     expect(cp.appends.flatMap((req) => req.records.map((r) => [req.root, r.path, r.event, r.source]))).toEqual([
-      ['.', 'deploys.md', 'add', 'tool'],
-      ['.', MEMORY_INDEX, 'update', 'tool']
+      ['memory', 'deploys.md', 'add', 'tool'],
+      ['memory', MEMORY_INDEX, 'update', 'tool']
     ])
     expect(await fsp.readdir(join(cp.tree, 'memory'))).not.toContain(MEMORY_HISTORY_FILENAME)
     expect(existsSync(join(agent.dir, 'memory'))).toBe(false)
@@ -236,7 +238,7 @@ describe('every writer and reader goes through the ports', () => {
     expect(await fsp.readFile(join(cp.tree, 'channels', 'general-abc', 'memory', 'notes.md'), 'utf8')).toContain(
       'pinned'
     )
-    expect(cp.appends.at(-1)).toMatchObject({ agentId: AGENT, root: 'channels/general-abc' })
+    expect(cp.appends.at(-1)).toMatchObject({ agentId: AGENT, root: 'channels/general-abc/memory' })
     expect(cp.appends.at(-1)!.records.map((r) => [r.path, r.source])).toEqual([['notes.md', 'console']])
     expect(await fsp.readdir(join(cp.tree, 'channels', 'general-abc', 'memory'))).not.toContain(MEMORY_HISTORY_FILENAME)
     expect(log.warn).not.toHaveBeenCalled()


### PR DESCRIPTION
## What was wrong

Two halves of the change-log path landed with different ideas of what `root` names.

- The Control Plane (#1877, #1881) files and reads change-log rows under the **directory that holds the store's files**: `memory` for the agent's own store, `channels/<key>/memory` for a channel store (`memoryHistoryRoot`, and the append handler normalizes `./memory/` to `memory`).
- The daemon's `CpMemoryHistorySink` (#1880, wired in #1883) sent the store's **port root** instead — `.` for the agent tree (normalized to the empty string on the CP) and `channels/<key>` for a channel store.

Nothing is homed in the Control Plane yet, so no rows are misfiled today; the first agent to switch would have written its change log where the console's history read never looks — and the migration (step ⑧) would have copied every sidecar under the same wrong root.

## Fix

The sink keeps taking the store's port root — that is what `historyFor(store)` has — and files the log under that root's `memory/` directory: `joinTreeRoot(joinTreeRoot('.', root), MEMORY_DIRNAME)`. One line; the daemon side moves because the CP's convention is the more precise one (a change log belongs to the directory whose files it describes, which is also where the sidecar lives on disk).

## Verification

`memory-history-sink.test.ts`, `memory-home.test.ts`, `memory-fs-cp.test.ts` pass with the roots pinned to `memory` and `channels/<key>/memory` (a topic write and an index regeneration through the managed provider, and a channel-store write). Daemon typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
