### PR TITLE
fix(web): the Memory tab does not wake a sandbox for a Control-Plane memory home

### DIFF
--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -21,7 +21,8 @@ const api = vi.hoisted(() => ({
   listAgentMemory: vi.fn(),
   acceptDreamSkill: vi.fn(),
   dismissDreamSkill: vi.fn(),
-  fetchDreamSkill: vi.fn()
+  fetchDreamSkill: vi.fn(),
+  wakeAgent: vi.fn()
 }))
 
 vi.mock('@/lib/api', () => ({
@@ -65,6 +66,7 @@ const dream = (over: Partial<Record<string, unknown>> = {}) => ({
 beforeEach(() => {
   for (const [key, fn] of Object.entries(api)) if (key !== 'ApiError') (fn as ReturnType<typeof vi.fn>).mockReset()
   api.listDreams.mockResolvedValue([])
+  api.wakeAgent.mockResolvedValue({ state: 'resumed' })
   api.startDream.mockResolvedValue(dream({ status: 'pending' }))
   api.listDreamFiles.mockResolvedValue({
     exists: true,
@@ -255,6 +257,39 @@ describe('DreamPanel', () => {
     // The store review token from listDreamFiles is echoed on adopt (task #36 Phase B).
     expect(api.adoptDream).toHaveBeenCalledWith(AGENT, 'drm-1', false, 'sha256:store')
     expect(host.textContent).toContain('Outdated proposals were moved to History')
+  })
+
+  it('wakes the sandbox when the staged store refuses as asleep, then reads it once the pod answers', async () => {
+    // Dream staging stays on the pod whatever the memory home (#1078): a Control-Plane-home agent's Memory tab no
+    // longer wakes on open, so the review presses the wake itself and polls the listing until the pod answers.
+    vi.useFakeTimers()
+    try {
+      api.listDreams.mockResolvedValue([dream()])
+      api.listDreamFiles.mockRejectedValueOnce(
+        Object.assign(new FakeApiError(503), { code: 'WORKSPACE_SANDBOX_UNAVAILABLE' })
+      )
+      const host = await render()
+
+      await act(async () => button(host, 'Review')?.click())
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(api.wakeAgent).toHaveBeenCalledWith(AGENT)
+      expect(host.textContent).toContain('Starting the agent’s sandbox')
+      // The refusal is a state, not an error line.
+      expect(host.textContent).not.toContain('http 503')
+
+      // The wake answered; the first poll re-issues the listing, which the pod now serves.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_100)
+      })
+      const lineDiff = host.querySelector('table[aria-label="Line changes"]')
+      expect(lineDiff?.querySelector('[data-diff-kind="add"]')?.textContent).toContain('# Memory (rebuilt)')
+      expect(host.textContent).not.toContain('Starting the agent’s sandbox')
+      expect(api.wakeAgent).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('discards a ready dream from its row without making the user open review', async () => {

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -562,6 +562,43 @@ describe('DreamPanel', () => {
     vi.useRealTimers()
   })
 
+  it('wakes the sandbox when a suggested skill’s staged body refuses as asleep, then enables Accept once it loads', async () => {
+    // The skill body is staged content on the pod too; an adopted dream has no Review button, so this read
+    // must carry its own wake rather than lean on the memory-store review's.
+    vi.useFakeTimers()
+    try {
+      const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+      api.listDreams.mockResolvedValue([dream({ status: 'adopted', skills })])
+      api.fetchDreamSkill.mockRejectedValueOnce(
+        Object.assign(new FakeApiError(503), { code: 'WORKSPACE_SANDBOX_UNAVAILABLE' })
+      )
+      const host = await render()
+      const details = host.querySelector<HTMLDetailsElement>('details')!
+      await act(async () => {
+        details.open = true
+        details.dispatchEvent(new Event('toggle'))
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(api.wakeAgent).toHaveBeenCalledWith(AGENT)
+      expect(host.textContent).toContain('Starting the agent’s sandbox')
+      expect(host.textContent).not.toContain('http 503')
+      expect(button(host, 'Accept')?.disabled).toBe(true)
+
+      // The wake answered; the first poll re-issues the read, the body renders, and Accept opens up.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_100)
+      })
+      expect(host.textContent).toContain('echo deploying')
+      expect(host.textContent).not.toContain('Starting the agent’s sandbox')
+      expect(button(host, 'Accept')?.disabled).toBe(false)
+      expect(api.wakeAgent).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps Accept disabled while the body is loading, and on error or missing staging', async () => {
     const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
     api.listDreams.mockResolvedValue([dream({ skills })])

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -553,6 +553,46 @@ export function DreamPanel({
   )
 }
 
+/**
+ * What every staged-content read shares (#1078): staging lives on the agent's pod whatever its memory home, so a
+ * read refused with the asleep code is the asleep state — the pod is woken once, the read re-issued (`attempt`) until
+ * it answers, and the shared notice drawn in place of the error line. The Memory tab no longer presses that wake on
+ * open for a Control-Plane home, so the staged surfaces press it themselves.
+ */
+function useStagedRead(agentId: string, loaded: boolean) {
+  const [error, setError] = useState<string | null>(null)
+  const [asleep, setAsleep] = useState(false)
+  const [attempt, setAttempt] = useState(0)
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+  const readState: SandboxReadState = asleep ? 'asleep' : error ? 'failed' : loaded ? 'ready' : 'pending'
+  const wake = useSandboxWake(agentId, readState, retry)
+  const reset = useCallback(() => {
+    setError(null)
+    setAsleep(false)
+  }, [])
+  const refused = useCallback((e: unknown, fallback: string) => {
+    if (e instanceof ApiError && e.code === SANDBOX_ASLEEP_CODE) setAsleep(true)
+    else setError(e instanceof Error ? e.message : fallback)
+  }, [])
+  const asleepNotice = asleep ? (
+    wake.phase === 'starting' ? (
+      <SandboxStartingNotice compact />
+    ) : (
+      <SandboxAsleepNotice
+        wake={wake}
+        startable
+        compact
+        notice={
+          <div className="px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-secondary)">
+            {DREAM_SANDBOX_ASLEEP_NOTICE}
+          </div>
+        }
+      />
+    )
+  ) : null
+  return { attempt, error, asleepNotice, reset, refused }
+}
+
 /** Line diff of one staged file against what is live now, for a completed dream. */
 function DreamReview({
   agentId,
@@ -578,17 +618,7 @@ function DreamReview({
   const [staged, setStaged] = useState<string>('')
   const [live, setLive] = useState<string>('')
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  // Staging lives on the pod whatever the memory home (#1078): a read refused as asleep presses the wake here, since the Memory tab no longer does on open.
-  const [asleep, setAsleep] = useState(false)
-  const [attempt, setAttempt] = useState(0)
-  const retry = useCallback(() => setAttempt((n) => n + 1), [])
-  const readState: SandboxReadState = asleep ? 'asleep' : error ? 'failed' : paths === null ? 'pending' : 'ready'
-  const wake = useSandboxWake(agentId, readState, retry)
-  const refused = (e: unknown, fallback: string) => {
-    if (e instanceof ApiError && e.code === SANDBOX_ASLEEP_CODE) setAsleep(true)
-    else setError(e instanceof Error ? e.message : fallback)
-  }
+  const { attempt, error, asleepNotice, reset, refused } = useStagedRead(agentId, paths !== null)
   // Same-bytes review fence token from the staged listing; echoed on Adopt so the
   // daemon binds adoption to exactly the bytes shown here (task #36 Phase B).
   const [reviewToken, setReviewToken] = useState<string | undefined>(undefined)
@@ -598,8 +628,7 @@ function DreamReview({
     let alive = true
     setPaths(null)
     setSelected(null)
-    setError(null)
-    setAsleep(false)
+    reset()
     setReviewToken(undefined)
     void (async () => {
       try {
@@ -626,7 +655,7 @@ function DreamReview({
       alive = false
     }
     // `attempt` is the wake's re-issue of this read.
-  }, [agentId, dreamId, attempt])
+  }, [agentId, dreamId, attempt, reset, refused])
 
   useEffect(() => {
     if (!selected) return
@@ -649,30 +678,14 @@ function DreamReview({
         if (id === request.current) setLoading(false)
       }
     })()
-  }, [agentId, dreamId, selected])
+  }, [agentId, dreamId, selected, refused])
 
   const deleting = (paths ?? []).filter((p) => p.live && !p.staged)
 
   return (
     <div className="flex flex-col gap-3 rounded-(--radius-md) border border-(--border-subtle) bg-(--surface-sunken) p-3">
-      {asleep ? (
-        wake.phase === 'starting' ? (
-          <SandboxStartingNotice compact />
-        ) : (
-          <SandboxAsleepNotice
-            wake={wake}
-            startable
-            compact
-            notice={
-              <div className="px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-secondary)">
-                {DREAM_SANDBOX_ASLEEP_NOTICE}
-              </div>
-            }
-          />
-        )
-      ) : error ? (
-        <div className="font-sans text-[12px] leading-normal text-(--status-error)">{error}</div>
-      ) : null}
+      {asleepNotice ??
+        (error ? <div className="font-sans text-[12px] leading-normal text-(--status-error)">{error}</div> : null)}
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="flex flex-wrap items-center gap-1">
@@ -809,27 +822,39 @@ function SkillBody({
   onRead: (reviewToken?: string) => void
 }) {
   const [content, setContent] = useState<DreamSkillContentDto | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+  const { attempt, error, asleepNotice, reset, refused } = useStagedRead(agentId, content !== null)
+  // The parent's callback is an inline arrow; a ref keeps its identity out of the read effect.
+  const onReadRef = useRef(onRead)
+  onReadRef.current = onRead
+
+  // Read once opened, and again when the wake re-issues it (`attempt`); a body already shown is never re-read.
+  useEffect(() => {
+    if (!open || content) return
+    let alive = true
+    reset()
+    void fetchDreamSkill(agentId, dreamId, name)
+      .then((body) => {
+        if (!alive) return
+        setContent(body)
+        // Only a body that actually rendered counts as reviewed — a pending
+        // request, an error, or vanished staging must all keep Accept off.
+        if (body.exists && body.skill) onReadRef.current(body.reviewToken)
+      })
+      .catch((err) => {
+        if (alive) refused(err, 'Could not load this skill.')
+      })
+    return () => {
+      alive = false
+    }
+  }, [open, content, attempt, agentId, dreamId, name, reset, refused])
 
   return (
-    <details
-      className="w-full"
-      onToggle={(e) => {
-        if (!(e.currentTarget as HTMLDetailsElement).open || content) return
-        void fetchDreamSkill(agentId, dreamId, name)
-          .then((body) => {
-            setContent(body)
-            // Only a body that actually rendered counts as reviewed — a pending
-            // request, an error, or vanished staging must all keep Accept off.
-            if (body.exists && body.skill) onRead(body.reviewToken)
-          })
-          .catch((err) => setError(err instanceof Error ? err.message : 'Could not load this skill.'))
-      }}
-    >
+    <details className="w-full" onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}>
       <summary className="cursor-pointer list-none font-sans text-[11px] font-medium leading-normal text-(--brand-soft-text) [&::-webkit-details-marker]:hidden">
         Show what this installs
       </summary>
-      {error ? <div className="mt-1 font-sans text-[11px] text-(--status-error)">{error}</div> : null}
+      {asleepNotice ?? (error ? <div className="mt-1 font-sans text-[11px] text-(--status-error)">{error}</div> : null)}
       {content?.exists === false ? (
         <div className="mt-1 font-sans text-[11px] text-(--text-tertiary)">This candidate is no longer staged.</div>
       ) : null}

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -42,6 +42,13 @@ import { Icon, Button } from '@/components/ui'
 import { Spinner } from '@/components/marks'
 import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
 import { LineDiff } from '@/components/console/LineDiff'
+import { SANDBOX_ASLEEP_CODE } from '@/components/console/workspace-tree'
+import { useSandboxWake, type SandboxReadState } from '@/components/console/sandbox-wake'
+import {
+  DREAM_SANDBOX_ASLEEP_NOTICE,
+  SandboxAsleepNotice,
+  SandboxStartingNotice
+} from '@/components/console/SandboxWakeNotice'
 
 /** While a dream is in flight the list changes fast. */
 const POLL_MS = 4000
@@ -572,6 +579,16 @@ function DreamReview({
   const [live, setLive] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Staging lives on the pod whatever the memory home (#1078): a read refused as asleep presses the wake here, since the Memory tab no longer does on open.
+  const [asleep, setAsleep] = useState(false)
+  const [attempt, setAttempt] = useState(0)
+  const retry = useCallback(() => setAttempt((n) => n + 1), [])
+  const readState: SandboxReadState = asleep ? 'asleep' : error ? 'failed' : paths === null ? 'pending' : 'ready'
+  const wake = useSandboxWake(agentId, readState, retry)
+  const refused = (e: unknown, fallback: string) => {
+    if (e instanceof ApiError && e.code === SANDBOX_ASLEEP_CODE) setAsleep(true)
+    else setError(e instanceof Error ? e.message : fallback)
+  }
   // Same-bytes review fence token from the staged listing; echoed on Adopt so the
   // daemon binds adoption to exactly the bytes shown here (task #36 Phase B).
   const [reviewToken, setReviewToken] = useState<string | undefined>(undefined)
@@ -582,6 +599,7 @@ function DreamReview({
     setPaths(null)
     setSelected(null)
     setError(null)
+    setAsleep(false)
     setReviewToken(undefined)
     void (async () => {
       try {
@@ -596,14 +614,19 @@ function DreamReview({
           .sort((a, b) => Number(a.staged) - Number(b.staged) || a.name.localeCompare(b.name))
         setPaths(merged)
         setSelected(merged[0]?.name ?? null)
+        // Nothing to read for a file, so the file read's own spinner never starts.
+        if (merged.length === 0) setLoading(false)
       } catch (e) {
-        if (alive) setError(e instanceof Error ? e.message : 'Could not load the staged store.')
+        if (!alive) return
+        setLoading(false)
+        refused(e, 'Could not load the staged store.')
       }
     })()
     return () => {
       alive = false
     }
-  }, [agentId, dreamId])
+    // `attempt` is the wake's re-issue of this read.
+  }, [agentId, dreamId, attempt])
 
   useEffect(() => {
     if (!selected) return
@@ -621,7 +644,7 @@ function DreamReview({
         setStaged(stagedFile.exists ? stagedFile.content : '')
         setLive(liveFile.exists ? liveFile.content : '')
       } catch (e) {
-        if (id === request.current) setError(e instanceof Error ? e.message : 'Could not load that file.')
+        if (id === request.current) refused(e, 'Could not load that file.')
       } finally {
         if (id === request.current) setLoading(false)
       }
@@ -632,7 +655,24 @@ function DreamReview({
 
   return (
     <div className="flex flex-col gap-3 rounded-(--radius-md) border border-(--border-subtle) bg-(--surface-sunken) p-3">
-      {error ? <div className="font-sans text-[12px] leading-normal text-(--status-error)">{error}</div> : null}
+      {asleep ? (
+        wake.phase === 'starting' ? (
+          <SandboxStartingNotice compact />
+        ) : (
+          <SandboxAsleepNotice
+            wake={wake}
+            startable
+            compact
+            notice={
+              <div className="px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.55] text-(--text-secondary)">
+                {DREAM_SANDBOX_ASLEEP_NOTICE}
+              </div>
+            }
+          />
+        )
+      ) : error ? (
+        <div className="font-sans text-[12px] leading-normal text-(--status-error)">{error}</div>
+      ) : null}
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="flex flex-wrap items-center gap-1">

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -726,7 +726,9 @@ describe('MemoryPanel sandbox wake', () => {
     vi.mocked(fetchAgentMemoryFull).mockImplementation(() => Promise.reject(error()))
   }
 
-  const mount = async (props: { sandboxed?: boolean; memoryProvider?: string } = {}) => {
+  const mount = async (
+    props: { sandboxed?: boolean; memoryProvider?: string; memoryHome?: 'daemon' | 'control-plane' } = {}
+  ) => {
     container = document.createElement('div')
     document.body.append(container)
     root = createRoot(container)
@@ -736,6 +738,7 @@ describe('MemoryPanel sandbox wake', () => {
           agentId={AGENT}
           canEdit
           memoryProvider={props.memoryProvider ?? 'managed'}
+          memoryHome={props.memoryHome}
           autoDistill={false}
           sandboxed={props.sandboxed}
         />
@@ -814,6 +817,14 @@ describe('MemoryPanel sandbox wake', () => {
     // The reads answered, so nothing is left on screen to explain.
     expect(text()).not.toContain('Starting the agent’s sandbox')
     expect(text()).not.toContain('Memory is not available right now')
+  })
+
+  it('never presses for a sandboxed agent whose memory home is the Control Plane', async () => {
+    // The tree is read through the daemon's Control Plane connection; the pod has nothing to do with it.
+    await mount({ sandboxed: true, memoryHome: 'control-plane' })
+
+    expect(vi.mocked(wakeAgent)).not.toHaveBeenCalled()
+    expect(startButton()).toBeUndefined()
   })
 
   it('never presses for a backend that does not live on the sandbox volume', async () => {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -583,6 +583,8 @@ export function MemoryPanel({
   // Only the managed directory lives on the sandbox volume: a runtime-native, external or off backend reads nothing
   // from a pod, so it reports `ready` and can never press a wake.
   const managedMemory = persistedProvider === 'managed'
+  // A `control-plane` home is read through the daemon's connection, never from the pod: no wake on open for it.
+  const sandboxedMemory = sandboxed && managedMemory && persistedSettings.home !== 'control-plane'
   const readState: SandboxReadState = !managedMemory
     ? 'ready'
     : listErrorCode === SANDBOX_ASLEEP_CODE || errorCode === SANDBOX_ASLEEP_CODE
@@ -601,10 +603,10 @@ export function MemoryPanel({
     void loadList()
     void loadFile(selectedRef.current)
   }, [loadFile, loadList])
-  const wake = useSandboxWake(agentId, readState, retryRead, { sandboxed })
+  const wake = useSandboxWake(agentId, readState, retryRead, { sandboxed: sandboxedMemory })
   // The asleep story outranks the offline one on either pane: the memory is fine, just behind a pod that is not running.
   const asleepRead = readState === 'asleep'
-  const startable = sandboxed || asleepRead
+  const startable = sandboxedMemory || asleepRead
 
   useEffect(() => {
     loadRequest.current += 1

--- a/packages/web/src/components/console/SandboxWakeNotice.tsx
+++ b/packages/web/src/components/console/SandboxWakeNotice.tsx
@@ -17,6 +17,10 @@ export const SANDBOX_ASLEEP_NOTICE =
 export const MEMORY_SANDBOX_ASLEEP_NOTICE =
   'Memory is not available right now — this agent runs in a cluster sandbox and its pod is not running. It starts again on the agent’s next turn, and its memory comes back with it.'
 
+/** And for a dream's staged store, which stays on that volume whatever the agent's memory home. */
+export const DREAM_SANDBOX_ASLEEP_NOTICE =
+  'The staged dream is not available right now — this agent runs in a cluster sandbox and its pod is not running. It starts again on the agent’s next turn, and the staged files come back with it.'
+
 /** What is drawn while the sandbox is being started. Not an error: nothing is wrong, and the read is being polled. */
 export function SandboxStartingNotice({ compact = false }: { compact?: boolean }) {
   return (


### PR DESCRIPTION
## What happened

Opening the Memory tab of a pool agent whose memory home is the Control Plane showed no "starting the sandbox" notice — the reads all answered — yet a pod still came up. The console's eager wake (#1077) fires on open for any agent placed on the pool (`sandboxed`), on the assumption that its managed memory is only readable through a running pod. With `home: control-plane` (#1883) that assumption no longer holds: list/read/history go through the daemon's Control Plane connection, and the pod has nothing to do with them. The wake was pressed silently and resumed the agent sandbox for nothing.

## Fix

`MemoryPanel` gates the eager press on the persisted home: `sandboxed && managed && home !== 'control-plane'`. The asleep fallback (a read refusing with the sandbox-asleep code) is unchanged — it cannot trigger for a Control-Plane home, and still wakes for a `daemon` home on the pool.

Dream staging still lives on the agent's volume whatever the home, and the nested Dreams panel had been relying on the tab's eager press. Its two staged reads now press that wake themselves through one shared `useStagedRead` hook: the memory-store review (`DreamReview`) and the suggested-skill preview (`SkillBody`, which an adopted dream reaches with no Review button). A read refused with the asleep code is the asleep state — the shared starting/asleep notice (with Start) replaces the raw refusal, the pod is woken once through `useSandboxWake`, and the read is polled until it answers. Ordinary memory browsing stays pod-free.

## Verification

- `MemoryPanel.test.tsx`: new case — a sandboxed agent with `memoryHome: 'control-plane'` opens the tab with no `wakeAgent` call and no Start button; the existing "wakes a sandboxed agent on open" case (daemon home) still passes.
- `DreamPanel.test.tsx`: two new cases — a staged listing refused with `WORKSPACE_SANDBOX_UNAVAILABLE` presses `wakeAgent` once and shows the starting notice instead of the error line, and after the wake answers the first poll re-issues the listing and the line diff renders; the same for a proposed skill's body on an adopted dream, ending with Accept enabled.
- Web typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
