### PR TITLE
fix(control-plane): every unreachable memory home answers 503, not only a sleeping sandbox

### DIFF
--- a/packages/control-plane/src/agent-memory/unavailable.test.ts
+++ b/packages/control-plane/src/agent-memory/unavailable.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { ProtocolError } from '../domain/errors.js'
+import { MemoryHomeUnavailableReason, memoryHomeUnavailable } from './unavailable.js'
+
+const refused = (reason?: string) =>
+  new ProtocolError('BAD_PAYLOAD', 'memory/write failed: home unreachable', reason ? { details: { reason } } : {})
+
+describe('memoryHomeUnavailable', () => {
+  it('keeps the sleeping-sandbox answer byte-for-byte: the workspace code the console wakes on', () => {
+    expect(memoryHomeUnavailable(refused('sandbox-unavailable'))).toEqual({
+      status: 503,
+      error: 'Service Unavailable',
+      message: 'memory/write failed: home unreachable',
+      code: 'WORKSPACE_SANDBOX_UNAVAILABLE'
+    })
+  })
+
+  it('answers every other reason with 503 and the reason as a MEMORY_HOME_* code, never the wake code', () => {
+    for (const reason of MemoryHomeUnavailableReason.options.filter((r) => r !== 'sandbox-unavailable')) {
+      const failure = memoryHomeUnavailable(refused(reason))
+      expect(failure?.status, reason).toBe(503)
+      expect(failure?.code, reason).toBe(`MEMORY_HOME_${reason.toUpperCase().replaceAll('-', '_')}`)
+    }
+  })
+
+  it('is null for a refusal that names no home reason, so the route keeps its 400', () => {
+    expect(memoryHomeUnavailable(refused())).toBeNull()
+    expect(memoryHomeUnavailable(refused('path-escape'))).toBeNull()
+    expect(
+      memoryHomeUnavailable(new ProtocolError('CONFLICT', 'stale', { details: { reason: 'migrating' } }))
+    ).toBeNull()
+    expect(memoryHomeUnavailable(new Error('connection closed'))).toBeNull()
+  })
+})

--- a/packages/control-plane/src/agent-memory/unavailable.ts
+++ b/packages/control-plane/src/agent-memory/unavailable.ts
@@ -1,0 +1,37 @@
+// Every way an agent's memory home can be out of reach (memory-evolution.md §3.2.1 "Degradation"): the daemon refuses
+// the request with one of these reasons, and each is "not now" for the console — a 503 that says why, never a 400.
+import { z } from 'zod'
+import { ProtocolError } from '../domain/errors.js'
+
+/** The daemon's `MemoryHomeUnavailableReason` set; add a reason here and every memory route answers it with 503. */
+export const MemoryHomeUnavailableReason = z.enum([
+  'sandbox-unavailable',
+  'connection',
+  'feature',
+  'scope-denied',
+  'migrating',
+  'pool-daemon-home'
+])
+export type MemoryHomeUnavailableReason = z.infer<typeof MemoryHomeUnavailableReason>
+
+/** The one code the console acts on (it wakes the sandbox, #1077) — shared with the workspace reader, kept verbatim. */
+export const SANDBOX_UNAVAILABLE_CODE = 'WORKSPACE_SANDBOX_UNAVAILABLE'
+
+export interface MemoryHomeUnavailable {
+  status: 503
+  error: 'Service Unavailable'
+  message: string
+  code: string
+}
+
+/** The 503 a memory home refusal maps to, or null when `err` is not one; only the sandbox case carries the wake code. */
+export function memoryHomeUnavailable(err: unknown): MemoryHomeUnavailable | null {
+  if (!(err instanceof ProtocolError) || err.code !== 'BAD_PAYLOAD') return null
+  const reason = MemoryHomeUnavailableReason.safeParse(err.details?.reason)
+  if (!reason.success) return null
+  const code =
+    reason.data === 'sandbox-unavailable'
+      ? SANDBOX_UNAVAILABLE_CODE
+      : `MEMORY_HOME_${reason.data.toUpperCase().replaceAll('-', '_')}`
+  return { status: 503, error: 'Service Unavailable', message: err.message, code }
+}

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -99,6 +99,7 @@ import {
   resolveMemoryBindingOnUpdate
 } from '../../agent-memory/home.js'
 import { memoryHistoryRoot, toHistoryEvent } from '../../agent-memory/history.js'
+import { memoryHomeUnavailable, SANDBOX_UNAVAILABLE_CODE } from '../../agent-memory/unavailable.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { refreshMutationAgent as refreshAgentUnderMutation } from '../mutation-agent.js'
 import { canView, canViewSession, canEdit, canManageSharing, type ViewCtx } from '../../authorization/policy.js'
@@ -744,7 +745,7 @@ export function workspaceErrorCode(err: ProtocolError): string | null {
  *  running, so its files are unreachable until it is. 503 like an offline daemon, because that is
  *  what it is — but WITH the code, which is how the console tells "come back in a moment" from a
  *  daemon that may never come back, and from an empty workspace. */
-const SANDBOX_UNAVAILABLE = 'WORKSPACE_SANDBOX_UNAVAILABLE'
+const SANDBOX_UNAVAILABLE = SANDBOX_UNAVAILABLE_CODE
 
 /** Status a console can act on instead of the 503 that reads as an offline daemon:
  *  a worktree the daemon lacks is 404 (as when the CP pre-empts the read), a bad path
@@ -784,13 +785,13 @@ function sendWorkspaceFailure(reply: FastifyReply, err: unknown): boolean {
   return true
 }
 
-/** A memory or dream request refused because the agent's sandbox is not running: the workspace
- *  reader's transient 503 + code, so the console wakes the sandbox (#1077). false ⇒ not that. */
-function sendSandboxUnavailable(reply: FastifyReply, err: unknown): boolean {
-  if (!(err instanceof ProtocolError) || workspaceErrorCode(err) !== SANDBOX_UNAVAILABLE) return false
-  void reply
-    .code(503)
-    .send({ error: 'Service Unavailable', statusCode: 503, message: err.message, code: SANDBOX_UNAVAILABLE })
+/** A memory request refused because the agent's memory home is out of reach (a sleeping sandbox, a Control-Plane
+ *  tree behind a missing connection, feature, scope, or migration): a 503 with the reason as `code`, so the console
+ *  retries — and wakes the sandbox on the one code it knows (#1077). false ⇒ not that. */
+function sendMemoryHomeUnavailable(reply: FastifyReply, err: unknown): boolean {
+  const failure = memoryHomeUnavailable(err)
+  if (!failure) return false
+  void reply.code(503).send({ error: failure.error, statusCode: 503, message: failure.message, code: failure.code })
   return true
 }
 
@@ -866,11 +867,9 @@ function memoryAdminFailure(err: unknown): {
   message: string
   code?: string
 } | null {
-  // A cluster agent's memory tree is on its sandbox volume: asleep is the workspace reader's transient
-  // 503 + code, which the console answers by waking the sandbox (#1077) — never a 400.
-  if (err instanceof ProtocolError && workspaceErrorCode(err) === SANDBOX_UNAVAILABLE) {
-    return { status: 503, error: 'Service Unavailable', message: err.message, code: SANDBOX_UNAVAILABLE }
-  }
+  // The memory home is out of reach (asleep sandbox, unreachable Control-Plane tree): transient 503 + reason, never a 400.
+  const unreachable = memoryHomeUnavailable(err)
+  if (unreachable) return unreachable
   if (err instanceof ProtocolError && err.code === 'BAD_PAYLOAD') {
     return { status: 400, error: 'Bad Request', message: `daemon rejected the request: ${err.message}` }
   }
@@ -3512,7 +3511,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Read the agent memory index',
           description:
-            "Proxy the agent's memory index (<agent-root>/memory/MEMORY.md) live from the owning daemon; a not-yet-created file is data (exists:false). 503 when unplaced or the daemon is offline.",
+            "Proxy the agent's memory index (<agent-root>/memory/MEMORY.md) live from the owning daemon; a not-yet-created file is data (exists:false). 503 when unplaced or the daemon is offline. 503 also when the memory home of the agent is not reachable right now; `code` says why.",
           operationId: 'readAgentMemory',
           params: IdParam,
           querystring: MemoryFileQueryDto,
@@ -3545,7 +3544,7 @@ export function agentRoutes(deps: HttpDeps) {
           })
           return toAgentMemoryDto(rep)
         } catch (err) {
-          if (sendSandboxUnavailable(reply, err)) return
+          if (sendMemoryHomeUnavailable(reply, err)) return
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {
             return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
@@ -3563,7 +3562,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'List agent memory files',
           description:
-            "List the files in the agent's memory dir (MEMORY.md index + topic files) live from the owning daemon. 503 when unplaced or the daemon is offline.",
+            "List the files in the agent's memory dir (MEMORY.md index + topic files) live from the owning daemon. 503 when unplaced or the daemon is offline. 503 also when the memory home of the agent is not reachable right now; `code` says why.",
           operationId: 'listAgentMemoryFiles',
           params: IdParam,
           querystring: MemoryFilesQueryDto,
@@ -3593,7 +3592,7 @@ export function agentRoutes(deps: HttpDeps) {
           })
           return toMemoryFilesDto(rep)
         } catch (err) {
-          if (sendSandboxUnavailable(reply, err)) return
+          if (sendMemoryHomeUnavailable(reply, err)) return
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {
             return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
@@ -3611,7 +3610,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'List agent channel memory folders',
           description:
-            'List the channels that have their own memory folder for a channel-scoped agent, live from the owning daemon (empty for agent-scoped agents). 503 when unplaced or the daemon is offline.',
+            'List the channels that have their own memory folder for a channel-scoped agent, live from the owning daemon (empty for agent-scoped agents). 503 when unplaced or the daemon is offline. 503 also when the memory home of the agent is not reachable right now; `code` says why.',
           operationId: 'listAgentMemoryChannels',
           params: IdParam,
           response: { 200: MemoryChannelsDto, 400: ErrorDto, 404: ErrorDto, 503: ErrorDto }
@@ -3638,7 +3637,7 @@ export function agentRoutes(deps: HttpDeps) {
             }))
           }
         } catch (err) {
-          if (sendSandboxUnavailable(reply, err)) return
+          if (sendMemoryHomeUnavailable(reply, err)) return
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {
             return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
@@ -3656,7 +3655,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Read a memory file',
           description:
-            'Proxy one byte slice of a memory file (?path defaults to MEMORY.md) live from the owning daemon; a missing file is data (exists:false). 503 when unplaced or the daemon is offline.',
+            'Proxy one byte slice of a memory file (?path defaults to MEMORY.md) live from the owning daemon; a missing file is data (exists:false). 503 when unplaced or the daemon is offline. 503 also when the memory home of the agent is not reachable right now; `code` says why.',
           operationId: 'readAgentMemoryFile',
           params: IdParam,
           querystring: MemoryFileQueryDto,
@@ -3689,7 +3688,7 @@ export function agentRoutes(deps: HttpDeps) {
           })
           return toAgentMemoryDto(rep)
         } catch (err) {
-          if (sendSandboxUnavailable(reply, err)) return
+          if (sendMemoryHomeUnavailable(reply, err)) return
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {
             return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
@@ -3708,7 +3707,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Replace a memory file',
           description:
-            'Replace one memory file (?path defaults to MEMORY.md) on the owning daemon; returns the written size/mtime. `ifMatchMtime` (optional) is optimistic concurrency — a 409 if the file changed under you. Requires edit permission. 503 when unplaced or the daemon is offline.',
+            'Replace one memory file (?path defaults to MEMORY.md) on the owning daemon; returns the written size/mtime. `ifMatchMtime` (optional) is optimistic concurrency — a 409 if the file changed under you. Requires edit permission. 503 when unplaced or the daemon is offline. 503 also when the memory home of the agent is not reachable right now; `code` says why.',
           operationId: 'putAgentMemoryFile',
           params: IdParam,
           querystring: PutMemoryFileQueryDto,
@@ -3754,7 +3753,7 @@ export function agentRoutes(deps: HttpDeps) {
           })
           return { path: ok.path, size: ok.size, mtime: ok.mtime }
         } catch (err) {
-          if (sendSandboxUnavailable(reply, err)) return
+          if (sendMemoryHomeUnavailable(reply, err)) return
           // The daemon rejects a stale write (CONFLICT) or an over-budget / bad-path
           // write (BAD_PAYLOAD) — surface those as 409 / 400, not the generic 503.
           if (err instanceof ProtocolError && err.code === 'CONFLICT') {
@@ -3781,7 +3780,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'List memory file history',
           description:
-            'Return one newest-first page of add/update/delete provenance for a managed memory file. For a memory home on the daemon the page is proxied live from the owning daemon and not persisted here; for a home in the Control Plane it is answered from the change log the Control Plane keeps, with no daemon involved.',
+            'Return one newest-first page of add/update/delete provenance for a managed memory file. For a memory home on the daemon the page is proxied live from the owning daemon and not persisted here; for a home in the Control Plane it is answered from the change log the Control Plane keeps, with no daemon involved. 503 when unplaced, the daemon is offline, or the memory home of the agent is not reachable right now; `code` says why.',
           operationId: 'listAgentMemoryFileHistory',
           params: IdParam,
           querystring: MemoryHistoryQueryDto,

--- a/packages/control-plane/test/integration/agents.memory.route.test.ts
+++ b/packages/control-plane/test/integration/agents.memory.route.test.ts
@@ -335,6 +335,49 @@ describe('PUT /agents/:id/memory/file (replace, edit-gated, proxied)', () => {
     }
   })
 
+  it('answers every other unreachable-home reason with 503 + the reason on the write and history routes', async () => {
+    // A `control-plane` home behind a missing connection, feature, scope, migration copy, or a pool member's daemon home
+    // is "not now" exactly like a sleeping sandbox (§3.2.1) — a 503 the console retries, never a 400 that stops it. Only
+    // the sandbox carries the wake code; these carry the reason as their own code.
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    for (const reason of ['connection', 'feature', 'scope-denied', 'migrating', 'pool-daemon-home']) {
+      const unreachable = () => {
+        throw new ProtocolError('BAD_PAYLOAD', `memory/write failed: home unreachable (${reason})`, {
+          details: { reason }
+        })
+      }
+      const s = { memoryWrite: unreachable, memoryHistory: unreachable }
+      running = buildHttpApp(prisma, undefined, LIVE, s as unknown as ControlSender)
+      for (const request of [
+        { method: 'PUT' as const, url: `${ORG}/agents/${AGENT}/memory/file`, payload: { content: 'x' } },
+        { method: 'GET' as const, url: `${ORG}/agents/${AGENT}/memory/history?path=MEMORY.md` }
+      ]) {
+        const res = await running.app.inject(request)
+        const label = `${reason} ${request.url}`
+        expect(res.statusCode, label).toBe(503)
+        expect((res.json() as { code?: string }).code, label).toBe(
+          `MEMORY_HOME_${reason.toUpperCase().replaceAll('-', '_')}`
+        )
+      }
+      await running.close()
+      running = undefined
+    }
+  })
+
+  it('keeps 400 for a refusal that names no home reason on the history route', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const s = {
+      async memoryHistory(): Promise<MemoryHistoryPage> {
+        throw new ProtocolError('BAD_PAYLOAD', 'memory/history failed: path escapes the memory root')
+      }
+    }
+    running = buildHttpApp(prisma, undefined, LIVE, s as unknown as ControlSender)
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/memory/history?path=../x.md` })
+    expect(res.statusCode).toBe(400)
+  })
+
   it('rejects an unknown body field (.strict)', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })


### PR DESCRIPTION
## Why

The daemon refuses a memory request whose home is out of reach with a `BAD_PAYLOAD` carrying one of six reasons: `sandbox-unavailable`, `connection`, `feature`, `scope-denied`, `migrating`, `pool-daemon-home` (the last lands with #1890). Per `memory-evolution.md` §3.2.1 every one of them is "not now" for the console. The Control Plane knew only the sandbox one: the memory-file write route and every route behind `memoryAdminFailure` (history, records, dreams) turned the other five into a 400 — which tells the console the request itself was wrong and to stop retrying. The GET routes already fell through to a 503, but a reasonless one.

## What changed

- New `packages/control-plane/src/agent-memory/unavailable.ts` holds the reason set once (`MemoryHomeUnavailableReason`) and `memoryHomeUnavailable(err)`, the refusal-to-503 mapping. A future reason is added there and nowhere else.
- Every memory route (index, files, channels, file read, file write, history, and the record/dream routes via `memoryAdminFailure`) answers each reason with 503 and the reason as `code`: `MEMORY_HOME_CONNECTION`, `MEMORY_HOME_FEATURE`, `MEMORY_HOME_SCOPE_DENIED`, `MEMORY_HOME_MIGRATING`, `MEMORY_HOME_POOL_DAEMON_HOME`. `ErrorDto` has no `reason` field and the Zod response serializer would drop one, so the reason rides in `code`, the way the sandbox case already does.
- OpenAPI descriptions of the six memory-file routes gain one sentence: the 503 also covers a memory home that is not reachable right now, and `code` says why.

## What stays byte-for-byte

`sandbox-unavailable` still answers `503` with `code: WORKSPACE_SANDBOX_UNAVAILABLE` on every route — the console's wake logic (#1077) compares on that exact code, and the other reasons deliberately do not carry it. A `BAD_PAYLOAD` naming no home reason (a path refusal, an over-budget write) is still a 400.

## Non-goals

No daemon or web changes; no new reasons.

## Verification

- `pnpm --filter @agentconnect.md/control-plane typecheck` and `test:unit` green; new `unavailable.test.ts` covers the sandbox answer, the five `MEMORY_HOME_*` codes, and the null cases (no reason, a workspace reason, a `CONFLICT`, a plain error).
- `test:int` green locally against Docker Postgres (125 files). `agents.memory.route.test.ts` gains: each of the five non-sandbox reasons → 503 + its code on the write and history routes; a reasonless refusal on the history route → 400; the existing sandbox-on-every-route and write-400 tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
