### PR TITLE
feat(web): the memory home is chosen once, moved forward with a confirmation, and brought back only by force

### DIFF
--- a/packages/web/src/components/console/ConfirmationDialog.tsx
+++ b/packages/web/src/components/console/ConfirmationDialog.tsx
@@ -10,6 +10,7 @@ export function ConfirmationDialog({
   busy = false,
   busyLabel = 'Saving…',
   error,
+  destructive = false,
   onConfirm,
   onClose
 }: {
@@ -19,6 +20,8 @@ export function ConfirmationDialog({
   busy?: boolean
   busyLabel?: string
   error?: string | null
+  /** The confirmed action keeps nothing: error-toned glyph and a danger button, the way the delete modals read. */
+  destructive?: boolean
   onConfirm: () => void
   onClose: () => void
 }) {
@@ -36,9 +39,15 @@ export function ConfirmationDialog({
     <div className="scrim">
       <div className="modal max-w-[480px]" role="dialog" aria-modal="true" aria-labelledby={titleId}>
         <div className="modalhead">
-          <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-paused-soft)">
-            <Icon name="triangle-alert" size={16} color="var(--amber-500)" />
-          </span>
+          {destructive ? (
+            <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
+              <Icon name="triangle-alert" size={16} color="var(--status-error)" />
+            </span>
+          ) : (
+            <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-paused-soft)">
+              <Icon name="triangle-alert" size={16} color="var(--amber-500)" />
+            </span>
+          )}
           <span id={titleId} className="flex-1 font-sans text-[16px] font-semibold leading-normal">
             {title}
           </span>
@@ -62,7 +71,7 @@ export function ConfirmationDialog({
           <Button variant="ghost" disabled={busy} onClick={onClose}>
             Cancel
           </Button>
-          <Button disabled={busy} onClick={onConfirm}>
+          <Button variant={destructive ? 'danger' : 'primary'} disabled={busy} onClick={onConfirm}>
             {busy ? busyLabel : confirmLabel}
           </Button>
         </div>

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -306,6 +306,7 @@ describe('MemoryPanel settings draft', () => {
       memory: {
         provider: 'managed',
         autoDistill: false,
+        home: 'daemon',
         dreaming: { enabled: true, schedule: '0 4 * * *', mineSkills: true, autoAdopt: false }
       }
     })
@@ -353,6 +354,7 @@ describe('MemoryPanel settings draft', () => {
       memory: {
         provider: 'managed',
         autoDistill: false,
+        home: 'daemon',
         dreaming: { enabled: true, schedule: '0 4 * * *', mineSkills: false, autoAdopt: true }
       }
     })
@@ -433,7 +435,7 @@ describe('MemoryPanel settings draft', () => {
     )
     await act(async () => save?.click())
     expect(mocks.updateAgent).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', {
-      memory: { provider: 'managed', autoDistill: false, scope: 'channel' }
+      memory: { provider: 'managed', autoDistill: false, scope: 'channel', home: 'daemon' }
     })
   })
 
@@ -819,5 +821,125 @@ describe('MemoryPanel sandbox wake', () => {
     await mount({ sandboxed: true, memoryProvider: 'native' })
 
     expect(vi.mocked(wakeAgent)).not.toHaveBeenCalled()
+  })
+})
+
+// The managed home is chosen one way (memory-evolution.md §3.2.1): `daemon` → `control-plane` from the selector behind a
+// confirmation, the return only as a forced action behind its own dialog, and on the pool no choice at all.
+describe('MemoryPanel memory home', () => {
+  const AGENT_ID = '22222222-2222-4222-8222-222222222222'
+
+  const mount = async (props: Partial<Parameters<typeof MemoryPanel>[0]> = {}) => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(<MemoryPanel agentId={AGENT_ID} canEdit memoryProvider="managed" autoDistill={false} {...props} />)
+    })
+    return container
+  }
+
+  const homePill = (host: HTMLElement, value: string) =>
+    host.querySelector<HTMLButtonElement>(`[data-memory-home="${value}"]`)
+  const dialog = (host: HTMLElement) => host.querySelector<HTMLElement>('[role="dialog"]')
+  const dialogButton = (host: HTMLElement, label: string) =>
+    Array.from(dialog(host)?.querySelectorAll('button') ?? []).find((button) => button.textContent === label)
+
+  it('reads the home from the binding and carries it through an unrelated save', async () => {
+    const host = await mount({ memoryHome: 'control-plane' })
+    expect(host.textContent).toContain('In the Control Plane')
+    await openSettings(host)
+    const autoDistill = host.querySelector<HTMLInputElement>('input[type="checkbox"]')
+    await act(async () => autoDistill?.click())
+    await clickButton(host, 'Save memory settings')
+    expect(mocks.updateAgent).toHaveBeenCalledWith(AGENT_ID, {
+      memory: { provider: 'managed', autoDistill: true, home: 'control-plane' }
+    })
+  })
+
+  it('moves daemon → control-plane from the selector, but only after the confirmation', async () => {
+    const host = await mount()
+    await openSettings(host)
+    expect(homePill(host, 'daemon')?.getAttribute('aria-pressed')).toBe('true')
+    expect(homePill(host, 'daemon')?.disabled).toBe(false)
+    expect(homePill(host, 'control-plane')?.disabled).toBe(false)
+
+    await act(async () => homePill(host, 'control-plane')?.click())
+    await clickButton(host, 'Save memory settings')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(dialog(host)?.textContent).toContain('Move memory to the Control Plane?')
+    expect(dialog(host)?.textContent).toContain('Memory is unavailable until the copy completes')
+
+    await act(async () => dialogButton(host, 'Move')?.click())
+    expect(mocks.updateAgent).toHaveBeenCalledWith(AGENT_ID, {
+      memory: { provider: 'managed', autoDistill: false, home: 'control-plane' }
+    })
+    expect(dialog(host)).toBeNull()
+  })
+
+  it('shows the quiet status and locks the control while the copy is pending', async () => {
+    const host = await mount({ memoryHome: 'control-plane', memoryHomeMigration: 'pending' })
+    expect(host.querySelector('[data-memory-home-status]')?.textContent).toContain(
+      'Moving memory to the Control Plane…'
+    )
+    await openSettings(host)
+    expect(homePill(host, 'daemon')).toBeNull()
+    expect(homePill(host, 'control-plane')?.disabled).toBe(true)
+    expect(host.textContent).not.toContain('Move memory back to the daemon')
+  })
+
+  it('offers no daemon in the selector once the home is control-plane; the return is a forced action', async () => {
+    const host = await mount({ memoryHome: 'control-plane' })
+    await openSettings(host)
+    expect(homePill(host, 'daemon')).toBeNull()
+    expect(homePill(host, 'control-plane')?.getAttribute('aria-pressed')).toBe('true')
+
+    await clickButton(host, 'Move memory back to the daemon')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(dialog(host)?.textContent).toContain('Move memory back to the daemon?')
+    expect(dialog(host)?.textContent).toContain('Nothing is kept')
+
+    await act(async () => dialogButton(host, 'Move')?.click())
+    expect(mocks.updateAgent).toHaveBeenCalledWith(AGENT_ID, {
+      memory: { provider: 'managed', autoDistill: false, home: 'daemon' },
+      force: true
+    })
+    expect(dialog(host)).toBeNull()
+    expect(host.textContent).toContain('On the daemon')
+  })
+
+  it("surfaces the server's refusal inside the return dialog", async () => {
+    mocks.updateAgent.mockRejectedValueOnce(new ApiError('moving the memory home back requires force', 409))
+    const host = await mount({ memoryHome: 'control-plane' })
+    await openSettings(host)
+    await clickButton(host, 'Move memory back to the daemon')
+    await act(async () => dialogButton(host, 'Move')?.click())
+    expect(dialog(host)?.querySelector('[role="alert"]')?.textContent).toContain('requires force')
+  })
+
+  it('fixes the home to control-plane on the pool, with a reason and no way back', async () => {
+    const host = await mount({ poolPlaced: true })
+    await openSettings(host)
+    expect(homePill(host, 'daemon')).toBeNull()
+    expect(homePill(host, 'control-plane')?.disabled).toBe(true)
+    expect(homePill(host, 'control-plane')?.getAttribute('aria-pressed')).toBe('true')
+    expect(host.querySelector('[data-memory-home-reason]')?.textContent).toContain('managed pool')
+    expect(host.textContent).not.toContain('Move memory back to the daemon')
+
+    // A pool agent's binding always carries the only home it may have, even when the DTO predates the field.
+    const autoDistill = host.querySelector<HTMLInputElement>('input[type="checkbox"]')
+    await act(async () => autoDistill?.click())
+    await clickButton(host, 'Save memory settings')
+    expect(mocks.updateAgent).toHaveBeenCalledWith(AGENT_ID, {
+      memory: { provider: 'managed', autoDistill: true, home: 'control-plane' }
+    })
+  })
+
+  it('renders the field and the return action on mobile too', async () => {
+    mocks.isMobile = true
+    const host = await mount({ memoryHome: 'control-plane' })
+    await openSettings(host)
+    expect(homePill(host, 'control-plane')).toBeTruthy()
+    expect(host.textContent).toContain('Move memory back to the daemon')
   })
 })

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -942,4 +942,41 @@ describe('MemoryPanel memory home', () => {
     expect(homePill(host, 'control-plane')).toBeTruthy()
     expect(host.textContent).toContain('Move memory back to the daemon')
   })
+
+  it('drops the cached browser and reads again once the home has changed underneath it', async () => {
+    const host = await mount({ memoryHome: 'control-plane' })
+    const lists = vi.mocked(listAgentMemory).mock.calls.length
+    const reads = vi.mocked(fetchAgentMemoryFull).mock.calls.length
+    await openSettings(host)
+    await clickButton(host, 'Move memory back to the daemon')
+    await act(async () => dialogButton(host, 'Move')?.click())
+    // The agents poll delivers the returned binding; the tree the browser showed is gone with it.
+    await act(async () => {
+      root?.render(
+        <MemoryPanel agentId={AGENT_ID} canEdit memoryProvider="managed" autoDistill={false} memoryHome="daemon" />
+      )
+    })
+    expect(vi.mocked(listAgentMemory).mock.calls.length).toBeGreaterThan(lists)
+    expect(vi.mocked(fetchAgentMemoryFull).mock.calls.length).toBeGreaterThan(reads)
+  })
+
+  it('retries the reads when the pending copy clears', async () => {
+    const host = await mount({ memoryHome: 'control-plane', memoryHomeMigration: 'pending' })
+    const lists = vi.mocked(listAgentMemory).mock.calls.length
+    const reads = vi.mocked(fetchAgentMemoryFull).mock.calls.length
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId={AGENT_ID}
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+          memoryHome="control-plane"
+        />
+      )
+    })
+    expect(host.querySelector('[data-memory-home-status]')).toBeNull()
+    expect(vi.mocked(listAgentMemory).mock.calls.length).toBeGreaterThan(lists)
+    expect(vi.mocked(fetchAgentMemoryFull).mock.calls.length).toBeGreaterThan(reads)
+  })
 })

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -979,4 +979,28 @@ describe('MemoryPanel memory home', () => {
     expect(vi.mocked(listAgentMemory).mock.calls.length).toBeGreaterThan(lists)
     expect(vi.mocked(fetchAgentMemoryFull).mock.calls.length).toBeGreaterThan(reads)
   })
+
+  it('lists the channel folders again once a copy that refused the read has cleared', async () => {
+    // During the copy the daemon refuses the channel read; the picker must not stay empty after completion.
+    vi.mocked(fetchAgentMemoryChannels).mockRejectedValueOnce(new ApiError('memory unavailable', 503))
+    await mount({ memoryHome: 'control-plane', memoryHomeMigration: 'pending', memoryScope: 'channel' })
+    const before = vi.mocked(fetchAgentMemoryChannels).mock.calls.length
+    vi.mocked(fetchAgentMemoryChannels).mockResolvedValueOnce({
+      channels: [{ channelKey: 'slack:C1', channel: 'general', transportScope: null }]
+    })
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId={AGENT_ID}
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+          memoryHome="control-plane"
+          memoryScope="channel"
+        />
+      )
+    })
+    expect(vi.mocked(fetchAgentMemoryChannels).mock.calls.length).toBeGreaterThan(before)
+    expect(container?.textContent).toContain('general')
+  })
 })

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -627,8 +627,9 @@ export function MemoryPanel({
       loadRequest.current += 1
       listRequest.current += 1
     }
-  }, [loadList, loadFile, persistedProvider])
+  }, [loadList, loadFile, persistedProvider, persistedSettings.home, homeMigrationPending])
 
+  // A home change (the forward copy clearing, or the forced return) swaps the tree underneath, so nothing cached survives it.
   // Under channel scope, load the list of channels that have their own memory folder
   // so the viewer can offer a channel selector. Always reset the selection first —
   // the component instance is reused across agent navigations, so a stale channelKey
@@ -650,7 +651,7 @@ export function MemoryPanel({
     return () => {
       live = false
     }
-  }, [agentId, persistedProvider, persistedSettings.scope])
+  }, [agentId, persistedProvider, persistedSettings.scope, persistedSettings.home])
 
   const select = (name: string) => {
     if (name === selected) {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -21,6 +21,7 @@ import {
   fetchAgentMemoryChannels,
   ApiError,
   type MemoryFileEntry,
+  type ManagedMemoryHome,
   type ManagedMemoryScope,
   type MemoryChannelDto,
   type MemoryDreamingConfig
@@ -36,8 +37,11 @@ import {
 import { MemoryProviderPicker } from '@/components/console/MemoryProviderPicker'
 import {
   cloneMemorySettings,
+  MEMORY_HOME_OPTIONS,
   memoryBackendChanged,
   memoryConfigForDraft,
+  memoryHomeLabel,
+  memoryHomeMovesForward,
   memoryProviderLabel,
   memorySettingsBlocker,
   memorySettingsChanged,
@@ -150,10 +154,82 @@ function MemoryScopeField({
   )
 }
 
+const HOME_POOL_REASON = 'Agents on the managed pool keep their memory in the Control Plane.'
+const HOME_PENDING_STATUS = 'Moving memory to the Control Plane…'
+const HOME_CONTROL_PLANE_FIXED =
+  'Memory in the Control Plane stays there; moving it back is a separate, forced action below.'
+
+// The home is chosen one way (memory-evolution.md §3.2.1): `daemon` is offered only while it is the current value.
+function MemoryHomeField({
+  home,
+  persistedHome,
+  canEdit,
+  poolPlaced,
+  pending,
+  onChange
+}: {
+  home: ManagedMemoryHome
+  persistedHome: ManagedMemoryHome
+  canEdit: boolean
+  poolPlaced: boolean
+  pending: boolean
+  onChange: (next: ManagedMemoryHome) => void
+}) {
+  const options = MEMORY_HOME_OPTIONS.filter(
+    (option) => option.value !== 'daemon' || (persistedHome === 'daemon' && !poolPlaced)
+  )
+  const editable = canEdit && !poolPlaced && !pending
+  const reason = poolPlaced
+    ? HOME_POOL_REASON
+    : pending
+      ? HOME_PENDING_STATUS
+      : persistedHome === 'control-plane'
+        ? HOME_CONTROL_PLANE_FIXED
+        : null
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <span className="font-sans text-[13px] font-semibold leading-normal">Memory home</span>
+        <span className="pillbar">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              disabled={!editable}
+              data-memory-home={option.value}
+              aria-pressed={home === option.value}
+              className={`pill ${home === option.value ? 'on' : ''} px-2 py-1 text-[12px] ${editable ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+              onClick={() => {
+                if (editable) onChange(option.value)
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </span>
+      </div>
+      <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+        {MEMORY_HOME_OPTIONS.find((option) => option.value === home)?.help}
+      </span>
+      {reason ? (
+        <span
+          data-memory-home-reason
+          className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)"
+          aria-live={pending ? 'polite' : undefined}
+        >
+          {reason}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
 function settingsFromProps(input: {
   memoryProvider: string
   autoDistill: boolean
   memoryScope?: ManagedMemoryScope
+  memoryHome?: ManagedMemoryHome
+  poolPlaced?: boolean
   memoryDreaming?: MemoryDreamingConfig
   memoryConnectionId?: string
   memoryRecall?: ExternalMemoryBindingDraft['recall']
@@ -163,6 +239,8 @@ function settingsFromProps(input: {
     provider: input.memoryProvider,
     autoDistill: input.autoDistill,
     scope: input.memoryScope,
+    // The pool refuses `daemon`, so a pool-placed agent's draft is pinned to the only home it may carry.
+    home: input.poolPlaced ? 'control-plane' : input.memoryHome,
     dreaming: input.memoryDreaming,
     connectionId: input.memoryConnectionId,
     recall: input.memoryRecall,
@@ -176,18 +254,25 @@ export function MemoryPanel({
   memoryProvider,
   autoDistill,
   memoryScope,
+  memoryHome,
+  memoryHomeMigration,
   memoryDreaming,
   memoryConnectionId,
   memoryRecall,
   memoryCaptureMode,
   sessionBasePath,
-  sandboxed = false
+  sandboxed = false,
+  poolPlaced = false
 }: {
   agentId: string
   canEdit: boolean
   memoryProvider: string
   autoDistill: boolean
   memoryScope?: ManagedMemoryScope
+  /** Where the managed tree lives; absent reads as `daemon`. */
+  memoryHome?: ManagedMemoryHome
+  /** Set while the owning daemon copies the tree into the Control Plane; the home control waits for it to clear. */
+  memoryHomeMigration?: 'pending'
   memoryDreaming?: MemoryDreamingConfig
   memoryConnectionId?: string
   memoryRecall?: ExternalMemoryBindingDraft['recall']
@@ -195,6 +280,8 @@ export function MemoryPanel({
   sessionBasePath?: string
   /** The agent runs in a cluster sandbox: its managed memory is readable only through a running pod, so opening the tab wakes it rather than waiting for the read to refuse. */
   sandboxed?: boolean
+  /** Placed on the install-wide pool, where the home is fixed to `control-plane` and there is no way back. */
+  poolPlaced?: boolean
 }) {
   const { updateAgent } = useConsoleData()
   const isMobile = useIsMobile()
@@ -229,6 +316,8 @@ export function MemoryPanel({
     memoryProvider,
     autoDistill,
     memoryScope,
+    memoryHome,
+    poolPlaced,
     memoryDreaming,
     memoryConnectionId,
     memoryRecall,
@@ -241,6 +330,12 @@ export function MemoryPanel({
   const [savingProvider, setSavingProvider] = useState(false)
   const [providerError, setProviderError] = useState<string | null>(null)
   const [confirmingBackendChange, setConfirmingBackendChange] = useState(false)
+  const [confirmingHomeMove, setConfirmingHomeMove] = useState(false)
+  // The forced return (`control-plane` → `daemon`) is its own action with its own dialog, never a selector choice.
+  const [confirmingHomeReturn, setConfirmingHomeReturn] = useState(false)
+  const [returningHome, setReturningHome] = useState(false)
+  const [homeReturnError, setHomeReturnError] = useState<string | null>(null)
+  const homeMigrationPending = memoryHomeMigration === 'pending'
   // The settings form is collapsed behind a one-line summary by default so the
   // memory content itself stays the page's focus. Closing the form discards any
   // unsaved draft — a closed form always summarizes the persisted settings.
@@ -258,6 +353,8 @@ export function MemoryPanel({
       memoryProvider,
       autoDistill,
       memoryScope,
+      memoryHome,
+      poolPlaced,
       memoryDreaming,
       memoryConnectionId,
       memoryRecall,
@@ -267,11 +364,14 @@ export function MemoryPanel({
     setPersistedSettings(cloneMemorySettings(next))
     setProviderError(null)
     setConfirmingBackendChange(false)
+    setConfirmingHomeMove(false)
   }, [
     agentId,
     memoryProvider,
     autoDistill,
     memoryScope,
+    memoryHome,
+    poolPlaced,
     memoryDreaming?.enabled,
     memoryDreaming?.sessionWindow,
     memoryDreaming?.schedule,
@@ -291,6 +391,7 @@ export function MemoryPanel({
   const persistedProvider = persistedSettings.provider
   const settingsChanged = memorySettingsChanged(persistedSettings, settings)
   const backendChanged = memoryBackendChanged(persistedSettings, settings)
+  const homeMovesForward = memoryHomeMovesForward(persistedSettings, settings)
   const settingsBlocker = memorySettingsBlocker(settings)
   const persistedProviderLabel = memoryProviderLabel(persistedProvider)
   const providerLabel = memoryProviderLabel(provider)
@@ -313,6 +414,7 @@ export function MemoryPanel({
       await updateAgent(agentId, { memory: memoryConfigForDraft(settings) })
       setPersistedSettings(cloneMemorySettings(settings))
       setConfirmingBackendChange(false)
+      setConfirmingHomeMove(false)
       setSettingsOpen(false)
     } catch (e) {
       setProviderError(e instanceof Error ? e.message : String(e))
@@ -332,7 +434,33 @@ export function MemoryPanel({
       setConfirmingBackendChange(true)
       return
     }
+    if (homeMovesForward) {
+      setProviderError(null)
+      setConfirmingHomeMove(true)
+      return
+    }
     void persistMemorySettings()
+  }
+
+  // Sends the persisted binding with `home: 'daemon'` and `force: true`; the CP drops every file and its history.
+  const returnHomeToDaemon = async () => {
+    if (returningHome) return
+    setReturningHome(true)
+    setHomeReturnError(null)
+    try {
+      const memory = memoryConfigForDraft(persistedSettings)
+      if (memory.provider !== 'managed') throw new Error('memory is not managed')
+      await updateAgent(agentId, { memory: { ...memory, home: 'daemon' }, force: true })
+      const next = cloneMemorySettings({ ...persistedSettings, home: 'daemon' })
+      setPersistedSettings(next)
+      setSettings(cloneMemorySettings(next))
+      setConfirmingHomeReturn(false)
+      setSettingsOpen(false)
+    } catch (e) {
+      setHomeReturnError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setReturningHome(false)
+    }
   }
 
   const discardMemorySettings = () => {
@@ -340,6 +468,7 @@ export function MemoryPanel({
     setSettings(cloneMemorySettings(persistedSettings))
     setProviderError(null)
     setConfirmingBackendChange(false)
+    setConfirmingHomeMove(false)
   }
 
   const closeSettings = () => {
@@ -356,6 +485,7 @@ export function MemoryPanel({
         if (persistedSettings.scope === 'channel') {
           return [
             'Managed directory',
+            memoryHomeLabel(persistedSettings.home),
             `Auto-distill ${persistedSettings.autoDistill ? 'on' : 'off'}`,
             'Channel scope'
           ].join(' · ')
@@ -364,6 +494,7 @@ export function MemoryPanel({
         const cadence = dreaming.schedule === '0 4 * * *' ? 'daily' : dreaming.schedule ? 'scheduled' : 'manual'
         return [
           'Managed directory',
+          memoryHomeLabel(persistedSettings.home),
           `Auto-distill ${persistedSettings.autoDistill ? 'on' : 'off'}`,
           dreaming.enabled ? `Dreaming ${cadence}` : 'Dreaming off',
           ...(dreaming.enabled && dreaming.mineSkills === true ? ['Skill mining on'] : []),
@@ -769,6 +900,16 @@ export function MemoryPanel({
                   Unsaved changes
                 </span>
               ) : null}
+              {persistedProvider === 'managed' && homeMigrationPending ? (
+                <span
+                  data-memory-home-status
+                  className="inline-flex items-center gap-1 font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)"
+                  aria-live="polite"
+                >
+                  <Spinner size={11} />
+                  {HOME_PENDING_STATUS}
+                </span>
+              ) : null}
             </div>
             <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
               {settingsSummary}
@@ -819,6 +960,20 @@ export function MemoryPanel({
                 canEdit={canEdit && !savingProvider}
                 onChange={(next) => {
                   setSettings((current) => ({ ...current, scope: next }))
+                  setProviderError(null)
+                }}
+              />
+            ) : null}
+
+            {provider === 'managed' ? (
+              <MemoryHomeField
+                home={settings.home}
+                persistedHome={persistedSettings.home}
+                canEdit={canEdit && !savingProvider}
+                poolPlaced={poolPlaced}
+                pending={homeMigrationPending}
+                onChange={(next) => {
+                  setSettings((current) => ({ ...current, home: next }))
                   setProviderError(null)
                 }}
               />
@@ -994,6 +1149,34 @@ export function MemoryPanel({
                 ) : null}
               </div>
             ) : null}
+
+            {canEdit &&
+            persistedProvider === 'managed' &&
+            persistedSettings.home === 'control-plane' &&
+            !poolPlaced &&
+            !homeMigrationPending ? (
+              <div className="flex flex-col gap-2 rounded-md border border-(--status-error-soft) px-3 py-3 desktop:flex-row desktop:items-center desktop:justify-between">
+                <div className="flex min-w-0 flex-col gap-[3px]">
+                  <span className="font-sans text-[12.5px] font-semibold leading-normal">
+                    Move memory back to the daemon
+                  </span>
+                  <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                    Deletes every memory file and its history in the Control Plane; the agent starts with empty memory.
+                  </span>
+                </div>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  disabled={savingProvider || returningHome}
+                  onClick={() => {
+                    setHomeReturnError(null)
+                    setConfirmingHomeReturn(true)
+                  }}
+                >
+                  Move memory back to the daemon
+                </Button>
+              </div>
+            ) : null}
           </div>
         ) : null}
       </section>
@@ -1138,6 +1321,42 @@ export function MemoryPanel({
             This switches the agent from <strong className="font-semibold">{persistedProviderLabel}</strong> to{' '}
             <strong className="font-semibold">{memoryProviderLabel(provider)}</strong>. Existing memory is not migrated,
             and any pending capture stays with its original connection.
+          </p>
+        </ConfirmationDialog>
+      ) : null}
+      {confirmingHomeMove ? (
+        <ConfirmationDialog
+          title="Move memory to the Control Plane?"
+          confirmLabel="Move"
+          busy={savingProvider}
+          error={providerError}
+          onClose={() => {
+            if (!savingProvider) setConfirmingHomeMove(false)
+          }}
+          onConfirm={() => void persistMemorySettings()}
+        >
+          <p className="m-0">
+            The owning daemon copies this agent&apos;s memory into the Control Plane. Memory is unavailable until the
+            copy completes, and it cannot be moved back without deleting it.
+          </p>
+        </ConfirmationDialog>
+      ) : null}
+      {confirmingHomeReturn ? (
+        <ConfirmationDialog
+          title="Move memory back to the daemon?"
+          confirmLabel="Move"
+          busyLabel="Moving…"
+          destructive
+          busy={returningHome}
+          error={homeReturnError}
+          onClose={() => {
+            if (!returningHome) setConfirmingHomeReturn(false)
+          }}
+          onConfirm={() => void returnHomeToDaemon()}
+        >
+          <p className="m-0">
+            Nothing is kept. Every memory file and its history in the Control Plane is deleted, and the agent starts
+            with empty memory on its daemon.
           </p>
         </ConfirmationDialog>
       ) : null}

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -651,7 +651,7 @@ export function MemoryPanel({
     return () => {
       live = false
     }
-  }, [agentId, persistedProvider, persistedSettings.scope, persistedSettings.home])
+  }, [agentId, persistedProvider, persistedSettings.scope, persistedSettings.home, homeMigrationPending])
 
   const select = (name: string) => {
     if (name === selected) {

--- a/packages/web/src/components/console/memory-settings.test.ts
+++ b/packages/web/src/components/console/memory-settings.test.ts
@@ -6,6 +6,7 @@ import {
   dreamingConfigForDraft,
   memoryBackendChanged,
   memoryConfigForDraft,
+  memoryHomeMovesForward,
   memorySettingsBlocker,
   memorySettingsChanged,
   memorySettingsDraft
@@ -74,7 +75,8 @@ describe('memory settings UX model', () => {
     // default, so it remains compact on the wire.
     expect(memoryConfigForDraft(memorySettingsDraft({ provider: 'managed', autoDistill: true }))).toEqual({
       provider: 'managed',
-      autoDistill: true
+      autoDistill: true,
+      home: 'daemon'
     })
     expect(memoryConfigForDraft(memorySettingsDraft({ provider: 'native', autoDistill: true }))).toEqual({
       provider: 'native',
@@ -100,7 +102,7 @@ describe('memory settings UX model', () => {
       autoAdopt: true,
       mineSkills: true
     })
-    expect(memoryConfigForDraft(defaults)).toEqual({ provider: 'managed', autoDistill: false })
+    expect(memoryConfigForDraft(defaults)).toEqual({ provider: 'managed', autoDistill: false, home: 'daemon' })
     expect(dreamingConfigForDraft(defaults.dreaming)).toBeUndefined()
 
     const manualReview = {
@@ -111,6 +113,7 @@ describe('memory settings UX model', () => {
     expect(memoryConfigForDraft(manualReview)).toEqual({
       provider: 'managed',
       autoDistill: false,
+      home: 'daemon',
       dreaming: { enabled: true, mineSkills: true, autoAdopt: false }
     })
 
@@ -118,6 +121,7 @@ describe('memory settings UX model', () => {
     expect(memoryConfigForDraft(disabled)).toEqual({
       provider: 'managed',
       autoDistill: false,
+      home: 'daemon',
       dreaming: { enabled: false, schedule: '0 4 * * *', mineSkills: true, autoAdopt: true }
     })
 
@@ -125,6 +129,7 @@ describe('memory settings UX model', () => {
     expect(memoryConfigForDraft(noSkills)).toEqual({
       provider: 'managed',
       autoDistill: false,
+      home: 'daemon',
       dreaming: { enabled: true, schedule: '0 4 * * *', mineSkills: false, autoAdopt: true }
     })
   })
@@ -137,7 +142,12 @@ describe('memory settings UX model', () => {
     const channel = memorySettingsDraft({ provider: 'managed', autoDistill: false, scope: 'channel' })
     expect(channel.scope).toBe('channel')
     // Serializing channel scope never carries a dreaming policy.
-    expect(memoryConfigForDraft(channel)).toEqual({ provider: 'managed', autoDistill: false, scope: 'channel' })
+    expect(memoryConfigForDraft(channel)).toEqual({
+      provider: 'managed',
+      autoDistill: false,
+      scope: 'channel',
+      home: 'daemon'
+    })
 
     // Switching agent → channel is a change (even though dreaming fields are equal).
     expect(memorySettingsChanged(agent, { ...agent, scope: 'channel' })).toBe(true)
@@ -186,6 +196,7 @@ describe('memory settings UX model', () => {
     expect(memoryConfigForDraft(edited)).toEqual({
       provider: 'managed',
       autoDistill: true,
+      home: 'daemon',
       dreaming: {
         enabled: true,
         sessionWindow: 40,
@@ -254,5 +265,33 @@ describe('dreaming schedule validation gates the save', () => {
       dreaming: { enabled: false, schedule: 'not a cron' } as never
     })
     expect(memorySettingsBlocker(off)).toBeNull()
+  })
+})
+
+describe('memory home travels with the managed draft (memory-evolution.md §3.2.1)', () => {
+  it('reads an absent home as daemon and sends the home on every managed save', () => {
+    const legacy = memorySettingsDraft({ provider: 'managed', autoDistill: false })
+    expect(legacy.home).toBe('daemon')
+    const moved = memorySettingsDraft({ provider: 'managed', autoDistill: false, home: 'control-plane' })
+    expect(moved.home).toBe('control-plane')
+    expect(memoryConfigForDraft(moved)).toEqual({ provider: 'managed', autoDistill: false, home: 'control-plane' })
+    expect(memoryConfigForDraft({ ...moved, scope: 'channel' })).toEqual({
+      provider: 'managed',
+      autoDistill: false,
+      scope: 'channel',
+      home: 'control-plane'
+    })
+  })
+
+  it('counts a home change as a change, and only daemon → control-plane as the forward move', () => {
+    const daemon = memorySettingsDraft({ provider: 'managed', autoDistill: false })
+    const controlPlane = { ...daemon, home: 'control-plane' as const }
+    expect(memorySettingsChanged(daemon, controlPlane)).toBe(true)
+    expect(memoryHomeMovesForward(daemon, controlPlane)).toBe(true)
+    expect(memoryHomeMovesForward(controlPlane, daemon)).toBe(false)
+    expect(memoryHomeMovesForward(daemon, daemon)).toBe(false)
+    // A backend switch is not a home move, even when the managed draft says control-plane.
+    const native = memorySettingsDraft({ provider: 'native', autoDistill: false })
+    expect(memoryHomeMovesForward(native, controlPlane)).toBe(false)
   })
 })

--- a/packages/web/src/components/console/memory-settings.ts
+++ b/packages/web/src/components/console/memory-settings.ts
@@ -1,4 +1,4 @@
-import type { AgentMemoryConfig, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
+import type { AgentMemoryConfig, ManagedMemoryHome, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
 import { isIanaTimezone, isValidCron } from '@/lib/cron'
 import {
   DEFAULT_EXTERNAL_MEMORY_BINDING,
@@ -36,6 +36,26 @@ export const DEFAULT_DREAMING_DRAFT: DreamingDraft = {
 
 export type MemoryProviderChoice = 'managed' | 'native' | 'external' | 'none'
 
+/** `daemon` is the default home (memory-evolution.md §3.2.1); a binding written before the field existed reads as it. */
+export const DEFAULT_MEMORY_HOME: ManagedMemoryHome = 'daemon'
+
+export const MEMORY_HOME_OPTIONS: ReadonlyArray<{ value: ManagedMemoryHome; label: string; help: string }> = [
+  {
+    value: 'daemon',
+    label: 'On the daemon',
+    help: 'The daemon keeps the memory files on the machine that runs the agent.'
+  },
+  {
+    value: 'control-plane',
+    label: 'In the Control Plane',
+    help: 'The Control Plane keeps the memory files, so they follow the agent to any daemon and need no machine to be up.'
+  }
+]
+
+export function memoryHomeLabel(value: ManagedMemoryHome): string {
+  return MEMORY_HOME_OPTIONS.find((option) => option.value === value)?.label ?? value
+}
+
 export const MEMORY_PROVIDER_OPTIONS: ReadonlyArray<{
   value: MemoryProviderChoice
   label: string
@@ -53,6 +73,8 @@ export interface MemorySettingsDraft {
   /** Managed partitioning (#653). `channel` gives each channel its own memory and
    *  disables dreaming (offline consolidation doesn't map onto per-channel folders). */
   scope: ManagedMemoryScope
+  /** Where the managed tree lives; every save sends it, so the CP's "absent keeps current" fallback is never relied on. */
+  home: ManagedMemoryHome
   dreaming: DreamingDraft
   external: ExternalMemoryBindingDraft
 }
@@ -89,6 +111,7 @@ export function memorySettingsDraft(input: {
   provider: string
   autoDistill: boolean
   scope?: ManagedMemoryScope
+  home?: ManagedMemoryHome
   dreaming?: MemoryDreamingConfig | null
   connectionId?: string
   recall?: ExternalMemoryBindingDraft['recall']
@@ -98,6 +121,7 @@ export function memorySettingsDraft(input: {
     provider: memoryProviderChoice(input.provider),
     autoDistill: input.autoDistill,
     scope: input.scope === 'channel' ? 'channel' : 'agent',
+    home: input.home === 'control-plane' ? 'control-plane' : DEFAULT_MEMORY_HOME,
     dreaming: input.dreaming
       ? {
           enabled: input.dreaming.enabled,
@@ -134,6 +158,7 @@ export function memorySettingsChanged(persisted: MemorySettingsDraft, draft: Mem
   if (persisted.provider !== draft.provider) return true
   if (draft.provider === 'managed') {
     if (persisted.scope !== draft.scope) return true
+    if (persisted.home !== draft.home) return true
     // Under channel scope dreaming is hidden/disabled, so its draft fields don't count.
     if (draft.scope === 'channel') return persisted.autoDistill !== draft.autoDistill
     return persisted.autoDistill !== draft.autoDistill || !sameDreaming(persisted.dreaming, draft.dreaming)
@@ -145,6 +170,16 @@ export function memorySettingsChanged(persisted: MemorySettingsDraft, draft: Mem
 export function memoryBackendChanged(persisted: MemorySettingsDraft, draft: MemorySettingsDraft): boolean {
   if (persisted.provider !== draft.provider) return true
   return draft.provider === 'external' && persisted.external.connectionId !== draft.external.connectionId
+}
+
+/** The one-way move: a managed binding whose home goes `daemon` → `control-plane`, which the owning daemon migrates. */
+export function memoryHomeMovesForward(persisted: MemorySettingsDraft, draft: MemorySettingsDraft): boolean {
+  return (
+    persisted.provider === 'managed' &&
+    draft.provider === 'managed' &&
+    persisted.home === 'daemon' &&
+    draft.home === 'control-plane'
+  )
 }
 
 /**
@@ -195,10 +230,15 @@ export function memoryConfigForDraft(draft: MemorySettingsDraft): AgentMemoryCon
     // Channel scope has no dreaming (offline consolidation doesn't map onto
     // per-channel folders), so never serialize a dreaming policy with it.
     if (draft.scope === 'channel') {
-      return { provider: 'managed', autoDistill: draft.autoDistill, scope: 'channel' }
+      return { provider: 'managed', autoDistill: draft.autoDistill, scope: 'channel', home: draft.home }
     }
     const dreaming = dreamingConfigForDraft(draft.dreaming)
-    return { provider: 'managed', autoDistill: draft.autoDistill, ...(dreaming ? { dreaming } : {}) }
+    return {
+      provider: 'managed',
+      autoDistill: draft.autoDistill,
+      home: draft.home,
+      ...(dreaming ? { dreaming } : {})
+    }
   }
   return { provider: draft.provider, autoDistill: false }
 }

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -2195,12 +2195,15 @@ export default function AgentDetailView() {
           memoryProvider={da.memoryProvider}
           autoDistill={da.memoryAutoDistill}
           memoryScope={da.memoryScope}
+          memoryHome={da.memoryHome}
+          memoryHomeMigration={da.memoryHomeMigration}
           memoryDreaming={da.memoryDreaming}
           memoryConnectionId={da.memoryConnectionId}
           memoryRecall={da.memoryRecall}
           memoryCaptureMode={da.memoryCaptureMode}
           sessionBasePath={orgPath('/sessions')}
           sandboxed={isPoolPlacementKind(da.placementKind)}
+          poolPlaced={isPoolPlacementKind(da.placementKind, da.setId, orgSetIds)}
         />
       )}
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -286,6 +286,8 @@ export type AgentMemoryConfig =
       dreaming?: MemoryDreamingConfig
       scope?: ManagedMemoryScope
       home?: ManagedMemoryHome
+      /** CP-owned and read-only: set by the `daemon` → `control-plane` switch, cleared by the owning daemon's completion report. */
+      homeMigration?: 'pending'
     }
   | { provider: 'native' | 'none'; autoDistill?: boolean }
   | {
@@ -988,6 +990,8 @@ export interface UpdateAgentInput {
   managedSkills?: string[]
   /** Memory backend; null clears (revert to managed default). */
   memory?: AgentMemoryConfig | null
+  /** Accept a change the CP otherwise refuses with a 409, such as moving the memory home back to `daemon` (keeps no memory). */
+  force?: boolean
 }
 
 /** The ONE workspace input shape, shared verbatim by agent creation and workspace
@@ -1886,6 +1890,10 @@ export function agentFromDto(d: AgentDto): Agent {
     memoryAutoDistill: d.memory?.provider === 'managed' ? (d.memory.autoDistill ?? false) : false,
     ...(d.memory?.provider === 'managed' && d.memory.scope === 'channel' ? { memoryScope: 'channel' as const } : {}),
     ...(d.memory?.provider === 'managed' && d.memory.dreaming ? { memoryDreaming: d.memory.dreaming } : {}),
+    ...(d.memory?.provider === 'managed' && d.memory.home ? { memoryHome: d.memory.home } : {}),
+    ...(d.memory?.provider === 'managed' && d.memory.homeMigration
+      ? { memoryHomeMigration: d.memory.homeMigration }
+      : {}),
     ...(d.memory?.provider === 'external'
       ? {
           memoryConnectionId: d.memory.connectionId,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -4,7 +4,13 @@
 import type { AgentIcon } from '@/lib/agent-icon'
 import { gitRepoHostname, managedGitlabRepoPath } from './git-url-tile'
 import { isCodeHostHookKind, type HookKind } from '@agentconnect.md/protocol/code-host'
-import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig, PlanBody } from '@/lib/api'
+import type {
+  DaemonSessionRetention,
+  ManagedMemoryHome,
+  ManagedMemoryScope,
+  MemoryDreamingConfig,
+  PlanBody
+} from '@/lib/api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 import { randomUuid } from '@/lib/random-uuid'
@@ -526,6 +532,10 @@ export interface Agent {
   memoryScope?: ManagedMemoryScope
   /** Managed-memory dreaming policy; present only when configured (managed provider). */
   memoryDreaming?: MemoryDreamingConfig
+  /** Where the managed tree lives (memory-evolution.md §3.2.1); absent on a binding written before the field existed. */
+  memoryHome?: ManagedMemoryHome
+  /** Set while the owning daemon copies the tree into the Control Plane after a `daemon` → `control-plane` switch. */
+  memoryHomeMigration?: 'pending'
   /** External-memory binding metadata; present only when memoryProvider='external'. */
   memoryConnectionId?: string
   memoryRecall?: {


### PR DESCRIPTION
## Why

`docs/designs/memory-evolution.md` §3.2.1 says the console offers the managed memory home one way (`daemon` → `control-plane`), keeps the forced return behind its own confirmation, and offers no return on the pool, where `daemon` is refused. The Control Plane rules landed in #1881; this is the console side. Web only — no Control Plane or daemon changes.

## The field

- The managed settings gain a **Memory home** field next to Scope, in the same pill style: **On the daemon** (`daemon`) and **In the Control Plane** (`control-plane`), each with one line of help.
- `MemorySettingsDraft` now carries `home`, read from the binding (absent reads as `daemon`), and `memoryConfigForDraft` sends it on every managed save. A save no longer depends on the server's "absent keeps current" fallback.
- The collapsed summary names the home, and `api.ts` / `data.ts` type `home`, `homeMigration` and the top-level `force` that the update body accepts.

## One way forward

- Choosing `control-plane` while the current home is `daemon` is allowed from the selector. Saving opens the panel's existing `ConfirmationDialog` ("Move memory to the Control Plane?", button `Move`) stating that the owning daemon copies the memory and that memory is unavailable until the copy completes.
- While the binding carries `homeMigration: 'pending'`, the summary bar shows a quiet status ("Moving memory to the Control Plane…") and the home control is disabled. The panel already re-syncs from the polled agent DTO, so the status clears when the daemon's completion report does.

## The return

- Once the home is `control-plane`, the selector shows the value but no longer offers `daemon`.
- The return lives in a bordered destructive area at the bottom of the expanded form: **Move memory back to the daemon**. Its dialog (a new `destructive` variant of `ConfirmationDialog`: error-toned glyph, danger button) states plainly that nothing is kept — every memory file and its history in the Control Plane is deleted and the agent starts with empty memory — and its primary button is the bare verb `Move`.
- Confirming sends the persisted binding with `home: 'daemon'` and `force: true`; a refusal from the server is shown inside the dialog.

## The pool

`AgentDetailView` passes `poolPlaced={isPoolPlacementKind(da.placementKind, da.setId, orgSetIds)}` — the existing way the console tells an install-wide pool placement from a group placement. On the pool the draft's home is pinned to `control-plane`, the field is shown disabled with a one-line reason, and the return action is absent.

## Verification

- `pnpm --filter @agentconnect.md/web typecheck`, `eslint` on every touched file, `pnpm format:check`: clean.
- `vitest run` on `memory-settings.test.ts` and `MemoryPanel.test.tsx`: 41 passing, including nine new cases — the home travels through an unrelated save; the forward switch sends `home: 'control-plane'` only after `Move`; `pending` locks the control and shows the status; `control-plane` hides `daemon`; the return sends `force: true, home: 'daemon'` only after the dialog's `Move` and surfaces a 409 message; pool-placed agents show the fixed field with no return action; the field and action render on mobile.
- Browser: checked in the console's mock mode (desktop and ≤768px) that the field and summary render in the Scope row's style. Mock agents are read-only, so the dialogs and the return action were exercised by the tests rather than by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
