### PR TITLE
fix(daemon): the agent-config watcher leaves the memory tree alone, so Windows can archive it

### DIFF
--- a/packages/daemon/src/daemon/helpers.ts
+++ b/packages/daemon/src/daemon/helpers.ts
@@ -6,11 +6,19 @@ import { SandboxError, sandboxBoundary } from '../acp/sandbox.js'
 import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { Config } from '../config/config-schema.js'
+import { DAEMON_OWNED_AGENT_DIRNAMES, MEMORY_ARCHIVE_DIRNAME_PREFIX } from '../memory/store.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
 
 export function ignoreAgentWatchPath(agentsDir: string, path: string, stats?: Stats): boolean {
   const segments = relative(agentsDir, path).split(sep)
   if (segments.some((segment) => segment === 'node_modules' || segment.startsWith('.'))) return true
+  // The watcher only wants `agent.json`; the memory tree is the daemon's own, and Windows cannot rename a watched dir.
+  const owned = segments[1]
+  if (
+    owned !== undefined &&
+    (DAEMON_OWNED_AGENT_DIRNAMES.includes(owned) || owned.startsWith(MEMORY_ARCHIVE_DIRNAME_PREFIX))
+  )
+    return true
   return stats !== undefined && !stats.isDirectory() && basename(path) !== 'agent.json'
 }
 

--- a/packages/daemon/src/memory/store.ts
+++ b/packages/daemon/src/memory/store.ts
@@ -70,6 +70,8 @@ export const MEMORY_HISTORY_FILENAME = '.history'
 export const MEMORY_DREAMS_DIRNAME = 'memory-dreams'
 /** The retained pre-adoption copy of the store (`<root>/memory-backups/`), the undo path for the last dream. */
 export const MEMORY_BACKUPS_DIRNAME = 'memory-backups'
+/** Prefix of the `<root>/memory-archive-<stamp>/` dir the forced home return moves the live store into. */
+export const MEMORY_ARCHIVE_DIRNAME_PREFIX = 'memory-archive-'
 
 /** Cap on a `before`/`after` snapshot stored in a history line — keeps a single log
  *  entry bounded even for a large file. Over this, the snapshot is truncated (with a
@@ -134,6 +136,13 @@ export function memoryDir(agentDir: string): string {
 /** Sibling of `memory/` that holds one self-contained memory subtree per channel
  *  when the agent's memory scope is `channel` (#653). */
 export const CHANNEL_MEMORY_DIRNAME = 'channels'
+/** The daemon-owned dirs directly under an agent dir that never hold `agent.json`; the archive dirs join by prefix. */
+export const DAEMON_OWNED_AGENT_DIRNAMES: readonly string[] = [
+  MEMORY_DIRNAME,
+  CHANNEL_MEMORY_DIRNAME,
+  MEMORY_BACKUPS_DIRNAME,
+  MEMORY_DREAMS_DIRNAME
+]
 
 /** A deterministic, filesystem-safe folder name for one channel's memory. Keeps a
  *  readable prefix and appends a short digest so distinct (transportScope, channel)

--- a/packages/daemon/test/daemon-helpers.test.ts
+++ b/packages/daemon/test/daemon-helpers.test.ts
@@ -1,0 +1,33 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ignoreAgentWatchPath } from '../src/daemon/helpers.js'
+
+const agentsDir = join('/home/agent/workspace', 'agents')
+const agent = join(agentsDir, 'bot-a')
+const dir = { isDirectory: () => true } as never
+const file = { isDirectory: () => false } as never
+
+describe('ignoreAgentWatchPath', () => {
+  it.each(['memory', 'channels', 'memory-backups', 'memory-dreams', 'memory-archive-2026-09-09T10-00-00-000Z'])(
+    'ignores the daemon-owned %s dir and everything beneath it',
+    (name) => {
+      expect(ignoreAgentWatchPath(agentsDir, join(agent, name), dir)).toBe(true)
+      expect(ignoreAgentWatchPath(agentsDir, join(agent, name), undefined)).toBe(true)
+      expect(ignoreAgentWatchPath(agentsDir, join(agent, name, 'deploys.md'), file)).toBe(true)
+      expect(ignoreAgentWatchPath(agentsDir, join(agent, name, 'C123', 'memory'), dir)).toBe(true)
+    }
+  )
+
+  it('still watches agent.json at the agent root and unrelated directories', () => {
+    expect(ignoreAgentWatchPath(agentsDir, join(agent, 'agent.json'), file)).toBe(false)
+    expect(ignoreAgentWatchPath(agentsDir, agent, dir)).toBe(false)
+    expect(ignoreAgentWatchPath(agentsDir, join(agent, 'workspace'), dir)).toBe(false)
+    expect(ignoreAgentWatchPath(agentsDir, join(agent, 'workspace', 'src'), dir)).toBe(false)
+  })
+
+  it('keeps the existing rules: node_modules, dot segments, and files other than agent.json', () => {
+    expect(ignoreAgentWatchPath(agentsDir, join(agent, 'node_modules'), dir)).toBe(true)
+    expect(ignoreAgentWatchPath(agentsDir, join(agent, '.git', 'HEAD'), file)).toBe(true)
+    expect(ignoreAgentWatchPath(agentsDir, join(agent, 'workspace', 'README.md'), file)).toBe(true)
+  })
+})

--- a/packages/daemon/test/memory-home-migration.test.ts
+++ b/packages/daemon/test/memory-home-migration.test.ts
@@ -469,59 +469,54 @@ describe('the daemon runs it', () => {
       stop: vi.fn().mockResolvedValue(undefined)
     }) as never
 
-  // Not on Windows: the daemon's agent-config watcher holds a handle on every directory beneath the agent dir, and
-  // Windows refuses to move a directory with open handles beneath it — the flat `memory/` moves, `channels/` does not.
-  // The archive itself is covered on every platform above; releasing the watcher's grip is the watcher's own change.
-  it.skipIf(process.platform === 'win32')(
-    'starts the copy when a pending binding arrives, serves the CP tree once accepted, and archives the tree on the forced return',
-    async () => {
-      const root = daemonRoot()
-      const agentDir = join(root, 'agents', AGENT)
-      await seedSource(agentDir)
-      const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: inertHost })
-      await daemon.start()
-      const cp = fakeCp()
-      const seam = daemon as unknown as {
-        cpClient: unknown
-        cpConfigApply(): { applyAgentUpsert(upsert: { agentId: string; spec: AgentSpec }): Promise<unknown> }
-        agents: Map<string, { memory?: AgentMemoryBinding }>
-        memory: {
-          write(
-            scope: { agentId: string },
-            path: string,
-            content: string,
-            ifMatch?: string,
-            source?: 'tool'
-          ): Promise<unknown>
-        }
+  // On Windows this also proves the agent-config watcher holds no handle beneath the memory tree, or the move would half-fail.
+  it('starts the copy when a pending binding arrives, serves the CP tree once accepted, and archives the tree on the forced return', async () => {
+    const root = daemonRoot()
+    const agentDir = join(root, 'agents', AGENT)
+    await seedSource(agentDir)
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: inertHost })
+    await daemon.start()
+    const cp = fakeCp()
+    const seam = daemon as unknown as {
+      cpClient: unknown
+      cpConfigApply(): { applyAgentUpsert(upsert: { agentId: string; spec: AgentSpec }): Promise<unknown> }
+      agents: Map<string, { memory?: AgentMemoryBinding }>
+      memory: {
+        write(
+          scope: { agentId: string },
+          path: string,
+          content: string,
+          ifMatch?: string,
+          source?: 'tool'
+        ): Promise<unknown>
       }
-      // The connection as the homes see it, plus the lifecycle calls the daemon makes on it at shutdown.
-      seam.cpClient = Object.assign(cp, { stop: async () => {}, emitMemoryConnectionFacts: () => {} })
-
-      // The CP's push: the binding flipped, and it carries the marker. The trigger is applying it.
-      const upsert = (memory: AgentMemoryBinding) =>
-        seam.cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: { name: 'bot-a', memory } as AgentSpec })
-      await upsert(pending())
-      await vi.waitFor(() => expect(cp.migrated).toEqual([{ agentId: AGENT }]))
-      expect(snapshot(cp.tree)).toEqual(carried(snapshot(agentDir)))
-      // Accepted: the marker is dropped locally, ahead of the CP's next push, so the CP tree is what gets served.
-      await vi.waitFor(() =>
-        expect(seam.agents.get(AGENT)?.memory).toEqual({ provider: 'managed', home: 'control-plane' })
-      )
-      await seam.memory.write({ agentId: AGENT }, 'after.md', '- lives in the Control Plane\n', undefined, 'tool')
-      expect(readFileSync(join(cp.tree, 'memory', 'after.md'), 'utf8')).toContain('lives in the Control Plane')
-      expect(existsSync(join(agentDir, 'memory', 'after.md'))).toBe(false)
-
-      // The forced return: the CP dropped its rows; the pre-switch tree on this disk moves aside, nothing is resurrected.
-      await upsert({ provider: 'managed', home: 'daemon' })
-      expect(existsSync(join(agentDir, 'memory'))).toBe(false)
-      expect(existsSync(join(agentDir, 'channels'))).toBe(false)
-      expect(existsSync(join(agentDir, 'memory-backups'))).toBe(false)
-      const archives = readdirSync(agentDir).filter((name) => name.startsWith('memory-archive-'))
-      expect(archives).toHaveLength(1)
-      expect(existsSync(join(agentDir, archives[0]!, 'memory', 'deploys.md'))).toBe(true)
-      expect(existsSync(join(agentDir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'))).toBe(true)
-      await daemon.stop()
     }
-  )
+    // The connection as the homes see it, plus the lifecycle calls the daemon makes on it at shutdown.
+    seam.cpClient = Object.assign(cp, { stop: async () => {}, emitMemoryConnectionFacts: () => {} })
+
+    // The CP's push: the binding flipped, and it carries the marker. The trigger is applying it.
+    const upsert = (memory: AgentMemoryBinding) =>
+      seam.cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: { name: 'bot-a', memory } as AgentSpec })
+    await upsert(pending())
+    await vi.waitFor(() => expect(cp.migrated).toEqual([{ agentId: AGENT }]))
+    expect(snapshot(cp.tree)).toEqual(carried(snapshot(agentDir)))
+    // Accepted: the marker is dropped locally, ahead of the CP's next push, so the CP tree is what gets served.
+    await vi.waitFor(() =>
+      expect(seam.agents.get(AGENT)?.memory).toEqual({ provider: 'managed', home: 'control-plane' })
+    )
+    await seam.memory.write({ agentId: AGENT }, 'after.md', '- lives in the Control Plane\n', undefined, 'tool')
+    expect(readFileSync(join(cp.tree, 'memory', 'after.md'), 'utf8')).toContain('lives in the Control Plane')
+    expect(existsSync(join(agentDir, 'memory', 'after.md'))).toBe(false)
+
+    // The forced return: the CP dropped its rows; the pre-switch tree on this disk moves aside, nothing is resurrected.
+    await upsert({ provider: 'managed', home: 'daemon' })
+    expect(existsSync(join(agentDir, 'memory'))).toBe(false)
+    expect(existsSync(join(agentDir, 'channels'))).toBe(false)
+    expect(existsSync(join(agentDir, 'memory-backups'))).toBe(false)
+    const archives = readdirSync(agentDir).filter((name) => name.startsWith('memory-archive-'))
+    expect(archives).toHaveLength(1)
+    expect(existsSync(join(agentDir, archives[0]!, 'memory', 'deploys.md'))).toBe(true)
+    expect(existsSync(join(agentDir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'))).toBe(true)
+    await daemon.stop()
+  })
 })


### PR DESCRIPTION
## Why

The agent-config watcher (`chokidar(agentsDir, { depth: 4, ignored })`) only ever wants `agent.json`: its callbacks are `add`/`change` into a debounced agent-config reload. But `ignoreAgentWatchPath` ignored no directories, so the watcher held a handle on every directory beneath every agent dir, including the daemon-owned memory tree. Windows refuses to rename a directory with open handles beneath it, so the forced memory-home return (`archiveMemoryTreeAside`) moved the flat `memory/` but left `channels/` and `memory-backups/` behind: a half-archived tree. The daemon-level test case for the forced return was on `it.skipIf(process.platform === 'win32')` for exactly this reason.

## What changes

- `ignoreAgentWatchPath` now ignores any path whose segment directly under an agent dir is `memory`, `channels`, `memory-backups`, `memory-dreams`, or starts with `memory-archive-`, directories and everything beneath them. The existing rules (`node_modules`, dot-prefixed segments, non-`agent.json` files) are unchanged.
- The names come from `memory/store.ts`: a new `DAEMON_OWNED_AGENT_DIRNAMES` list built from the existing dirname constants, plus `MEMORY_ARCHIVE_DIRNAME_PREFIX`. `home-migration.ts` was left untouched because a parallel change owns it; it pulls in the CP memory client, so importing it from `daemon/helpers.ts` was not the right dependency direction anyway.
- New `test/daemon-helpers.test.ts` covers each ignored directory, a nested path beneath one, an archive dir with a stamp, and that `agent.json` at the agent root and an unrelated `workspace/` are still watched.
- The daemon-level forced-return case in `test/memory-home-migration.test.ts` is un-skipped, so the Windows shard now proves the archive completes with `channels/` and `memory-backups/` included. The bounded retry inside `archiveMemoryTreeAside` is unchanged.

No doc change: the design doc does not mention the Windows limitation.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck`
- `vitest run test/memory-home-migration.test.ts test/daemon-helpers.test.ts test/reconcile-watch.test.ts test/daemon-smoke.test.ts` (94 passed)
- eslint and prettier on the touched files
- CI's `Unit Test (Windows)` job is the proof for the un-skipped case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
