### PR TITLE
feat(control-plane): pool-placed agents are flipped to the Control Plane memory home at boot

### DIFF
--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -362,8 +362,10 @@ reachable", not "the pod is bound". Established sessions are unaffected. No loca
 cache in this step.
 
 **Rollout.** CP first (table, frames, feature), daemon second (adapter, copy,
-refusal). Existing pool agents are flipped by the CP in the same release — every agent
-placed on the install-wide pool gets `home: control-plane` — and the member holding
+refusal). Existing pool agents are flipped by the CP in the same release — a pass that
+runs at every CP boot, idempotent, gives every agent placed on the install-wide pool
+`home: control-plane` through the ordinary update path, so the flip reaches the member
+like any other edit — and the member holding
 each one runs the same one-way migration on its next activation, the source being the
 sandbox volume through the shim: it binds the pod, copies whatever the volume holds
 (an empty tree, if the sandbox was reclaimed in between) and reports completion the

--- a/packages/control-plane/src/agent-memory/home.ts
+++ b/packages/control-plane/src/agent-memory/home.ts
@@ -45,9 +45,10 @@ export class MemoryHomeRefusedError extends Error {
   }
 }
 
-/** What a caller hands the row-locked write: the submitted binding and the two facts the resolution needs. */
+/** What a caller hands the row-locked write: the submitted binding and the two facts the resolution needs. A function
+ *  receives the binding as it is under the lock, for a caller whose patch depends on it (the boot-time pool flip). */
 export interface MemoryHomeUpdate {
-  input: MemoryBindingInput | null
+  input: MemoryBindingInput | null | ((current: AgentMemoryBinding | null) => MemoryBindingInput | null)
   onPool: boolean
   force: boolean
 }

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -202,6 +202,7 @@ import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './orchestrator/dutyLease.
 import { registerPoolMetrics } from './observability/pool-metrics.js'
 import { registerOrgMetrics } from './observability/org-metrics.js'
 import { AgentDelivery } from './orchestrator/agentDelivery.js'
+import { PoolMemoryHomeReconciler } from './orchestrator/poolMemoryHomeReconciler.js'
 import { AgentRoutingConverger } from './orchestrator/agentRouting.js'
 import { PlacementResolver, type ResolvableAgent } from './orchestrator/placementResolver.js'
 import { DutyRecomputeSweep } from './orchestrator/dutyRecompute.js'
@@ -1657,6 +1658,14 @@ export function buildContainer(
   // the sweep converges to a no-op after its first complete run.
   const presetBackfill = config.PRESET_AGENTS_ENABLED ? new PresetAgentBackfill(prisma, http.log) : undefined
 
+  // The memory-home rollout flip (memory-evolution.md §3.2.1): one idempotent pass per boot, armed by startBackground().
+  const poolMemoryHome = new PoolMemoryHomeReconciler({
+    agents: repos.agent,
+    memberSets: repos.memberSet,
+    delivery: agentDelivery,
+    log: http.log
+  })
+
   // Relay failover sweep (shared-bot-relay.md §5): deletes `relay` rows whose
   // heartbeat lapsed and re-fans the shrunk roster to daemons. Same lifecycle as
   // the cron reaper (armed by startBackground, never in tests).
@@ -2322,6 +2331,7 @@ export function buildContainer(
       // One-shot (not a re-arming loop): the worklist empties itself; a partially
       // failed boot resumes on the next one. Never blocks listen.
       void presetBackfill?.run().catch((err) => http.log.error({ err }, 'preset-backfill: sweep failed'))
+      void poolMemoryHome.run().catch((err) => http.log.error({ err }, 'pool-memory-home: pass failed'))
     },
     async shutdown() {
       cronRunReaper.stop()

--- a/packages/control-plane/src/orchestrator/poolMemoryHomeReconciler.ts
+++ b/packages/control-plane/src/orchestrator/poolMemoryHomeReconciler.ts
@@ -1,0 +1,77 @@
+// The rollout flip (memory-evolution.md §3.2.1): a pool-placed agent with a `daemon` home is moved to `control-plane`.
+import type { AgentMemoryBinding } from '@agentconnect.md/protocol'
+import { managedMemoryHomeOf, type ManagedMemoryBindingInput } from '../agent-memory/home.js'
+import { DaemonId } from '../domain/ids.js'
+import type { AgentRepo, MemberSetRepo } from '../persistence/ports.js'
+import type { AgentDelivery } from './agentDelivery.js'
+
+export interface PoolMemoryHomeLog {
+  info(obj: unknown, msg?: string): void
+  warn(obj: unknown, msg?: string): void
+}
+
+export interface PoolMemoryHomeSummary {
+  flipped: number
+  already: number
+  skipped: number
+  failed: number
+}
+
+/** The patch that moves a managed binding home: its policy fields kept, `home` set, the CP-owned flag left to the rule. */
+function flipInput(current: AgentMemoryBinding | null): ManagedMemoryBindingInput {
+  if (current?.provider !== 'managed') return { provider: 'managed', home: 'control-plane' }
+  const { home: _home, homeMigration: _flag, ...policy } = current
+  return { ...policy, home: 'control-plane' }
+}
+
+export class PoolMemoryHomeReconciler {
+  constructor(
+    private readonly deps: {
+      agents: Pick<AgentRepo, 'listForSet' | 'listForDaemon' | 'update'>
+      memberSets: Pick<MemberSetRepo, 'crossOrgSetId' | 'memberIdsOf'>
+      delivery: Pick<AgentDelivery, 'upsert'>
+      log: PoolMemoryHomeLog
+    }
+  ) {}
+
+  /** One pass over the pool's agents. Per-agent failures are logged and retried on the next boot. */
+  async run(): Promise<PoolMemoryHomeSummary> {
+    const summary: PoolMemoryHomeSummary = { flipped: 0, already: 0, skipped: 0, failed: 0 }
+    const pool = await this.deps.memberSets.crossOrgSetId()
+    if (!pool) return summary
+    // On the pool: placed on the org-less set, or pinned to a machine that is one of its members (a legacy row).
+    const members = await this.deps.memberSets.memberIdsOf(pool)
+    const pinned = await Promise.all(members.map((daemonId) => this.deps.agents.listForDaemon(DaemonId(daemonId))))
+    for (const agent of [...(await this.deps.agents.listForSet(pool)), ...pinned.flat()]) {
+      const home = managedMemoryHomeOf(agent.memory)
+      // A provider without a managed tree has no home to move.
+      if (home === null) {
+        summary.skipped++
+        continue
+      }
+      if (home === 'control-plane') {
+        summary.already++
+        continue
+      }
+      try {
+        // The route's own row-locked write, so the rule module decides the binding (`homeMigration: 'pending'`).
+        const flipped = await this.deps.agents.update(
+          agent.orgId,
+          agent.id,
+          {},
+          { memoryHome: { input: flipInput(agent.memory), onPool: true, force: false } }
+        )
+        // Pushed like a PATCH, so the holding member learns of the flip now; an offline one re-syncs on reconnect.
+        await this.deps.delivery.upsert(flipped, (err, daemonId) =>
+          this.deps.log.warn({ err, agentId: agent.id, daemonId }, 'pool-memory-home: agent/upsert failed')
+        )
+        summary.flipped++
+      } catch (err) {
+        summary.failed++
+        this.deps.log.warn({ err, agentId: agent.id }, 'pool-memory-home: flip failed — will retry next boot')
+      }
+    }
+    this.deps.log.info(summary, 'pool-memory-home: pass complete')
+    return summary
+  }
+}

--- a/packages/control-plane/src/orchestrator/poolMemoryHomeReconciler.ts
+++ b/packages/control-plane/src/orchestrator/poolMemoryHomeReconciler.ts
@@ -17,6 +17,21 @@ export interface PoolMemoryHomeSummary {
   failed: number
 }
 
+/** Where a binding stands for the flip: `flip` when its home is the daemon, else the summary bucket it lands in. */
+function verdict(memory: AgentMemoryBinding | null): 'flip' | 'already' | 'skipped' {
+  const home = managedMemoryHomeOf(memory)
+  // A provider without a managed tree has no home to move.
+  if (home === null) return 'skipped'
+  return home === 'control-plane' ? 'already' : 'flip'
+}
+
+/** Raised from under the row lock when the binding changed since the scan and no longer needs the flip. */
+class NothingToFlip extends Error {
+  constructor(readonly verdict: 'already' | 'skipped') {
+    super('nothing to flip')
+  }
+}
+
 /** The patch that moves a managed binding home: its policy fields kept, `home` set, the CP-owned flag left to the rule. */
 function flipInput(current: AgentMemoryBinding | null): ManagedMemoryBindingInput {
   if (current?.provider !== 'managed') return { provider: 'managed', home: 'control-plane' }
@@ -43,23 +58,30 @@ export class PoolMemoryHomeReconciler {
     const members = await this.deps.memberSets.memberIdsOf(pool)
     const pinned = await Promise.all(members.map((daemonId) => this.deps.agents.listForDaemon(DaemonId(daemonId))))
     for (const agent of [...(await this.deps.agents.listForSet(pool)), ...pinned.flat()]) {
-      const home = managedMemoryHomeOf(agent.memory)
-      // A provider without a managed tree has no home to move.
-      if (home === null) {
-        summary.skipped++
-        continue
-      }
-      if (home === 'control-plane') {
-        summary.already++
+      // The scan is the cheap filter; the verdict that counts is taken again under the row lock below.
+      const scanned = verdict(agent.memory)
+      if (scanned !== 'flip') {
+        summary[scanned]++
         continue
       }
       try {
-        // The route's own row-locked write, so the rule module decides the binding (`homeMigration: 'pending'`).
+        // The route's own row-locked write, so the rule module decides the binding (`homeMigration: 'pending'`). The
+        // input is derived from the LOCKED binding: an edit that landed since the scan is honored, never overwritten.
         const flipped = await this.deps.agents.update(
           agent.orgId,
           agent.id,
           {},
-          { memoryHome: { input: flipInput(agent.memory), onPool: true, force: false } }
+          {
+            memoryHome: {
+              input: (locked) => {
+                const now = verdict(locked)
+                if (now !== 'flip') throw new NothingToFlip(now)
+                return flipInput(locked)
+              },
+              onPool: true,
+              force: false
+            }
+          }
         )
         // Pushed like a PATCH, so the holding member learns of the flip now; an offline one re-syncs on reconnect.
         await this.deps.delivery.upsert(flipped, (err, daemonId) =>
@@ -67,6 +89,10 @@ export class PoolMemoryHomeReconciler {
         )
         summary.flipped++
       } catch (err) {
+        if (err instanceof NothingToFlip) {
+          summary[err.verdict]++
+          continue
+        }
         summary.failed++
         this.deps.log.warn({ err, agentId: agent.id }, 'pool-memory-home: flip failed — will retry next boot')
       }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -951,6 +951,8 @@ export interface AgentRepo {
   /** Agents placed on a specific daemon — the reconcile roster (`register/ok.agents`).
    *  A daemon only ever receives the specs of the agents it owns (1 agent : 1 machine). */
   listForDaemon(daemonId: DaemonId): Promise<AgentRecord[]>
+  /** Agents placed on a set — unscoped, for the boot-time pass that walks the install-wide pool. */
+  listForSet(setId: string): Promise<AgentRecord[]>
   /** Unscoped batch read by id — the duty half of the reconcile roster, whose
    *  agents are named by the ledger rather than by placement. */
   listByIds(agentIds: readonly AgentId[]): Promise<AgentRecord[]>

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -617,7 +617,13 @@ export class PgAgentRepo implements AgentRepo {
       // `memory/home/migrated` recorded since the caller read the agent is what this write sees, not the caller's copy.
       if (opts?.memoryHome) {
         const { input, onPool, force } = opts.memoryHome
-        const change = resolveMemoryBindingOnUpdate(cur?.memory ?? null, input, onPool, force)
+        const locked = cur?.memory ?? null
+        const change = resolveMemoryBindingOnUpdate(
+          locked,
+          typeof input === 'function' ? input(locked) : input,
+          onPool,
+          force
+        )
         if (change.kind === 'refused') throw new MemoryHomeRefusedError(change.refused, change.message)
         if (change.kind === 'write') {
           if (change.memory === null) delete next.memory

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -1102,6 +1102,15 @@ export class PgAgentRepo implements AgentRepo {
     return rows.map(toRecord)
   }
 
+  async listForSet(setId: string): Promise<AgentRecord[]> {
+    const rows = await this.db.agent.findMany({
+      where: { setId, placementKind: 'set' },
+      orderBy: { createdAt: 'asc' },
+      include: withUsers
+    })
+    return rows.map(toRecord)
+  }
+
   // The org PEER directory (agent-collaboration §2.5/§6.1). A narrow `select` on the
   // agent table alone — no `withUsers` join (audit identities are console-only) and
   // deliberately NO `visibilityWhere`: ResourceVisibility gates human console access,

--- a/packages/control-plane/test/integration/pool-memory-home.reconciler.test.ts
+++ b/packages/control-plane/test/integration/pool-memory-home.reconciler.test.ts
@@ -1,0 +1,151 @@
+// The boot-time memory-home flip (memory-evolution.md §3.2.1 "Rollout"): pool-placed agents, and only those, move home.
+import { afterEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type { Ack, AgentActivate, AgentDetach, AgentUpsert, McpServerSpec } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon, seedDutyGroup } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { poolSetId, seedPoolMember } from '../fakes/member-set.js'
+import type { DaemonLiveness } from '../../src/ports.js'
+import type { ControlSender } from '../../src/orchestrator/outbound.js'
+import { PoolMemoryHomeReconciler } from '../../src/orchestrator/poolMemoryHomeReconciler.js'
+
+const SOURCE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const MEMBER = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const CAPS = { platforms: ['slack'], runtimes: ['Claude Code'], acp: true, features: ['agent-move-v1'] }
+
+const CP = { provider: 'managed', home: 'control-plane' }
+const PENDING = { ...CP, homeMigration: 'pending' }
+const DAEMON_HOME = { provider: 'managed', home: 'daemon' }
+const EXTERNAL = { provider: 'external', connectionId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }
+
+let running: HttpApp | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+/** The daemon-side seam: records every spec push with the binding it carried. */
+class ControlSpy {
+  readonly upserts: Array<{ daemonId: string; agentId: string; memory: unknown }> = []
+  async agentDetach(_daemonId: string, _value: AgentDetach): Promise<Ack> {
+    return { ok: true }
+  }
+  async agentActivate(_daemonId: string, _value: AgentActivate): Promise<Ack> {
+    return { ok: true }
+  }
+  async agentUpsert(daemonId: string, value: AgentUpsert): Promise<void> {
+    this.upserts.push({ daemonId, agentId: value.agentId, memory: (value.spec as { memory?: unknown }).memory })
+  }
+  async mcpServerUpsert(_daemonId: string, _spec: McpServerSpec): Promise<void> {}
+  async mcpServerRemove(_daemonId: string, _orgId: string, _name: string): Promise<void> {}
+}
+
+const live: DaemonLiveness = {
+  get: (id) => ([SOURCE, MEMBER].includes(id) ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
+}
+
+const logs: unknown[] = []
+const log = { info: (obj: unknown) => void logs.push(obj), warn: () => {} }
+
+function harness(): { reconciler: PoolMemoryHomeReconciler; spy: ControlSpy } {
+  const spy = new ControlSpy()
+  running = buildHttpApp(prisma, undefined, live, spy as unknown as ControlSender)
+  const { repos, agentDelivery } = running.deps
+  return {
+    reconciler: new PoolMemoryHomeReconciler({
+      agents: repos.agent,
+      memberSets: repos.memberSet,
+      delivery: agentDelivery,
+      log
+    }),
+    spy
+  }
+}
+
+const row = (agentId: string) => prisma.agent.findUniqueOrThrow({ where: { id: agentId } })
+const storedMemory = async (agentId: string) =>
+  ((await row(agentId)).runtimeOverrides as { memory?: unknown } | null)?.memory ?? null
+
+/** An agent on the pool set, or pinned to a machine; `memory` is what its row already carries. */
+async function seed(
+  memory: Record<string, unknown> | null,
+  placement: { pool: true } | { daemonId: string }
+): Promise<string> {
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, {
+    ...('pool' in placement ? { setId: await poolSetId(prisma) } : { daemonId: placement.daemonId }),
+    ...(memory ? { runtimeOverrides: { memory } } : {})
+  })
+  return agentId
+}
+
+describe('PoolMemoryHomeReconciler', () => {
+  it('a pool agent with no binding is flipped to the Control Plane, flagged for migration, and pushed to its holder', async () => {
+    await seedPoolMember(prisma, MEMBER)
+    const agentId = await seed(null, { pool: true })
+    await seedDutyGroup(prisma, randomUUID(), MEMBER, [agentId], { confirmed: true })
+    const before = await row(agentId)
+    const { reconciler, spy } = harness()
+
+    expect(await reconciler.run()).toEqual({ flipped: 1, already: 0, skipped: 0, failed: 0 })
+    expect(await storedMemory(agentId)).toEqual(PENDING)
+    const after = await row(agentId)
+    expect(after.configRevision).toBe(before.configRevision + 1n)
+    expect(spy.upserts).toEqual([{ daemonId: MEMBER, agentId, memory: PENDING }])
+  })
+
+  it('a legacy agent pinned to a pool member keeps its managed policy and is pushed to that member', async () => {
+    await seedPoolMember(prisma, MEMBER)
+    const agentId = await seed({ ...DAEMON_HOME, autoDistill: false }, { daemonId: MEMBER })
+    const { reconciler, spy } = harness()
+
+    expect(await reconciler.run()).toMatchObject({ flipped: 1 })
+    expect(await storedMemory(agentId)).toEqual({ ...PENDING, autoDistill: false })
+    expect(spy.upserts.map((u) => u.daemonId)).toEqual([MEMBER])
+  })
+
+  it('leaves alone what has no daemon home to move: already homed, non-managed, or not on the pool', async () => {
+    await seedDaemon(prisma, SOURCE, { capabilities: CAPS })
+    await seedPoolMember(prisma, MEMBER)
+    const homed = await seed(CP, { pool: true })
+    const migrating = await seed(PENDING, { pool: true })
+    const external = await seed(EXTERNAL, { pool: true })
+    const selfHosted = await seed(DAEMON_HOME, { daemonId: SOURCE })
+    const selfHostedBare = await seed(null, { daemonId: SOURCE })
+    await seedDutyGroup(prisma, randomUUID(), MEMBER, [homed, migrating, external], { confirmed: true })
+    const revisions = await Promise.all(
+      [homed, migrating, external, selfHosted].map(async (id) => (await row(id)).configRevision)
+    )
+    const { reconciler, spy } = harness()
+
+    expect(await reconciler.run()).toEqual({ flipped: 0, already: 2, skipped: 1, failed: 0 })
+    expect(await storedMemory(homed)).toEqual(CP)
+    expect(await storedMemory(migrating)).toEqual(PENDING)
+    expect(await storedMemory(external)).toEqual(EXTERNAL)
+    expect(await storedMemory(selfHosted)).toEqual(DAEMON_HOME)
+    expect(await storedMemory(selfHostedBare)).toBeNull()
+    expect(
+      await Promise.all([homed, migrating, external, selfHosted].map(async (id) => (await row(id)).configRevision))
+    ).toEqual(revisions)
+    expect(spy.upserts).toEqual([])
+  })
+
+  it('is idempotent: a second pass changes nothing and pushes nothing', async () => {
+    await seedPoolMember(prisma, MEMBER)
+    const bare = await seed(null, { pool: true })
+    const pinned = await seed(DAEMON_HOME, { daemonId: MEMBER })
+    await seedDutyGroup(prisma, randomUUID(), MEMBER, [bare], { confirmed: true })
+    const { reconciler, spy } = harness()
+
+    expect(await reconciler.run()).toEqual({ flipped: 2, already: 0, skipped: 0, failed: 0 })
+    expect(spy.upserts.map((u) => u.agentId).sort()).toEqual([bare, pinned].sort())
+    const revisions = await Promise.all([bare, pinned].map(async (id) => (await row(id)).configRevision))
+
+    expect(await reconciler.run()).toEqual({ flipped: 0, already: 2, skipped: 0, failed: 0 })
+    expect(spy.upserts).toHaveLength(2)
+    expect(await Promise.all([bare, pinned].map(async (id) => (await row(id)).configRevision))).toEqual(revisions)
+    expect(await storedMemory(bare)).toEqual(PENDING)
+    expect(logs.at(-1)).toEqual({ flipped: 0, already: 2, skipped: 0, failed: 0 })
+  })
+})

--- a/packages/control-plane/test/integration/pool-memory-home.reconciler.test.ts
+++ b/packages/control-plane/test/integration/pool-memory-home.reconciler.test.ts
@@ -131,6 +131,39 @@ describe('PoolMemoryHomeReconciler', () => {
     expect(spy.upserts).toEqual([])
   })
 
+  it('honors an edit that lands between the scan and the row lock instead of overwriting it', async () => {
+    await seedPoolMember(prisma, MEMBER)
+    const switched = await seed(null, { pool: true })
+    const repoliced = await seed({ ...DAEMON_HOME, autoDistill: true }, { pool: true })
+    await seedDutyGroup(prisma, randomUUID(), MEMBER, [switched, repoliced], { confirmed: true })
+    const spy = new ControlSpy()
+    running = buildHttpApp(prisma, undefined, live, spy as unknown as ControlSender)
+    const { repos, agentDelivery } = running.deps
+    // A user's edit commits after the scan read the row and before the flip takes the lock.
+    const raced: Record<string, Record<string, unknown>> = {
+      [switched]: { provider: 'none' },
+      [repoliced]: { ...DAEMON_HOME, autoDistill: false }
+    }
+    const agents: typeof repos.agent = Object.assign(Object.create(repos.agent), {
+      update: async (...args: Parameters<typeof repos.agent.update>) => {
+        const [orgId, agentId] = args
+        await repos.agent.update(orgId, agentId, { memory: raced[agentId] as never })
+        return repos.agent.update(...args)
+      }
+    })
+    const reconciler = new PoolMemoryHomeReconciler({
+      agents,
+      memberSets: repos.memberSet,
+      delivery: agentDelivery,
+      log
+    })
+
+    expect(await reconciler.run()).toEqual({ flipped: 1, already: 0, skipped: 1, failed: 0 })
+    expect(await storedMemory(switched)).toEqual({ provider: 'none' })
+    expect(await storedMemory(repoliced)).toEqual({ ...PENDING, autoDistill: false })
+    expect(spy.upserts.map((u) => u.agentId)).toEqual([repoliced])
+  })
+
   it('is idempotent: a second pass changes nothing and pushes nothing', async () => {
     await seedPoolMember(prisma, MEMBER)
     const bare = await seed(null, { pool: true })


### PR DESCRIPTION
## Why

Step ⑩a of the managed-memory `home` rollout. `docs/designs/memory-evolution.md` §3.2.1 "Rollout" says existing pool agents are flipped by the Control Plane in the same release: every agent placed on the install-wide pool gets `home: control-plane`, and the member holding it runs the one-way migration on its next activation, the sandbox volume being the source. Steps ①–⑨ landed the rule module, the row-locked write, the frames, and the daemon-side copy; this PR is the flip itself.

## What

`packages/control-plane/src/orchestrator/poolMemoryHomeReconciler.ts` — one idempotent pass over the pool's agents, armed from `startBackground()` after the app is listening (next to the preset backfill; never delays readiness).

**Flipped**: an agent on the pool — placed on the org-less set, or a legacy row pinned to one of its members — whose managed memory resolves to the `daemon` home (no binding, or a managed binding with `home: 'daemon'`). Its policy fields (`autoDistill`, `dreaming`, `scope`) are kept; the result is `home: 'control-plane', homeMigration: 'pending'`.

**Left alone**: agents already homed in the Control Plane (pending or settled), agents with a non-managed provider (`external` / `native` / `none` have no managed tree to move), and every agent not on the pool.

One info line per boot carries the counts (`flipped` / `already` / `skipped` / `failed`); a per-agent failure is logged and retried on the next boot.

## Why through the update path

The flip goes through the same row-locked `AgentRepo.update(..., { memoryHome })` the PATCH route uses, so the rule module decides the stored binding against the row as it is under the lock, and `configRevision` advances. The scan is only the cheap filter: `MemoryHomeUpdate.input` now also accepts a function of the locked binding, and the reconciler re-takes its verdict there — an edit that landed between the scan and the lock (a provider switch, a policy change) is honored, never overwritten, and a binding that no longer needs the flip aborts the transaction with nothing written. It is then pushed through the same `AgentDelivery.upsert` fan-out the route uses, so the member holding the agent receives the new binding as `agent/upsert` now and starts the copy. A raw row update that nobody pushes would leave the member serving the old home until its next reconnect.

`AgentRepo.listForSet(setId)` is the one new repo read, mirroring `listForDaemon`.

## Idempotency

A second pass finds every agent already homed and changes nothing: no write, no revision bump, no push. Covered by the test.

## Design doc

The Rollout sentence in §3.2.1 now says the pass runs at every CP boot, is idempotent, and goes through the ordinary update path so the flip reaches the member like any other edit.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean.
- `test:unit` — 194 files, 2276 tests pass.
- `test:int` (Docker, real Postgres): new `test/integration/pool-memory-home.reconciler.test.ts` — a pool agent with no binding is flipped with `pending` and pushed once to its confirmed duty holder with the new binding in the spec; a legacy member-pinned agent keeps its policy and is pushed to that member; already-homed / external / self-hosted agents are untouched with their `configRevision` unchanged and no push; a second run flips nothing and pushes nothing. Neighboring `agents.memory-home.route` and `agents.replication.route` suites still pass.
- eslint and prettier on touched files; diff scanned for private identifiers.

No daemon changes (the `--k8s` refusal of a `daemon` home is step ⑩b, after this flip is verified live); no web; no data copy (the member does that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
