### PR TITLE
feat(daemon): the one-way memory home migration, and the forced return that keeps nothing

### DIFF
--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -319,7 +319,9 @@ the provider still does not (§6, §9).** The binding change is the trigger: whe
 owning daemon applies a binding whose `home` became `control-plane`, it copies `memory/`
 and `channels/` once through the two ports (`copyMemoryTree(from, to)`, under the
 directory lock), the change log with them — sidecar lines become rows, one batch,
-bounded by the sidecar cap — and reports completion on a frame of its own,
+bounded by the sidecar cap; unlike a write's sink these batches are not best-effort,
+since a batch that fails leaves the copy pending and the re-run sends the same ids,
+which the CP takes once — and reports completion on a frame of its own,
 `memory/home/migrated` → `memory/home/migrated/ok`, which the CP records on the
 binding; it is not an op in the store set, because it is not a file operation. The
 record is the CP-owned `homeMigration: 'pending'` the binding carries from the flip
@@ -339,7 +341,9 @@ binding change (409) and accepts it only as a forced one (`force: true` on the a
 edit), which keeps nothing — the CP drops
 the agent's rows and its change log, and the daemon starts from an empty tree, the
 pre-switch local tree archived aside rather than resurrected (a snapshot from before
-the switch is not the memory the agent has been using since). The console offers the
+the switch is not the memory the agent has been using since): `memory/`, `channels/`
+and `memory-backups/` move under `<agent dir>/memory-archive-<timestamp>/` beside
+them, and `memory-dreams/` stays, since staging belongs to the host. The console offers the
 selector one way and the forced return behind its own confirmation; on the pool there
 is no return at all, since `daemon` is refused there. `daemon` stays the default for
 now; making `control-plane` the default is a later decision, not this one.

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -62,6 +62,8 @@ import type {
   MemoryFsReply,
   MemoryHistoryAppendReq,
   MemoryHistoryAppendOk,
+  MemoryHomeMigratedReq,
+  MemoryHomeMigratedOk,
   OrgSkillsReq,
   OrgSkillsOk,
   OrganizationSuggestionsSyncReq,
@@ -1165,6 +1167,24 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected memory/history/append/ok, got ${rep.type}`, false)
     }
     return rep.payload as MemoryHistoryAppendOk
+  }
+
+  // `memory/home/migrated` (D→C REQ): the one-way copy of this agent's tree is complete — one send on one deadline, like
+  // `memoryStore`. A repeated report is the same success on the CP, so a lost reply is retried by the caller, never here.
+  async memoryHomeMigrated(payload: MemoryHomeMigratedReq): Promise<MemoryHomeMigratedOk> {
+    this.requireReady('memory/home/migrated')
+    if (!this.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+      throw new WireError('INTERNAL', 'control plane does not serve the memory store', false)
+    }
+    const frame = this.scopedFrame('memory/home/migrated', payload)
+    const rep = await this.correlator.request(frame, (e) => this.transport!.send(e), {
+      maxTries: 1,
+      ackTimeoutMs: MEMORY_STORE_TIMEOUT_MS
+    })
+    if (rep.type !== 'memory/home/migrated/ok') {
+      throw new WireError('INTERNAL', `expected memory/home/migrated/ok, got ${rep.type}`, false)
+    }
+    return rep.payload as MemoryHomeMigratedOk
   }
 
   async knowledgeList(payload: KnowledgeListReq): Promise<KnowledgeListOk> {

--- a/packages/daemon/src/cp/cp-agent-registry.ts
+++ b/packages/daemon/src/cp/cp-agent-registry.ts
@@ -189,6 +189,18 @@ export class CpAgentRegistry {
     return decision
   }
 
+  // The CP accepted `memory/home/migrated` and cleared `homeMigration` durably; mirror that on the replica now, so the
+  // next resolution serves the CP tree without waiting for the push that carries the cleared binding (it applies as a
+  // newer revision with the same content). False when the binding carries no marker to drop.
+  settleMemoryHomeMigration(agentId: string): boolean {
+    const agent = this.active.get(agentId)
+    if (agent?.memory?.provider !== 'managed' || agent.memory.homeMigration !== 'pending') return false
+    const { homeMigration: _cleared, ...memory } = agent.memory
+    this.active.set(agentId, { ...agent, memory })
+    this.onChange()
+    return true
+  }
+
   remove(agentId: string): void {
     assertSafeLifecycleId(agentId)
     const agent = this.active.get(agentId) ?? this.detached.get(agentId)

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -148,6 +148,8 @@ export interface CpClientSeamHost {
   memoryHomePortsFor(agentId: string): MemoryHomePorts | undefined
   /** Drain the managed captures deferred while a memory home was out of reach — a READY connection is a reachable `control-plane` home. */
   wakeMemoryOutbox(): void
+  /** Re-run every pending memory home migration from the start — its copy and completion report ride this connection. */
+  wakeMemoryHomeMigrations(): void
   gitCommitIdentity(): GitCommitIdentity | undefined
   sessionThreadUrl(session: SessionRecord): string | undefined
   childSessionStatusProbe(probe: ChildSessionStatusProbe): Promise<ChildSessionStatus>
@@ -268,6 +270,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       host.cpClient()?.emitMemoryConnectionFacts(host.memoryConnections()?.facts() ?? [])
       // A READY connection is a reachable `control-plane` memory home: distill the turns that waited for it.
       host.wakeMemoryOutbox()
+      host.wakeMemoryHomeMigrations()
       await host.replayHookTerminalReports()
       await host.replayChannelSnapshots()
       // Only snapshots written to the durable outbox by this build are

--- a/packages/daemon/src/cp/memory-history.ts
+++ b/packages/daemon/src/cp/memory-history.ts
@@ -50,6 +50,11 @@ function failureReason(err: unknown): string {
   return err instanceof Error ? `${err.name}: ${err.message}` : String(err)
 }
 
+/** Where the CP files a store's change log, from the store's port root: under the directory that holds its files (`memory`, `channels/<key>/memory`), the root the CP's `memory/history` read filters on. */
+export function cpMemoryHistoryRoot(storeRoot: string): string {
+  return joinTreeRoot(joinTreeRoot(CP_MEMORY_TREE_ROOT, storeRoot), MEMORY_DIRNAME)
+}
+
 // The sink over the CP. `root` is the store's port root in `CpMemoryFs` coordinates (`.` for the agent's tree,
 // `channels/<key>` for a channel store); the log is filed under the directory that holds the store's files — `memory`,
 // `channels/<key>/memory` — which is the root the CP's `memory/history` read filters on, so a page finds what a batch wrote.
@@ -62,7 +67,7 @@ export class CpMemoryHistorySink implements MemoryHistorySink {
     root: string = CP_MEMORY_TREE_ROOT,
     private readonly log: Pick<Logger, 'warn'>
   ) {
-    this.root = joinTreeRoot(joinTreeRoot(CP_MEMORY_TREE_ROOT, root), MEMORY_DIRNAME)
+    this.root = cpMemoryHistoryRoot(root)
   }
 
   /** Best-effort: the write already happened, so any failure is one warn line naming what went unrecorded, never a rejection. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -408,6 +408,7 @@ import {
   type MemoryHomeDeps,
   type MemoryHomePorts
 } from './memory/home.js'
+import { MemoryHomeMigrator, archiveMemoryTreeAside, memoryHomeReturnedToDaemon } from './memory/home-migration.js'
 import { CpCronRegistry } from './cp/cp-cron.js'
 import { DutyRegistry } from './cp/duty-registry.js'
 import { DutyCoordinator, type DutyHost } from './cp/duty-coordinator.js'
@@ -1186,6 +1187,15 @@ export class Daemon {
   private memoryConnections?: CpMemoryConnectionRegistry
   /** Durable reply-after-delivery capture pump. Bodies remain in LocalStore. */
   private memoryOutbox?: MemoryCaptureOutbox
+  // The one-way memory home migration (memory-evolution.md §3.2.1): runs for every held agent whose binding still
+  // carries the CP's `homeMigration: 'pending'`, re-run from the start on CP READY, its completion mirrored below.
+  private readonly memoryHomeMigrations = new MemoryHomeMigrator({
+    agents: () => this.heldManagedMemoryAgents(),
+    homes: () => ({ ...this.memoryHomeDeps(), cp: this.cpClient }),
+    withMemoryHome: (agentId, work) => this.withMemoryHome(agentId, work),
+    onMigrated: (agentId) => this.onMemoryHomeMigrated(agentId),
+    log: { info: (message) => this.log.info(message), warn: (message) => this.log.warn(message) }
+  })
   private cpClient?: CpClient
   private remoteWebchatGrants?: RemoteWebchatGrantManager
   private managedSkillCache?: ManagedSkillCache
@@ -2477,14 +2487,7 @@ export class Daemon {
     this.memoryOutbox = new MemoryCaptureOutbox(
       this.store,
       withManagedDistill(this.memoryConnections!, {
-        agentIds: () =>
-          [...this.agents.values()]
-            .filter(
-              (agent) =>
-                memoryKindOf(agent) === 'managed' &&
-                (!this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(agent.id))
-            )
-            .map((agent) => agent.id),
+        agentIds: () => this.heldManagedMemoryAgents().map((agent) => agent.id),
         // "The home is reachable", not "the pod is bound": the CP READY with the feature for a `control-plane` tree.
         reachable: (agentId) => {
           const agent = this.agents.get(agentId)
@@ -3532,6 +3535,9 @@ export class Daemon {
       if (previous?.allowRuntimeChangesInChat === true && !a.allowRuntimeChangesInChat) {
         this.permissions.disableChatPermissionSurfaces(a.id)
       }
+      // A forced return of the memory home archives the pre-switch tree BEFORE the binding is live: while the home was
+      // still `control-plane`, nothing on this disk was being written, so the move races no writer.
+      if (previous && memoryHomeReturnedToDaemon(previous, a)) await this.archiveMemoryHomeAside(a as LoadedAgent)
       // ALWAYS publish fresh config first, so live reads — output.mode (per dispatch),
       // per-session cwd/tools, routing (mergedRules reads this.agents) — see the new config.
       this.agents.set(a.id, a as LoadedAgent)
@@ -3639,6 +3645,8 @@ export class Daemon {
     // capabilities. No-op when nothing changed. Optional call: tests inject
     // partial cpClient fakes (same as emitDaemonRuntimes).
     this.cpClient?.updateCapabilities?.()
+    // A binding that arrived with the CP's migration marker starts its copy now; one whose marker moved on is forgotten.
+    this.memoryHomeMigrations.reconcile()
   }
 
   /**
@@ -3804,6 +3812,51 @@ export class Daemon {
   /** Where a memory home is reached from: this member's sandbox plane (under `--k8s`) and its CP connection. */
   private memoryHomeDeps(): MemoryHomeDeps {
     return { sandbox: this.k8sPlane, cp: this.cpClient, log: this.log }
+  }
+
+  /** The managed-memory agents this member serves right now — under duty, only the ones it holds. */
+  private heldManagedMemoryAgents(): LoadedAgent[] {
+    return [...this.agents.values()].filter(
+      (agent) =>
+        memoryKindOf(agent) === 'managed' && (!this.dutyCoordinator.dutyEnforced() || this.duties.holdsAgent(agent.id))
+    )
+  }
+
+  // Authorized background work over an agent's `daemon`-home tree, like a turn: under --k8s wake and bind the sandbox
+  // (the tree, or the dream host and its staging, live there) and hold it against the idle sweep for the job's
+  // duration; a local agent's home is always up.
+  private async withMemoryHome<T>(agentId: string, work: () => Promise<T>): Promise<T> {
+    const plane = this.k8sPlane
+    if (!plane) return work()
+    return plane.withSandbox(agentId, async () => {
+      await plane.ensureChannel(agentId)
+      return work()
+    })
+  }
+
+  // The CP recorded the copy: mirror its clear on the local replica now — the next resolution serves the CP tree — and
+  // let reconcile rebuild the session boundary, as it does for any memory-binding change.
+  private async onMemoryHomeMigrated(agentId: string): Promise<void> {
+    if (this.cpAgents?.settleMemoryHomeMigration(agentId)) await this.flushReconcile()
+  }
+
+  // The forced return (memory-evolution.md §3.2.1): the CP has dropped its rows, so the tree this disk kept from before
+  // the switch moves aside and the agent starts from an empty one. Nothing to move on the pool, where the tree never
+  // lived on this disk; a failed move is logged, never a reason to keep the binding from applying.
+  private async archiveMemoryHomeAside(agent: LoadedAgent): Promise<void> {
+    if (this.k8sPlane) return
+    try {
+      const archive = await archiveMemoryTreeAside(agent.dir, new Date(this.clock.now()))
+      if (archive) {
+        this.log.info(
+          `memory: agent "${agent.id}" returned its memory home to this daemon; the pre-switch tree is archived at ${archive}`
+        )
+      }
+    } catch (err) {
+      this.log.error(
+        `memory: agent "${agent.id}" returned its memory home to this daemon, but the pre-switch tree could not be archived aside: ${formatErr(err)}`
+      )
+    }
   }
 
   /** The ports every managed-memory consumer is built on — `live` for the store, `staging` for `memory-dreams/`, the change-log sink — decided by the agent's `home` and this member's placement; undefined for an unknown agent, and it throws `MemoryHomeUnavailableError` while the home is out of reach. */
@@ -6069,17 +6122,7 @@ export class Daemon {
       withSkillAcceptance: async (agentId, publish) => {
         return this.withWorkspaceFileWrite(agentId, publish)
       },
-      // A dream is authorized background work like a turn: under --k8s wake and bind the sandbox
-      // (the memory tree and the dream host both live there) and hold it against the idle sweep
-      // for the job's duration; a local agent's home is always up.
-      withMemoryHome: async (agentId, work) => {
-        const plane = this.k8sPlane
-        if (!plane) return work()
-        return plane.withSandbox(agentId, async () => {
-          await plane.ensureChannel(agentId)
-          return work()
-        })
-      },
+      withMemoryHome: (agentId, work) => this.withMemoryHome(agentId, work),
       onEvent: (event) => this.recordDreamLifecycle(event),
       log: this.log
     })
@@ -17757,6 +17800,7 @@ export class Daemon {
       runtimeCommands: () => this.runtimeCommands,
       memoryHomePortsFor: (agentId) => this.memoryHomePortsFor(agentId),
       wakeMemoryOutbox: () => this.memoryOutbox?.wake(),
+      wakeMemoryHomeMigrations: () => this.memoryHomeMigrations.wake(),
       gitCommitIdentity: () => this.gitCommitIdentity,
       sessionThreadUrl: (session) => this.sessionThreadUrl(session),
       childSessionStatusProbe: (probe) => this.collab.childSessionStatusProbe(probe),
@@ -18739,6 +18783,8 @@ export class Daemon {
     while (this.agentLifecycleTails.size > 0) {
       await Promise.all([...this.agentLifecycleTails.values()])
     }
+    // A memory home copy stops between files and reports nothing; the CP's marker keeps it pending for the next start.
+    await this.memoryHomeMigrations.stop().catch((e) => errors.push(e))
     // Stop the body-bearing capture pump before closing its verified clients or
     // SQLite store. Unfinished operations remain durable for restart recovery.
     await Promise.resolve(this.memoryOutbox?.stop()).catch((e) => errors.push(e))

--- a/packages/daemon/src/dream/runner.ts
+++ b/packages/daemon/src/dream/runner.ts
@@ -29,7 +29,9 @@ import {
   type MemoryIndexEntry,
   MAX_INDEX_INJECT_BYTES,
   MAX_MEMORY_FILE_BYTES,
+  MEMORY_BACKUPS_DIRNAME as BACKUPS_DIRNAME,
   MEMORY_DIRNAME,
+  MEMORY_DREAMS_DIRNAME as DREAMS_DIRNAME,
   MemoryHomeUnavailableError,
   listMemory,
   memoryHistoryRecord,
@@ -247,8 +249,6 @@ const LAST_SUCCESSFUL_DREAM_SCAN = 50
 // activity since the last successful dream" (no operator config), but a first
 // dream — or a long-idle agent — must not mine an unbounded corpus.
 const MAX_AUTO_SESSION_WINDOW = 100
-const DREAMS_DIRNAME = 'memory-dreams'
-const BACKUPS_DIRNAME = 'memory-backups'
 /** A dream stages into a real memory store (`<dream>/memory/`), so every store helper
  *  — listing, index generation, the memory tools — works on it unchanged. Dreams
  *  staged before that lived in `output/`; those keep resolving for review and adoption. */

--- a/packages/daemon/src/memory/home-migration.ts
+++ b/packages/daemon/src/memory/home-migration.ts
@@ -13,7 +13,7 @@ import {
   type MemoryHomeMigratedReq
 } from '@agentconnect.md/protocol'
 import { CP_MEMORY_TREE_ROOT, CpMemoryFs } from '../cp/memory-fs.js'
-import { packMemoryHistoryBatches } from '../cp/memory-history.js'
+import { cpMemoryHistoryRoot, packMemoryHistoryBatches } from '../cp/memory-history.js'
 import type { Logger } from '../log.js'
 import { MemoryHomeUnavailableError, MemoryPathError, MemoryTooLargeError, type MemoryFs } from './fs.js'
 import {
@@ -143,14 +143,18 @@ export async function copyMemoryTree(
   return report
 }
 
-/** The migration's batches are not a write's best-effort ones: a failed batch fails the copy, and the re-run sends the same ids, which the CP takes once. */
+// One store's log to the CP, filed where `CpMemoryHistorySink` files a live write's (`cpMemoryHistoryRoot`), so the
+// console's page finds it. Unlike a write's best-effort sink, a failed batch fails the copy: the re-run sends the same
+// ids, which the CP takes once.
 export async function sendMemoryHistory(
   link: CpMemoryMigrationLink,
   agentId: string,
-  root: string,
+  storeRoot: string,
   records: readonly MemoryHistoryRecord[]
 ): Promise<void> {
-  for (const batch of packMemoryHistoryBatches(agentId, root, records)) await link.memoryHistoryAppend(batch)
+  for (const batch of packMemoryHistoryBatches(agentId, cpMemoryHistoryRoot(storeRoot), records)) {
+    await link.memoryHistoryAppend(batch)
+  }
 }
 
 /** The forced return, `control-plane` → `daemon` on a managed binding: the CP has dropped its rows, and nothing local may be resurrected. */
@@ -165,6 +169,25 @@ export function memoryHomeReturnedToDaemon(
 /** The archive directory beside the tree, stamped without the characters a Windows path refuses. */
 export function memoryArchiveDirname(at: Date): string {
   return `memory-archive-${at.toISOString().replace(/[:.]/g, '-')}`
+}
+
+const WINDOWS_RENAME_RETRIES = 10
+const WINDOWS_RENAME_DELAY_MS = 100
+const WINDOWS_TRANSIENT_FS_ERRORS = new Set(['EACCES', 'EBUSY', 'EPERM'])
+
+// Windows refuses to rename a directory while another handle (a watcher's, a scanner's) is briefly open inside it — a
+// race POSIX never has — so the move is retried a bounded number of times, as the workspace manager's directory swap is.
+async function renameAside(from: string, to: string): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fsp.rename(from, to)
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      const transient = process.platform === 'win32' && code !== undefined && WINDOWS_TRANSIENT_FS_ERRORS.has(code)
+      if (!transient || attempt >= WINDOWS_RENAME_RETRIES) throw err
+      await new Promise((resolve) => setTimeout(resolve, WINDOWS_RENAME_DELAY_MS))
+    }
+  }
 }
 
 // Move the live store aside — `memory/`, `channels/`, `memory-backups/` under `<agent dir>/memory-archive-<stamp>/` —
@@ -182,7 +205,7 @@ export async function archiveMemoryTreeAside(agentDir: string, at: Date): Promis
       throw err
     }
     if (!moved) await fsp.mkdir(archive)
-    await fsp.rename(source, join(archive, name))
+    await renameAside(source, join(archive, name))
     moved = true
   }
   return moved ? archive : undefined

--- a/packages/daemon/src/memory/home-migration.ts
+++ b/packages/daemon/src/memory/home-migration.ts
@@ -1,0 +1,334 @@
+// The one-way memory home migration and the forced return (memory-evolution.md §3.2.1). A managed binding whose `home`
+// became `control-plane` carries the CP's `homeMigration: 'pending'` until the owning daemon has copied `memory/` and
+// `channels/` from the `daemon` home into the CP — the sidecars as change-log rows — and reported `memory/home/migrated`.
+// The copy is restartable by doing nothing clever: the source is frozen from the flip (no writer touches a `daemon` tree
+// once the home is `control-plane`) and the target is served to nobody until the CP holds the completion, so an
+// interrupted copy runs again from the start and overwrites by path. The source tree is never deleted.
+import { promises as fsp } from 'node:fs'
+import { join } from 'node:path'
+import { WireError } from '@agentconnect.md/connection'
+import {
+  AGENT_MEMORY_STORE_V1_FEATURE,
+  type MemoryHomeMigratedOk,
+  type MemoryHomeMigratedReq
+} from '@agentconnect.md/protocol'
+import { CP_MEMORY_TREE_ROOT, CpMemoryFs } from '../cp/memory-fs.js'
+import { packMemoryHistoryBatches } from '../cp/memory-history.js'
+import type { Logger } from '../log.js'
+import { MemoryHomeUnavailableError, MemoryPathError, MemoryTooLargeError, type MemoryFs } from './fs.js'
+import {
+  daemonHomeMemoryFs,
+  memoryHomeMigrationPending,
+  memoryHomeOf,
+  type CpMemoryHomeLink,
+  type MemoryHomeAgent,
+  type MemoryHomeDeps
+} from './home.js'
+import {
+  CHANNEL_MEMORY_DIRNAME,
+  MEMORY_BACKUPS_DIRNAME,
+  MEMORY_DIRNAME,
+  MEMORY_DREAMS_DIRNAME,
+  MEMORY_HISTORY_FILENAME,
+  channelMemoryRoot,
+  listChannelMemoryKeys,
+  readMemoryHistoryHoldingLock,
+  withMemoryDirLock,
+  type MemoryHistoryRecord
+} from './store.js'
+
+/** The CP connection as the migration sees it: the home's two request pairs, and the completion report. */
+export interface CpMemoryMigrationLink extends CpMemoryHomeLink {
+  memoryHomeMigrated(req: MemoryHomeMigratedReq): Promise<MemoryHomeMigratedOk>
+}
+
+/** What one copy moved: files and bytes written by path, change-log records sent, files the target refused. */
+export interface MemoryTreeCopyReport {
+  files: number
+  bytes: number
+  records: number
+  skipped: number
+}
+
+export interface CopyMemoryTreeOptions {
+  /** Deliver one store's whole change log (`.` or `channels/<key>`); a rejection fails the copy, unlike a write's sink. */
+  history(root: string, records: MemoryHistoryRecord[]): Promise<void>
+  log: Pick<Logger, 'warn'>
+  signal?: AbortSignal | undefined
+}
+
+/** Never carried: dream staging belongs to the extraction host, the pre-adoption backup to the adoption that made it. */
+const STAYS_BEHIND = new Set([MEMORY_DREAMS_DIRNAME, MEMORY_BACKUPS_DIRNAME])
+
+/** Walked past as a file: the sidecar (sent as rows instead) and the temp file a crashed write left behind. */
+function walkedPast(name: string): boolean {
+  return name === MEMORY_HISTORY_FILENAME || name.endsWith('.tmp')
+}
+
+/** The target refused this one file (over the cap, or a name the tree refuses): skipped with a warning, since the source keeps it. */
+function refusedByTarget(err: unknown): boolean {
+  if (err instanceof MemoryTooLargeError || err instanceof MemoryPathError) return true
+  return err instanceof WireError && err.code === 'BAD_PAYLOAD'
+}
+
+function describeFailure(err: unknown): string {
+  if (err instanceof WireError) return `${err.code}: ${err.message}`
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+}
+
+async function copyDir(
+  from: MemoryFs,
+  to: MemoryFs,
+  rel: string,
+  report: MemoryTreeCopyReport,
+  opts: CopyMemoryTreeOptions
+): Promise<void> {
+  await to.mkdir(rel)
+  for (const entry of await from.readdir(rel)) {
+    const path = `${rel}/${entry.name}`
+    if (entry.kind === 'dir') {
+      if (!STAYS_BEHIND.has(entry.name)) await copyDir(from, to, path, report, opts)
+      continue
+    }
+    if (entry.kind !== 'file' || walkedPast(entry.name)) continue
+    opts.signal?.throwIfAborted()
+    const file = await from.readFile(path)
+    if (!file) continue
+    try {
+      // Verbatim text, frontmatter and all; the target's own mtime is then set back to the source's.
+      await to.writeFile(path, file.content)
+    } catch (err) {
+      if (!refusedByTarget(err)) throw err
+      opts.log.warn(
+        `memory: ${path} was not copied into the Control Plane (${describeFailure(err)}); the source keeps it`
+      )
+      report.skipped += 1
+      continue
+    }
+    await to.utimes(path, file.mtime)
+    report.files += 1
+    report.bytes += file.size
+  }
+}
+
+/** One store's sidecar as rows, read with durable ids under that store's lock and handed over whole. */
+async function sendStoreHistory(store: MemoryFs, root: string, opts: CopyMemoryTreeOptions): Promise<number> {
+  const records = await readMemoryHistoryHoldingLock(store)
+  if (records.length > 0) await opts.history(root, records)
+  return records.length
+}
+
+// Copy `memory/` and `channels/` from one store to another by path, overwriting, then each store's change log — the
+// agent tree's and every channel store's, in the coordinates `CpMemoryFs` names. Held under the source's memory-dir
+// lock: the home has flipped, so no writer should be left, and the lock is cheap.
+export async function copyMemoryTree(
+  from: MemoryFs,
+  to: MemoryFs,
+  opts: CopyMemoryTreeOptions
+): Promise<MemoryTreeCopyReport> {
+  const report: MemoryTreeCopyReport = { files: 0, bytes: 0, records: 0, skipped: 0 }
+  await withMemoryDirLock(from, async () => {
+    const present = new Set((await from.readdir('')).filter((entry) => entry.kind === 'dir').map((entry) => entry.name))
+    for (const dir of [MEMORY_DIRNAME, CHANNEL_MEMORY_DIRNAME]) {
+      if (present.has(dir)) await copyDir(from, to, dir, report, opts)
+    }
+    report.records += await sendStoreHistory(from, CP_MEMORY_TREE_ROOT, opts)
+    for (const key of await listChannelMemoryKeys(from)) {
+      const store = channelMemoryRoot(from, key)
+      report.records += await withMemoryDirLock(store, () =>
+        sendStoreHistory(store, `${CHANNEL_MEMORY_DIRNAME}/${key}`, opts)
+      )
+    }
+  })
+  return report
+}
+
+/** The migration's batches are not a write's best-effort ones: a failed batch fails the copy, and the re-run sends the same ids, which the CP takes once. */
+export async function sendMemoryHistory(
+  link: CpMemoryMigrationLink,
+  agentId: string,
+  root: string,
+  records: readonly MemoryHistoryRecord[]
+): Promise<void> {
+  for (const batch of packMemoryHistoryBatches(agentId, root, records)) await link.memoryHistoryAppend(batch)
+}
+
+/** The forced return, `control-plane` → `daemon` on a managed binding: the CP has dropped its rows, and nothing local may be resurrected. */
+export function memoryHomeReturnedToDaemon(
+  previous: Pick<MemoryHomeAgent, 'memory'>,
+  next: Pick<MemoryHomeAgent, 'memory'>
+): boolean {
+  if (previous.memory?.provider !== 'managed' || next.memory?.provider !== 'managed') return false
+  return memoryHomeOf(previous) === 'control-plane' && memoryHomeOf(next) === 'daemon'
+}
+
+/** The archive directory beside the tree, stamped without the characters a Windows path refuses. */
+export function memoryArchiveDirname(at: Date): string {
+  return `memory-archive-${at.toISOString().replace(/[:.]/g, '-')}`
+}
+
+// Move the live store aside — `memory/`, `channels/`, `memory-backups/` under `<agent dir>/memory-archive-<stamp>/` —
+// so the agent starts from an empty tree; `memory-dreams/` stays, since staging belongs to the host. Undefined when
+// there was nothing to move.
+export async function archiveMemoryTreeAside(agentDir: string, at: Date): Promise<string | undefined> {
+  const archive = join(agentDir, memoryArchiveDirname(at))
+  let moved = false
+  for (const name of [MEMORY_DIRNAME, CHANNEL_MEMORY_DIRNAME, MEMORY_BACKUPS_DIRNAME]) {
+    const source = join(agentDir, name)
+    try {
+      await fsp.lstat(source)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue
+      throw err
+    }
+    if (!moved) await fsp.mkdir(archive)
+    await fsp.rename(source, join(archive, name))
+    moved = true
+  }
+  return moved ? archive : undefined
+}
+
+type Timer = ReturnType<typeof setTimeout>
+
+export interface MemoryHomeMigratorDeps {
+  /** The managed-memory agents this member serves, with their bindings as the daemon holds them right now. */
+  agents(): Iterable<MemoryHomeAgent>
+  /** Where the homes are reached from, read on every run: the sandbox plane of a `--k8s` member, the CP connection. */
+  homes(): MemoryHomeDeps & { cp?: CpMemoryMigrationLink | undefined }
+  /** Under `--k8s`, bind the agent pod around the copy — the source is its volume; self-hosted, run the work as it is. */
+  withMemoryHome<T>(agentId: string, work: () => Promise<T>): Promise<T>
+  /** The CP recorded the completion: drop the marker from the local binding and rebuild the session boundary. */
+  onMigrated(agentId: string): Promise<void>
+  log: Pick<Logger, 'info' | 'warn'>
+  /** Backoff after a failed copy, doubling from `retryBaseMs` up to `retryMaxMs`; a READY connection resets it. */
+  retryBaseMs?: number
+  retryMaxMs?: number
+  setTimer?: (fn: () => void, ms: number) => Timer
+  clearTimer?: (timer: Timer) => void
+}
+
+interface MigrationState {
+  attempts: number
+  inFlight?: Promise<void> | undefined
+  timer?: Timer | undefined
+  /** The binding the CP answered `CONFLICT` for: nothing runs again until the binding changes. */
+  conflicted?: string | undefined
+}
+
+const RETRY_BASE_MS = 5_000
+const RETRY_MAX_MS = 5 * 60_000
+
+// Runs the copy for every agent whose binding says the CP is waiting for it — once at a time per agent, retried with
+// backoff, re-run from the start on CP READY — and hands each accepted completion back to the daemon.
+export class MemoryHomeMigrator {
+  private readonly runs = new Map<string, MigrationState>()
+  private readonly abort = new AbortController()
+  private running = true
+
+  constructor(private readonly deps: MemoryHomeMigratorDeps) {}
+
+  /** The roster changed: start the copy for each pending binding, and forget the agents whose binding moved on. */
+  reconcile(): void {
+    if (!this.running) return
+    const pending = new Set<string>()
+    for (const agent of this.deps.agents()) {
+      if (!memoryHomeMigrationPending(agent)) continue
+      pending.add(agent.id)
+      this.consider(agent)
+    }
+    for (const [agentId, state] of this.runs) {
+      if (pending.has(agentId) || state.inFlight) continue
+      this.clearTimer(state)
+      this.runs.delete(agentId)
+    }
+  }
+
+  /** The CP connection is READY again: every copy that waited on it runs now, from the start, its backoff forgotten. */
+  wake(): void {
+    for (const state of this.runs.values()) {
+      state.attempts = 0
+      this.clearTimer(state)
+    }
+    this.reconcile()
+  }
+
+  /** Nothing new starts, a running copy stops between files, and no completion is reported after this. */
+  async stop(): Promise<void> {
+    this.running = false
+    this.abort.abort()
+    for (const state of this.runs.values()) this.clearTimer(state)
+    await Promise.allSettled([...this.runs.values()].map((state) => state.inFlight))
+  }
+
+  private consider(agent: MemoryHomeAgent): void {
+    const state = this.runs.get(agent.id) ?? { attempts: 0 }
+    this.runs.set(agent.id, state)
+    const binding = JSON.stringify(agent.memory)
+    if (state.conflicted !== undefined && state.conflicted !== binding) state.conflicted = undefined
+    if (state.inFlight || state.timer || state.conflicted !== undefined) return
+    state.inFlight = this.run(agent.id, state, binding).finally(() => {
+      state.inFlight = undefined
+    })
+  }
+
+  private async run(agentId: string, state: MigrationState, binding: string): Promise<void> {
+    const { log } = this.deps
+    let agent: MemoryHomeAgent | undefined
+    for (const candidate of this.deps.agents()) if (candidate.id === agentId) agent = candidate
+    if (!agent || !memoryHomeMigrationPending(agent)) return
+    const source = agent
+    try {
+      const homes = this.deps.homes()
+      const cp = homes.cp
+      if (!cp?.connected()) {
+        throw new MemoryHomeUnavailableError('connection', 'the Control Plane connection is not ready')
+      }
+      if (!cp.supportsServerFeature(AGENT_MEMORY_STORE_V1_FEATURE)) {
+        throw new MemoryHomeUnavailableError('feature', 'the Control Plane does not serve the memory store')
+      }
+      log.info(`memory: agent "${agentId}": copying its memory tree into the Control Plane`)
+      const report = await this.deps.withMemoryHome(agentId, () =>
+        copyMemoryTree(daemonHomeMemoryFs(source, homes.sandbox), new CpMemoryFs(cp, agentId), {
+          history: (root, records) => sendMemoryHistory(cp, agentId, root, records),
+          log,
+          signal: this.abort.signal
+        })
+      )
+      if (!this.running) return
+      await cp.memoryHomeMigrated({ agentId })
+      state.attempts = 0
+      const refused = report.skipped > 0 ? `, ${report.skipped} refused by the target` : ''
+      log.info(
+        `memory: agent "${agentId}": memory home migrated to the Control Plane (${report.files} file(s), ${report.bytes} byte(s), ${report.records} change-log record(s)${refused})`
+      )
+      await this.deps.onMigrated(agentId)
+    } catch (err) {
+      if (err instanceof WireError && err.code === 'CONFLICT') {
+        // The home moved on since the flip: whatever the CP holds now is not this copy's business, and neither tree is touched.
+        state.conflicted = binding
+        log.warn(
+          `memory: agent "${agentId}": the Control Plane no longer expects the copy (${err.message}); leaving both trees as they are`
+        )
+        return
+      }
+      if (!this.running) return
+      state.attempts += 1
+      const base = this.deps.retryBaseMs ?? RETRY_BASE_MS
+      const delay = Math.min(this.deps.retryMaxMs ?? RETRY_MAX_MS, base * 2 ** (state.attempts - 1))
+      log.warn(
+        `memory: agent "${agentId}": memory home migration failed (${describeFailure(err)}); retrying in ${Math.round(delay / 1000)}s`
+      )
+      state.timer = (this.deps.setTimer ?? setTimeout)(() => {
+        state.timer = undefined
+        this.reconcile()
+      }, delay)
+      state.timer.unref?.()
+    }
+  }
+
+  private clearTimer(state: MigrationState): void {
+    if (!state.timer) return
+    ;(this.deps.clearTimer ?? clearTimeout)(state.timer)
+    state.timer = undefined
+  }
+}

--- a/packages/daemon/src/memory/home.ts
+++ b/packages/daemon/src/memory/home.ts
@@ -65,12 +65,21 @@ function sandboxAsleep(agentId: string): MemorySandboxUnavailableError {
   return new MemorySandboxUnavailableError(`agent "${agentId}" has no running sandbox, so its memory cannot be reached`)
 }
 
-/** The tree the agent's pod holds, or this disk without a plane: the `daemon` home's store, and every home's dream staging. */
-function sandboxOrLocalPort(agent: MemoryHomeAgent, sandbox: SandboxMemoryFsSource | undefined): MemoryFs {
+/** The tree the agent's pod holds, or this disk without a plane: the `daemon` home's store, every home's dream staging, and the source of the one-way migration. */
+export function daemonHomeMemoryFs(agent: MemoryHomeAgent, sandbox: SandboxMemoryFsSource | undefined): MemoryFs {
   if (!sandbox) return new LocalMemoryFs(agent.dir)
   const fs = sandbox.memoryFsFor(agent.id)
   if (!fs) throw sandboxAsleep(agent.id)
   return fs
+}
+
+/** Whether the binding still carries the CP's migration marker: the copy has not been reported complete. */
+export function memoryHomeMigrationPending(agent: Pick<MemoryHomeAgent, 'memory'>): boolean {
+  return (
+    agent.memory?.provider === 'managed' &&
+    agent.memory.home === 'control-plane' &&
+    agent.memory.homeMigration === 'pending'
+  )
 }
 
 // Why the agent's memory home is out of reach right now, or undefined when it can be served: the activation gate
@@ -85,8 +94,8 @@ export function memoryHomeUnavailable(
     return deps.sandbox && !deps.sandbox.memoryFsFor(agent.id) ? sandboxAsleep(agent.id) : undefined
   }
   const home = `agent "${agent.id}" keeps its memory in the Control Plane, which`
-  // Step ④ stamps `homeMigration: 'pending'` on a flipped binding and step ⑧ clears it after the copy: no CP tree is served before the copy exists.
-  if ((agent.memory as { homeMigration?: 'pending' } | undefined)?.homeMigration === 'pending') {
+  // The CP stamps `homeMigration: 'pending'` on a flipped binding and the migration clears it after the copy: no CP tree is served before the copy exists.
+  if (memoryHomeMigrationPending(agent)) {
     return new MemoryHomeUnavailableError('migrating', `${home} is still receiving the copy of its tree`)
   }
   if (!deps.cp?.connected()) return new MemoryHomeUnavailableError('connection', `${home} is unreachable`)
@@ -100,7 +109,7 @@ export function memoryHomeUnavailable(
 // agent's sandbox volume, reachable exactly while the pod is bound. A `control-plane` home puts `live` and the sink on
 // the CP connection without touching any pod, and leaves `staging` where the extraction host can see it.
 export function resolveMemoryHomePorts(agent: MemoryHomeAgent, deps: MemoryHomeDeps): MemoryHomePorts {
-  if (memoryHomeOf(agent) !== 'control-plane') return localMemoryHome(sandboxOrLocalPort(agent, deps.sandbox))
+  if (memoryHomeOf(agent) !== 'control-plane') return localMemoryHome(daemonHomeMemoryFs(agent, deps.sandbox))
   const unavailable = memoryHomeUnavailable(agent, deps)
   if (unavailable) throw unavailable
   const cp = deps.cp!
@@ -109,7 +118,7 @@ export function resolveMemoryHomePorts(agent: MemoryHomeAgent, deps: MemoryHomeD
     live,
     // Looked up on use, not at activation: the store never needs the pod, and a review of a draft on the pool still wakes it.
     get staging(): MemoryFs {
-      return sandboxOrLocalPort(agent, deps.sandbox)
+      return daemonHomeMemoryFs(agent, deps.sandbox)
     },
     // A store under `live` logs to the CP table in its own coordinates; a staged store, never in the CP, keeps its sidecar.
     historyFor: (store) =>

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -66,6 +66,11 @@ export const MAX_MEMORY_FILE_BYTES = 256_000
  *  (who/what/when changed a file). Dotfile so it never surfaces as a topic. */
 export const MEMORY_HISTORY_FILENAME = '.history'
 
+/** Dream staging beside the live store (`<root>/memory-dreams/<dreamId>/`), which belongs to the extraction host, never the home. */
+export const MEMORY_DREAMS_DIRNAME = 'memory-dreams'
+/** The retained pre-adoption copy of the store (`<root>/memory-backups/`), the undo path for the last dream. */
+export const MEMORY_BACKUPS_DIRNAME = 'memory-backups'
+
 /** Cap on a `before`/`after` snapshot stored in a history line — keeps a single log
  *  entry bounded even for a large file. Over this, the snapshot is truncated (with a
  *  `…` marker) rather than omitted, so the line stays small but still human-readable. */
@@ -386,6 +391,14 @@ async function compactHistoryFile(fs: MemoryFs): Promise<void> {
   const canonical = canonicalizeMemoryHistory(raw)
   if (canonical === raw) return
   await fs.writeFile(HISTORY_PATH, canonical, { mode: 0o600 })
+}
+
+// One store's whole change log, oldest first, every record carrying a durable id: the sidecar is compacted first (a
+// no-op on a canonical file), so a legacy row is given its id on disk before anyone copies it and a re-read yields
+// the same rows. The caller holds the store's memory-dir lock.
+export async function readMemoryHistoryHoldingLock(fs: MemoryFs): Promise<MemoryHistoryRecord[]> {
+  await compactHistoryFile(fs)
+  return parseHistory(await readHistoryRaw(fs)).records
 }
 
 /** The sidecar sink: `<root>/memory/.history`, rewritten once per append, the fixed retention applied in the same pass. */

--- a/packages/daemon/src/reconciler/reconciler.ts
+++ b/packages/daemon/src/reconciler/reconciler.ts
@@ -33,10 +33,14 @@ function hostSpawnSig(a: Agent): string {
     // memory — see memoryProviderFor), so a provider change must respawn the host.
     // An external connection switch also changes the trusted scope/client captured
     // by the host. Recall/capture limits stay out: those policy-only edits are hot.
+    // A managed home's place and its pending copy decide what a session starts with (memory-evolution.md §3.2.1):
+    // the flip, its completion, and the forced return each rebuild the session boundary.
     memory:
       a.memory?.provider === 'external'
         ? { provider: 'external', connectionId: a.memory.connectionId }
-        : a.memory?.provider,
+        : a.memory?.provider === 'managed'
+          ? { provider: 'managed', home: a.memory.home, homeMigration: a.memory.homeMigration }
+          : a.memory?.provider,
     env: a.runtimeOverrides?.env,
     // Secrets are baked into the child env at spawn (agentChildEnv) and
     // materialized as config files (config-file-env.ts) — a value edit that

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -1138,6 +1138,58 @@ describe('CpClient dispatch', () => {
   })
 })
 
+describe('CpClient memory/home/migrated (D→C REQ)', () => {
+  it('names the agent, stamps its org, unwraps memory/home/migrated/ok, and surfaces CONFLICT by code', async () => {
+    const { client, t } = await readyClient(
+      { orgForAgent: (agentId) => (agentId === CRON_AGENT_ID ? 'org-1' : undefined) },
+      ['agent-memory-store-v1'],
+      'frame'
+    )
+    const pending = client.memoryHomeMigrated({ agentId: CRON_AGENT_ID })
+    await tick()
+    const req = JSON.parse(t.sent[0]!)
+    expect(req).toMatchObject({ type: 'memory/home/migrated', orgId: 'org-1', payload: { agentId: CRON_AGENT_ID } })
+    t.pushInbound(
+      JSON.stringify(buildEnvelope('memory/home/migrated/ok', { accepted: true }, { corr: req.id, orgId: 'org-1' }))
+    )
+    await expect(pending).resolves.toEqual({ accepted: true })
+
+    // The home moved on since the flip: the CP's refusal arrives as itself, for the caller to stop on.
+    const moved = client.memoryHomeMigrated({ agentId: CRON_AGENT_ID })
+    await tick()
+    const second = JSON.parse(t.sent[1]!)
+    t.pushInbound(
+      JSON.stringify(
+        buildEnvelope(
+          'error',
+          { code: 'CONFLICT', message: 'the agent memory home is no longer the Control Plane', retryable: false },
+          { corr: second.id }
+        )
+      )
+    )
+    await expect(moved).rejects.toMatchObject({ code: 'CONFLICT', retryable: false })
+  })
+
+  it('refuses before sending when the CP never advertised the feature, and sends exactly once on one deadline', async () => {
+    const older = await readyClient({}, [])
+    await expect(older.client.memoryHomeMigrated({ agentId: CRON_AGENT_ID })).rejects.toMatchObject({
+      code: 'INTERNAL',
+      retryable: false
+    })
+    expect(older.t.sent).toHaveLength(0)
+
+    const { client, t, clock } = await readyClient({}, ['agent-memory-store-v1'])
+    const reports = () => t.sent.filter((raw) => JSON.parse(raw).type === 'memory/home/migrated')
+    const pending = client.memoryHomeMigrated({ agentId: CRON_AGENT_ID })
+    await tick()
+    clock.advance(29_000)
+    expect(reports()).toHaveLength(1)
+    clock.advance(1_000)
+    await expect(pending).rejects.toMatchObject({ code: 'INTERNAL', retryable: true })
+    expect(reports()).toHaveLength(1)
+  })
+})
+
 describe('CpClient memory/store (D→C REQ)', () => {
   const op = { op: 'memory-read', root: '.', rel: 'memory/index.md', offset: 0, limit: 1024 } as const
 

--- a/packages/daemon/test/cp/cp-agent-registry.test.ts
+++ b/packages/daemon/test/cp/cp-agent-registry.test.ts
@@ -51,6 +51,24 @@ describe('CpAgentRegistry (memory-only CP specs)', () => {
     expect(onChange).toHaveBeenCalledOnce()
   })
 
+  it('mirrors the CP clearing the memory home migration marker — once, and only where the marker is', () => {
+    const { reg, onChange } = makeReg()
+    reg.upsert(A1, spec({ memory: { provider: 'managed', home: 'control-plane', homeMigration: 'pending' } }))
+    reg.upsert(A2, spec({ name: 'other', memory: { provider: 'managed', home: 'control-plane' } }))
+    onChange.mockClear()
+    expect(reg.settleMemoryHomeMigration(A1)).toBe(true)
+    expect(reg.agents().find((agent) => agent.id === A1)?.memory).toEqual({
+      provider: 'managed',
+      home: 'control-plane'
+    })
+    expect(onChange).toHaveBeenCalledOnce()
+    // Nothing to drop: a settled binding, a binding without the marker, an unknown agent.
+    expect(reg.settleMemoryHomeMigration(A1)).toBe(false)
+    expect(reg.settleMemoryHomeMigration(A2)).toBe(false)
+    expect(reg.settleMemoryHomeMigration('33333333-3333-4333-8333-333333333333')).toBe(false)
+    expect(onChange).toHaveBeenCalledOnce()
+  })
+
   it('deletes only the same-id agent.json and preserves every other local file', () => {
     const { dir, reg } = makeReg()
     const matching = writeLocal(dir, 'custom', A1, { description: 'legacy' })

--- a/packages/daemon/test/memory-home-migration.test.ts
+++ b/packages/daemon/test/memory-home-migration.test.ts
@@ -1,0 +1,506 @@
+// The one-way memory home migration and the forced return (memory-evolution.md §3.2.1): a pending binding copies the
+// `daemon` tree into the CP once and reports it; an interrupted copy runs again from the start and lands the same tree
+// and the same rows; `CONFLICT` stops it; the pool copies whatever the bound volume holds; the return archives aside.
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  promises as fsp,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { WireError } from '@agentconnect.md/connection'
+import {
+  AGENT_MEMORY_STORE_V1_FEATURE,
+  MemoryHistoryAppendReq,
+  MemoryHomeMigratedReq,
+  MemoryStoreReq,
+  type AgentMemoryBinding,
+  type AgentSpec,
+  type MemoryFsPayload,
+  type MemoryHistoryAppendOk,
+  type MemoryHomeMigratedOk
+} from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { LocalMemoryFs } from '../src/memory/fs.js'
+import type { MemoryHomeAgent } from '../src/memory/home.js'
+import {
+  MemoryHomeMigrator,
+  archiveMemoryTreeAside,
+  memoryHomeReturnedToDaemon,
+  type CpMemoryMigrationLink,
+  type MemoryHomeMigratorDeps
+} from '../src/memory/home-migration.js'
+import {
+  MEMORY_HISTORY_FILENAME,
+  SidecarMemoryHistorySink,
+  channelMemoryRoot,
+  ensureMemory,
+  writeChannelMemoryMeta,
+  writeMemoryFile,
+  type MemoryHistoryRecord
+} from '../src/memory/store.js'
+import { applyMemoryFsPayload } from '../src/shim/memory-fs-channel.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { pathExecutor, pod } from './fixtures/memory-fs-pod.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const CHANNEL = 'general-abc'
+const STAMP = '2026-01-02T03:04:05.000Z'
+
+const dirs: string[] = []
+afterAll(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function newDir(prefix = 'ac-migrate-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+
+const settle = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const pending = (): AgentMemoryBinding => ({ provider: 'managed', home: 'control-plane', homeMigration: 'pending' })
+
+type Agent = MemoryHomeAgent & { memory: AgentMemoryBinding }
+const agentWith = (memory: AgentMemoryBinding, dir: string): Agent => ({ id: AGENT, dir, memory })
+
+type FakeCp = CpMemoryMigrationLink & {
+  tree: string
+  ops: MemoryFsPayload[]
+  appends: MemoryHistoryAppendReq[]
+  migrated: MemoryHomeMigratedReq[]
+  /** The CP table: each id taken once (`skipDuplicates`), so a resent batch is the same rows. */
+  rows: Map<string, { root: string; record: MemoryHistoryRecord }>
+  up: boolean
+  feature: boolean
+  /** Every store op past this many fails as a dropped request. */
+  failOpsAfter: number | undefined
+  /** The 1-based append calls that fail as dropped requests. */
+  failAppends: Set<number>
+  answerMigrated: () => MemoryHomeMigratedOk
+}
+
+/** The CP connection as the migration sees it: a tree directory behind the store pair, a dedup table behind the log pair, a recorder behind the report. */
+function fakeCp(): FakeCp {
+  const tree = newDir('ac-migrate-tree-')
+  const executor = pathExecutor()
+  const dropped = () => new WireError('INTERNAL', 'no ack after 1 try', true)
+  const link: FakeCp = {
+    tree,
+    ops: [],
+    appends: [],
+    migrated: [],
+    rows: new Map(),
+    up: true,
+    feature: true,
+    failOpsAfter: undefined,
+    failAppends: new Set(),
+    answerMigrated: () => ({ accepted: true }),
+    connected: () => link.up,
+    supportsServerFeature: (feature) => link.feature && feature === AGENT_MEMORY_STORE_V1_FEATURE,
+    async memoryStore(req) {
+      const parsed = MemoryStoreReq.parse(req)
+      link.ops.push(parsed.op)
+      if (link.failOpsAfter !== undefined && link.ops.length > link.failOpsAfter) throw dropped()
+      return applyMemoryFsPayload({ ...parsed.op, root: join(tree, parsed.op.root) }, tree, executor)
+    },
+    async memoryHistoryAppend(req): Promise<MemoryHistoryAppendOk> {
+      const parsed = MemoryHistoryAppendReq.parse(req)
+      link.appends.push(parsed)
+      if (link.failAppends.has(link.appends.length)) throw dropped()
+      for (const record of parsed.records) {
+        if (!link.rows.has(record.id!)) link.rows.set(record.id!, { root: parsed.root, record })
+      }
+      return { accepted: true }
+    },
+    async memoryHomeMigrated(req) {
+      link.migrated.push(MemoryHomeMigratedReq.parse(req))
+      return link.answerMigrated()
+    }
+  }
+  return link
+}
+
+/** A `daemon` tree with everything the copy must carry and everything it must leave behind. */
+async function seedSource(dir: string): Promise<void> {
+  const fs = new LocalMemoryFs(dir)
+  const sink = new SidecarMemoryHistorySink(fs)
+  await ensureMemory(fs, 'bot-a')
+  const body = '---\ndescription: how we ship\n---\n- region sea\n'
+  await writeMemoryFile(fs, 'deploys.md', body, undefined, 'tool', sink)
+  await writeMemoryFile(fs, 'deploys.md', `${body}- region ams\n`, undefined, 'console', sink)
+  await fs.utimes('memory/deploys.md', STAMP)
+  const channel = channelMemoryRoot(fs, CHANNEL)
+  await writeChannelMemoryMeta(fs, CHANNEL, { channel: 'C1' })
+  await writeMemoryFile(channel, 'notes.md', '- pinned\n', undefined, 'tool', new SidecarMemoryHistorySink(channel))
+  // Stays behind: a staged dream, the pre-adoption backup, and the temp file of a crashed write.
+  mkdirSync(join(dir, 'memory-dreams', 'drm-1', 'memory'), { recursive: true })
+  writeFileSync(join(dir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'), '# draft\n')
+  mkdirSync(join(dir, 'memory-backups', 'b1', 'memory'), { recursive: true })
+  writeFileSync(join(dir, 'memory-backups', 'b1', 'memory', 'MEMORY.md'), '# before adoption\n')
+  writeFileSync(join(dir, 'memory', '.agentconnect-memory-dead.tmp'), 'half a write')
+}
+
+/** Every file under `dir` by relative path, with its text. */
+function snapshot(dir: string, rel = ''): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!existsSync(join(dir, rel))) return out
+  for (const entry of readdirSync(join(dir, rel), { withFileTypes: true })) {
+    const path = rel ? `${rel}/${entry.name}` : entry.name
+    if (entry.isDirectory()) Object.assign(out, snapshot(dir, path))
+    else out[path] = readFileSync(join(dir, path), 'utf8')
+  }
+  return out
+}
+
+/** What the copy carries out of a source snapshot: `memory/` and `channels/` only, minus the sidecars and temp files. */
+function carried(source: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(source).filter(
+      ([path]) =>
+        (path.startsWith('memory/') || path.startsWith('channels/')) &&
+        !path.endsWith(`/${MEMORY_HISTORY_FILENAME}`) &&
+        !path.endsWith('.tmp')
+    )
+  )
+}
+
+function sidecarIds(dir: string, ...store: string[]): string[] {
+  return readFileSync(join(dir, ...store, 'memory', MEMORY_HISTORY_FILENAME), 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => (JSON.parse(line) as MemoryHistoryRecord).id!)
+}
+
+function rowsByRoot(cp: FakeCp): Record<string, string[]> {
+  const out: Record<string, string[]> = {}
+  for (const [id, { root }] of cp.rows) (out[root] ??= []).push(id)
+  return out
+}
+
+function migratorFor(agent: Agent, cp: FakeCp, over: Partial<MemoryHomeMigratorDeps> = {}) {
+  const log = { info: vi.fn(), warn: vi.fn() }
+  const migrated: string[] = []
+  const delays: number[] = []
+  const migrator = new MemoryHomeMigrator({
+    agents: () => [agent],
+    homes: () => ({ cp, log }),
+    withMemoryHome: (_agentId, work) => work(),
+    // The daemon's part: the marker is dropped from the local binding once the CP has accepted the report.
+    onMigrated: async (agentId) => {
+      migrated.push(agentId)
+      agent.memory = { provider: 'managed', home: 'control-plane' }
+    },
+    log,
+    retryBaseMs: 5,
+    retryMaxMs: 20,
+    // Timers are recorded, never fired: a test drives every re-run itself.
+    setTimer: (_fn, ms) => {
+      delays.push(ms)
+      return setTimeout(() => {}, 0)
+    },
+    ...over
+  })
+  return { migrator, migrated, delays, log }
+}
+
+describe('the one-way copy', () => {
+  it('copies the tree once — every file by path, both sidecars as rows — and reports completion exactly once', async () => {
+    const dir = newDir()
+    await seedSource(dir)
+    const before = snapshot(dir)
+    const cp = fakeCp()
+    const agent = agentWith(pending(), dir)
+    const { migrator, migrated, log } = migratorFor(agent, cp)
+    migrator.reconcile()
+    await vi.waitFor(() => expect(migrated).toEqual([AGENT]))
+    expect(cp.migrated).toEqual([{ agentId: AGENT }])
+    expect(agent.memory).toEqual({ provider: 'managed', home: 'control-plane' })
+    // Verbatim, frontmatter and all; the mtime survives; nothing that stays behind, and no sidecar as a file.
+    expect(snapshot(cp.tree)).toEqual(carried(before))
+    expect(snapshot(cp.tree)['memory/deploys.md']).toMatch(/^---\ndescription: how we ship\n/)
+    expect((await fsp.stat(join(cp.tree, 'memory', 'deploys.md'))).mtime.toISOString()).toBe(STAMP)
+    // The change log: the agent store's rows under `.`, the channel's under its own root, the ids the daemon minted.
+    expect(rowsByRoot(cp)).toEqual({
+      '.': sidecarIds(dir),
+      [`channels/${CHANNEL}`]: sidecarIds(dir, 'channels', CHANNEL)
+    })
+    // The source is frozen: byte for byte what it was.
+    expect(snapshot(dir)).toEqual(before)
+    const records = sidecarIds(dir).length + sidecarIds(dir, 'channels', CHANNEL).length
+    expect(log.info.mock.calls.map(([line]) => line)).toEqual([
+      expect.stringContaining('copying its memory tree'),
+      expect.stringMatching(
+        new RegExp(
+          `migrated to the Control Plane \\(4 file\\(s\\), \\d+ byte\\(s\\), ${records} change-log record\\(s\\)\\)`
+        )
+      )
+    ])
+    expect(log.warn).not.toHaveBeenCalled()
+    // Nothing is pending any more, so another pass starts nothing.
+    const ops = cp.ops.length
+    migrator.reconcile()
+    await settle()
+    expect(cp.ops).toHaveLength(ops)
+    expect(cp.migrated).toHaveLength(1)
+    await migrator.stop()
+  })
+
+  it('an interrupted copy leaves the marker in place; the re-run yields the identical tree and no duplicate history ids', async () => {
+    const dir = newDir()
+    await seedSource(dir)
+    const cp = fakeCp()
+    const agent = agentWith(pending(), dir)
+    const { migrator, migrated, delays, log } = migratorFor(agent, cp)
+    // The link drops out a few file ops in: one file landed, the rest and the change log did not.
+    cp.failOpsAfter = 4
+    migrator.reconcile()
+    await vi.waitFor(() => expect(delays).toEqual([5]))
+    expect(cp.migrated).toEqual([])
+    expect(migrated).toEqual([])
+    expect(agent.memory).toMatchObject({ homeMigration: 'pending' })
+    expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining('retrying in'))
+    expect(Object.keys(snapshot(cp.tree))).toHaveLength(1)
+
+    // READY again: the whole copy runs from the start; this time the channel's change-log batch is the one dropped.
+    cp.failOpsAfter = undefined
+    cp.failAppends.add(cp.appends.length + 2)
+    migrator.wake()
+    await vi.waitFor(() => expect(delays).toEqual([5, 5]))
+    expect(cp.migrated).toEqual([])
+    expect(rowsByRoot(cp)).toEqual({ '.': sidecarIds(dir) })
+
+    // Third time: everything lands. Overwriting by path gave the same tree, and the resent `.` batch the same rows.
+    migrator.wake()
+    await vi.waitFor(() => expect(migrated).toEqual([AGENT]))
+    expect(cp.migrated).toHaveLength(1)
+    expect(snapshot(cp.tree)).toEqual(carried(snapshot(dir)))
+    const expectedIds = [...sidecarIds(dir), ...sidecarIds(dir, 'channels', CHANNEL)]
+    expect(rowsByRoot(cp)).toEqual({
+      '.': sidecarIds(dir),
+      [`channels/${CHANNEL}`]: sidecarIds(dir, 'channels', CHANNEL)
+    })
+    // Every id the CP ever saw is one the sidecars hold: the ids are the daemon's, so its dedup keeps exactly those rows.
+    const sent = cp.appends.flatMap((batch) => batch.records.map((record) => record.id))
+    expect(sent.length).toBeGreaterThan(expectedIds.length)
+    expect(new Set(sent)).toEqual(new Set(expectedIds))
+    await migrator.stop()
+  })
+
+  it('CONFLICT stops the migration without touching the source, and the same binding never starts another copy', async () => {
+    const dir = newDir()
+    await seedSource(dir)
+    const before = snapshot(dir)
+    const cp = fakeCp()
+    cp.answerMigrated = () => {
+      throw new WireError('CONFLICT', 'the agent memory home is no longer the Control Plane', false)
+    }
+    const agent = agentWith(pending(), dir)
+    const { migrator, migrated, delays, log } = migratorFor(agent, cp)
+    migrator.reconcile()
+    await vi.waitFor(() => expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('no longer expects the copy')))
+    expect(cp.migrated).toHaveLength(1)
+    expect(migrated).toEqual([])
+    expect(delays).toEqual([])
+    expect(agent.memory).toMatchObject({ homeMigration: 'pending' })
+    expect(snapshot(dir)).toEqual(before)
+    // Neither a roster pass nor a READY connection re-runs it; the CP's push of the changed binding is what moves on.
+    const ops = cp.ops.length
+    migrator.reconcile()
+    migrator.wake()
+    await settle()
+    expect(cp.ops).toHaveLength(ops)
+    expect(cp.migrated).toHaveLength(1)
+    await migrator.stop()
+  })
+
+  it('leaves the marker in place and retries when the CP is unreachable or refuses this member', async () => {
+    const dir = newDir()
+    await seedSource(dir)
+    const cp = fakeCp()
+    cp.up = false
+    const agent = agentWith(pending(), dir)
+    const { migrator, migrated, delays, log } = migratorFor(agent, cp)
+    migrator.reconcile()
+    await vi.waitFor(() => expect(delays).toEqual([5]))
+    expect(cp.ops).toEqual([])
+    expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining('connection is not ready'))
+
+    cp.up = true
+    cp.answerMigrated = () => {
+      throw new WireError('SCOPE_DENIED', 'agent is not served by this daemon', false)
+    }
+    migrator.wake()
+    await vi.waitFor(() => expect(delays).toEqual([5, 5]))
+    expect(cp.migrated).toHaveLength(1)
+    expect(migrated).toEqual([])
+    expect(agent.memory).toMatchObject({ homeMigration: 'pending' })
+    expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining('SCOPE_DENIED'))
+    // Backoff doubles per attempt from the same failure, and a READY connection resets it.
+    cp.failOpsAfter = 0
+    migrator.wake()
+    await vi.waitFor(() => expect(delays).toEqual([5, 5, 5]))
+    await migrator.stop()
+  })
+
+  it('on a pool member the source is the bound pod volume: the copy binds it, an empty volume is an empty source, and completion is reported', async () => {
+    const cp = fakeCp()
+    const { fs } = pod()
+    let bound = false
+    const sandbox = { memoryFsFor: vi.fn(() => (bound ? fs : undefined)) }
+    const agent = agentWith(pending(), newDir())
+    const binds: string[] = []
+    const { migrator, migrated, log } = migratorFor(agent, cp, {
+      homes: () => ({ cp, sandbox, log: { warn: () => {} } }),
+      withMemoryHome: async (agentId, work) => {
+        binds.push(agentId)
+        bound = true
+        try {
+          return await work()
+        } finally {
+          bound = false
+        }
+      }
+    })
+    migrator.reconcile()
+    await vi.waitFor(() => expect(migrated).toEqual([AGENT]))
+    expect(binds).toEqual([AGENT])
+    expect(sandbox.memoryFsFor).toHaveBeenCalledWith(AGENT)
+    expect(cp.migrated).toEqual([{ agentId: AGENT }])
+    // Nothing to write and nothing to log: the volume held no tree, which is a legitimate empty source.
+    expect(cp.ops).toEqual([])
+    expect(cp.appends).toEqual([])
+    expect(log.info).toHaveBeenLastCalledWith(expect.stringContaining('(0 file(s), 0 byte(s), 0 change-log record(s))'))
+    // Nothing was created on this member's disk either.
+    expect(readdirSync(agent.dir)).toEqual([])
+    await migrator.stop()
+  })
+})
+
+describe('the forced return keeps nothing', () => {
+  it('is control-plane → daemon on a managed binding, and nothing else', () => {
+    const managed = (home: 'daemon' | 'control-plane'): AgentMemoryBinding => ({ provider: 'managed', home })
+    const at = (memory?: AgentMemoryBinding) => (memory ? { memory } : {})
+    expect(memoryHomeReturnedToDaemon(at(managed('control-plane')), at(managed('daemon')))).toBe(true)
+    expect(memoryHomeReturnedToDaemon(at(pending()), at(managed('daemon')))).toBe(true)
+    expect(memoryHomeReturnedToDaemon(at(managed('control-plane')), at(managed('control-plane')))).toBe(false)
+    expect(memoryHomeReturnedToDaemon(at(managed('daemon')), at(managed('daemon')))).toBe(false)
+    expect(memoryHomeReturnedToDaemon(at(managed('daemon')), at(managed('control-plane')))).toBe(false)
+    expect(memoryHomeReturnedToDaemon(at(managed('control-plane')), at({ provider: 'none' }))).toBe(false)
+    expect(memoryHomeReturnedToDaemon(at(), at(managed('daemon')))).toBe(false)
+  })
+
+  it('moves memory/, channels/ and memory-backups/ under a dated archive beside them, and leaves memory-dreams/ where it is', async () => {
+    const dir = newDir()
+    await seedSource(dir)
+    const before = snapshot(dir)
+    const archive = await archiveMemoryTreeAside(dir, new Date('2026-09-09T10:11:12.345Z'))
+    expect(archive).toBe(join(dir, 'memory-archive-2026-09-09T10-11-12-345Z'))
+    expect(readdirSync(dir).sort()).toEqual(['memory-archive-2026-09-09T10-11-12-345Z', 'memory-dreams'])
+    // The archive is the tree as it was, sidecars and temp file included; staging is untouched.
+    const staged = Object.entries(before).filter(([path]) => path.startsWith('memory-dreams/'))
+    expect(snapshot(archive!)).toEqual(
+      Object.fromEntries(Object.entries(before).filter(([path]) => !path.startsWith('memory-dreams/')))
+    )
+    expect(snapshot(dir, 'memory-dreams')).toEqual(Object.fromEntries(staged))
+    // Nothing left to move means no second archive.
+    expect(await archiveMemoryTreeAside(dir, new Date('2026-09-09T10:11:13.000Z'))).toBeUndefined()
+    expect(readdirSync(dir).sort()).toEqual(['memory-archive-2026-09-09T10-11-12-345Z', 'memory-dreams'])
+  })
+})
+
+describe('the daemon runs it', () => {
+  function daemonRoot(): string {
+    const root = newDir('ac-migrate-daemon-')
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { claude: { command: 'node', args: [] } }
+      })
+    )
+    const agentDir = join(root, 'agents', AGENT)
+    mkdirSync(agentDir, { recursive: true })
+    writeFileSync(
+      join(agentDir, 'agent.json'),
+      JSON.stringify({
+        id: AGENT,
+        name: 'bot-a',
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(agentDir, 'ws') },
+        integrations: [],
+        output: { mode: 'medium' }
+      })
+    )
+    return root
+  }
+
+  const inertHost = (agent: { id: string }) =>
+    ({
+      id: agent.id,
+      start: vi.fn().mockResolvedValue(undefined),
+      newSession: vi.fn(),
+      prompt: vi.fn(),
+      cancel: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined)
+    }) as never
+
+  it('starts the copy when a pending binding arrives, serves the CP tree once accepted, and archives the tree on the forced return', async () => {
+    const root = daemonRoot()
+    const agentDir = join(root, 'agents', AGENT)
+    await seedSource(agentDir)
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: inertHost })
+    await daemon.start()
+    const cp = fakeCp()
+    const seam = daemon as unknown as {
+      cpClient: unknown
+      cpConfigApply(): { applyAgentUpsert(upsert: { agentId: string; spec: AgentSpec }): Promise<unknown> }
+      agents: Map<string, { memory?: AgentMemoryBinding }>
+      memory: {
+        write(
+          scope: { agentId: string },
+          path: string,
+          content: string,
+          ifMatch?: string,
+          source?: 'tool'
+        ): Promise<unknown>
+      }
+    }
+    // The connection as the homes see it, plus the lifecycle calls the daemon makes on it at shutdown.
+    seam.cpClient = Object.assign(cp, { stop: async () => {}, emitMemoryConnectionFacts: () => {} })
+
+    // The CP's push: the binding flipped, and it carries the marker. The trigger is applying it.
+    const upsert = (memory: AgentMemoryBinding) =>
+      seam.cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: { name: 'bot-a', memory } as AgentSpec })
+    await upsert(pending())
+    await vi.waitFor(() => expect(cp.migrated).toEqual([{ agentId: AGENT }]))
+    expect(snapshot(cp.tree)).toEqual(carried(snapshot(agentDir)))
+    // Accepted: the marker is dropped locally, ahead of the CP's next push, so the CP tree is what gets served.
+    await vi.waitFor(() =>
+      expect(seam.agents.get(AGENT)?.memory).toEqual({ provider: 'managed', home: 'control-plane' })
+    )
+    await seam.memory.write({ agentId: AGENT }, 'after.md', '- lives in the Control Plane\n', undefined, 'tool')
+    expect(readFileSync(join(cp.tree, 'memory', 'after.md'), 'utf8')).toContain('lives in the Control Plane')
+    expect(existsSync(join(agentDir, 'memory', 'after.md'))).toBe(false)
+
+    // The forced return: the CP dropped its rows; the pre-switch tree on this disk moves aside, nothing is resurrected.
+    await upsert({ provider: 'managed', home: 'daemon' })
+    expect(existsSync(join(agentDir, 'memory'))).toBe(false)
+    expect(existsSync(join(agentDir, 'channels'))).toBe(false)
+    expect(existsSync(join(agentDir, 'memory-backups'))).toBe(false)
+    const archives = readdirSync(agentDir).filter((name) => name.startsWith('memory-archive-'))
+    expect(archives).toHaveLength(1)
+    expect(existsSync(join(agentDir, archives[0]!, 'memory', 'deploys.md'))).toBe(true)
+    expect(existsSync(join(agentDir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'))).toBe(true)
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/memory-home-migration.test.ts
+++ b/packages/daemon/test/memory-home-migration.test.ts
@@ -26,6 +26,7 @@ import {
   type MemoryHistoryAppendOk,
   type MemoryHomeMigratedOk
 } from '@agentconnect.md/protocol'
+import { CpMemoryHistorySink } from '../src/cp/memory-history.js'
 import { Daemon } from '../src/daemon.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
 import type { MemoryHomeAgent } from '../src/memory/home.js'
@@ -52,10 +53,20 @@ import { pathExecutor, pod } from './fixtures/memory-fs-pod.js'
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const CHANNEL = 'general-abc'
 const STAMP = '2026-01-02T03:04:05.000Z'
+/** Where the CP files each store's change log: the directory holding the store's files, which its `memory/history` read filters on. */
+const AGENT_LOG_ROOT = 'memory'
+const CHANNEL_LOG_ROOT = `channels/${CHANNEL}/memory`
 
 const dirs: string[] = []
 afterAll(() => {
-  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+  // Best-effort: on Windows a daemon root can still be held for a moment after `stop()`, and a leftover temp dir is no failure.
+  for (const dir of dirs.splice(0)) {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      /* left for the OS to reclaim */
+    }
+  }
 })
 
 function newDir(prefix = 'ac-migrate-'): string {
@@ -227,10 +238,14 @@ describe('the one-way copy', () => {
     expect(snapshot(cp.tree)).toEqual(carried(before))
     expect(snapshot(cp.tree)['memory/deploys.md']).toMatch(/^---\ndescription: how we ship\n/)
     expect((await fsp.stat(join(cp.tree, 'memory', 'deploys.md'))).mtime.toISOString()).toBe(STAMP)
-    // The change log: the agent store's rows under `.`, the channel's under its own root, the ids the daemon minted.
+    // The change log: filed where the sink files a live write's — the directory holding each store's files, which is the
+    // root the CP's page reads — with the ids the daemon minted.
+    const quiet = { warn: () => {} }
+    expect(AGENT_LOG_ROOT).toBe(new CpMemoryHistorySink(cp, AGENT, '.', quiet).root)
+    expect(CHANNEL_LOG_ROOT).toBe(new CpMemoryHistorySink(cp, AGENT, `channels/${CHANNEL}`, quiet).root)
     expect(rowsByRoot(cp)).toEqual({
-      '.': sidecarIds(dir),
-      [`channels/${CHANNEL}`]: sidecarIds(dir, 'channels', CHANNEL)
+      [AGENT_LOG_ROOT]: sidecarIds(dir),
+      [CHANNEL_LOG_ROOT]: sidecarIds(dir, 'channels', CHANNEL)
     })
     // The source is frozen: byte for byte what it was.
     expect(snapshot(dir)).toEqual(before)
@@ -275,17 +290,17 @@ describe('the one-way copy', () => {
     migrator.wake()
     await vi.waitFor(() => expect(delays).toEqual([5, 5]))
     expect(cp.migrated).toEqual([])
-    expect(rowsByRoot(cp)).toEqual({ '.': sidecarIds(dir) })
+    expect(rowsByRoot(cp)).toEqual({ [AGENT_LOG_ROOT]: sidecarIds(dir) })
 
-    // Third time: everything lands. Overwriting by path gave the same tree, and the resent `.` batch the same rows.
+    // Third time: everything lands. Overwriting by path gave the same tree, and the resent agent batch the same rows.
     migrator.wake()
     await vi.waitFor(() => expect(migrated).toEqual([AGENT]))
     expect(cp.migrated).toHaveLength(1)
     expect(snapshot(cp.tree)).toEqual(carried(snapshot(dir)))
     const expectedIds = [...sidecarIds(dir), ...sidecarIds(dir, 'channels', CHANNEL)]
     expect(rowsByRoot(cp)).toEqual({
-      '.': sidecarIds(dir),
-      [`channels/${CHANNEL}`]: sidecarIds(dir, 'channels', CHANNEL)
+      [AGENT_LOG_ROOT]: sidecarIds(dir),
+      [CHANNEL_LOG_ROOT]: sidecarIds(dir, 'channels', CHANNEL)
     })
     // Every id the CP ever saw is one the sidecars hold: the ids are the daemon's, so its dedup keeps exactly those rows.
     const sent = cp.appends.flatMap((batch) => batch.records.map((record) => record.id))

--- a/packages/daemon/test/memory-home-migration.test.ts
+++ b/packages/daemon/test/memory-home-migration.test.ts
@@ -469,53 +469,59 @@ describe('the daemon runs it', () => {
       stop: vi.fn().mockResolvedValue(undefined)
     }) as never
 
-  it('starts the copy when a pending binding arrives, serves the CP tree once accepted, and archives the tree on the forced return', async () => {
-    const root = daemonRoot()
-    const agentDir = join(root, 'agents', AGENT)
-    await seedSource(agentDir)
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: inertHost })
-    await daemon.start()
-    const cp = fakeCp()
-    const seam = daemon as unknown as {
-      cpClient: unknown
-      cpConfigApply(): { applyAgentUpsert(upsert: { agentId: string; spec: AgentSpec }): Promise<unknown> }
-      agents: Map<string, { memory?: AgentMemoryBinding }>
-      memory: {
-        write(
-          scope: { agentId: string },
-          path: string,
-          content: string,
-          ifMatch?: string,
-          source?: 'tool'
-        ): Promise<unknown>
+  // Not on Windows: the daemon's agent-config watcher holds a handle on every directory beneath the agent dir, and
+  // Windows refuses to move a directory with open handles beneath it — the flat `memory/` moves, `channels/` does not.
+  // The archive itself is covered on every platform above; releasing the watcher's grip is the watcher's own change.
+  it.skipIf(process.platform === 'win32')(
+    'starts the copy when a pending binding arrives, serves the CP tree once accepted, and archives the tree on the forced return',
+    async () => {
+      const root = daemonRoot()
+      const agentDir = join(root, 'agents', AGENT)
+      await seedSource(agentDir)
+      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: inertHost })
+      await daemon.start()
+      const cp = fakeCp()
+      const seam = daemon as unknown as {
+        cpClient: unknown
+        cpConfigApply(): { applyAgentUpsert(upsert: { agentId: string; spec: AgentSpec }): Promise<unknown> }
+        agents: Map<string, { memory?: AgentMemoryBinding }>
+        memory: {
+          write(
+            scope: { agentId: string },
+            path: string,
+            content: string,
+            ifMatch?: string,
+            source?: 'tool'
+          ): Promise<unknown>
+        }
       }
+      // The connection as the homes see it, plus the lifecycle calls the daemon makes on it at shutdown.
+      seam.cpClient = Object.assign(cp, { stop: async () => {}, emitMemoryConnectionFacts: () => {} })
+
+      // The CP's push: the binding flipped, and it carries the marker. The trigger is applying it.
+      const upsert = (memory: AgentMemoryBinding) =>
+        seam.cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: { name: 'bot-a', memory } as AgentSpec })
+      await upsert(pending())
+      await vi.waitFor(() => expect(cp.migrated).toEqual([{ agentId: AGENT }]))
+      expect(snapshot(cp.tree)).toEqual(carried(snapshot(agentDir)))
+      // Accepted: the marker is dropped locally, ahead of the CP's next push, so the CP tree is what gets served.
+      await vi.waitFor(() =>
+        expect(seam.agents.get(AGENT)?.memory).toEqual({ provider: 'managed', home: 'control-plane' })
+      )
+      await seam.memory.write({ agentId: AGENT }, 'after.md', '- lives in the Control Plane\n', undefined, 'tool')
+      expect(readFileSync(join(cp.tree, 'memory', 'after.md'), 'utf8')).toContain('lives in the Control Plane')
+      expect(existsSync(join(agentDir, 'memory', 'after.md'))).toBe(false)
+
+      // The forced return: the CP dropped its rows; the pre-switch tree on this disk moves aside, nothing is resurrected.
+      await upsert({ provider: 'managed', home: 'daemon' })
+      expect(existsSync(join(agentDir, 'memory'))).toBe(false)
+      expect(existsSync(join(agentDir, 'channels'))).toBe(false)
+      expect(existsSync(join(agentDir, 'memory-backups'))).toBe(false)
+      const archives = readdirSync(agentDir).filter((name) => name.startsWith('memory-archive-'))
+      expect(archives).toHaveLength(1)
+      expect(existsSync(join(agentDir, archives[0]!, 'memory', 'deploys.md'))).toBe(true)
+      expect(existsSync(join(agentDir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'))).toBe(true)
+      await daemon.stop()
     }
-    // The connection as the homes see it, plus the lifecycle calls the daemon makes on it at shutdown.
-    seam.cpClient = Object.assign(cp, { stop: async () => {}, emitMemoryConnectionFacts: () => {} })
-
-    // The CP's push: the binding flipped, and it carries the marker. The trigger is applying it.
-    const upsert = (memory: AgentMemoryBinding) =>
-      seam.cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: { name: 'bot-a', memory } as AgentSpec })
-    await upsert(pending())
-    await vi.waitFor(() => expect(cp.migrated).toEqual([{ agentId: AGENT }]))
-    expect(snapshot(cp.tree)).toEqual(carried(snapshot(agentDir)))
-    // Accepted: the marker is dropped locally, ahead of the CP's next push, so the CP tree is what gets served.
-    await vi.waitFor(() =>
-      expect(seam.agents.get(AGENT)?.memory).toEqual({ provider: 'managed', home: 'control-plane' })
-    )
-    await seam.memory.write({ agentId: AGENT }, 'after.md', '- lives in the Control Plane\n', undefined, 'tool')
-    expect(readFileSync(join(cp.tree, 'memory', 'after.md'), 'utf8')).toContain('lives in the Control Plane')
-    expect(existsSync(join(agentDir, 'memory', 'after.md'))).toBe(false)
-
-    // The forced return: the CP dropped its rows; the pre-switch tree on this disk moves aside, nothing is resurrected.
-    await upsert({ provider: 'managed', home: 'daemon' })
-    expect(existsSync(join(agentDir, 'memory'))).toBe(false)
-    expect(existsSync(join(agentDir, 'channels'))).toBe(false)
-    expect(existsSync(join(agentDir, 'memory-backups'))).toBe(false)
-    const archives = readdirSync(agentDir).filter((name) => name.startsWith('memory-archive-'))
-    expect(archives).toHaveLength(1)
-    expect(existsSync(join(agentDir, archives[0]!, 'memory', 'deploys.md'))).toBe(true)
-    expect(existsSync(join(agentDir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'))).toBe(true)
-    await daemon.stop()
-  })
+  )
 })

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -50,6 +50,25 @@ describe('diffAgents', () => {
     expect(toChange[0]!.agent.id).toBe('x')
   })
 
+  it('classifies a managed memory home change — the flip, its completed copy, the forced return — as a host-spawn change', () => {
+    const at = (memory: Agent['memory']) => ({ ...a('x'), memory }) as Agent
+    const local = at({ provider: 'managed', home: 'daemon' })
+    const flipped = at({ provider: 'managed', home: 'control-plane', homeMigration: 'pending' })
+    const settled = at({ provider: 'managed', home: 'control-plane' })
+    for (const [before, after] of [
+      [local, flipped],
+      [flipped, settled],
+      [settled, local]
+    ]) {
+      expect(diffAgents([after!], actual(before!)).toChange[0]).toMatchObject({
+        hostRespawn: true,
+        workspace: false,
+        integrations: false
+      })
+    }
+    expect(diffAgents([settled], actual(at({ provider: 'managed', home: 'control-plane' }))).toChange).toEqual([])
+  })
+
   it('classifies enabling or disabling the OS sandbox as a host-spawn change', () => {
     const unsandboxed = a('x')
     const sandboxed = { ...unsandboxed, runInSandbox: true } as Agent


### PR DESCRIPTION
## Why

`docs/designs/memory-evolution.md` §3.2.1 makes the `home` change one way, `daemon` → `control-plane`, and makes it migrate: the CP stamps `homeMigration: 'pending'` on the flipped binding (#1881), and until the owning daemon reports `memory/home/migrated` nothing serves the CP tree (#1883's `migrating` gate). This is the daemon half that was still missing — the copy, the completion report, and the forced return that keeps nothing.

## The trigger

`MemoryHomeMigrator` (`packages/daemon/src/memory/home-migration.ts`) runs at the end of every reconcile pass over the managed-memory agents this member holds: a binding that arrived with the marker starts its copy, once at a time per agent, retried with backoff (5 s doubling to 5 min), and re-run from the start on CP READY (`wakeMemoryHomeMigrations` beside `wakeMemoryOutbox` in the client's `onReady`). A binding whose marker moved on is forgotten. `stop()` aborts a running copy between files and reports nothing; the CP's marker keeps it pending for the next start.

## What is copied, and what is not

`copyMemoryTree(from, to)` copies `memory/` and `channels/` from the `daemon` home's port — `LocalMemoryFs(agent.dir)` self-hosted; on a `--k8s` member the sandbox-volume port, read inside `withMemoryHome` so the pod is bound, an empty or missing tree there being a legitimate empty source — into `CpMemoryFs(cp, agentId)`: every file by path, verbatim (frontmatter intact), overwriting, with `utimes` so mtimes survive. Then each store's sidecar (`memory/.history`, `channels/<key>/memory/.history`) is read with durable ids under that store's memory-dir lock and sent as `memory/history/append` batches filed where the live sink files a write's rows since #1886 — under the directory holding the store's files, `memory` / `channels/<key>/memory`, the root the CP's `memory/history` read filters on. `cpMemoryHistoryRoot` is the one mapping, shared by `CpMemoryHistorySink` and the migration, and the suite asserts they agree. Not carried: `memory-dreams/` (staging belongs to the extraction host), `memory-backups/` (belongs to the adoption that made it), any `.history` as a file, and the temp file a crashed write left behind. A file the target refuses (over the cap, `BAD_PAYLOAD`) is warned about and skipped rather than wedging the migration; the source keeps it.

## Why a re-run is safe

The source is frozen from the flip — no writer touches a `daemon` tree once the home is `control-plane` — and the target is served to nobody until the CP holds the completion, so an interrupted copy simply runs again from the start and overwrites by path. No staging prefix, no marker file. The change-log ids are the daemon's, so a re-sent batch is the same rows on the CP. One deliberate difference from a write's sink: the migration's history batches are not best-effort — a batch that fails fails the copy and leaves the marker pending, because the completion report is the statement that the CP holds the log. The source tree is never deleted.

## The completion protocol

`CpClient.memoryHomeMigrated({ agentId })` is a single send on one deadline, like `memoryStore`. On `{ accepted: true }` the registry drops `homeMigration` from the local replica (`CpAgentRegistry.settleMemoryHomeMigration`) ahead of the CP's next push — which arrives as a newer revision with the same content — so the next resolution serves the CP tree, and reconcile rebuilds the session boundary the way any memory-binding change does: a managed home and its pending copy are now in the host-spawn signature, so the flip, its completion, and the forced return each evict the host. `CONFLICT` (the home moved on) stops the copy, logs, touches neither tree, and does not run again for the same binding. `SCOPE_DENIED` and connection failures leave the marker in place and retry.

## The forced return

When a binding update changes a managed `home` from `control-plane` (as the daemon last knew it) to `daemon`, reconcile archives the pre-switch local tree aside before the binding goes live: `memory/`, `channels/` and `memory-backups/` move under `<agent dir>/memory-archive-<timestamp>/` (colons and dots replaced, for Windows), `memory-dreams/` stays. The move retries a bounded number of times on the transient EPERM/EACCES/EBUSY a Windows scanner causes, as the workspace manager's directory swap does.

**Known limitation (Windows, self-hosted):** the daemon's agent-config watcher (chokidar, depth 4) holds a handle on every directory beneath an agent dir, and Windows refuses to move a directory with open handles beneath it. The flat `memory/` archives; `channels/` and `memory-backups/`, which have subdirectories, do not — the daemon logs the error and the binding still applies. The daemon-level test case therefore skips on Windows (the archive itself is covered there by the unit case). The fix is the watcher's: exclude the daemon-owned memory-tree directories from the watch, which also drops the handles it holds on dream staging today. That is a separate change. The agent starts from an empty tree; nothing is resurrected. Nothing to move on the pool, where the tree never lived on this disk. The design doc records the archive path and the strict batches.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck`
- New `test/memory-home-migration.test.ts`: the full copy (files, channel stores, both sidecars as rows, `memory/home/migrated` exactly once, source byte-for-byte unchanged); an interrupted copy (the link dropped mid-files, then mid-history) leaves the marker and the re-run yields the identical tree with no duplicate ids; `CONFLICT` stops without touching the source and never re-runs for the same binding; connection down / `SCOPE_DENIED` retry with backoff; the pool source (pod bound around the copy, empty volume, completion with zero files); the forced-return archive; and a daemon-level case driving `applyAgentUpsert` with the pending binding through to a write that lands on the CP port, then the forced return archiving the tree.
- Added cases: `reconciler.test.ts` (home changes are host-spawn changes), `cp-agent-registry.test.ts` (the local mirror of the clear), `cp/client-dispatch.test.ts` (the new frame).
- The memory, dream, reconcile, CP client, and k8s-mode daemon suites (22 files, 500 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
