### PR TITLE
fix(daemon): drain microsandbox terminal events before disposal

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -255,6 +255,10 @@ process completion or releasing the VM's active-execution count. Closing stdin
 sends EOF; it does not close a process that is still running. This avoids relying
 on garbage collection of the SDK's high-level exec handles, while retaining
 independent ACP streams, cancellation, backpressure, and live output limits.
+After an output-limit failure, the daemon kills the process and drains its
+terminal event before closing: the pinned relay can otherwise reuse the client
+ID while old output is still arriving. Losing transport before that terminal
+event fences and stops the VM before another execution can reuse it.
 
 The first implementation uses private flat ext4 root disks and explicit
 host-bound workspace/cache mounts. The clone strategy is `auto`: preparation can

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -61,7 +61,7 @@ interface EnvironmentState {
   sandbox: Promise<Sandbox>
   active: number
   closing?: Promise<void>
-  bridgeFailed?: boolean
+  failed?: boolean
   processes: Set<MicrosandboxProcess>
   pending: Set<Promise<void>>
   lastUsed: number
@@ -384,7 +384,8 @@ export class MicrosandboxManager {
       handle,
       stdin,
       (data) => process.stderr.write(data),
-      () => {}
+      () => {},
+      () => this.stopFailedEnvironment(id)
     )
     try {
       const reader = bridge.fromAgent.getReader()
@@ -409,11 +410,7 @@ export class MicrosandboxManager {
         if (this.bridges.get(id) === bridge) {
           this.bridges.delete(id)
           this.options.log?.error(`microsandbox: socket bridge exited for ${id}`)
-          const state = this.environments.get(id)
-          if (state) {
-            state.bridgeFailed = true
-            this.stopFailedEnvironment(id)
-          }
+          this.stopFailedEnvironment(id)
         }
       })
     } catch (error) {
@@ -423,6 +420,8 @@ export class MicrosandboxManager {
   }
 
   private stopFailedEnvironment(id: string): void {
+    const state = this.environments.get(id)
+    if (state) state.failed = true
     void this.closeEnvironment(id, false, true).catch((error: unknown) => {
       this.options.log?.error(`microsandbox: failed to stop environment ${id}: ${String(error)}`)
     })
@@ -432,9 +431,9 @@ export class MicrosandboxManager {
     if (this.closed) throw new Error('microsandbox manager is shutting down')
     let state = this.environments.get(environment.id)
     if (state?.closing) throw new Error(`microsandbox environment ${environment.id} is stopping`)
-    if (state?.bridgeFailed) {
+    if (state?.failed) {
       this.stopFailedEnvironment(environment.id)
-      throw new Error(`microsandbox environment ${environment.id} socket bridge failed; stopping before retry`)
+      throw new Error(`microsandbox environment ${environment.id} transport failed; stopping before retry`)
     }
     const spec = this.spec(environment)
     if (state && state.spec !== spec)
@@ -519,10 +518,20 @@ export class MicrosandboxManager {
         await handle.close()
         throw new Error('microsandbox did not provide process stdin')
       }
-      const runtime = new MicrosandboxProcess(handle, stdin, stderr, () => {
-        state.processes.delete(runtime)
-        release()
-      })
+      if (state.failed || state.closing) {
+        await handle.close()
+        throw new Error(`microsandbox environment ${environment.id} is stopping`)
+      }
+      const runtime = new MicrosandboxProcess(
+        handle,
+        stdin,
+        stderr,
+        () => {
+          state.processes.delete(runtime)
+          release()
+        },
+        () => this.stopFailedEnvironment(environment.id)
+      )
       state.processes.add(runtime)
       return runtime
     } catch (error) {
@@ -607,7 +616,8 @@ class MicrosandboxProcess implements SpawnedRuntime {
     private readonly handle: MicrosandboxExecStream,
     private readonly stdin: MicrosandboxExecStdin,
     private readonly stderr: (data: Uint8Array) => void,
-    private readonly release: () => void
+    private readonly release: () => void,
+    private readonly transportFailure: () => void
   ) {
     this.exited = new Promise((resolve, reject) => {
       this.finishExit = resolve
@@ -635,7 +645,10 @@ class MicrosandboxProcess implements SpawnedRuntime {
       },
       { highWaterMark: 64 * 1024, size: (chunk) => chunk.byteLength }
     )
-    void this.pump().catch((error: unknown) => this.fail(error))
+    void this.pump().catch((error: unknown) => {
+      this.failure ??= error
+      return this.finish()
+    })
   }
 
   onExit(listener: () => void): void {
@@ -677,17 +690,17 @@ class MicrosandboxProcess implements SpawnedRuntime {
     this.failure = error
     this.discardOutput = true
     this.wakeOutput?.()
-    try {
-      await this.handle.kill()
-    } catch (killError) {
-      error = new AggregateError([error, killError], 'microsandbox process failure and cleanup failure')
-      this.failure = error
-    }
-    await this.finish()
+    void this.handle.kill().catch((killError: unknown) => {
+      if (this.finishing) return this.finishing
+      this.failure = new AggregateError([error, killError], 'microsandbox process failure and cleanup failure')
+      return this.finish()
+    })
+    if (!(await this.waitExit(STOP_TIMEOUT_MS))) await this.finish()
   }
 
   private finish(code?: number): Promise<void> {
     return (this.finishing ??= (async () => {
+      if (!this.handle.terminal) this.transportFailure()
       try {
         await this.handle.close()
       } catch (error) {
@@ -717,8 +730,12 @@ class MicrosandboxProcess implements SpawnedRuntime {
           })
         }
         if (!this.discardOutput && !this.finished) this.output.enqueue(event.data)
-      } else if (event.kind === 'stderr') {
-        this.stderr(event.data)
+      } else if (event.kind === 'stderr' && !this.discardOutput) {
+        try {
+          this.stderr(event.data)
+        } catch (error) {
+          void this.fail(error)
+        }
       } else if (event.kind === 'exited') {
         if (this.finished) return
         await this.finish(event.code)

--- a/packages/daemon/src/microsandbox/exec.ts
+++ b/packages/daemon/src/microsandbox/exec.ts
@@ -39,7 +39,11 @@ export async function openExecStream(
     let closing: Promise<void> | undefined
     let stdinTaken = false
     let stdinClosed = false
+    let terminal = false
     return {
+      get terminal() {
+        return terminal
+      },
       close: () => (closing ??= client.close()),
       signal: (signal: number) => send('signal', { signal }),
       kill: () => send('signal', { signal: 9 }),
@@ -57,6 +61,7 @@ export async function openExecStream(
       },
       async *[Symbol.asyncIterator](): AsyncGenerator<ExecEvent> {
         for await (const frame of stream) {
+          terminal ||= (frame.flags & 1) !== 0
           const envelope = MessageSchema.parse(decode(frame.body))
           const payload: unknown = decode(envelope.p)
           switch (envelope.t) {

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -10,7 +10,7 @@ import { MICROSANDBOX_NODE } from '../src/microsandbox/guest.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../src/shim/sandbox-paths.js'
 
 class FakeExec {
-  private readonly queue: Array<ExecEvent | undefined> = []
+  private readonly queue: Array<ExecEvent | Error | undefined> = []
   private wake?: () => void
   readonly id = 1
   readonly writes: Uint8Array[] = []
@@ -20,7 +20,7 @@ class FakeExec {
   readonly close = vi.fn(async () => {})
   request?: { cmd: string; args: string[]; cwd: string; env: string[]; user: string; tty: boolean }
 
-  push(event: ExecEvent | undefined): void {
+  push(event: ExecEvent | Error | undefined): void {
     this.queue.push(event)
     this.wake?.()
   }
@@ -32,6 +32,7 @@ class FakeExec {
           this.wake = resolve
         })
       const event = this.queue.shift()
+      if (event instanceof Error) throw event
       const { kind, ...payload } = event ?? { kind: 'failed', message: 'guest execution failed' }
       yield {
         id: this.id,
@@ -48,7 +49,7 @@ function fakeSdk() {
   const sandboxes = new Map<string, FakeSandbox>()
   const created: FakeSandbox[] = []
   const processes: FakeExec[] = []
-  let onRun: ((process: FakeExec) => void) | undefined
+  let onRun: ((process: FakeExec) => void | Promise<void>) | undefined
 
   class FakeSandbox {
     readonly id = `vm-${created.length}`
@@ -130,7 +131,7 @@ function fakeSdk() {
             if (process.request.args[1] === 'sockets') process.push({ kind: 'stdout', data: Buffer.from('ready\n') })
             else {
               processes.push(process)
-              onRun?.(process)
+              await onRun?.(process)
             }
             return process
           },
@@ -208,7 +209,7 @@ function fakeSdk() {
     sdk,
     created,
     processes,
-    runWith: (callback: (process: FakeExec) => void) => {
+    runWith: (callback: (process: FakeExec) => void | Promise<void>) => {
       onRun = callback
     }
   }
@@ -305,7 +306,7 @@ describe('microsandbox process and VM ownership', () => {
     expect(await manager.environmentIds()).toEqual([])
   })
 
-  it('kills an SDK failure event and releases the execution without hanging readers', async () => {
+  it('closes a terminal failure before releasing the execution without hanging readers', async () => {
     const { manager, environment, request, processes, runWith } = await fixture()
     let releaseClose!: () => void
     const closeGate = new Promise<void>((resolve) => {
@@ -326,7 +327,7 @@ describe('microsandbox process and VM ownership', () => {
     releaseClose()
     await read
     await exited
-    expect(processes[0]!.kill).toHaveBeenCalledOnce()
+    expect(processes[0]!.kill).not.toHaveBeenCalled()
     await manager.suspend(environment.id)
   })
 
@@ -386,7 +387,7 @@ describe('microsandbox process and VM ownership', () => {
     expect(terminal).toHaveBeenCalledOnce()
     expect(await manager.environmentIds()).toEqual([environment.id])
 
-    await expect(driver.launch(request)).rejects.toThrow('socket bridge failed')
+    await expect(driver.launch(request)).rejects.toThrow('transport failed')
     await manager.suspend(environment.id)
     expect(vm.status).toBe('stopped')
     const recovered = await driver.launch(request)
@@ -399,13 +400,64 @@ describe('microsandbox process and VM ownership', () => {
     await manager.discard(environment.id)
   })
 
-  it('enforces output bounds by killing the guest command', async () => {
+  it('drains the killed command before releasing its connection after exceeding output bounds', async () => {
     const { manager, environment, processes, runWith } = await fixture()
-    runWith((process) => process.push({ kind: 'stderr', data: Buffer.from('oversized') }))
-    await expect(manager.exec(environment, 'test', [], { maxBytes: 4 })).rejects.toThrow('output limit exceeded')
-    expect(processes[0]!.kill).toHaveBeenCalledOnce()
+    runWith((process) => {
+      process.kill.mockImplementationOnce(async () => {})
+      process.push({ kind: 'stderr', data: Buffer.from('oversized') })
+    })
+    const execution = expect(manager.exec(environment, 'test', [], { maxBytes: 4 })).rejects.toThrow(
+      'output limit exceeded'
+    )
+    await vi.waitFor(() => expect(processes[0]!.kill).toHaveBeenCalledOnce())
+    expect(processes[0]!.close).not.toHaveBeenCalled()
+    await expect(manager.suspend(environment.id)).rejects.toThrow('1 active executions')
+    processes[0]!.push({ kind: 'stdout', data: Buffer.from('late output') })
+    processes[0]!.push({ kind: 'exited', code: 137 })
+    await execution
     expect(processes[0]!.close).toHaveBeenCalledOnce()
     await manager.suspend(environment.id)
+  })
+
+  it('stops a VM after transport failure before allowing another execution', async () => {
+    const { manager, environment, request, created, processes, runWith } = await fixture()
+    const driver = manager.driverFor(environment)
+    const runtime = await driver.launch(request)
+    const vm = created[0]!
+    let releaseOpening!: () => void
+    const openingGate = new Promise<void>((resolve) => {
+      releaseOpening = resolve
+    })
+    runWith(() => openingGate)
+    const opening = expect(driver.launch(request)).rejects.toThrow('is stopping')
+    await vi.waitFor(() => expect(processes).toHaveLength(2))
+    let releaseStop!: () => void
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve
+    })
+    vm.stopWithTimeout.mockImplementationOnce(async () => {
+      await stopGate
+      vm.status = 'stopped'
+    })
+    const read = expect(runtime.fromAgent.getReader().read()).rejects.toThrow('transport disconnected')
+    processes[0]!.push(new Error('transport disconnected'))
+    await read
+    expect(processes[0]!.close).toHaveBeenCalledOnce()
+    await expect(driver.launch(request)).rejects.toThrow('is stopping')
+    expect(vm.stopWithTimeout).not.toHaveBeenCalled()
+    releaseOpening()
+    await opening
+    expect(processes[1]!.close).toHaveBeenCalledOnce()
+    await vi.waitFor(() => expect(vm.stopWithTimeout).toHaveBeenCalledOnce())
+    expect(processes).toHaveLength(2)
+    releaseStop()
+    await manager.suspend(environment.id)
+    expect(vm.status).toBe('stopped')
+    const recovered = await driver.launch(request)
+    expect(vm.status).toBe('running')
+    expect(created).toHaveLength(1)
+    await recovered.stop(0)
+    await manager.discard(environment.id)
   })
 
   it('closes a timed-out command without closing another active stream', async () => {


### PR DESCRIPTION
After an output-limit failure, closing a microsandbox connection immediately after sending SIGKILL can deliver the old command's output and exit event to the next command. The pinned relay reuses client IDs before the guest has finished terminating the old process. A real-VM probe reproduced `sleep 30` returning an unrelated exit event and stale stderr before cancellation.

Keep draining the killed process until its terminal event, then close the client and release the execution. Cleanup has a deadline covering both the kill send and terminal drain. If transport is lost or termination cannot be confirmed, fence and stop the VM before allowing reuse; also reject launches already being prepared when the fence occurs. The retained disk remains available after restart.

Follow-up to #1894; related to #1884. The SDK connection cap, auth handling, and default SRT behavior are unchanged.

Validation:
- All 20 microsandbox driver, guest, and launch tests passed, including delayed terminal disposal, concurrent in-flight launch fencing, and retained-VM recovery.
- Daemon typecheck, ESLint/Prettier, and the self-contained daemon build passed.
- Real manager/guest-bridge stress: 192 sequential plus 64 concurrent executions beside a live stream; clients returned from 3 to 3, peak 19, no connection-limit rejection or forced GC.
- Repeated timeout/stdout-limit/stderr-limit/failure/cancellation chains passed without stale output. Reader cancellation, TERM/KILL, retained restart, and forced transport-loss recovery also passed with the test file preserved on disk.

Created by Codex . GPT-6
