### PR TITLE
fix(daemon): close microsandbox execution connections explicitly

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -249,6 +249,13 @@ travel inside its OCI image. In particular, the pool's shim startup and UID/HOME
 configuration are not a substitute for the local VM's launch settings. See the
 upstream [execution semantics](https://docs.microsandbox.dev/sandboxes/commands).
 
+Each streaming execution owns an SDK `AgentClient` connection. The daemon uses
+the pinned SDK's exec protocol and explicitly closes that client before reporting
+process completion or releasing the VM's active-execution count. Closing stdin
+sends EOF; it does not close a process that is still running. This avoids relying
+on garbage collection of the SDK's high-level exec handles, while retaining
+independent ACP streams, cancellation, backpressure, and live output limits.
+
 The first implementation uses private flat ext4 root disks and explicit
 host-bound workspace/cache mounts. The clone strategy is `auto`: preparation can
 reuse a base image, while each private disk clone can fall back from reflink to

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -59,6 +59,7 @@
     "@opentelemetry/semantic-conventions": "^1.43.0",
     "@slack/bolt": "^5.0.0",
     "@slack/web-api": "^8.1.0",
+    "cborg": "^6.1.2",
     "chokidar": "^5.0.0",
     "commander": "^15.0.0",
     "croner": "^10.0.1",

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, posix } from 'node:path'
 import { promisify } from 'node:util'
-import type { ExecHandle, ExecSink, Sandbox, SandboxHandle } from 'microsandbox'
+import type { Sandbox, SandboxHandle } from 'microsandbox'
 import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-driver.js'
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
@@ -11,6 +11,7 @@ import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-run
 import { SinkRelPathSchema } from '../shim/file-sink.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../shim/sandbox-paths.js'
 import { MICROSANDBOX_GUEST_ENTRY, MICROSANDBOX_NODE } from './guest.js'
+import { openExecStream, type MicrosandboxExecStdin, type MicrosandboxExecStream } from './exec.js'
 
 const runFile = promisify(execFile)
 const STOP_TIMEOUT_MS = 10_000
@@ -48,7 +49,7 @@ export interface MicrosandboxExecResult {
 export interface MicrosandboxManagerOptions {
   root: string
   config: { image: string; cpus: number; memoryMiB: number; diskGiB: number }
-  sdk: Pick<typeof import('microsandbox'), 'Sandbox' | 'SandboxNotFoundError'>
+  sdk: Pick<typeof import('microsandbox'), 'Sandbox' | 'SandboxNotFoundError' | 'AgentClient'>
   msbCommand: { command: string; args: string[] }
   log?: Logger
   sockets: { mcp: string; gitcred: string }
@@ -370,12 +371,13 @@ export class MicrosandboxManager {
   }
 
   private async startBridge(id: string, sandbox: Sandbox): Promise<void> {
-    const handle = await sandbox.execStreamWith(MICROSANDBOX_NODE, (exec) =>
-      exec.args([MICROSANDBOX_GUEST_ENTRY, 'sockets']).stdinPipe().tty(false)
-    )
+    const handle = await openExecStream(this.options.sdk, sandbox, MICROSANDBOX_NODE, [
+      MICROSANDBOX_GUEST_ENTRY,
+      'sockets'
+    ])
     const stdin = await handle.takeStdin()
     if (!stdin) {
-      await handle.kill()
+      await handle.close()
       throw new Error('microsandbox socket bridge did not provide a stream')
     }
     const bridge = new MicrosandboxProcess(
@@ -508,17 +510,13 @@ export class MicrosandboxManager {
         if (!output.success) throw new Error('microsandbox could not protect materialized file permissions')
       }
       options.abort?.throwIfAborted()
-      const handle = await sandbox.execStreamWith(command, (exec) =>
-        exec
-          .args(args)
-          .cwd(options.cwd ?? environment.workspaceRoot)
-          .envs(env)
-          .stdinPipe()
-          .tty(false)
-      )
+      const handle = await openExecStream(this.options.sdk, sandbox, command, args, {
+        cwd: options.cwd ?? environment.workspaceRoot,
+        env
+      })
       const stdin = await handle.takeStdin()
       if (!stdin) {
-        await handle.kill()
+        await handle.close()
         throw new Error('microsandbox did not provide process stdin')
       }
       const runtime = new MicrosandboxProcess(handle, stdin, stderr, () => {
@@ -602,11 +600,12 @@ class MicrosandboxProcess implements SpawnedRuntime {
   private discardOutput = false
   private outputCancelled = false
   private failing?: Promise<void>
+  private finishing?: Promise<void>
   private failure?: unknown
 
   constructor(
-    private readonly handle: ExecHandle,
-    private readonly stdin: ExecSink,
+    private readonly handle: MicrosandboxExecStream,
+    private readonly stdin: MicrosandboxExecStdin,
     private readonly stderr: (data: Uint8Array) => void,
     private readonly release: () => void
   ) {
@@ -644,13 +643,23 @@ class MicrosandboxProcess implements SpawnedRuntime {
     else this.listeners.add(listener)
   }
 
-  closeStdin(): Promise<void> {
-    return this.stdin.close()
+  async closeStdin(): Promise<void> {
+    if (this.finishing) return this.finishing
+    try {
+      await this.stdin.close()
+    } catch (error) {
+      if (this.finishing) return this.finishing
+      throw error
+    }
   }
 
   stop(deadlineMs: number, eofGraceMs = 0): Promise<void> {
+    if (this.finishing) return this.finishing
     if (!this.stopping) {
-      const stopping = this.stopProcess(deadlineMs, eofGraceMs)
+      const stopping = this.stopProcess(deadlineMs, eofGraceMs).catch((error: unknown) => {
+        if (this.finishing) return this.finishing
+        throw error
+      })
       this.stopping = stopping
       void stopping.catch(() => {
         if (this.stopping === stopping) this.stopping = undefined
@@ -674,23 +683,33 @@ class MicrosandboxProcess implements SpawnedRuntime {
       error = new AggregateError([error, killError], 'microsandbox process failure and cleanup failure')
       this.failure = error
     }
-    if (this.finished) return
-    this.output.error(error)
-    this.rejectExit(error)
-    this.finish()
+    await this.finish()
   }
 
-  private finish(): void {
-    this.finished = true
-    this.wakeOutput?.()
-    this.release()
-    for (const listener of this.listeners) listener()
-    this.listeners.clear()
+  private finish(code?: number): Promise<void> {
+    return (this.finishing ??= (async () => {
+      try {
+        await this.handle.close()
+      } catch (error) {
+        this.failure ??= error
+      }
+      if (this.failure !== undefined) {
+        if (!this.outputCancelled) this.output.error(this.failure)
+        this.rejectExit(this.failure)
+      } else {
+        if (!this.outputCancelled) this.output.close()
+        this.finishExit(code!)
+      }
+      this.finished = true
+      this.wakeOutput?.()
+      this.release()
+      for (const listener of this.listeners) listener()
+      this.listeners.clear()
+    })())
   }
 
   private async pump(): Promise<void> {
     for await (const event of this.handle) {
-      if (!event) throw new Error('microsandbox emitted an unsupported process failure event')
       if (event.kind === 'stdout' && !this.discardOutput) {
         while ((this.output.desiredSize ?? 0) <= 0 && !this.discardOutput && !this.finished) {
           await new Promise<void>((resolve) => {
@@ -702,14 +721,7 @@ class MicrosandboxProcess implements SpawnedRuntime {
         this.stderr(event.data)
       } else if (event.kind === 'exited') {
         if (this.finished) return
-        if (this.failure !== undefined) {
-          this.output.error(this.failure)
-          this.rejectExit(this.failure)
-        } else {
-          if (!this.outputCancelled) this.output.close()
-          this.finishExit(event.code)
-        }
-        this.finish()
+        await this.finish(event.code)
         return
       }
     }

--- a/packages/daemon/src/microsandbox/exec.ts
+++ b/packages/daemon/src/microsandbox/exec.ts
@@ -1,0 +1,91 @@
+import type { ExecEvent, Sandbox } from 'microsandbox'
+import { z } from 'zod'
+
+const MessageSchema = z.object({ v: z.literal(7), t: z.string(), p: z.instanceof(Uint8Array) })
+const DataSchema = z.object({ data: z.instanceof(Uint8Array) })
+const ErrorSchema = z.object({ message: z.string() })
+const ConfigSchema = z.object({
+  env: z.array(z.object({ key: z.string(), value: z.string() })).default([]),
+  runtime: z.object({ workdir: z.string().nullable().optional(), user: z.string().nullable().optional() })
+})
+
+// The pinned SDK exposes deterministic close on AgentClient, but not on its typed exec handles.
+export async function openExecStream(
+  sdk: Pick<typeof import('microsandbox'), 'AgentClient'>,
+  sandbox: Sandbox,
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: Record<string, string> } = {}
+) {
+  const { decode, encode } = await import('cborg')
+  const message = (type: string, payload: unknown) =>
+    Buffer.from(encode({ v: 7, t: `core.exec.${type}`, p: encode(payload) }))
+  const config = ConfigSchema.parse(await sandbox.config())
+  const env = { ...Object.fromEntries(config.env.map(({ key, value }) => [key, value])), ...options.env }
+  const client = await sdk.AgentClient.connectSandbox(sandbox.name)
+  try {
+    const stream = await client.stream(
+      2,
+      message('request', {
+        cmd: command,
+        args,
+        env: Object.entries(env).map(([key, value]) => `${key}=${value}`),
+        cwd: options.cwd ?? config.runtime.workdir ?? '/',
+        user: config.runtime.user ?? null,
+        tty: false
+      })
+    )
+    const send = (type: string, payload: unknown) => client.send(stream.id, 0, message(type, payload))
+    let closing: Promise<void> | undefined
+    let stdinTaken = false
+    let stdinClosed = false
+    return {
+      close: () => (closing ??= client.close()),
+      signal: (signal: number) => send('signal', { signal }),
+      kill: () => send('signal', { signal: 9 }),
+      async takeStdin() {
+        if (stdinTaken) return null
+        stdinTaken = true
+        return {
+          write: (data: Uint8Array) => send('stdin', { data }),
+          async close() {
+            if (stdinClosed) return
+            stdinClosed = true
+            await send('stdin', { data: new Uint8Array() })
+          }
+        }
+      },
+      async *[Symbol.asyncIterator](): AsyncGenerator<ExecEvent> {
+        for await (const frame of stream) {
+          const envelope = MessageSchema.parse(decode(frame.body))
+          const payload: unknown = decode(envelope.p)
+          switch (envelope.t) {
+            case 'core.exec.started':
+              yield { kind: 'started', ...z.object({ pid: z.number().int() }).parse(payload) }
+              break
+            case 'core.exec.stdout':
+              yield { kind: 'stdout', ...DataSchema.parse(payload) }
+              break
+            case 'core.exec.stderr':
+              yield { kind: 'stderr', ...DataSchema.parse(payload) }
+              break
+            case 'core.exec.exited':
+              yield { kind: 'exited', ...z.object({ code: z.number().int() }).parse(payload) }
+              return
+            case 'core.exec.failed':
+            case 'core.exec.stdin.error':
+              throw new Error(`microsandbox exec failed: ${ErrorSchema.parse(payload).message}`)
+            default:
+              throw new Error('microsandbox emitted an unsupported exec event')
+          }
+        }
+      }
+    }
+  } catch (error) {
+    await client.close()
+    throw error
+  }
+}
+
+export type MicrosandboxExecStream = Awaited<ReturnType<typeof openExecStream>>
+export type MicrosandboxExecStdin = NonNullable<Awaited<ReturnType<MicrosandboxExecStream['takeStdin']>>>

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runInNewContext } from 'node:vm'
+import { decode, encode } from 'cborg'
 import type { ExecEvent } from 'microsandbox'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MicrosandboxManager, type MicrosandboxManagerOptions } from '../src/microsandbox/driver.js'
@@ -11,23 +12,17 @@ import { SANDBOX_MCP_BRIDGE_ENTRY } from '../src/shim/sandbox-paths.js'
 class FakeExec {
   private readonly queue: Array<ExecEvent | undefined> = []
   private wake?: () => void
+  readonly id = 1
   readonly writes: Uint8Array[] = []
+  readonly stdin = vi.fn((_data: Uint8Array) => {})
   readonly signal = vi.fn(async (_signal: number) => this.push({ kind: 'exited', code: 0 }))
   readonly kill = vi.fn(async () => this.push({ kind: 'exited', code: 137 }))
+  readonly close = vi.fn(async () => {})
+  request?: { cmd: string; args: string[]; cwd: string; env: string[]; user: string; tty: boolean }
 
   push(event: ExecEvent | undefined): void {
     this.queue.push(event)
     this.wake?.()
-  }
-
-  async takeStdin() {
-    return {
-      write: async (data: Uint8Array) => {
-        this.writes.push(data)
-        this.push({ kind: 'stdout', data })
-      },
-      close: async () => {}
-    }
   }
 
   async *[Symbol.asyncIterator]() {
@@ -37,8 +32,13 @@ class FakeExec {
           this.wake = resolve
         })
       const event = this.queue.shift()
-      yield event
-      if (event?.kind === 'exited') return
+      const { kind, ...payload } = event ?? { kind: 'failed', message: 'guest execution failed' }
+      yield {
+        id: this.id,
+        flags: kind === 'exited' || kind === 'failed' ? 1 : 0,
+        body: Buffer.from(encode({ v: 7, t: `core.exec.${kind}`, p: encode(payload) }))
+      }
+      if (kind === 'exited' || kind === 'failed') return
     }
   }
 }
@@ -54,7 +54,11 @@ function fakeSdk() {
     readonly id = `vm-${created.length}`
     status = 'running'
     readonly processes: FakeExec[] = []
-    readonly spec = { image: 'test-image' }
+    readonly spec = {
+      image: 'test-image',
+      env: [{ key: 'PATH', value: '/image/bin' }],
+      runtime: { workdir: '/image', user: 'agent' }
+    }
     readonly stopWithTimeout = vi.fn(async () => {
       this.status = 'stopped'
       for (const process of this.processes) process.push({ kind: 'exited', code: 0 })
@@ -106,40 +110,51 @@ function fakeSdk() {
       )
       return { success: true, code: 0, stdout: () => stdout }
     })
-    async execStreamWith(_command: string, configure: (options: unknown) => unknown) {
-      let args: string[] = []
-      const options = {
-        args(value: string[]) {
-          args = value
-          return options
-        },
-        cwd() {
-          return options
-        },
-        envs() {
-          return options
-        },
-        stdinPipe() {
-          return options
-        },
-        tty() {
-          return options
-        }
-      }
-      configure(options)
-      const process = new FakeExec()
-      this.processes.push(process)
-      if (args[1] === 'sockets') process.push({ kind: 'stdout', data: Buffer.from('ready\n') })
-      else {
-        processes.push(process)
-        onRun?.(process)
-      }
-      return process
-    }
   }
 
   const sdk = {
     SandboxNotFoundError,
+    AgentClient: {
+      async connectSandbox(name: string) {
+        const sandbox = sandboxes.get(name)!
+        const process = new FakeExec()
+        return {
+          close: process.close,
+          async stream(flags: number, body: Uint8Array) {
+            const message = decode(body) as { v: number; t: string; p: Uint8Array }
+            expect(flags).toBe(2)
+            expect(message).toMatchObject({ v: 7, t: 'core.exec.request' })
+            process.request = decode(message.p) as NonNullable<FakeExec['request']>
+            sandbox.processes.push(process)
+            process.push({ kind: 'started', pid: 1 })
+            if (process.request.args[1] === 'sockets') process.push({ kind: 'stdout', data: Buffer.from('ready\n') })
+            else {
+              processes.push(process)
+              onRun?.(process)
+            }
+            return process
+          },
+          async send(id: number, flags: number, body: Uint8Array) {
+            expect(id).toBe(process.id)
+            expect(flags).toBe(0)
+            const message = decode(body) as { t: string; p: Uint8Array }
+            if (message.t === 'core.exec.stdin') {
+              const { data } = decode(message.p) as { data: Uint8Array }
+              process.stdin(data)
+              if (data.length) {
+                process.writes.push(data)
+                process.push({ kind: 'stdout', data })
+              }
+            } else {
+              expect(message.t).toBe('core.exec.signal')
+              const { signal } = decode(message.p) as { signal: number }
+              if (signal === 9) await process.kill()
+              else await process.signal(signal)
+            }
+          }
+        }
+      }
+    },
     Sandbox: {
       async get(name: string) {
         const sandbox = sandboxes.get(name)
@@ -225,23 +240,66 @@ describe('microsandbox process and VM ownership', () => {
   it('shares a VM, preserves binary ACP data, and refuses suspend while another execution is active', async () => {
     const { manager, environment, request, created, processes } = await fixture()
     const [first, second] = await Promise.all([
-      manager.driverFor(environment).launch(request),
+      manager.driverFor(environment).launch({ ...request, env: { PATH: '/session/bin' } }),
       manager.driverFor(environment).launch(request)
     ])
     expect(created).toHaveLength(1)
+    expect(created[0]!.processes[0]!.request).toMatchObject({
+      cwd: '/image',
+      env: ['PATH=/image/bin'],
+      user: 'agent'
+    })
+    expect(processes[0]!.request).toMatchObject({
+      cmd: request.command,
+      args: request.args,
+      cwd: '/workspace',
+      env: ['PATH=/session/bin'],
+      user: 'agent',
+      tty: false
+    })
+    expect(processes[1]!.request?.env).toEqual(['PATH=/image/bin'])
     const writer = first.toAgent.getWriter()
     const reader = first.fromAgent.getReader()
     const bytes = Uint8Array.of(0, 255, 10, 13, 128)
     await writer.write(bytes)
     expect((await reader.read()).value).toEqual(bytes)
     await expect(manager.suspend(environment.id)).rejects.toThrow('2 active executions')
-    await first.stop(0)
+    let releaseClose!: () => void
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve
+    })
+    processes[0]!.close.mockImplementationOnce(() => closeGate)
+    const terminal = vi.fn()
+    const exited = new Promise<void>((resolve) => first.onExit(resolve))
+    first.onExit(terminal)
+    processes[0]!.push({ kind: 'exited', code: 0 })
+    await vi.waitFor(() => expect(processes[0]!.close).toHaveBeenCalledOnce())
+    expect(terminal).not.toHaveBeenCalled()
+    const stopped = vi.fn()
+    const stdinClosed = vi.fn()
+    const stopping = first.stop(1).then(stopped)
+    const closingStdin = writer.close().then(stdinClosed)
+    await expect(manager.suspend(environment.id)).rejects.toThrow('2 active executions')
+    await second.toAgent.getWriter().write(bytes)
+    expect((await second.fromAgent.getReader().read()).value).toEqual(bytes)
+    expect(processes[1]!.close).not.toHaveBeenCalled()
+    expect(processes[0]!.signal).not.toHaveBeenCalled()
+    expect(processes[0]!.kill).not.toHaveBeenCalled()
+    expect(processes[0]!.stdin).toHaveBeenCalledExactlyOnceWith(bytes)
+    expect(stopped).not.toHaveBeenCalled()
+    expect(stdinClosed).not.toHaveBeenCalled()
+    releaseClose()
+    await Promise.all([exited, stopping, closingStdin])
+    expect(stopped).toHaveBeenCalledOnce()
+    expect(stdinClosed).toHaveBeenCalledOnce()
     await expect(manager.suspend(environment.id)).rejects.toThrow('1 active executions')
     processes[1]!.signal.mockImplementation(async () => {})
     await second.stop(1)
     expect(processes[1]!.kill).toHaveBeenCalledOnce()
+    expect(processes[1]!.close).toHaveBeenCalledOnce()
     await manager.suspendIdle(Date.now())
     expect(created[0]!.status).toBe('stopped')
+    expect(created[0]!.processes[0]!.close).toHaveBeenCalledOnce()
     expect(await manager.environmentIds()).toEqual([environment.id])
     await manager.discard(environment.id)
     expect(await manager.environmentIds()).toEqual([])
@@ -249,10 +307,24 @@ describe('microsandbox process and VM ownership', () => {
 
   it('kills an SDK failure event and releases the execution without hanging readers', async () => {
     const { manager, environment, request, processes, runWith } = await fixture()
-    runWith((process) => process.push(undefined))
+    let releaseClose!: () => void
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve
+    })
+    runWith((process) => {
+      process.close.mockImplementationOnce(() => closeGate)
+      process.push(undefined)
+    })
     const runtime = await manager.driverFor(environment).launch(request)
     const exited = new Promise<void>((resolve) => runtime.onExit(resolve))
-    await expect(runtime.fromAgent.getReader().read()).rejects.toThrow('unsupported process failure event')
+    const terminal = vi.fn()
+    runtime.onExit(terminal)
+    const read = expect(runtime.fromAgent.getReader().read()).rejects.toThrow('guest execution failed')
+    await vi.waitFor(() => expect(processes[0]!.close).toHaveBeenCalledOnce())
+    expect(terminal).not.toHaveBeenCalled()
+    await expect(manager.suspend(environment.id)).rejects.toThrow('1 active executions')
+    releaseClose()
+    await read
     await exited
     expect(processes[0]!.kill).toHaveBeenCalledOnce()
     await manager.suspend(environment.id)
@@ -320,7 +392,7 @@ describe('microsandbox process and VM ownership', () => {
     const recovered = await driver.launch(request)
     expect(created).toHaveLength(1)
     expect(vm.status).toBe('running')
-    const bytes = Buffer.from('recovered\n')
+    const bytes = new TextEncoder().encode('recovered\n')
     await recovered.toAgent.getWriter().write(bytes)
     expect((await recovered.fromAgent.getReader().read()).value).toEqual(bytes)
     await recovered.stop(0)
@@ -332,6 +404,21 @@ describe('microsandbox process and VM ownership', () => {
     runWith((process) => process.push({ kind: 'stderr', data: Buffer.from('oversized') }))
     await expect(manager.exec(environment, 'test', [], { maxBytes: 4 })).rejects.toThrow('output limit exceeded')
     expect(processes[0]!.kill).toHaveBeenCalledOnce()
+    expect(processes[0]!.close).toHaveBeenCalledOnce()
+    await manager.suspend(environment.id)
+  })
+
+  it('closes a timed-out command without closing another active stream', async () => {
+    const { manager, environment, request, processes } = await fixture()
+    const runtime = await manager.driverFor(environment).launch(request)
+    await expect(manager.exec(environment, 'test', [], { timeoutMs: 1 })).rejects.toThrow('timed out')
+    expect(processes[1]!.signal).toHaveBeenCalledWith(15)
+    expect(processes[1]!.close).toHaveBeenCalledOnce()
+    expect(processes[0]!.close).not.toHaveBeenCalled()
+    const bytes = new TextEncoder().encode('still running\n')
+    await runtime.toAgent.getWriter().write(bytes)
+    expect((await runtime.fromAgent.getReader().read()).value).toEqual(bytes)
+    await runtime.stop(0)
     await manager.suspend(environment.id)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@slack/web-api':
         specifier: ^8.1.0
         version: 8.1.1
+      cborg:
+        specifier: ^6.1.2
+        version: 6.1.2
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -4437,6 +4440,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  cborg@6.1.2:
+    resolution: {integrity: sha512-hQfFh6FuuCDoycN68FtUpjtQx5kCtxOLA8msbpJZxjtxaMqxgHl+4GNwO+0YexH/lHmVzhhAKa0ua+vtmTRoVw==}
+    hasBin: true
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -12944,6 +12951,8 @@ snapshots:
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
+
+  cborg@6.1.2: {}
 
   chalk@2.4.2:
     dependencies:


### PR DESCRIPTION
Routine Console Git polling could exhaust a microsandbox VM's 128 control connections because the SDK's high-level streaming handles release their clients only when garbage collected. Streaming executions now own the SDK's public `AgentClient` and close it before reporting completion or releasing their VM reservation.

The small exec protocol adapter preserves binary streaming, image defaults, stdin EOF, cancellation, backpressure, and live output limits. Concurrent cancellation joins a terminal cleanup already in progress. The pinned SDK still owns the transport; no worker, connection pool, scheduled GC, or cap increase is introduced.

Validation:
- All 19 microsandbox driver, guest, and launch tests passed, including delayed disposal, simultaneous stdin close/cancel, live-stream independence, timeout, and output limits.
- Daemon typecheck, targeted ESLint/Prettier, frozen dependency install, and the self-contained daemon build passed.
- The bundled production adapter completed 384 sequential commands plus 256 commands in batches of 16 beside a live interactive stream. Relay clients returned from 2 to 2, peaked at 18, and recorded zero connection-limit rejections while 2,564 JavaScript objects remained reachable. Binary I/O, environment/cwd, failed spawn, TERM/KILL, and closing a blocked read also passed.

Related to #1884. Published-daemon Console acceptance will be recorded after release.

Created by Codex . GPT-6
