### PR TITLE
fix(daemon): a forced memory-home return that happens while the daemon is offline is still archived on restart

### DIFF
--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -343,7 +343,9 @@ the agent's rows and its change log, and the daemon starts from an empty tree, t
 pre-switch local tree archived aside rather than resurrected (a snapshot from before
 the switch is not the memory the agent has been using since): `memory/`, `channels/`
 and `memory-backups/` move under `<agent dir>/memory-archive-<timestamp>/` beside
-them, and `memory-dreams/` stays, since staging belongs to the host. The console offers the
+them, and `memory-dreams/` stays, since staging belongs to the host. The daemon records the
+last home it applied per agent in its local store, so a return that happens while it is
+offline is still archived on its next start rather than served again. The console offers the
 selector one way and the forced return behind its own confirmation; on the pool there
 is no return at all, since `daemon` is refused there. `daemon` stays the default for
 now; making `control-plane` the default is a later decision, not this one.

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -211,6 +211,7 @@ export async function applyReconcileSnapshot(host: ConfigApplyHost, snap: Regist
             try {
               if (action === 'remove') {
                 cpAgents.remove(agentId)
+                await host.store().deleteMemoryHomeApplied(agentId)
                 await host.discardClusterSandbox(agentId)
                 host.moveStageMetadata().delete(agentId)
                 host.moveStagedAgents().delete(agentId)
@@ -409,6 +410,7 @@ export function applyAgentRemove(host: ConfigApplyHost, agentId: string): Promis
       if (!cpAgents) throw new Error('agent registry is not ready')
       try {
         cpAgents.remove(agentId)
+        await host.store().deleteMemoryHomeApplied(agentId)
       } catch (cleanupError) {
         if (removal.markerError) {
           throw new AggregateError(

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3537,9 +3537,7 @@ export class Daemon {
       if (previous?.allowRuntimeChangesInChat === true && !a.allowRuntimeChangesInChat) {
         this.permissions.disableChatPermissionSurfaces(a.id)
       }
-      // A forced return of the memory home archives the pre-switch tree BEFORE the binding is live: while the home was
-      // still `control-plane`, nothing on this disk was being written, so the move races no writer.
-      if (previous && memoryHomeReturnedToDaemon(previous, a)) await this.archiveMemoryHomeAside(a as LoadedAgent)
+      await this.applyMemoryHomeBinding(previous, a as LoadedAgent)
       // ALWAYS publish fresh config first, so live reads — output.mode (per dispatch),
       // per-session cwd/tools, routing (mergedRules reads this.agents) — see the new config.
       this.agents.set(a.id, a as LoadedAgent)
@@ -3615,6 +3613,7 @@ export class Daemon {
       if (change.integrations) connectionsDirty = true
     }
     for (const a of toStart) {
+      await this.applyMemoryHomeBinding(undefined, a as LoadedAgent)
       this.agents.set(a.id, a as LoadedAgent)
       // Rows may have been retained while this daemon did not own the agent. Adding it
       // already paused is still an explicit operator stop, so terminally discard that
@@ -3840,6 +3839,14 @@ export class Daemon {
   // let reconcile rebuild the session boundary, as it does for any memory-binding change.
   private async onMemoryHomeMigrated(agentId: string): Promise<void> {
     if (this.cpAgents?.settleMemoryHomeMigration(agentId)) await this.flushReconcile()
+  }
+
+  // The forced return archives the pre-switch tree before the binding is live (nothing wrote this disk while the home was `control-plane`); `previous` is this process's binding online, and after a restart the durable last-applied home stands in, so a return that happened while this daemon was offline is still archived rather than resurrected.
+  private async applyMemoryHomeBinding(previous: Pick<Agent, 'memory'> | undefined, next: LoadedAgent): Promise<void> {
+    const lastHome = previous ? undefined : await this.store.getMemoryHomeApplied(next.id)
+    const last = previous ?? (lastHome && { memory: { provider: 'managed' as const, home: lastHome } })
+    if (last && memoryHomeReturnedToDaemon(last, next)) await this.archiveMemoryHomeAside(next)
+    if (next.memory?.provider === 'managed') await this.store.setMemoryHomeApplied(next.id, next.memory.home)
   }
 
   // The forced return (memory-evolution.md §3.2.1): the CP has dropped its rows, so the tree this disk kept from before

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3,6 +3,7 @@ import type { SQLInputValue } from 'node:sqlite'
 import { chmodSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
 import {
+  ManagedMemoryHome,
   QuotedMessageSchema,
   SessionImageAttachment as SessionImageAttachmentSchema,
   type DreamInfo,
@@ -1637,6 +1638,11 @@ export class LocalStore {
       CREATE TABLE IF NOT EXISTS sandbox_generations (
         agentId TEXT PRIMARY KEY,
         generation INTEGER NOT NULL
+      );
+      -- The managed memory home this daemon last applied per agent: what a forced return is detected against on the first roster after a restart (memory-evolution.md §3.2.1).
+      CREATE TABLE IF NOT EXISTS memory_home_applied (
+        agentId TEXT PRIMARY KEY,
+        memoryHome TEXT NOT NULL          -- 'daemon' | 'control-plane'
       );
       CREATE TABLE IF NOT EXISTS duty_write_fence (
         groupId TEXT PRIMARY KEY,
@@ -5025,6 +5031,28 @@ export class LocalStore {
 
   async deleteRuntimeCommands(agentId: string): Promise<void> {
     await this.db.prepare('DELETE FROM runtime_commands WHERE agentId = ?').run(agentId)
+  }
+
+  /** The managed memory home this daemon last applied for an agent; undefined when no managed binding was ever applied. */
+  async getMemoryHomeApplied(agentId: string): Promise<ManagedMemoryHome | undefined> {
+    const row = (await this.db.prepare('SELECT memoryHome FROM memory_home_applied WHERE agentId = ?').get(agentId)) as
+      { memoryHome: string } | undefined
+    const parsed = ManagedMemoryHome.safeParse(row?.memoryHome)
+    return parsed.success ? parsed.data : undefined
+  }
+
+  /** Record the managed memory home just applied for an agent (latest-wins). */
+  async setMemoryHomeApplied(agentId: string, memoryHome: ManagedMemoryHome): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO memory_home_applied (agentId, memoryHome) VALUES (?, ?)
+         ON CONFLICT(agentId) DO UPDATE SET memoryHome = excluded.memoryHome`
+      )
+      .run(agentId, memoryHome)
+  }
+
+  async deleteMemoryHomeApplied(agentId: string): Promise<void> {
+    await this.db.prepare('DELETE FROM memory_home_applied WHERE agentId = ?').run(agentId)
   }
 
   async isChannelIntroSeeded(integrationId: string): Promise<boolean> {

--- a/packages/daemon/src/store/postgres-dialect.ts
+++ b/packages/daemon/src/store/postgres-dialect.ts
@@ -91,6 +91,7 @@ export const canonicalColumns = [
   'mainAgentId',
   'mainSessionKey',
   'manifestDigest',
+  'memoryHome',
   'memoryProvider',
   'mergeRequestIid',
   'mintedAt',

--- a/packages/daemon/test/memory-home-migration.test.ts
+++ b/packages/daemon/test/memory-home-migration.test.ts
@@ -525,3 +525,149 @@ describe('the daemon runs it', () => {
     }
   )
 })
+
+describe('the daemon remembers the last home it applied', () => {
+  type Seam = {
+    cpConfigApply(): {
+      applyAgentUpsert(upsert: { agentId: string; spec: AgentSpec }): Promise<unknown>
+      applyAgentRemove(agentId: string): Promise<void>
+    }
+    store: { getMemoryHomeApplied(agentId: string): Promise<string | undefined> }
+  }
+
+  const bootRoot = (): string => {
+    const root = newDir('ac-migrate-durable-')
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { claude: { command: 'node', args: [] } }
+      })
+    )
+    const agentDir = join(root, 'agents', AGENT)
+    mkdirSync(agentDir, { recursive: true })
+    writeFileSync(
+      join(agentDir, 'agent.json'),
+      JSON.stringify({
+        id: AGENT,
+        name: 'bot-a',
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(agentDir, 'ws') },
+        integrations: [],
+        output: { mode: 'medium' }
+      })
+    )
+    return root
+  }
+
+  const idleHost = (agent: { id: string }) =>
+    ({
+      id: agent.id,
+      start: vi.fn().mockResolvedValue(undefined),
+      newSession: vi.fn(),
+      prompt: vi.fn(),
+      cancel: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined)
+    }) as never
+
+  // A daemon over `root`, started, with the CP's push reduced to applying a binding for the one agent.
+  async function boot(
+    root: string
+  ): Promise<{ daemon: Daemon; seam: Seam; upsert(memory: AgentMemoryBinding): Promise<unknown> }> {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: idleHost })
+    await daemon.start()
+    const seam = daemon as unknown as Seam
+    const upsert = (memory: AgentMemoryBinding) =>
+      seam.cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: { name: 'bot-a', memory } as AgentSpec })
+    return { daemon, seam, upsert }
+  }
+
+  const cpHome = (): AgentMemoryBinding => ({ provider: 'managed', home: 'control-plane' })
+  const daemonHome = (): AgentMemoryBinding => ({ provider: 'managed', home: 'daemon' })
+
+  function archives(agentDir: string): string[] {
+    return readdirSync(agentDir).filter((name) => name.startsWith('memory-archive-'))
+  }
+
+  /** The three trees the forced return would move, by relative path. */
+  function trees(agentDir: string): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(snapshot(agentDir)).filter(([path]) => /^(memory|channels|memory-backups)\//.test(path))
+    )
+  }
+
+  function expectArchived(agentDir: string): void {
+    expect(existsSync(join(agentDir, 'memory'))).toBe(false)
+    expect(existsSync(join(agentDir, 'channels'))).toBe(false)
+    expect(existsSync(join(agentDir, 'memory-backups'))).toBe(false)
+    const [archive, ...rest] = archives(agentDir)
+    expect(rest).toEqual([])
+    expect(existsSync(join(agentDir, archive!, 'memory', 'deploys.md'))).toBe(true)
+    expect(existsSync(join(agentDir, archive!, 'channels', CHANNEL, 'memory', 'notes.md'))).toBe(true)
+    expect(existsSync(join(agentDir, archive!, 'memory-backups', 'b1', 'memory', 'MEMORY.md'))).toBe(true)
+    expect(existsSync(join(agentDir, 'memory-dreams', 'drm-1', 'memory', 'MEMORY.md'))).toBe(true)
+  }
+
+  // Not on Windows for the same reason as above: the agent-config watcher holds `channels/` open while it is moved.
+  const onPosix = it.skipIf(process.platform === 'win32')
+
+  onPosix('online, the return is still detected against the binding this process holds', async () => {
+    const root = bootRoot()
+    const agentDir = join(root, 'agents', AGENT)
+    await seedSource(agentDir)
+    const { daemon, seam, upsert } = await boot(root)
+    await upsert(cpHome())
+    expect(await seam.store.getMemoryHomeApplied(AGENT)).toBe('control-plane')
+    await upsert(daemonHome())
+    expectArchived(agentDir)
+    expect(await seam.store.getMemoryHomeApplied(AGENT)).toBe('daemon')
+    await daemon.stop()
+  })
+
+  onPosix(
+    'offline, the return arrives on the first roster after a restart and the pre-switch tree is archived',
+    async () => {
+      const root = bootRoot()
+      const agentDir = join(root, 'agents', AGENT)
+      await seedSource(agentDir)
+      const first = await boot(root)
+      await first.upsert(cpHome())
+      await first.daemon.stop()
+
+      // The forced return happened while this daemon was down: the restarted process has never seen `control-plane`.
+      const second = await boot(root)
+      await second.upsert(daemonHome())
+      expectArchived(agentDir)
+      expect(await second.seam.store.getMemoryHomeApplied(AGENT)).toBe('daemon')
+      await second.daemon.stop()
+    }
+  )
+
+  it('daemon after daemon across a restart archives nothing', async () => {
+    const root = bootRoot()
+    const agentDir = join(root, 'agents', AGENT)
+    await seedSource(agentDir)
+    const before = trees(agentDir)
+    const first = await boot(root)
+    await first.upsert(daemonHome())
+    await first.daemon.stop()
+
+    const second = await boot(root)
+    await second.upsert(daemonHome())
+    expect(archives(agentDir)).toEqual([])
+    expect(trees(agentDir)).toEqual(before)
+    await second.daemon.stop()
+  })
+
+  it('drops the record when the agent is removed from this daemon', async () => {
+    const root = bootRoot()
+    const { daemon, seam, upsert } = await boot(root)
+    await upsert(cpHome())
+    expect(await seam.store.getMemoryHomeApplied(AGENT)).toBe('control-plane')
+    await seam.cpConfigApply().applyAgentRemove(AGENT)
+    expect(await seam.store.getMemoryHomeApplied(AGENT)).toBeUndefined()
+    await daemon.stop()
+  })
+})


### PR DESCRIPTION
## Why

The forced return of the managed memory home (`control-plane` → `daemon`, memory-evolution.md §3.2.1) keeps nothing: the CP drops its rows and the daemon must archive the pre-switch local tree aside rather than serve it again. The daemon detected that return in `runReconcile()` by comparing the incoming binding against the one **this process** held in memory. That is enough while the daemon is online. When the return is applied while the daemon is offline, the restarted process receives `home: 'daemon'` on its first roster with no previous binding at all — nothing local is persisted for a CP agent beyond the id marker — so nothing archived the tree and the old `memory/` was resurrected, exactly what the design forbids.

## Where the last home is now recorded

A small durable row in the daemon's local store: table `memory_home_applied (agentId PRIMARY KEY, memoryHome)`, with `get/set/deleteMemoryHomeApplied` on `LocalStore`. It is a new table, so it lives in the `CREATE IF NOT EXISTS` block with no schema-version bump. The row is upserted whenever a managed binding is applied (both the `toChange` and `toStart` paths) and deleted where the agent is removed from this daemon (`agent/remove` and the reconcile-snapshot drop), alongside the registry removal that deletes its data root.

## How the boot-time check uses it

`applyMemoryHomeBinding(previous, next)` is now the one seam for both reconcile paths. With an in-memory `previous` (online change) it compares exactly as before. Without one (first roster after boot) it reads the durable row and, when that says `control-plane` and the incoming managed binding says `daemon`, runs the same `archiveMemoryHomeAside()` before the agent is stored. `daemon` after `daemon` archives nothing; a `control-plane` binding only updates the row. `--k8s` stays a no-op inside `archiveMemoryHomeAside` as before.

## What stays byte-for-byte

The online detection (`memoryHomeReturnedToDaemon(previous, next)` against `this.agents`), the archive itself (`archiveMemoryTreeAside`), the migration copy, and the CP are untouched. The design doc gains one sentence in §3.2.1.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` clean; eslint and prettier clean on touched files.
- `test/memory-home-migration.test.ts` (new `describe` at the end: online return, offline return across a restart, `daemon` after `daemon` across a restart, record dropped on removal), `test/cp/cp-agent-registry.test.ts`, `test/local-store.test.ts`, `test/reconciler.test.ts`: 147 passed.
- Mutation check: with the boot-time lookup replaced by a plain record write, the offline case fails; restored, it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
