### PR TITLE
fix(daemon): never re-import the agent's own rows from the turn-final thread snapshot

### DIFF
--- a/docs/designs/webchat-cross-integration-continuation.md
+++ b/docs/designs/webchat-cross-integration-continuation.md
@@ -566,8 +566,10 @@ session and keeps the read-only view otherwise.
   cancel is limited to the conversation's own turn and runtime-set ops are
   refused; a platform message arriving mid-continuation queues behind the
   reservation/turn; the posting agent's provider echo does not duplicate its
-  targeted dispatch, while other existing thread participants follow ordinary
-  activation rules. **Hook origin (§9):** a turn into a `hook:github:<repo>:<n>`
+  targeted dispatch — neither live nor when its turn-final thread snapshot reads
+  the mirror back under the agent's own authorship (the human row already exists
+  under the dispatch ts, so own-agent provider rows are never re-imported) —
+  while other existing thread participants follow ordinary activation rules. **Hook origin (§9):** a turn into a `hook:github:<repo>:<n>`
   session runs on that session's own key, posts nothing to any platform, and
   lands the human turn plus exactly ONE reply row in that session's transcript
   while streaming to the browser; a hook target that no longer resolves is

--- a/packages/daemon/src/session/thread-context.ts
+++ b/packages/daemon/src/session/thread-context.ts
@@ -82,7 +82,13 @@ export class ThreadContextCoordinator {
       if (snapshot) {
         // Provider history rows carry a platform author and no recipient: the refreshing
         // agent is what names the org that owns them on a shared store.
-        for (const event of snapshot.events) await this.store.appendTranscript({ ...event, orgAgentId: input.agentId })
+        for (const event of snapshot.events) {
+          // Skip this agent's OWN rows, as backfillThreadHistory does: replies are recorded at the send boundary, and a
+          // console-mirrored human turn wears this agent's authorship on Slack while its human row already exists under
+          // the dispatch ts — re-importing either under its Slack ts lands a duplicate the (channel,thread,ts) index misses.
+          if (event.sender === input.agentId) continue
+          await this.store.appendTranscript({ ...event, orgAgentId: input.agentId })
+        }
         completeness = snapshot.completeness
         providerCheckpoint = snapshot.checkpoint ?? providerCheckpoint
       } else {

--- a/packages/daemon/test/thread-context.test.ts
+++ b/packages/daemon/test/thread-context.test.ts
@@ -89,6 +89,41 @@ describe('ThreadContextCoordinator', () => {
     await db.close()
   })
 
+  it("never re-imports the agent's own provider rows, so a console-mirrored human turn stays one human row", async () => {
+    const db = await store()
+    const coordinator = new ThreadContextCoordinator(db)
+    // The console turn recorded the human under its dispatch ts; on Slack the same words landed as a bot
+    // post carrying this agent's authorship metadata, so the provider read returns them as `bot-a`.
+    await coordinator.observeInbound(text('1700000073188', 'U1', 'console question'))
+    await coordinator.observeInbound(text('1700000031.451949', 'bot-a', 'own reply'))
+    const snapshot = vi.fn(async () => ({
+      completeness: 'authoritative' as const,
+      checkpoint: '1700000100.000000',
+      events: [
+        { ...text('1700000031.451949', 'bot-a', 'own reply'), trustedAgentBot: true },
+        { ...text('1700000073.415209', 'bot-a', 'console question'), trustedAgentBot: true },
+        text('1700000099.000001', 'U2', 'peer human')
+      ]
+    }))
+
+    const refresh = await coordinator.refresh({
+      agentId: 'bot-a',
+      transcriptChannel: 'scope:C1',
+      thread: 'T1',
+      afterRevision: 0,
+      snapshot
+    })
+
+    const rows = await db.transcriptSinceRevision('scope:C1', 'T1', 0, 'bot-a')
+    expect(rows.filter((row) => row.text === 'console question').map((row) => row.sender)).toEqual(['U1'])
+    expect(rows.filter((row) => row.sender === 'bot-a').map((row) => row.ts)).toEqual(['1700000031.451949'])
+    expect(refresh.events.map((event) => [event.sender, event.text])).toEqual([
+      ['U1', 'console question'],
+      ['U2', 'peer human']
+    ])
+    await db.close()
+  })
+
   it('retries a failed snapshot and degrades to observed-only without hiding local events', async () => {
     const db = await store()
     const onFailure = vi.fn()


### PR DESCRIPTION
## What

`ThreadContextCoordinator.refresh` now skips provider snapshot rows whose `sender` is the refreshing agent itself before appending them to the transcript, the same rule `backfillThreadHistory` already applies on the cold/warm backfill path. A regression test covers the console-mirror shape, and the continuation design's test list records that the posting agent's echo must not duplicate on the snapshot read-back either.

## Why

A console-continued Slack session mirrors the human's message into the Slack thread as a bot post carrying the target agent's `author_agent_id` metadata (`webchat-cross-integration-continuation.md` §6). The turn-final provider snapshot (`fetchThreadHistory` → `ThreadContextCoordinator.refresh`) read that post back, `trustedAgentBot` resolved its sender to the agent, and it was appended under the Slack ts. The human's own row already existed under the dispatch ts, so the `(channel, thread, ts)` dedup index could not collapse them and the session showed the same sentence twice: once under the human, once under the agent.

Observed on a production session: seq N (sender = user, ms ts) and seq N-2 (sender = agent, Slack ts, `trustedAgentBot: true`) with identical text, 227 ms apart.

## Notes for review

- Own-agent rows are never needed from the snapshot: replies are recorded at the send boundary. Skipping them also removes the `minimal`-mode duplicate of the agent's own replies (recorded under a monotonic ts, so the Slack-ts snapshot copy never deduped), the same hazard the backfill comment already describes.
- No metadata marker was added for the mirror: for the target agent the mirror's author is by construction itself, so the sender skip covers it; peers keep the v1 behavior of treating the mirror as an agent-authored post, on the live path and the read-back path alike.
- Rows already written by earlier turns are not cleaned up; the fix applies to turns going forward.

## Test plan

- [x] `pnpm --filter @agentconnect.md/daemon exec vitest run test/thread-context.test.ts test/turn-output-workflow.test.ts test/daemon-webchat-session-continuation.test.ts` (27 passed; the new case fails without the fix)
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)