### PR TITLE
feat(daemon): a Telegram multi-select is assembled on the keyboard

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13913,9 +13913,9 @@ export class Daemon {
     const tap = parseTelegramElicit(cb.data)
     if (!tap) return await this.commands.handleTelegramCallback(cb, conn)
     void conn.answerCallback(cb.id)
-    await this.permissions.handleElicitChoice({
+    await this.permissions.handleElicitCardTap({
       requestId: tap.requestId,
-      value: tap.token,
+      token: tap.token,
       actor: { userId: cb.userId }
     })
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13916,6 +13916,9 @@ export class Daemon {
     await this.permissions.handleElicitCardTap({
       requestId: tap.requestId,
       token: tap.token,
+      // The card the button was on, so a fold can redraw it even when the post that carried it
+      // has not returned its own id yet — a reader can tap the moment Telegram shows the keyboard.
+      ts: String(cb.messageId),
       actor: { userId: cb.userId }
     })
   }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -994,12 +994,14 @@ export class PermissionCoordinator {
         })
         // Only a chat card is rewritten here: an editor decision settles approvals, and an
         // approval elicitation never lands on the webchat surface.
-        if (elicitation.surface === 'chat' && elicitation.ts) {
+        if (elicitation.surface === 'chat') {
           const label: ElicitCardLabel =
             req.decision === 'allow'
               ? { mark: 'answered', text: 'Allowed by Agent editor', fallback: 'Permission resolved' }
               : { mark: 'dismissed', text: 'Denied by Agent editor', fallback: 'Permission resolved' }
-          elicitation.facet.settle(elicitation, elicitSettlement(elicitation.params, false, label))
+          // Through settleChatCard, so a decision that beats the post leaves its label for the
+          // posting path instead of leaving a card standing with buttons nobody awaits.
+          this.settleChatCard(elicitation, req.requestId, false, label)
         }
         elicitation.resolve(req.decision === 'allow' ? { action: 'accept' } : { action: 'cancel' })
         return { ok: true }
@@ -1539,7 +1541,8 @@ export class PermissionCoordinator {
     // settlement left its own label here (#1794).
     if (!live) {
       const settled = this.takeSettledBeforePost(requestId)
-      if (ts) facet.settle({ conn: p.conn, channel: p.plan.channel, ts }, elicitSettlement(params, !!url, settled))
+      if (ts && settled)
+        facet.settle({ conn: p.conn, channel: p.plan.channel, ts }, elicitSettlement(params, !!url, settled))
       return await result
     }
     if (!ts) {
@@ -2175,12 +2178,16 @@ export class PermissionCoordinator {
     this.settledBeforePost.set(requestId, label)
   }
 
-  /** How a card the posting path found already settled must read. A settlement that beat the post
-   *  left its own label here; anything else really was the turn ending, which is Cancelled. */
-  private takeSettledBeforePost(requestId: string): ElicitCardLabel {
+  /** How a card the posting path found already settled must read, or undefined when it has already
+   *  been rewritten and must be left alone. Every chat-card settlement goes through
+   *  {@link settleChatCard}, which leaves its label here exactly when it had no message to rewrite
+   *  — so nothing left means the settlement DID rewrite the card, from a message id of its own
+   *  (a tap carries the card's, adopted before the send could record it), and re-settling would
+   *  call an answered card Cancelled. */
+  private takeSettledBeforePost(requestId: string): ElicitCardLabel | undefined {
     const settled = this.settledBeforePost.get(requestId)
     this.settledBeforePost.delete(requestId)
-    return settled ?? ELICIT_CANCELLED
+    return settled
   }
 
   /** Post one daemon-authored line on the card's OWN surface — a notice, so it lands where every

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -1903,12 +1903,24 @@ export class PermissionCoordinator {
    * Dismiss (`token === null`) is not folded into anything — it is the reader's one explicit
    * refusal on every card, assembled or not, and settles through the choice path unchanged.
    */
-  async handleElicitCardTap(a: { requestId: string; token: string | null; actor?: InteractionActor }): Promise<void> {
+  async handleElicitCardTap(a: {
+    requestId: string
+    token: string | null
+    /** The card's own message id AS THE TAP REPORTS IT — the same one fact `ElicitCardHandle.ts`
+     *  holds, in whichever dialect the surface spells it. A tap can beat the post it came from:
+     *  the reader sees the keyboard the instant the platform has it, while `awaitChatElicitation`
+     *  is still awaiting the send that will record the id. Adopting it is what lets a fold redraw
+     *  a card whose own post has not landed yet; that send then records the very same value. */
+    ts?: string
+    actor?: InteractionActor
+  }): Promise<void> {
     const actor = a.actor ? { actor: a.actor } : {}
     const rec = this.pendingElicits.get(a.requestId)
     // A one-tap card, an unknown request, and Dismiss all answer with the token as it came.
     if (a.token === null || !rec || rec.surface !== 'chat' || !rec.facet.tap || !rec.form)
       return await this.handleElicitChoice({ requestId: a.requestId, value: a.token, ...actor })
+    // Only ever fills a gap: a recorded id is the send's own and is never overwritten by a tap.
+    if (rec.ts === undefined && a.ts !== undefined) rec.ts = a.ts
     const form = this.cardForm(rec)
     if (!form) return
     const folded = rec.facet.tap(rec, { requestId: a.requestId, params: rec.params, form }, a.token)

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -1890,6 +1890,38 @@ export class PermissionCoordinator {
     }
   }
 
+  /**
+   * Route one tap on a chat elicitation card, for a surface whose card ASSEMBLES its answer.
+   *
+   * Slack needs none of this: its message carries the reader's half-filled state itself, and every
+   * value arrives on the Confirm. A Telegram keyboard has no state at all — a tap carries 64 bytes
+   * and nothing else — so the card is assembled here instead, tap by tap, and the Confirm submits
+   * through the very same {@link submitElicitForm} a Slack Confirm does. That is the point of
+   * routing it through core rather than letting the surface answer on its own: ONE re-derivation
+   * of the rendered form (#1815), one per-field validation, one refusal wording.
+   *
+   * Dismiss (`token === null`) is not folded into anything — it is the reader's one explicit
+   * refusal on every card, assembled or not, and settles through the choice path unchanged.
+   */
+  async handleElicitCardTap(a: { requestId: string; token: string | null; actor?: InteractionActor }): Promise<void> {
+    const actor = a.actor ? { actor: a.actor } : {}
+    const rec = this.pendingElicits.get(a.requestId)
+    // A one-tap card, an unknown request, and Dismiss all answer with the token as it came.
+    if (a.token === null || !rec || rec.surface !== 'chat' || !rec.facet.tap || !rec.form)
+      return await this.handleElicitChoice({ requestId: a.requestId, value: a.token, ...actor })
+    const form = this.cardForm(rec)
+    if (!form) return
+    const folded = rec.facet.tap(rec, { requestId: a.requestId, params: rec.params, form }, a.token)
+    // A token naming nothing this card offers is refused aloud and leaves the card live, exactly
+    // as an unoffered option value is: the reader just acted, so silence would read as a dead card.
+    if (!folded) {
+      this.noticeInTurn(rec, ELICIT_ANSWER_REFUSED)
+      return
+    }
+    if (folded.kind === 'pending') return
+    await this.submitElicitForm({ requestId: a.requestId, fields: folded.fields, ...actor })
+  }
+
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP
    *  request — `accept` with the chosen value (a LIST of them for a multi-select, a real number
    *  for a numeric field, a RECORD of value-per-field for a form, under the field name(s)), or

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -57,6 +57,12 @@ export interface ElicitCardHandle {
   readonly conn: unknown
   readonly channel: string
   ts?: string
+  /** The card's OWN opaque state slot, written by the surface that assembles an answer over
+   *  several taps (§7.3, the same shape `turnState` takes). Core never reads it; it exists so a
+   *  surface with no message state of its own — Telegram's keyboard, where a tap carries only 64
+   *  bytes — has somewhere to keep what has been picked so far, with core's own record lifetime.
+   *  Absent on a surface whose every tap is a whole answer. */
+  cardState?: unknown
 }
 
 /** How a settled card is MARKED, named by what happened rather than by any surface's glyph — a
@@ -110,6 +116,27 @@ export interface ElicitCardHost {
   turnState(turn: ElicitCardTurn): unknown
 }
 
+/**
+ * What one tap on an ASSEMBLED card meant, once the surface folded it into the card's state.
+ *
+ * A surface whose card submits on the tap itself never returns this — its taps are whole answers
+ * and take {@link ElicitCardFacet.tap}'s absence. A surface that assembles one (Telegram toggling
+ * a checkbox on a keyboard) reports which of three things just happened, and core does the rest:
+ * `pending` is a state change the surface has already redrawn, `submit` is a Confirm carrying the
+ * card's assembled fields — keyed exactly as a Slack Confirm's are, so both go through the SAME
+ * re-derivation (#1815) — and null is a tap this card does not offer.
+ */
+export type ElicitCardTap = { kind: 'pending' } | { kind: 'submit'; fields: Record<string, string | string[]> }
+
+/** The live card a tap is folded into: the id its buttons carry back, the ask they were built
+ *  from, and the field list core RE-DERIVED from that ask (#1815) — so a redraw offers the very
+ *  options the card was posted with. */
+export interface ElicitCardTapTarget {
+  readonly requestId: string
+  readonly params: CreateElicitationRequest
+  readonly form: readonly ElicitTarget[]
+}
+
 /** One chat surface's elicitation-card facet. Registered on that platform's
  *  {@link TurnOutputSurface}; absent ⇒ the surface cannot collect an answer and core declines the
  *  ask with the in-channel notice. */
@@ -135,6 +162,11 @@ export interface ElicitCardFacet {
   /** Rewrite a posted card as settled — Slack's `chat.update`, Telegram's `editMessageText` with
    *  the keyboard dropped. Best effort by construction: no ACP outcome depends on it. */
   settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void
+  /** Fold one tap into a card that ASSEMBLES its answer, redrawing the card as the fold requires.
+   *  Absent ⇒ every tap on this surface is already a whole answer and core resolves it directly.
+   *  `form` is re-derived by core from the card's own params, so it is the very field list the
+   *  card rendered. Null ⇒ the tap named nothing this card offers, and core refuses it aloud. */
+  tap?(handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null
   /** The namespace a tapping actor's id is scoped to on this surface, recorded beside an approval
    *  resolver so it is globally unique. Absent where the surface's user ids already are — a
    *  Telegram user id names one account across every chat, a Slack one only within its workspace. */

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -189,10 +189,16 @@ export function telegramElicitCheckboxes(
 
 /** An assembled card's own text: the question, then what the reader has to know to answer it that
  *  no checkbox can say — the field's description and a multi-select's bounds, which Telegram
- *  cannot enforce on the keyboard the way Slack's `max_selected_items` does. Pure. */
+ *  cannot enforce on the keyboard the way Slack's `max_selected_items` does.
+ *
+ *  The hint is inside the same budget the question is, and it is the QUESTION that yields: a hint
+ *  runs to 2000 characters where the message limit is 4096, so appending it to an already-clamped
+ *  question could push the whole card past what `sendMessage` takes — and a refused post is not a
+ *  shortened card, it is no card at all, cancelled without even the unrenderable notice. Pure. */
 export function telegramElicitFormText(message: string, target: ElicitTarget): string {
   const hint = elicitFormFieldHint(target)
-  return `${telegramElicitText(message)}${hint ? `\n${hint}` : ''}`
+  if (!hint) return telegramElicitText(message)
+  return `${telegramElicitText(clampTo(message, Math.max(0, TELEGRAM_ELICIT_MESSAGE_CAP - hint.length - 1)))}\n${hint}`
 }
 
 /** The one field an assembled Telegram card renders, or null when this form is not one — today
@@ -289,22 +295,25 @@ export const telegramElicitCards: ElicitCardFacet = {
     }
     const index = target.options.findIndex((_o, i) => elicitOptionToken(i) === token)
     if (index < 0) return null
+    // A tick nobody can be shown is not recorded. What the keyboard shows and what a Confirm would
+    // submit are ONE fact here — unlike Slack, where the message itself holds the reader's half-
+    // filled state — so a card with no addressable message refuses the tap instead of remembering
+    // a selection its own boxes still show unticked.
+    const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
+    if (!Number.isInteger(messageId)) return null
     if (state.chosen.has(index)) state.chosen.delete(index)
     else state.chosen.add(index)
     // Best effort, like every other card rewrite: a redraw that fails leaves the reader looking at
     // the previous ticks, and the Confirm still submits what THIS daemon recorded.
-    const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
-    if (Number.isInteger(messageId)) {
-      const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
-      void (handle.conn as TelegramConnection)
-        .editCard(
-          handle.channel,
-          messageId,
-          telegramElicitFormText(message, target),
-          telegramElicitCheckboxes(card.requestId, target.options, state.chosen)
-        )
-        .catch(() => {})
-    }
+    const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+    void (handle.conn as TelegramConnection)
+      .editCard(
+        handle.channel,
+        messageId,
+        telegramElicitFormText(message, target),
+        telegramElicitCheckboxes(card.requestId, target.options, state.chosen)
+      )
+      .catch(() => {})
     return { kind: 'pending' }
   },
 

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -3,11 +3,13 @@
  * {@link ElicitCardFacet}, and the reason the member exists rather than being guessed from Slack.
  *
  * WHAT TELEGRAM ACTUALLY HAS is one control: an inline keyboard of tappable buttons, each echoing
- * a ≤64-BYTE `callback_data` back as a `callback_query`. It has no multi-select, no text box and
- * no number box in a message — a Bot API keyboard is buttons and nothing else — so `reduction`
- * below claims exactly the two kinds one TAP can answer, and every other kind is declined with
- * the notice #1819/#1839 already post rather than half-rendered into a control that cannot
- * submit. That is the same line {@link SLACK_DM_ELICIT_SURFACE} draws, for the same reason.
+ * a ≤64-BYTE `callback_data` back as a `callback_query`. There is no multi-select widget and no
+ * typed box — a Bot API keyboard is buttons and nothing else — so a MULTI-SELECT is assembled out
+ * of the one control there is: one button per option, its label carrying the checkbox, a tap
+ * toggling it and redrawing the keyboard, and a Confirm submitting the set. The state that lives
+ * in a Slack message's own `state.values` lives here in the card's `cardState` slot instead,
+ * because 64 bytes of `callback_data` cannot carry a selection. Everything else — a typed box, a
+ * multi-question form, URL mode — is still declined with the notice #1819/#1839 already post.
  *
  * URL MODE IS DECLINED TOO, and not for want of a link button. An inline `url` button opens the
  * page but fires no `callback_query`, so the daemon would never learn the reader consented — and
@@ -26,6 +28,7 @@
  * 2026-09-08 against the Bot API: an edit omitting `reply_markup`, and one sending an empty
  * `inline_keyboard`, both return a message with no markup).
  */
+import { elicitFormBlockId } from '@agentconnect.md/protocol'
 import type {
   ElicitCardAsk,
   ElicitCardDraft,
@@ -34,12 +37,22 @@ import type {
   ElicitCardHost,
   ElicitCardMark,
   ElicitCardSettlement,
+  ElicitCardTap,
+  ElicitCardTapTarget,
   ElicitCardTurn
 } from '../elicit-card.js'
 import type { InlineButton, TelegramConnection } from '../../telegram/connection.js'
 import { TELEGRAM_MESSAGE_LIMIT } from '../../telegram/render.js'
 import type { TelegramTurnState } from './turn-output.js'
-import { clampTo, elicitCardShape, elicitOptionToken, type ElicitKind, type ElicitSurface } from '../../slack/render.js'
+import {
+  clampTo,
+  elicitCardShape,
+  elicitFormFieldHint,
+  elicitOptionToken,
+  type ElicitKind,
+  type ElicitSurface,
+  type ElicitTarget
+} from '../../slack/render.js'
 
 /**
  * The most options one Telegram elicitation keyboard offers.
@@ -51,7 +64,8 @@ import { clampTo, elicitCardShape, elicitOptionToken, type ElicitKind, type Elic
  * reach; 24 such buttons plus Dismiss serialized to 5.7 KB and was accepted, as were 40 buttons
  * of 75 four-byte characters each (9.1 KB). 24 is therefore Slack's own button cap re-derived
  * from Telegram's own refusals, with better than 2x headroom on the worst list this reduction can
- * produce — and a longer list is declined whole, never trimmed to fit.
+ * produce — and a longer list is declined whole, never trimmed to fit. A checkbox card adds one
+ * more button and a two-character tick per label, which the same headroom covers.
  */
 const TELEGRAM_ELICIT_MAX_BUTTONS = 24
 
@@ -64,6 +78,14 @@ const TELEGRAM_ELICIT_PREFIX = 'ac_el'
 
 /** The token a Dismiss button carries. Not a position, because Dismiss answers no option. */
 const TELEGRAM_ELICIT_DISMISS = 'x'
+
+/** The token a Confirm button carries — the tap that SUBMITS an assembled card. Not a position
+ *  for the same reason Dismiss is not: it names no option, it names the set of them. */
+const TELEGRAM_ELICIT_CONFIRM = 'ok'
+
+/** How an assembled card draws one option's checkbox. Literal emoji, as the marks are. */
+const TELEGRAM_ELICIT_CHECKED = '\u2611\ufe0f'
+const TELEGRAM_ELICIT_UNCHECKED = '\u2b1c\ufe0f'
 
 /**
  * How much of the ANSWER a settled card echoes back. The decision core supplies is not bounded —
@@ -90,14 +112,19 @@ const TELEGRAM_ELICIT_MARK: Record<ElicitCardMark, string> = {
 }
 
 /**
- * What a Telegram elicitation card can render AND collect: the two kinds one TAP answers, and no
- * more. A keyboard button submits the instant it is tapped, so a kind needing something filled in
- * first could be shown but never confirmed — the same verdict, and the same reasoning, as the
- * approval DM's surface.
+ * What a Telegram elicitation card can render AND collect: the two kinds one TAP answers, plus the
+ * multi-select a keyboard of checkboxes assembles over several taps. A typed box is still absent —
+ * nothing in a keyboard accepts characters — so `text` and `number`, and therefore every form
+ * carrying one, stay declined rather than posted as a control that cannot take an answer.
  */
 export const TELEGRAM_ELICIT_SURFACE: ElicitSurface = {
-  kinds: new Set<ElicitKind>(['enum', 'boolean']),
-  optionLimits: { enum: { maxOptions: TELEGRAM_ELICIT_MAX_BUTTONS } }
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum']),
+  optionLimits: {
+    enum: { maxOptions: TELEGRAM_ELICIT_MAX_BUTTONS },
+    // A checkbox keyboard is the SAME keyboard, one row longer for its Confirm — so it is bounded
+    // by the same measured refusal, not by a second number that could drift away from it.
+    'multi-enum': { maxOptions: TELEGRAM_ELICIT_MAX_BUTTONS }
+  }
 }
 
 /** One button's `callback_data`: the request and the option's position. Pure. */
@@ -140,10 +167,61 @@ export function telegramElicitButtons(requestId: string, options: readonly { lab
   return rows
 }
 
+/** One tappable button per option, each carrying its own checkbox, plus a Confirm/Dismiss row.
+ *  `chosen` holds POSITIONS, which is what the buttons carry and what the Confirm submits. Pure. */
+export function telegramElicitCheckboxes(
+  requestId: string,
+  options: readonly { label: string }[],
+  chosen: ReadonlySet<number>
+): InlineButton[][] {
+  const rows = options.map((o, i) => [
+    {
+      text: `${chosen.has(i) ? TELEGRAM_ELICIT_CHECKED : TELEGRAM_ELICIT_UNCHECKED} ${o.label}`,
+      callbackData: telegramElicitData(requestId, elicitOptionToken(i))
+    }
+  ])
+  rows.push([
+    { text: 'Confirm', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_CONFIRM) },
+    { text: 'Dismiss', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_DISMISS) }
+  ])
+  return rows
+}
+
+/** An assembled card's own text: the question, then what the reader has to know to answer it that
+ *  no checkbox can say — the field's description and a multi-select's bounds, which Telegram
+ *  cannot enforce on the keyboard the way Slack's `max_selected_items` does. Pure. */
+export function telegramElicitFormText(message: string, target: ElicitTarget): string {
+  const hint = elicitFormFieldHint(target)
+  return `${telegramElicitText(message)}${hint ? `\n${hint}` : ''}`
+}
+
+/** The one field an assembled Telegram card renders, or null when this form is not one — today
+ *  exactly a lone multi-select, the only kind a keyboard can assemble without a typed box. Pure. */
+export function telegramAssembledField(form: readonly ElicitTarget[]): ElicitTarget | null {
+  const only = form.length === 1 ? form[0]! : null
+  return only && only.kind === 'multi-enum' ? only : null
+}
+
 /** Telegram's per-turn elicitation draft: the message and the keyboard under it. */
 interface TelegramElicitDraft {
   text: string
   buttons: InlineButton[][]
+}
+
+/** What a checkbox card has collected so far — the POSITIONS ticked, kept in the card's own state
+ *  slot because a 64-byte `callback_data` cannot carry a selection back the way a Slack message's
+ *  `state.values` does. It never leaves this module: core stores it opaquely and drops it with the
+ *  record, so a card that ends without a Confirm leaves nothing behind. */
+interface TelegramElicitCardState {
+  chosen: Set<number>
+}
+
+function cardStateOf(handle: ElicitCardHandle): TelegramElicitCardState {
+  const existing = handle.cardState as TelegramElicitCardState | undefined
+  if (existing) return existing
+  const fresh: TelegramElicitCardState = { chosen: new Set<number>() }
+  handle.cardState = fresh
+  return fresh
 }
 
 export const telegramElicitCards: ElicitCardFacet = {
@@ -151,15 +229,22 @@ export const telegramElicitCards: ElicitCardFacet = {
   reduction: TELEGRAM_ELICIT_SURFACE,
 
   build(_host: ElicitCardHost, _turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null {
-    // No consent control, and no control for anything that has to be filled in first.
+    // No consent control, and no control for a typed box or a form carrying one.
     if (ask.url || !ask.form?.length) return null
-    if (elicitCardShape(ask.form) !== 'buttons') return null
-    const target = ask.form[0]!
+    const oneTap = elicitCardShape(ask.form) === 'buttons'
+    const assembled = oneTap ? null : telegramAssembledField(ask.form)
+    if (!oneTap && !assembled) return null
+    const target = assembled ?? ask.form[0]!
     if (!target.options.length || !telegramElicitDataFits(ask.requestId, target.options.length)) return null
-    const draft: TelegramElicitDraft = {
-      text: telegramElicitText(ask.message),
-      buttons: telegramElicitButtons(ask.requestId, target.options)
-    }
+    const draft: TelegramElicitDraft = assembled
+      ? {
+          text: telegramElicitFormText(ask.message, assembled),
+          buttons: telegramElicitCheckboxes(ask.requestId, assembled.options, new Set())
+        }
+      : {
+          text: telegramElicitText(ask.message),
+          buttons: telegramElicitButtons(ask.requestId, target.options)
+        }
     return draft
   },
 
@@ -182,6 +267,45 @@ export const telegramElicitCards: ElicitCardFacet = {
         ...(replyTo !== undefined ? { replyTo } : {})
       })
     )
+  },
+
+  /**
+   * Fold one tap into a checkbox card: an option position TOGGLES and the keyboard is redrawn in
+   * place, and the Confirm submits every ticked position as the field's carried value — the same
+   * `ac_o<n>` list a Slack multi-select's Confirm carries, under the same block id, so core's one
+   * re-derivation (#1815) validates both without knowing which surface sent it.
+   *
+   * Nothing is enforced here that core enforces on the answer: a selection breaking the field's
+   * own `minItems`/`maxItems` is refused by the submission with the field's own words, exactly as
+   * a Slack Confirm's is. Toggling is free; the Confirm is where a card is judged.
+   */
+  tap(handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null {
+    const target = telegramAssembledField(card.form)
+    if (!target) return null
+    const state = cardStateOf(handle)
+    if (token === TELEGRAM_ELICIT_CONFIRM) {
+      const picked = [...state.chosen].sort((a, b) => a - b).map(elicitOptionToken)
+      return { kind: 'submit', fields: { [elicitFormBlockId(0)]: picked } }
+    }
+    const index = target.options.findIndex((_o, i) => elicitOptionToken(i) === token)
+    if (index < 0) return null
+    if (state.chosen.has(index)) state.chosen.delete(index)
+    else state.chosen.add(index)
+    // Best effort, like every other card rewrite: a redraw that fails leaves the reader looking at
+    // the previous ticks, and the Confirm still submits what THIS daemon recorded.
+    const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
+    if (Number.isInteger(messageId)) {
+      const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+      void (handle.conn as TelegramConnection)
+        .editCard(
+          handle.channel,
+          messageId,
+          telegramElicitFormText(message, target),
+          telegramElicitCheckboxes(card.requestId, target.options, state.chosen)
+        )
+        .catch(() => {})
+    }
+    return { kind: 'pending' }
   },
 
   settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void {

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1550,7 +1550,7 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
 
 /** What one field's block says under its label: the question's own words, plus a multi-select's
  *  bounds, since a checkbox list cannot enforce them itself. Empty when there is nothing to add. */
-function elicitFormFieldHint(target: ElicitTarget): string {
+export function elicitFormFieldHint(target: ElicitTarget): string {
   const parts = [target.description ?? '', target.kind === 'multi-enum' ? selectionHint(target) : '']
   return clampTo(parts.filter(Boolean).join(' '), SLACK_HINT_TEXT_CAP)
 }

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -137,6 +137,8 @@ interface Harness {
   edits: { text: string; buttons: InlineButton[][] }[]
   acked: string[]
   notices: () => string[]
+  /** Hold the next card post's response, so a tap can be made to beat its own send. */
+  holdPost: (release: Promise<void>) => void
 }
 
 /** @param turn the turn's THREAD coordinate and its Telegram reply anchor — a plain supergroup
@@ -152,6 +154,7 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
   const edits: { text: string; buttons: InlineButton[][] }[] = []
   const acked: string[] = []
   const conn = Object.create(TelegramConnection.prototype)
+  let held: Promise<void> | undefined
   conn.postCard = async (
     _c: string,
     text: string,
@@ -159,6 +162,7 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
     opts: { threadTs?: string; replyTo?: number } = {}
   ) => {
     cards.push({ text, buttons, opts })
+    if (held) await held
     return '4242'
   }
   conn.editCard = async (_c: string, _id: number, text: string, buttons: InlineButton[][]) => {
@@ -201,7 +205,8 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
     cards,
     edits,
     acked,
-    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string),
+    holdPost: (release: Promise<void>) => void (held = release)
   }
 }
 
@@ -407,6 +412,27 @@ describe('a Telegram multi-select is assembled on the keyboard and submitted by 
     expect(h.edits.at(-1)!.buttons.map((r) => r[0]!.text)).toEqual(['☑️ lint', '⬜️ test', '⬜️ build', 'Confirm'])
     await tap(h, requestId, 'ok')
     await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint'] } })
+  })
+
+  it('keeps the answer on a card Confirmed before its own post returned', async () => {
+    // The tap carries the card's id, so the settlement rewrites it AS ANSWERED while the send is
+    // still in flight; the posting path must not then call that same card Cancelled.
+    const h = telegramTurn()
+    let release!: () => void
+    h.holdPost(new Promise<void>((r) => (release = r)))
+    const result = h.daemon.permissions.onAcpElicit('agent-1', 's1', form(CHECKS, ['checks']))
+    await vi.waitFor(() => expect(h.cards).toHaveLength(1))
+    const requestId = [...h.daemon.permissions.pendingElicits.keys()][0] as string
+
+    await tap(h, requestId, elicitOptionToken(0))
+    await tap(h, requestId, 'ok')
+    expect(h.daemon.permissions.pendingElicits.size).toBe(0)
+    // Only now does the post report its id, and the posting path finds the card already settled.
+    release()
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint'] } })
+
+    expect(h.edits.at(-1)!.text).toContain('✅ checks: lint')
+    expect(h.edits.map((e) => e.text).some((t) => t.includes('Cancelled'))).toBe(false)
   })
 
   it('refuses a tick it cannot show at all, rather than remembering one the boxes deny', () => {

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -19,6 +19,7 @@ import {
   telegramElicitButtons,
   telegramElicitCheckboxes,
   telegramElicitData,
+  telegramElicitFormText,
   telegramElicitDataFits,
   telegramElicitCards
 } from '../src/platforms/telegram/elicit-card.js'
@@ -390,6 +391,48 @@ describe('a Telegram multi-select is assembled on the keyboard and submitted by 
     await tap(h, requestId, 'x')
     await expect(result).resolves.toEqual({ action: 'decline' })
     expect(h.edits.at(-1)!.text).toContain('🚫 Dismissed')
+  })
+
+  it("redraws a card tapped before its own post reported an id, from the tap's own message", async () => {
+    // A reader can tap the instant Telegram shows the keyboard, which can beat the send that
+    // records the card's id — the tick must still reach the boxes the reader is looking at.
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(CHECKS, ['checks']))
+    const rec = h.daemon.permissions.pendingElicits.get(requestId)
+    rec.ts = undefined
+    // The adoption is synchronous, so the state under test survives to the fold.
+    await h.daemon.permissions.handleElicitCardTap({ requestId, token: elicitOptionToken(0), ts: '4242' })
+
+    expect(rec.ts).toBe('4242')
+    expect(h.edits.at(-1)!.buttons.map((r) => r[0]!.text)).toEqual(['☑️ lint', '⬜️ test', '⬜️ build', 'Confirm'])
+    await tap(h, requestId, 'ok')
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint'] } })
+  })
+
+  it('refuses a tick it cannot show at all, rather than remembering one the boxes deny', () => {
+    const params = form(CHECKS, ['checks'])
+    const fields = elicitForm(params, TELEGRAM_ELICIT_SURFACE)!
+    const handle: any = { conn: {}, channel: '-100' }
+    expect(
+      telegramElicitCards.tap!(handle, { requestId: REQUEST_ID, params, form: fields }, elicitOptionToken(0))
+    ).toBe(null)
+    expect([...(handle.cardState?.chosen ?? [])]).toEqual([])
+  })
+
+  it('keeps a long question and its whole hint inside one Telegram message', () => {
+    // A hint runs to 2000 characters and the limit is 4096, so appending one to an already-clamped
+    // question would refuse the post outright — and a refused post is no card at all.
+    const target = {
+      propName: 'checks',
+      kind: 'multi-enum' as const,
+      options: [{ value: 'lint', label: 'lint' }],
+      description: 'd'.repeat(300),
+      minItems: 1
+    }
+    const text = telegramElicitFormText('q'.repeat(4000), target)
+    expect([...text].length).toBeLessThanOrEqual(4096)
+    // The question yields, never the hint: the bounds are what the keyboard cannot say itself.
+    expect(text).toContain('Select at least 1.')
   })
 
   it('refuses a position no checkbox on the card held, and leaves the card live', async () => {

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -1,7 +1,10 @@
 /**
  * Telegram's elicitation card — the second implementer of the Layer-2 elicitation-card facet
- * (issue #1794, gap 6). An inline keyboard is the only control Telegram has, so the two kinds one
- * TAP answers are offered and every other kind is declined with the notice #1819/#1839 post.
+ * (issue #1794, gap 6). An inline keyboard is the only control Telegram has, so a multi-select is
+ * ASSEMBLED out of it: checkbox buttons that toggle and redraw, and a Confirm that submits the set
+ * through the same re-derivation a Slack Confirm goes through. A typed box has no keyboard
+ * equivalent at all, so `text`/`number` — and any form carrying one — are still declined with the
+ * notice #1819/#1839 post.
  */
 import { describe, it, expect, vi } from 'vitest'
 import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
@@ -14,6 +17,7 @@ import {
   TELEGRAM_ELICIT_SURFACE,
   parseTelegramElicit,
   telegramElicitButtons,
+  telegramElicitCheckboxes,
   telegramElicitData,
   telegramElicitDataFits,
   telegramElicitCards
@@ -31,6 +35,8 @@ function form(properties: Record<string, unknown>, required: string[] = []): Cre
 }
 
 const BRANCH = { branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' } }
+
+const CHECKS = { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test', 'build'] } } }
 
 describe("the wire a Telegram tap comes back on — 64 bytes, so it carries the option's position", () => {
   it("fits Telegram's own callback_data cap for the widest card this scheme can mint", () => {
@@ -66,18 +72,15 @@ describe("the wire a Telegram tap comes back on — 64 bytes, so it carries the 
 })
 
 describe('what Telegram declares it can collect, and what it declines', () => {
-  it('claims exactly the two kinds one tap answers', () => {
-    expect([...TELEGRAM_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum'])
+  it('claims the two kinds one tap answers, plus the multi-select a keyboard assembles', () => {
+    expect([...TELEGRAM_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum', 'multi-enum'])
   })
 
-  it('reduces an enum and a boolean, and nothing that has to be filled in first', () => {
+  it('reduces an enum, a boolean and a multi-select, but nothing that has to be TYPED', () => {
     expect(elicitTarget(form(BRANCH), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('enum')
     expect(elicitTarget(form({ ok: { type: 'boolean' } }), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('boolean')
-    for (const prop of [
-      { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } },
-      { note: { type: 'string' } },
-      { count: { type: 'integer' } }
-    ])
+    expect(elicitTarget(form(CHECKS), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('multi-enum')
+    for (const prop of [{ note: { type: 'string' } }, { count: { type: 'integer' } }])
       expect(elicitForm(form(prop, Object.keys(prop)), TELEGRAM_ELICIT_SURFACE)).toBeNull()
   })
 
@@ -104,6 +107,23 @@ describe('what Telegram declares it can collect, and what it declines', () => {
         form: elicitForm(two, TELEGRAM_ELICIT_SURFACE) ?? undefined
       })
     ).toBeNull()
+  })
+})
+
+describe('the checkbox keyboard a multi-select is assembled on', () => {
+  it('carries one ticked-or-blank button per option, then Confirm and Dismiss', () => {
+    const rows = telegramElicitCheckboxes(REQUEST_ID, [{ label: 'lint' }, { label: 'test' }], new Set([1]))
+    expect(rows.slice(0, 2).map((r) => (r[0] as InlineButton).text)).toEqual(['⬜️ lint', '☑️ test'])
+    expect(rows[2]!.map((b) => b.text)).toEqual(['Confirm', 'Dismiss'])
+    // Every option button still carries its POSITION, never its value — the 64-byte cap is why.
+    expect(rows.slice(0, 2).map((r) => (r[0] as InlineButton).callbackData)).toEqual([
+      telegramElicitData(REQUEST_ID, elicitOptionToken(0)),
+      telegramElicitData(REQUEST_ID, elicitOptionToken(1))
+    ])
+    expect(rows[2]!.map((b) => b.callbackData)).toEqual([
+      telegramElicitData(REQUEST_ID, 'ok'),
+      telegramElicitData(REQUEST_ID, 'x')
+    ])
   })
 })
 
@@ -246,7 +266,7 @@ describe('a Telegram turn posts an elicitation card and settles it in place', ()
 
   it('declines a kind Telegram has no control for, and says so in the chat', async () => {
     const h = telegramTurn()
-    const req = form({ checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } }, ['checks'])
+    const req = form({ note: { type: 'string' } }, ['note'])
     await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
     expect(h.cards).toEqual([])
     expect(h.notices()[0]).toContain("this chat can't collect an answer for")
@@ -310,5 +330,74 @@ describe('a Telegram turn posts an elicitation card and settles it in place', ()
     await expect(result).resolves.toEqual({ action: 'cancel' })
     expect(h.edits[0]!.text).toContain('⏳ Cancelled')
     expect(h.daemon.permissions.pendingElicits.has(requestId)).toBe(false)
+  })
+})
+
+describe('a Telegram multi-select is assembled on the keyboard and submitted by Confirm', () => {
+  async function tap(h: Harness, requestId: string, token: string): Promise<void> {
+    await h.daemon.handleTelegramCallback(
+      { id: `cb-${token}`, data: telegramElicitData(requestId, token), channel: '-100', messageId: 4242, userId: '77' },
+      h.conn
+    )
+  }
+
+  it('posts checkboxes, toggles one on and off in place, and accepts the Confirmed set', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(CHECKS, ['checks']))
+    expect(h.notices()).toEqual([])
+    expect(h.cards[0]!.buttons.map((r) => r[0]!.text)).toEqual(['⬜️ lint', '⬜️ test', '⬜️ build', 'Confirm'])
+
+    await tap(h, requestId, elicitOptionToken(0))
+    await tap(h, requestId, elicitOptionToken(2))
+    await tap(h, requestId, elicitOptionToken(0))
+    await tap(h, requestId, elicitOptionToken(1))
+    // Each tap redraws the same message; the card is still open, nothing has been answered yet.
+    expect(h.edits).toHaveLength(4)
+    expect(h.edits[3]!.buttons.map((r) => r[0]!.text)).toEqual(['⬜️ lint', '☑️ test', '☑️ build', 'Confirm'])
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+
+    await tap(h, requestId, 'ok')
+    // The ticks come back as the LIST the schema asked for, in the card's own option order.
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['test', 'build'] } })
+    expect(h.edits.at(-1)!.text).toBe('💬 Which branch should I cut from?\n✅ checks: test, build')
+    expect(h.edits.at(-1)!.buttons).toEqual([])
+  })
+
+  it('says on the card what the keyboard cannot enforce — the selection bounds', async () => {
+    const h = telegramTurn()
+    const bounded = { checks: { ...CHECKS.checks, minItems: 2 } }
+    const { requestId } = await raise(h, form(bounded, ['checks']))
+    expect(h.cards[0]!.text).toBe('💬 Which branch should I cut from?\nSelect at least 2.')
+
+    // And a Confirm that breaks them is refused with the field's own words, card still live.
+    await tap(h, requestId, elicitOptionToken(0))
+    await tap(h, requestId, 'ok')
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain('Select at least 2.')
+  })
+
+  it('Confirms an untouched optional multi-select as an omission, not as an empty answer', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(CHECKS))
+    await tap(h, requestId, 'ok')
+    await expect(result).resolves.toEqual({ action: 'accept', content: {} })
+  })
+
+  it('reads Dismiss on an assembled card as the decline it is on every other card', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(CHECKS, ['checks']))
+    await tap(h, requestId, elicitOptionToken(1))
+    await tap(h, requestId, 'x')
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(h.edits.at(-1)!.text).toContain('🚫 Dismissed')
+  })
+
+  it('refuses a position no checkbox on the card held, and leaves the card live', async () => {
+    const h = telegramTurn()
+    const { requestId } = await raise(h, form(CHECKS, ['checks']))
+    await tap(h, requestId, elicitOptionToken(9))
+    expect(h.edits).toEqual([])
+    expect(h.notices()).toEqual(["That answer wasn't accepted — the question is still open."])
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
   })
 })


### PR DESCRIPTION
## What was broken

Session [`d3e3afd5`](https://test-app.agentconnect.md/agentconnect/sessions/d3e3afd5-ac16-46ec-beb1-c5128cd67364), Telegram thread `tg:277`:

```
user  : 发个多选给我, 选项有三个, 每个包含一个句子
tool  : AskUserQuestion  multiSelect: true  (3 options)
elicit: {"outcome":"unrenderable"}          ← declined, no card ever posted
tool  ← "The user did not answer the questions."
agent : 多选已经发出去了，不过你没有选（跳过了）
```

The Telegram surface (#1853) claimed only `enum` and `boolean` — the two kinds one tap
answers — so a multi-select was declined before it reached the chat, and the agent was told
the reader had *skipped* it. That is the worst shape a decline can take: the agent believes
it asked a question and was ignored, and says so to the reader who was never asked.

## What it does now

Telegram has exactly one control, so the multi-select is assembled out of it:

```
💬 请选择你认同的说法（可多选）：
┌──────────────────────────────┐
│ ⬜️ 今天的天气很适合出门散步。   │
│ ☑️ 晚饭我想吃一碗热乎乎的面。   │
│ ⬜️ 睡前我打算读几页书再休息。   │
│ Confirm          Dismiss     │
└──────────────────────────────┘
```

One button per option carrying its own checkbox; a tap toggles it and redraws the keyboard
in place (`editMessageText`); Confirm submits the ticked set; Dismiss stays the one explicit
decline it is on every other card. The bounds a checkbox cannot enforce — `minItems` /
`maxItems`, which Slack gets free from `max_selected_items` — are stated on the card instead,
and a Confirm that breaks them is refused with the field's own words while the card stays live.

## One re-derivation, two surfaces

The Confirm submits through `submitElicitForm` — the very function a Slack Confirm goes
through — with the field's carried `ac_o<n>` values under the same `elicitFormBlockId(0)`.
So both surfaces share ONE re-derivation of the rendered form (#1815), one per-field
validation, and one refusal wording. Nothing about what an answer must be lives in the
platform module.

## The seam

What Telegram lacks is somewhere to keep a half-made selection: 64 bytes of `callback_data`
cannot carry one the way a Slack message's own `state.values` does. Two optional additions to
`ElicitCardFacet`, both of which Slack and webchat take by *absence*:

- `ElicitCardHandle.cardState` — an opaque per-card slot the surface owns, with core's own
  record lifetime (the same shape `turnState` already takes). Core never reads it.
- `ElicitCardFacet.tap(handle, card, token)` — folds one tap into that state and reports
  `pending` (redrawn, nothing answered yet) or `submit` (the assembled fields). Absent ⇒
  every tap on this surface is already a whole answer, which is what Slack's is.

Per CLAUDE.md's rule about extracting a member from one implementer: both branches of this
member are realized today — Telegram implements it, Slack and webchat take its absence — so
it is a variation point with two live behaviours rather than an interface guessed from one.

## Still declined on Telegram

`text` / `number` have no keyboard equivalent at all, so they and any form carrying one stay
declined with the notice #1819/#1839 post, as does URL mode (an inline `url` button fires no
`callback_query`, so consent could never be observed). Those are follow-ups on #1794 —
a `ForceReply` answer channel for a typed box, and a field-at-a-time chain for a form.

## Verification

- `packages/daemon/test/telegram-elicit-card.test.ts` — 22 tests. Every new/changed assertion
  was confirmed **red** on reverted sources before the fix (8 of 22).
- New coverage: checkbox keyboard shape; toggle on/off redrawing in place; the Confirmed set
  arriving as the schema's list in card order; bounds stated on the card and a bounds-breaking
  Confirm refused with the card left live; an untouched optional multi-select Confirmed as an
  omission rather than an empty answer; Dismiss on an assembled card; an unoffered position
  refused aloud.
- `pnpm --filter @agentconnect.md/daemon typecheck`, `pnpm lint`, `pnpm format:check` clean.
- `pnpm eval:gates`: 192/193, the one failure being the known pre-existing
  `evaluation-runner` › "records a raw ACP baseline…".

Refs #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
