### PR TITLE
feat(daemon): ask the user before a private session writes shared memory

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -661,6 +661,22 @@ from `isDm`/webchat/launch-correlation alone. The gate therefore has two layers:
      acknowledgement, typically sub-second", not "at the moment of the API
      call".
 
+**The one exception to the write exclusion is an explicit approval in the
+session.** The human in a private session owns its content, so when the agent
+calls an explicit memory write tool (`writeMemory`, `saveMemory`,
+`updateMemory`, `deleteMemory`) from a capture-excluded session, the daemon does
+not refuse — it asks that human, through the same approval surfaces a runtime
+permission prompt uses (webchat's in-stream card, the platform's elicitation
+card where it has one, otherwise the Agent-editor approval queue). The card
+names the target file or record and a short content summary, and offers three
+choices: **Allow once** (exactly that call and payload), **Allow for this
+session** (later writes from the same session skip the ask; held in daemon
+memory and forgotten on restart), and **Deny**. A denied, dismissed, or
+cancelled ask returns a read-only refusal to the model. When there is no human
+to ask — a headless cron run, an A2A child, a suppressed or ended turn — the
+write is refused at once rather than left waiting. Reads, post-turn
+distillation, and dream capture are unchanged by this.
+
 **Already-captured memory is not scrubbed.** Distilled memory cannot be
 reliably attributed back to source turns, so tightening a session stops
 _future_ capture but does not retract what was distilled while it was

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -794,10 +794,16 @@ retracted. Until a session's daemon has confirmed the current state, that daemon
 capture rather than assuming the session is shareable.
 
 The block covers both ways a session reaches shared memory: the automatic post-turn
-distillation, and an explicit write by the agent itself. A private session's memory-write
-tools refuse with an explanation rather than failing silently, and reads stay available —
-recalling what the agent already knows is not a disclosure of the current conversation.
-Dream sessions skip private transcripts entirely.
+distillation, and an explicit write by the agent itself. Distillation is simply withheld.
+An explicit write asks the human in the session first — the card names the target and a
+short summary of the content and offers Allow once, Allow for this session, and Deny —
+because that person owns the conversation and an explicit approval is consent to share it.
+The ask reaches the same surfaces a permission prompt does (the webchat card, the
+platform's own card, otherwise the Agent-editor queue); when nobody can be asked (a
+headless run, an agent-to-agent child) or the answer is no, the tool refuses with an
+explanation that says the memory is read-only here rather than failing silently. Reads
+stay available — recalling what the agent already knows is not a disclosure of the
+current conversation. Dream sessions skip private transcripts entirely.
 
 **Agents on native runtime memory are the exception, and the product must say so.** With
 that backend the runtime persists memory inside its own process for the whole agent, with

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -78,6 +78,7 @@ import { attachmentMention, sniffImageMimeType } from './session/attachment-bloc
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
 import type { CodeHostEffectReq, SessionContext } from './mcp/ops.js'
+import type { MemoryAccessDecision, MemoryWriteAsk, MemoryWriteVerdict } from './mcp/ops/memory.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import { GitlabBroker } from './gitlab/broker.js'
 import { gitlabApiBaseUrl } from './gitlab/api-base.js'
@@ -2833,24 +2834,11 @@ export class Daemon {
       replyGithubReviewThreads: (req) => this.githubReviews.replyGithubReviewThreads(req),
       codeHostEffect: (req) => this.runCodeHostEffect(req),
       memory: this.memory,
-      // Every session may READ shared agent memory; only a non-isolated session
-      // may WRITE it, so a private DM/A2A turn can use existing memory but cannot
-      // push its own content into the cross-user store (#653; capture stays gated
-      // like post-turn distillation). Resolved from trusted session coords at call
-      // time so a policy change takes effect for an already-running ACP session.
-      memoryAccessAllowed: async (ctx, mode) => {
-        if (mode === 'read') return true
-        // A daemon-minted binding (distillation) carries its own authorization: it has
-        // no persisted session row, so the capture gate below would fail closed on it,
-        // and the privacy decision was already made upstream — queueMemoryPostTurn
-        // refuses to distill a capture-excluded turn at all. The binding is never
-        // model-supplied, so this cannot be forged from inside a session.
-        if (ctx.memoryBinding) return true
-        return !(await this.store.isCaptureExcluded(
-          ctx.agentId,
-          sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
-        ))
-      },
+      // Every session may READ shared agent memory; a private session's WRITE asks the human in it
+      // first (#653; capture stays gated like post-turn distillation). Resolved from trusted session
+      // coords at call time so a policy change takes effect for an already-running ACP session.
+      memoryAccessDecision: (ctx, mode) => this.memoryAccessDecisionFor(ctx, mode),
+      requestMemoryWriteApproval: (ctx, ask) => this.requestMemoryWriteApprovalFor(ctx, ask),
       memoryScope: (ctx) => this.memoryScope(ctx.agentId, ctx.channel, ctx.transportScope),
       resolveAttachment: async (ctx, name) => {
         const found = await this.store.transcriptAttachmentByName(
@@ -5063,6 +5051,28 @@ export class Daemon {
       if (turn.selectedHost) selected.add(turn.selectedHost)
     }
     await Promise.all([...selected].map((lifecycle) => lifecycle.stop(0)))
+  }
+
+  /** The memory-tool gate (#653): reads always pass; a private session's write asks unless it holds a session grant. */
+  private async memoryAccessDecisionFor(ctx: SessionContext, mode: 'read' | 'write'): Promise<MemoryAccessDecision> {
+    if (mode === 'read') return 'allow'
+    // A daemon-minted binding (distillation) carries its own authorization: it has no persisted
+    // row, so the capture gate would fail closed on it, and queueMemoryPostTurn already refused
+    // to distill a capture-excluded turn. Never model-supplied, so it cannot be forged.
+    if (ctx.memoryBinding) return 'allow'
+    const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+    if (!(await this.store.isCaptureExcluded(ctx.agentId, key))) return 'allow'
+    return this.memoryWriteGrants.has(key) ? 'allow' : 'ask'
+  }
+
+  /** Ask the human behind the session's live turn about ONE write; "for this session" is remembered here. */
+  private async requestMemoryWriteApprovalFor(ctx: SessionContext, ask: MemoryWriteAsk): Promise<MemoryWriteVerdict> {
+    const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+    const p = [...this.pending.values()].find((pending) => pending.plan.sessionKey === key)
+    if (!p) return 'no_approver'
+    const outcome = await this.permissions.askMemoryWriteApproval(p.hostKey, p.acpSessionId, ask)
+    if (outcome === 'allow_session') this.memoryWriteGrants.add(key)
+    return outcome === 'allow_once' || outcome === 'allow_session' ? 'allowed' : outcome
   }
 
   /** Build the memory scope for an agent + conversation. For a `channel`-scoped
@@ -11337,10 +11347,9 @@ export class Daemon {
           // conversation post, not an address — it must not defeat the response-choice
           // rule (webchat-multi-agents.md §5.2a).
           directAgentCall: plan.directAgentCall,
-          // Memory READS (index injection + auto-recall) are no longer session-
-          // gated — every session may use shared memory (#653). WRITES stay gated
-          // (memory write tools via memoryAccessAllowed; post-turn distillation via
-          // isCaptureExcluded at recordTurnForBinding).
+          // Memory READS (index injection + auto-recall) are not session-gated — every session may
+          // use shared memory (#653). WRITES stay gated (memory write tools via memoryAccessDecision,
+          // which asks the human in a private session; post-turn distillation via isCaptureExcluded).
           ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {}),
           ...(entry.selectedHost ? { host: entry.selectedHost.host } : {}),
           ...(webchatIsolation ? { workspaceIsolation: webchatIsolation } : {}),
@@ -13842,6 +13851,11 @@ export class Daemon {
    */
   private activeTurnCallMeta = new Map<string, CallMeta>()
 
+  /** Private sessions whose human chose "Allow for this session" on a memory write, by logical
+   *  sessionKey (session-visibility.md §5.1): later writes there skip the ask. In-memory on purpose —
+   *  a daemon restart forgets the grant — and dropped with the session row. */
+  private readonly memoryWriteGrants = new Set<string>()
+
   /** The active turn's trusted `shareFile` post target, by logical sessionKey — the
    *  coordinate + per-platform anchor the tool may NOT receive from the model
    *  (agent-authored-attachments.md §3.1), plus the two coordinate refusals (§3.2). */
@@ -16337,6 +16351,7 @@ export class Daemon {
           await this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })
         ) {
           removed += 1
+          this.memoryWriteGrants.delete(rec.key)
           if (rec.acpSessionId)
             this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
           await this.modelSessions.release(rec.key)

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,5 +1,5 @@
 import { z, type ZodType } from 'zod'
-import { MEMORY_ACCESS_BLOCKED } from '../memory/tools.js'
+import { MEMORY_WRITE_NO_APPROVER, MEMORY_WRITE_NOT_APPROVED } from '../memory/tools.js'
 import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import { allAttachmentReadTools, isAttachmentReadTool, sessionToolOwner } from '../platforms/read-ports.js'
 import type { SessionContext, ToolHandler } from './ops/context.js'
@@ -19,6 +19,7 @@ import {
   getMemory,
   GET_MEMORY_ARGS,
   MEMORY_TOOL_ACCESS_MODES,
+  memoryWriteAsk,
   readMemory,
   READ_MEMORY_ARGS,
   saveMemory,
@@ -321,8 +322,15 @@ export async function executeTool(
   // Session-isolation gate for the memory tools (#653), checked at CALL time so a
   // mid-session policy change takes effect immediately.
   const memoryMode = MEMORY_TOOL_ACCESS_MODES[name]
-  if (memoryMode !== undefined && (await deps.memoryAccessAllowed?.(ctx, memoryMode)) === false) {
-    throw new Error(MEMORY_ACCESS_BLOCKED)
+  if (memoryMode !== undefined) {
+    const decision = (await deps.memoryAccessDecision?.(ctx, memoryMode)) ?? 'allow'
+    if (decision === 'deny') throw new Error(MEMORY_WRITE_NO_APPROVER)
+    if (decision === 'ask') {
+      // The approval covers THIS call's payload and nothing else: it is awaited inline, never cached.
+      const verdict = (await deps.requestMemoryWriteApproval?.(ctx, memoryWriteAsk(name, args))) ?? 'no_approver'
+      if (verdict === 'no_approver') throw new Error(MEMORY_WRITE_NO_APPROVER)
+      if (verdict !== 'allowed') throw new Error(MEMORY_WRITE_NOT_APPROVED)
+    }
   }
   const handler = HANDLERS.get(name)
   if (handler) return await handler(ctx, args, deps)

--- a/packages/daemon/src/mcp/ops/memory.ts
+++ b/packages/daemon/src/mcp/ops/memory.ts
@@ -18,19 +18,73 @@ export interface MemoryOpsDeps {
   /** The agent memory provider — backs the `readMemory`/`writeMemory` tools.
    *  Universal (every agent has memory), independent of the platform. */
   memory: MemoryProvider
-  /** Session-isolation gate for the explicit memory-tool path, by operation
-   *  (#653). Agent memory is shared across users: every session may READ it
-   *  (read/search/get), but only a non-isolated session may WRITE it
-   *  (write/save/update/delete), so a private DM/A2A turn cannot push its content
-   *  into shared memory. Automatic recall is always allowed; post-turn capture and
-   *  Dream selection are gated at their own boundaries. Checked at CALL time so a
-   *  mid-session policy change takes effect immediately. Absent ⇒ allowed (e.g. in
-   *  unit fixtures). */
-  memoryAccessAllowed?: (ctx: SessionContext, mode: 'read' | 'write') => boolean | Promise<boolean>
+  /** Session-isolation gate for the explicit memory-tool path, by operation (#653): agent memory is
+   *  shared across users, so every session may READ it but a private session's WRITE is `ask` — the
+   *  human in the session decides (or `deny` when nothing can ask). Post-turn capture and Dream
+   *  selection are gated at their own boundaries. Checked at CALL time; absent ⇒ allowed (fixtures). */
+  memoryAccessDecision?: (
+    ctx: SessionContext,
+    mode: 'read' | 'write'
+  ) => MemoryAccessDecision | Promise<MemoryAccessDecision>
+  /** Ask the human in the session to approve ONE pending write (the `ask` decision). Covers exactly
+   *  this call's payload; a session-wide grant is the daemon's to remember. Absent ⇒ nobody to ask. */
+  requestMemoryWriteApproval?: (ctx: SessionContext, ask: MemoryWriteAsk) => Promise<MemoryWriteVerdict>
   /** Build the memory scope for a tool call — carries the per-channel folder key
    *  for a channel-scoped agent so tools read/write that channel's memory (#653).
    *  Absent ⇒ agent-level store (unit fixtures). */
   memoryScope?: (ctx: SessionContext) => MemoryScope
+}
+
+/** The gate's verdict for one memory-tool call: proceed, refuse, or ask the human first. */
+export type MemoryAccessDecision = 'allow' | 'deny' | 'ask'
+
+/** How an `ask` ended: approved, declined (or abandoned), or nobody could be asked at all. */
+export type MemoryWriteVerdict = 'allowed' | 'denied' | 'no_approver'
+
+/** What the approval card shows for one pending write: the tool, its target, and a bounded summary. */
+export interface MemoryWriteAsk {
+  tool: string
+  /** The memory file or record the write lands on. */
+  target: string
+  /** One line: the first ~200 chars of the content, or what an edit/delete does. */
+  summary: string
+}
+
+const ASK_SUMMARY_MAX = 200
+
+function clip(text: string, max = ASK_SUMMARY_MAX): string {
+  const one = text.replace(/\s+/g, ' ').trim()
+  return one.length > max ? `${one.slice(0, max - 1)}…` : one
+}
+
+const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined)
+
+/** Describe a pending memory write for the approval card, from the RAW arguments: total, never
+ *  throws — a malformed call is refused by the handler's own parsing once (if) it is approved. */
+export function memoryWriteAsk(tool: string, args: Record<string, unknown>): MemoryWriteAsk {
+  switch (tool) {
+    case 'writeMemory': {
+      const target = str(args.path) ?? 'MEMORY.md'
+      const oldString = str(args.oldString)
+      const newString = str(args.newString)
+      if (oldString !== undefined || newString !== undefined) {
+        const summary = newString
+          ? `Replace "${clip(oldString ?? '', 80)}" with "${clip(newString, 120)}"`
+          : `Remove "${clip(oldString ?? '')}"`
+        return { tool, target, summary }
+      }
+      const content = str(args.content)
+      return { tool, target, summary: content ? `Content: "${clip(content)}"` : `Clear ${target} (empty write)` }
+    }
+    case 'saveMemory':
+      return { tool, target: 'a new memory record', summary: `Content: "${clip(str(args.text) ?? '')}"` }
+    case 'updateMemory':
+      return { tool, target: `record ${str(args.id) ?? '?'}`, summary: `New content: "${clip(str(args.text) ?? '')}"` }
+    case 'deleteMemory':
+      return { tool, target: `record ${str(args.id) ?? '?'}`, summary: `Delete record ${str(args.id) ?? '?'}` }
+    default:
+      return { tool, target: 'shared memory', summary: '' }
+  }
 }
 
 /** `readMemory` arguments; an omitted `path` reads the MEMORY.md index. */

--- a/packages/daemon/src/memory/tools.ts
+++ b/packages/daemon/src/memory/tools.ts
@@ -1,9 +1,13 @@
 import type { MemoryPluginOperation } from '@agentconnect.md/protocol'
 import { obj, type ToolDescriptor } from '../tool-schema/descriptor.js'
 
-/** Refusal surfaced to the model when an isolated session tries to access agent memory shared with other users. */
-export const MEMORY_ACCESS_BLOCKED =
-  'Shared agent memory is unavailable in this session. Keep the information in this conversation instead; do not retry.'
+const MEMORY_READ_ONLY_HERE = "This session is private, so the agent's shared memory is read-only here."
+
+/** Refusal surfaced to the model when the user declined (or never answered) a private session's write. */
+export const MEMORY_WRITE_NOT_APPROVED = `${MEMORY_READ_ONLY_HERE} The user did not approve saving this; keep the information in this conversation and do not retry.`
+
+/** Refusal surfaced to the model when a private session's write has nobody who could approve it. */
+export const MEMORY_WRITE_NO_APPROVER = `${MEMORY_READ_ONLY_HERE} No one could be asked to approve this write; keep the information in this conversation and do not retry.`
 
 /** The agent's long-term memory tools, for EVERY agent: `<agent-root>/memory/` with a `MEMORY.md` index plus topic files. */
 export const MEMORY_TOOLS: ToolDescriptor[] = [

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -80,6 +80,13 @@ import {
   type ApprovalRequestParts
 } from '../daemon/tool-classification.js'
 import { pendingTurnKey, turnState, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
+import { isSyntheticA2aChannel } from '../cp/cp-collab-routes.js'
+import type { MemoryWriteAsk } from '../mcp/ops/memory.js'
+import {
+  memoryWriteApprovalElicitation,
+  memoryWriteApprovalFrom,
+  type MemoryWriteApprovalOutcome
+} from './memory-write-approval.js'
 
 /** The union of a turn's explicit human-approval waits, measured here and nowhere else.
  *  Regeneration budgets subtract it while retaining runtime/tool work time; `depth` counts
@@ -1439,6 +1446,44 @@ export class PermissionCoordinator {
     if (!form) return this.noticeUnrenderableElicit(p, params, isApproval)
     if (isApproval && elicitCardShape(form) === 'inputs') return this.noticeUnrenderableElicit(p, params, isApproval)
     return await this.awaitChatElicitation(agentId, sessionId, params, p, facet, { form }, isApproval)
+  }
+
+  /**
+   * The daemon's own ask: a capture-excluded session's memory write waits for the human in that
+   * session (session-visibility.md §5.1). One synthetic three-way form takes the SAME surfaces an
+   * agent's elicitation does — webchat's in-stream card, the platform's elicitation card where it
+   * has one, else the Agent-editor queue — and a turn with no human behind it (none live,
+   * suppressed, headless, an A2A child) answers `no_approver` at once rather than hanging the tool.
+   * Turn cancellation settles it through `releaseElicits`/`releaseEditorPermissions` as a decline.
+   */
+  async askMemoryWriteApproval(
+    owner: HostKey,
+    sessionId: string,
+    ask: MemoryWriteAsk
+  ): Promise<MemoryWriteApprovalOutcome> {
+    const agentId = hostKeyAgentId(owner)
+    const p = this.host.pending().get(pendingTurnKey(owner, sessionId))
+    if (!p || p.outputSuppressed) return 'no_approver'
+    if (p.entry.msg.headless === true || p.callMeta || isSyntheticA2aChannel(p.plan.channel)) return 'no_approver'
+    // The summary is model-authored text headed for a card: mask a secret it may have interpolated.
+    const params = this.host.maskAgentSecrets(agentId, memoryWriteApprovalElicitation(sessionId, ask))
+    try {
+      if (p.webchat && !p.webchat.continuation) {
+        const res = this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
+        return memoryWriteApprovalFrom(await this.trackHumanApprovalWait(p, res))
+      }
+      const facet = p.conn && !p.plan.approvalSurfaceSuppressed ? this.host.elicitCardFacet(p.plan.platform) : undefined
+      const form = facet ? elicitForm(params, facet.reduction) : null
+      if (facet && form) {
+        const res = this.awaitChatElicitation(agentId, sessionId, params, p, facet, { form }, false)
+        return memoryWriteApprovalFrom(await this.trackHumanApprovalWait(p, res))
+      }
+      // No card in this chat: the editor queue (console Approval requests, approval DM) decides.
+      return memoryWriteApprovalFrom(await this.awaitEditorElicitation(agentId, sessionId, params, p))
+    } catch (err) {
+      this.host.log().warn(`memory write approval could not be asked for "${p.plan.sessionKey}": ${formatErr(err)}`)
+      return 'no_approver'
+    }
   }
 
   /**

--- a/packages/daemon/src/permissions/memory-write-approval.ts
+++ b/packages/daemon/src/permissions/memory-write-approval.ts
@@ -1,0 +1,59 @@
+// The daemon's OWN ask: a private (capture-excluded) session's memory write needs the human in the
+// session to consent before it reaches the agent's cross-user memory (session-visibility.md §5.1).
+// It rides the elicitation machinery as one synthetic form so every surface renders it unchanged.
+import type { CreateElicitationRequest, CreateElicitationResponse } from '@agentclientprotocol/sdk'
+import type { MemoryWriteAsk } from '../mcp/ops/memory.js'
+
+/** The one field the card asks. */
+export const MEMORY_WRITE_APPROVAL_PROP = 'decision'
+
+/** The three answers, in card order; `deny` is offered explicitly even though Dismiss also declines. */
+export const MEMORY_WRITE_APPROVAL_OPTIONS = [
+  { value: 'allow_once', label: 'Allow once' },
+  { value: 'allow_session', label: 'Allow for this session' },
+  { value: 'deny', label: 'Deny' }
+] as const
+
+/** How the ask ended: one of the two grants, a decline of any kind, or nobody to ask. */
+export type MemoryWriteApprovalOutcome = 'allow_once' | 'allow_session' | 'denied' | 'no_approver'
+
+/** The first line is the question (the card's head); the lines below name the write. */
+export function memoryWriteApprovalMessage(ask: MemoryWriteAsk): string {
+  const lines = [
+    'Allow this write to shared agent memory from a private session?',
+    `${ask.tool} → ${ask.target}`,
+    ...(ask.summary ? [ask.summary] : [])
+  ]
+  return lines.join('\n')
+}
+
+/** The synthetic form: one required single-select, so every card surface shows a button per option. */
+export function memoryWriteApprovalElicitation(sessionId: string, ask: MemoryWriteAsk): CreateElicitationRequest {
+  return {
+    sessionId,
+    mode: 'form',
+    message: memoryWriteApprovalMessage(ask),
+    requestedSchema: {
+      type: 'object',
+      properties: {
+        [MEMORY_WRITE_APPROVAL_PROP]: {
+          type: 'string',
+          title: 'Shared memory write',
+          oneOf: MEMORY_WRITE_APPROVAL_OPTIONS.map((o) => ({ const: o.value, title: o.label }))
+        }
+      },
+      required: [MEMORY_WRITE_APPROVAL_PROP]
+    }
+  } as CreateElicitationRequest
+}
+
+/** Read the answer back: only an explicit grant allows; a bare `accept` (the editor queue's Allow)
+ *  is one write; decline, cancel and an unshown card (`undefined`) never are. */
+export function memoryWriteApprovalFrom(res: CreateElicitationResponse | undefined): MemoryWriteApprovalOutcome {
+  if (res === undefined) return 'no_approver'
+  if (res.action !== 'accept') return 'denied'
+  const picked = (res.content as Record<string, unknown> | undefined)?.[MEMORY_WRITE_APPROVAL_PROP]
+  if (picked === 'allow_session') return 'allow_session'
+  if (picked === 'deny') return 'denied'
+  return 'allow_once'
+}

--- a/packages/daemon/test/memory-write-approval.test.ts
+++ b/packages/daemon/test/memory-write-approval.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The daemon's own ask (session-visibility.md §5.1): a private session's memory write waits for
+ * the human in that session. It rides the elicitation machinery as one synthetic three-way card,
+ * so the surfaces, the answer validation, and turn cancellation are all the existing ones.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { agentHostKey } from '../src/acp/host-key.js'
+import { PermissionCoordinator, type PermissionHost } from '../src/permissions/coordinator.js'
+import {
+  MEMORY_WRITE_APPROVAL_OPTIONS,
+  memoryWriteApprovalElicitation,
+  memoryWriteApprovalFrom
+} from '../src/permissions/memory-write-approval.js'
+import type { ElicitCardFacet } from '../src/platforms/elicit-card.js'
+import { elicitOptionToken, SLACK_ELICIT_SURFACE } from '../src/slack/render.js'
+import { pendingTurnKey, type Pending } from '../src/daemon/turn-types.js'
+import type { MemoryWriteAsk } from '../src/mcp/ops/memory.js'
+
+const AGENT = 'bot-a'
+const OWNER = agentHostKey(AGENT)
+const ACP_SESSION = 'acp-1'
+const ASK: MemoryWriteAsk = { tool: 'writeMemory', target: 'deploys.md', summary: 'Content: "- ship on Fridays"' }
+const LABELS = ['Allow once', 'Allow for this session', 'Deny']
+
+interface WorldOptions {
+  platform?: string
+  webchat?: boolean
+  headless?: boolean
+  callMeta?: boolean
+  channel?: string
+  conn?: boolean
+  facet?: ElicitCardFacet
+  suppressed?: boolean
+}
+
+function world(over: WorldOptions = {}) {
+  const store = {
+    getSessionByAcpIdForAgent: async () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: async () => new Map<string, string>(),
+    createPermissionRequest: vi.fn(async () => {}),
+    resolvePermissionRequest: vi.fn(async () => true),
+    clearPermissionRequestNotify: vi.fn(async () => {}),
+    upsertElicit: vi.fn(async () => {})
+  }
+  const sink = { output: vi.fn(), done: vi.fn() }
+  const webchat = over.webchat ?? true
+  const p = {
+    plan: {
+      sessionKey: 'sess-key',
+      agentId: AGENT,
+      agentName: 'Butler',
+      platform: over.platform ?? 'webchat',
+      channel: over.channel ?? 'conv-1',
+      statusThread: 'conv-1',
+      transcriptChannel: 'conv-1',
+      requesterId: 'user-1',
+      approvalSurfaceSuppressed: false
+    },
+    approval: { waitMs: 0, depth: 0 },
+    acpSessionId: ACP_SESSION,
+    hostKey: OWNER,
+    outwardSessionId: 'outward-1',
+    builtinSystemToolCallIds: new Set<string>(),
+    entry: { msg: { text: 'please forget the deploy note', ...(over.headless ? { headless: true } : {}) } },
+    ...(over.callMeta ? { callMeta: { callerAgentId: 'bot-b' } } : {}),
+    ...(over.suppressed ? { outputSuppressed: 'paused' } : {}),
+    ...(over.conn ? { conn: {} } : {}),
+    ...(webchat
+      ? {
+          webchat: {
+            conversationId: 'conv-1',
+            turnId: 'turn-1',
+            sink,
+            index: 0,
+            replyText: '',
+            heldText: '',
+            messageEmitted: false
+          }
+        }
+      : {})
+  } as unknown as Pending
+  const pending = new Map<string, Pending>([[pendingTurnKey(OWNER, ACP_SESSION), p]])
+  const enqueueApply = vi.fn()
+  const host: PermissionHost = {
+    log: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) as never,
+    clock: () => ({ now: () => Date.now() }) as never,
+    store: () => store as never,
+    agents: () => new Map([[AGENT, { id: AGENT } as never]]),
+    pending: () => pending,
+    evalHooks: () => ({ emit: vi.fn() }) as never,
+    memoryExtractionInFlight: () => false,
+    enqueueApply,
+    postCardSerialized: vi.fn(async () => undefined),
+    elicitCardFacet: () => over.facet,
+    httpSlackSessionTarget: () => undefined,
+    maskAgentSecrets: (_agentId, payload) => payload,
+    logSessionAction: vi.fn(),
+    emitApprovalActivity: vi.fn(),
+    approvalGateOpened: () => false,
+    approvalGateClosed: vi.fn(),
+    cpApprovalRoute: () => undefined,
+    orgForAgent: () => 'org-1',
+    sessionLink: (sessionId) => `https://console.example.test/sessions/${sessionId}`,
+    slackConnFor: () => undefined,
+    approvalDmIntegrations: () => [],
+    slackDmSessionTarget: () => 'encoded-target'
+  }
+  const events = (): any[] => sink.output.mock.calls.map(([o]: any[]) => o.event)
+  return { store, sink, events, enqueueApply, coordinator: new PermissionCoordinator(host), p }
+}
+
+/** Wait for the card to be streamed and hand back its request id. */
+async function cardOf(w: ReturnType<typeof world>) {
+  await vi.waitFor(() => expect(w.events().some((e) => e.kind === 'elicitation')).toBe(true))
+  return w.events().find((e) => e.kind === 'elicitation')!
+}
+
+describe('the card a private webchat session is shown', () => {
+  it('names the tool, the target and the content summary, and offers exactly the three choices', async () => {
+    const w = world()
+    const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    const card = await cardOf(w)
+    const [head, ...rest] = (card.message as string).split('\n')
+    expect(head).toBe('Allow this write to shared agent memory from a private session?')
+    expect(rest).toEqual(['writeMemory → deploys.md', 'Content: "- ship on Fridays"'])
+    expect(card.options.map((o: { label: string }) => o.label)).toEqual(LABELS)
+    expect(card.options.map((o: { value: string }) => o.value)).toEqual(['allow_once', 'allow_session', 'deny'])
+    // The ask is durable transcript history like any other card (#1794).
+    expect(w.store.upsertElicit).toHaveBeenCalledTimes(1)
+    await w.coordinator.handleElicitChoice({
+      requestId: card.requestId,
+      value: 'allow_once',
+      webchatConversationId: 'conv-1'
+    })
+    await expect(outcome).resolves.toBe('allow_once')
+  })
+
+  it('reads each choice back as its own outcome, Dismiss included', async () => {
+    for (const [value, expected] of [
+      ['allow_session', 'allow_session'],
+      ['deny', 'denied'],
+      [null, 'denied']
+    ] as const) {
+      const w = world()
+      const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+      const card = await cardOf(w)
+      await w.coordinator.handleElicitChoice({ requestId: card.requestId, value, webchatConversationId: 'conv-1' })
+      await expect(outcome).resolves.toBe(expected)
+      const resolved = w.events().find((e) => e.kind === 'elicitation_resolved')
+      expect(resolved.outcome).toBe(value === null ? 'dismissed' : 'accepted')
+    }
+  })
+
+  it('refuses an answer the card never offered and stays open, and an answer from another conversation', async () => {
+    const w = world()
+    const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    const card = await cardOf(w)
+    await w.coordinator.handleElicitChoice({
+      requestId: card.requestId,
+      value: 'allow_forever',
+      webchatConversationId: 'conv-1'
+    })
+    await w.coordinator.handleElicitChoice({
+      requestId: card.requestId,
+      value: 'allow_once',
+      webchatConversationId: 'conv-2'
+    })
+    expect(w.events().some((e) => e.kind === 'elicitation_resolved')).toBe(false)
+    await w.coordinator.handleElicitChoice({
+      requestId: card.requestId,
+      value: 'deny',
+      webchatConversationId: 'conv-1'
+    })
+    await expect(outcome).resolves.toBe('denied')
+  })
+
+  it('settles as a decline when the turn is cancelled, and the card says so', async () => {
+    const w = world()
+    const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    const card = await cardOf(w)
+    await w.coordinator.releaseElicits(OWNER, ACP_SESSION)
+    await expect(outcome).resolves.toBe('denied')
+    const resolved = w.events().find((e) => e.kind === 'elicitation_resolved')
+    expect(resolved).toMatchObject({ requestId: card.requestId, outcome: 'cancelled' })
+  })
+
+  it('bills the wait to the turn as human-approval time', async () => {
+    const w = world()
+    const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    const card = await cardOf(w)
+    expect(w.p.approval.depth).toBe(1)
+    await w.coordinator.handleElicitChoice({
+      requestId: card.requestId,
+      value: 'deny',
+      webchatConversationId: 'conv-1'
+    })
+    await outcome
+    expect(w.p.approval.depth).toBe(0)
+  })
+})
+
+describe('a chat platform with an elicitation card', () => {
+  const facet = () => {
+    const sent: any[] = []
+    const settle = vi.fn()
+    const f = {
+      reduction: SLACK_ELICIT_SURFACE,
+      build: () => ({ draft: true }),
+      send: async (_host: unknown, _turn: unknown, ask: unknown) => {
+        sent.push(ask)
+        return 'ts-1'
+      },
+      settle
+    } as unknown as ElicitCardFacet
+    return { f, sent, settle }
+  }
+
+  it('posts the three-button card there and reads a tapped POSITION back as the choice', async () => {
+    const { f, sent, settle } = facet()
+    const w = world({ platform: 'slack', webchat: false, conn: true, facet: f })
+    const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    await vi.waitFor(() => expect(sent).toHaveLength(1))
+    const ask = sent[0]
+    expect(ask.message).toContain('writeMemory → deploys.md')
+    expect(ask.form.map((t: { options: { label: string }[] }) => t.options.map((o) => o.label))).toEqual([LABELS])
+    // Position 1 is "Allow for this session" — the card carries positions, never values (#1794).
+    await w.coordinator.handleElicitChoice({
+      requestId: ask.requestId,
+      value: elicitOptionToken(1),
+      actor: { userId: 'U1' }
+    })
+    await expect(outcome).resolves.toBe('allow_session')
+    // The card settles the way every enum card does; the transcript row carries the label.
+    expect(settle).toHaveBeenCalledTimes(1)
+    expect(settle.mock.calls[0]![1]).toMatchObject({ mark: 'answered' })
+    const rows = w.store.upsertElicit.mock.calls.map(([row]: any[]) => JSON.parse(row.body))
+    expect(rows.at(-1)).toMatchObject({ outcome: 'accepted', answerLabel: 'Allow for this session' })
+  })
+})
+
+describe('a chat with no card of its own takes the Agent-editor queue', () => {
+  it('records the request with the target, and an editor Allow is one write', async () => {
+    const w = world({ platform: 'discord', webchat: false, conn: true })
+    const outcome = w.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    await vi.waitFor(() => expect(w.store.createPermissionRequest).toHaveBeenCalledTimes(1))
+    const row = (w.store.createPermissionRequest.mock.calls[0] as any[])[0]
+    expect(row.command).toContain('deploys.md')
+    // The channel hears the same neutral notice every editor-queued request posts.
+    expect(w.enqueueApply.mock.calls[0]![1]).toMatchObject({ kind: 'notice' })
+    await w.coordinator.decideEditorPermission({ requestId: row.id, agentId: AGENT, decision: 'allow' })
+    await expect(outcome).resolves.toBe('allow_once')
+  })
+
+  it('an editor Deny, or the turn ending, is a decline', async () => {
+    const denied = world({ platform: 'discord', webchat: false, conn: true })
+    const first = denied.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    await vi.waitFor(() => expect(denied.store.createPermissionRequest).toHaveBeenCalledTimes(1))
+    const id = (denied.store.createPermissionRequest.mock.calls[0] as any[])[0].id as string
+    await denied.coordinator.decideEditorPermission({ requestId: id, agentId: AGENT, decision: 'deny' })
+    await expect(first).resolves.toBe('denied')
+
+    const ended = world({ platform: 'discord', webchat: false, conn: true })
+    const second = ended.coordinator.askMemoryWriteApproval(OWNER, ACP_SESSION, ASK)
+    await vi.waitFor(() => expect(ended.store.createPermissionRequest).toHaveBeenCalledTimes(1))
+    await ended.coordinator.releaseEditorPermissions(OWNER, ACP_SESSION)
+    await expect(second).resolves.toBe('denied')
+  })
+})
+
+describe('a turn with no human behind it is answered at once, never hung', () => {
+  it.each([
+    ['no live turn', () => world(), 'acp-other'],
+    ['a suppressed turn', () => world({ suppressed: true }), ACP_SESSION],
+    ['a headless run', () => world({ headless: true }), ACP_SESSION],
+    ['an agent-to-agent child', () => world({ callMeta: true }), ACP_SESSION],
+    ['a synthetic A2A channel', () => world({ channel: 'a2a:bot-b:bot-a' }), ACP_SESSION]
+  ])('%s', async (_name, make, sessionId) => {
+    const w = make()
+    await expect(w.coordinator.askMemoryWriteApproval(OWNER, sessionId, ASK)).resolves.toBe('no_approver')
+    expect(w.events()).toEqual([])
+    expect(w.store.createPermissionRequest).not.toHaveBeenCalled()
+  })
+})
+
+describe('the synthetic form and its answer, in isolation', () => {
+  it('is one required single-select whose options are the three choices', () => {
+    const params = memoryWriteApprovalElicitation('s1', ASK) as any
+    expect(params.mode).toBe('form')
+    expect(params.requestedSchema.required).toEqual(['decision'])
+    expect(params.requestedSchema.properties.decision.oneOf.map((o: { title: string }) => o.title)).toEqual(LABELS)
+    expect(MEMORY_WRITE_APPROVAL_OPTIONS.map((o) => o.label)).toEqual(LABELS)
+  })
+
+  it('reads a bare accept as one write and everything short of a grant as a decline', () => {
+    expect(memoryWriteApprovalFrom({ action: 'accept' })).toBe('allow_once')
+    expect(memoryWriteApprovalFrom({ action: 'accept', content: { decision: 'allow_session' } })).toBe('allow_session')
+    expect(memoryWriteApprovalFrom({ action: 'accept', content: { decision: 'deny' } })).toBe('denied')
+    expect(memoryWriteApprovalFrom({ action: 'decline' })).toBe('denied')
+    expect(memoryWriteApprovalFrom({ action: 'cancel' })).toBe('denied')
+    expect(memoryWriteApprovalFrom(undefined)).toBe('no_approver')
+  })
+})

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -2,16 +2,22 @@
  * The tool half of the shared-memory isolation gate (#653).
  *
  * Agent memory is shared across users. Every session may READ it (the agent can
- * use what it already knows anywhere), but only a non-isolated session may WRITE
- * it — automatic post-turn distillation is gated in the daemon, and the explicit
- * write tools are gated here, so a private session cannot push its content into
- * shared memory by either route. The gate is queried per operation (`read` vs
+ * use what it already knows anywhere). A non-isolated session WRITES it freely; a
+ * private session's write is `ask` — the human in that session approves exactly the
+ * pending call, or the tool is refused with a reason the model can act on. Post-turn
+ * distillation is gated in the daemon. The gate is queried per operation (`read` vs
  * `write`); this suite mirrors the daemon wiring where reads are always allowed.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
-import { boundWrittenTopics } from '../src/mcp/ops/memory.js'
-import { MEMORY_ACCESS_BLOCKED } from '../src/memory/tools.js'
+import {
+  boundWrittenTopics,
+  memoryWriteAsk,
+  type MemoryAccessDecision,
+  type MemoryWriteAsk,
+  type MemoryWriteVerdict
+} from '../src/mcp/ops/memory.js'
+import { MEMORY_WRITE_NO_APPROVER, MEMORY_WRITE_NOT_APPROVED } from '../src/memory/tools.js'
 
 const ctx = (): SessionContext => ({
   agentId: 'bot-a',
@@ -22,47 +28,132 @@ const ctx = (): SessionContext => ({
   tools: []
 })
 
-// Mirror the daemon: reads are always allowed; writes are gated on the session's
-// isolation verdict.
-function deps(writeAllowed: boolean, over: Partial<OpsDeps> = {}): OpsDeps {
+type WriteCalls = { mock: { calls: unknown[][] } }
+
+// Mirror the daemon: reads are always allowed; a write takes the session's verdict.
+function deps(write: MemoryAccessDecision, over: Partial<OpsDeps> = {}): OpsDeps {
   return {
     memory: {
       read: vi.fn(async () => ({ content: 'existing' })),
       write: vi.fn(async () => ({ ok: true }))
     },
-    memoryAccessAllowed: (_ctx: SessionContext, mode: 'read' | 'write') => mode === 'read' || writeAllowed,
+    memoryAccessDecision: (_ctx: SessionContext, mode: 'read' | 'write') => (mode === 'read' ? 'allow' : write),
     ...over
   } as unknown as OpsDeps
 }
 
-describe('file memory under the session-isolation gate', () => {
-  it('refuses a write from a private session, without touching the provider', async () => {
-    const d = deps(false)
-    await expect(executeTool(ctx(), 'writeMemory', { content: 'secret' }, d)).rejects.toThrow(MEMORY_ACCESS_BLOCKED)
+/** A private session whose human answers every ask the same way, recording what was asked. */
+function asking(verdict: MemoryWriteVerdict) {
+  const asks: MemoryWriteAsk[] = []
+  const d = deps('ask', {
+    requestMemoryWriteApproval: vi.fn(async (_ctx: SessionContext, ask: MemoryWriteAsk) => {
+      asks.push(ask)
+      return verdict
+    })
+  })
+  return { d, asks }
+}
+
+describe('a private session asks the human before writing file memory', () => {
+  it('proceeds with the write once the human allows it', async () => {
+    const { d, asks } = asking('allowed')
+    await executeTool(ctx(), 'writeMemory', { path: 'deploys.md', content: '- ship on Fridays' }, d)
+    expect(d.memory.write).toHaveBeenCalledTimes(1)
+    expect(asks).toEqual([{ tool: 'writeMemory', target: 'deploys.md', summary: 'Content: "- ship on Fridays"' }])
+  })
+
+  it('tells the model the user declined, and writes nothing', async () => {
+    const { d } = asking('denied')
+    await expect(executeTool(ctx(), 'writeMemory', { content: 'secret' }, d)).rejects.toThrow(MEMORY_WRITE_NOT_APPROVED)
     expect(d.memory.write).not.toHaveBeenCalled()
   })
 
-  it('allows a read from an isolated session — every session can use shared memory (#653)', async () => {
-    const d = deps(false)
-    await executeTool(ctx(), 'readMemory', {}, d)
-    expect(d.memory.read).toHaveBeenCalled()
+  it('tells the model nobody could be asked, without hanging', async () => {
+    const { d } = asking('no_approver')
+    await expect(executeTool(ctx(), 'writeMemory', { content: 'secret' }, d)).rejects.toThrow(MEMORY_WRITE_NO_APPROVER)
+    expect(d.memory.write).not.toHaveBeenCalled()
   })
 
-  it('allows the write when the session is org-visible', async () => {
-    const d = deps(true)
+  it('treats a missing asker, and a hard deny, as nobody to ask', async () => {
+    const unwired = deps('ask')
+    await expect(executeTool(ctx(), 'writeMemory', { content: 'x' }, unwired)).rejects.toThrow(MEMORY_WRITE_NO_APPROVER)
+    const denied = deps('deny')
+    await expect(executeTool(ctx(), 'writeMemory', { content: 'x' }, denied)).rejects.toThrow(MEMORY_WRITE_NO_APPROVER)
+    expect(unwired.memory.write).not.toHaveBeenCalled()
+    expect(denied.memory.write).not.toHaveBeenCalled()
+  })
+
+  it('asks once per call, for THAT call: two writes are two asks', async () => {
+    const { d, asks } = asking('allowed')
+    await executeTool(ctx(), 'writeMemory', { path: 'a.md', content: 'one' }, d)
+    await executeTool(ctx(), 'writeMemory', { path: 'b.md', content: 'two' }, d)
+    expect(asks.map((a) => a.target)).toEqual(['a.md', 'b.md'])
+  })
+
+  it('never asks for a read — every session can use shared memory (#653)', async () => {
+    const { d } = asking('denied')
+    await executeTool(ctx(), 'readMemory', {}, d)
+    expect(d.memory.read).toHaveBeenCalled()
+    expect(d.requestMemoryWriteApproval).not.toHaveBeenCalled()
+  })
+
+  it('does not ask when the session is org-visible', async () => {
+    const asker = vi.fn(async () => 'denied' as const)
+    const d = deps('allow', { requestMemoryWriteApproval: asker })
     await executeTool(ctx(), 'writeMemory', { content: 'shared fact' }, d)
     expect(d.memory.write).toHaveBeenCalled()
+    expect(asker).not.toHaveBeenCalled()
   })
 
   it('allows the write when no gate is wired at all (unit fixtures)', async () => {
-    const d = deps(true, { memoryAccessAllowed: undefined })
+    const d = deps('allow', { memoryAccessDecision: undefined })
     await executeTool(ctx(), 'writeMemory', { content: 'shared fact' }, d)
     expect(d.memory.write).toHaveBeenCalled()
   })
 })
 
+describe('what the approval card is told about the pending write', () => {
+  it('names the file and the first ~200 characters of a full write', () => {
+    const long = 'x'.repeat(500)
+    const ask = memoryWriteAsk('writeMemory', { path: 'deploys.md', content: long })
+    expect(ask.target).toBe('deploys.md')
+    expect(ask.summary.length).toBeLessThanOrEqual('Content: ""'.length + 200)
+    expect(ask.summary.endsWith('…"')).toBe(true)
+    expect(memoryWriteAsk('writeMemory', { content: 'idx' })).toEqual({
+      tool: 'writeMemory',
+      target: 'MEMORY.md',
+      summary: 'Content: "idx"'
+    })
+  })
+
+  it('says what an edit replaces or removes, and that an empty write clears the file', () => {
+    expect(memoryWriteAsk('writeMemory', { path: 'p.md', oldString: 'tabs', newString: 'spaces' }).summary).toBe(
+      'Replace "tabs" with "spaces"'
+    )
+    expect(memoryWriteAsk('writeMemory', { path: 'p.md', oldString: '- stale', newString: '' }).summary).toBe(
+      'Remove "- stale"'
+    )
+    expect(memoryWriteAsk('writeMemory', { path: 'p.md', content: '' }).summary).toBe('Clear p.md (empty write)')
+  })
+
+  it('describes the record tools by record, and never throws on malformed arguments', () => {
+    expect(memoryWriteAsk('saveMemory', { text: 'likes tabs' })).toEqual({
+      tool: 'saveMemory',
+      target: 'a new memory record',
+      summary: 'Content: "likes tabs"'
+    })
+    expect(memoryWriteAsk('deleteMemory', { id: 'r1' })).toEqual({
+      tool: 'deleteMemory',
+      target: 'record r1',
+      summary: 'Delete record r1'
+    })
+    expect(memoryWriteAsk('updateMemory', { id: 7, text: 42 }).summary).toBe('New content: ""')
+    expect(memoryWriteAsk('writeMemory', { path: 3, content: { nested: true } }).target).toBe('MEMORY.md')
+  })
+})
+
 describe('record-memory mutations under the same gate', () => {
-  const recordDeps = (writeAllowed: boolean): OpsDeps => {
+  const recordDeps = (write: MemoryAccessDecision, verdict: MemoryWriteVerdict = 'denied'): OpsDeps => {
     const surface = {
       shape: 'records' as const,
       capabilities: new Set(['recall', 'create', 'update', 'delete', 'get']),
@@ -73,18 +164,26 @@ describe('record-memory mutations under the same gate', () => {
     }
     return {
       memory: { adminSurface: () => surface, adminSurfaceForAgent: () => surface },
-      memoryAccessAllowed: (_ctx: SessionContext, mode: 'read' | 'write') => mode === 'read' || writeAllowed
+      memoryAccessDecision: (_ctx: SessionContext, mode: 'read' | 'write') => (mode === 'read' ? 'allow' : write),
+      requestMemoryWriteApproval: vi.fn(async () => verdict)
     } as unknown as OpsDeps
   }
 
-  it('refuses saveMemory (a write) from a private session', async () => {
+  it('refuses saveMemory (a write) from a private session whose human declined', async () => {
     await expect(
-      executeTool(ctx(), 'saveMemory', { content: 'secret', metadata: {} }, recordDeps(false))
-    ).rejects.toThrow(MEMORY_ACCESS_BLOCKED)
+      executeTool(ctx(), 'saveMemory', { text: 'secret', metadata: {} }, recordDeps('ask', 'denied'))
+    ).rejects.toThrow(MEMORY_WRITE_NOT_APPROVED)
+  })
+
+  it('lets deleteMemory through once approved', async () => {
+    await expect(executeTool(ctx(), 'deleteMemory', { id: 'r1' }, recordDeps('ask', 'allowed'))).resolves.toEqual({
+      id: 'r1',
+      deleted: true
+    })
   })
 
   it('allows searchMemory (a read) from an isolated session (#653)', async () => {
-    await expect(executeTool(ctx(), 'searchMemory', { query: 'deploys' }, recordDeps(false))).resolves.toBeDefined()
+    await expect(executeTool(ctx(), 'searchMemory', { query: 'deploys' }, recordDeps('ask'))).resolves.toBeDefined()
   })
 })
 
@@ -103,44 +202,45 @@ describe('a distillation-bound session writing through the shared tools', () => 
   })
 
   it('records the write as `distill`, not `tool`, so the dream rebase stays honest', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     await executeTool(distillCtx(), 'writeMemory', { path: 'prefs.md', content: '- likes tabs' }, d)
-    const [, , , , source] = (d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!
+    const [, , , , source] = (d.memory.write as unknown as WriteCalls).mock.calls[0]!
     expect(source).toBe('distill')
   })
 
   it('writes into the ORIGINATING channel store, not one derived from its own coordinates', async () => {
     // Its own coordinates are the synthetic `memory`/`distill` pair; resolving from
     // those would send a channel-scoped agent's facts to the wrong folder.
-    const d = deps(true, { memoryScope: () => ({ agentId: 'bot-a', channelKey: 'WRONG' }) })
+    const d = deps('allow', { memoryScope: () => ({ agentId: 'bot-a', channelKey: 'WRONG' }) })
     await executeTool(distillCtx(), 'writeMemory', { path: 'prefs.md', content: '- likes tabs' }, d)
-    const [scope] = (d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!
+    const [scope] = (d.memory.write as unknown as WriteCalls).mock.calls[0]!
     expect(scope).toMatchObject({ agentId: 'bot-a', channelKey: 'C1-abc123' })
   })
 
   it('still reads through the same surface', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     await executeTool(distillCtx(), 'readMemory', { path: 'prefs.md' }, d)
     expect(d.memory.read).toHaveBeenCalled()
   })
 
   it('leaves an ordinary turn writing as `tool`', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     await executeTool(ctx(), 'writeMemory', { content: 'shared fact' }, d)
-    const [, , , , source] = (d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!
+    const [, , , , source] = (d.memory.write as unknown as WriteCalls).mock.calls[0]!
     expect(source).toBe('tool')
   })
 })
 
 describe('the distillation binding is its own authorization', () => {
-  it('permits the write even though the synthetic session has no persisted row', async () => {
+  it('permits the write even though the synthetic session has no persisted row, and never asks', async () => {
     // The real daemon derives this verdict from `isCaptureExcluded`, which fails
     // CLOSED for coordinates with no session row — exactly what a synthetic
-    // distillation session has. Mocking the gate to `true` hid that, so model the
-    // real rule here: unknown session ⇒ excluded, unless a binding is present.
-    const realGate = async (ctx: SessionContext, mode: 'read' | 'write') =>
-      mode === 'read' || Boolean(ctx.memoryBinding) || false
-    const d = deps(false, { memoryAccessAllowed: realGate })
+    // distillation session has. Model the real rule here: unknown session ⇒ ask,
+    // unless a binding is present.
+    const realGate = (ctx: SessionContext, mode: 'read' | 'write'): MemoryAccessDecision =>
+      mode === 'read' || ctx.memoryBinding ? 'allow' : 'ask'
+    const asker = vi.fn(async () => 'denied' as const)
+    const d = deps('ask', { memoryAccessDecision: realGate, requestMemoryWriteApproval: asker })
 
     await executeTool(
       {
@@ -157,18 +257,20 @@ describe('the distillation binding is its own authorization', () => {
       d
     )
     expect(d.memory.write).toHaveBeenCalled()
+    expect(asker).not.toHaveBeenCalled()
 
-    // An ordinary session with no row is still refused — the binding is the only
-    // thing that grants this, and it is daemon-minted, never model-supplied.
-    const plain = deps(false, { memoryAccessAllowed: realGate })
-    await expect(executeTool(ctx(), 'writeMemory', { content: 'x' }, plain)).rejects.toThrow(MEMORY_ACCESS_BLOCKED)
+    // An ordinary session with no row still asks — and this human says no. The binding is
+    // the only thing that skips the ask, and it is daemon-minted, never model-supplied.
+    const plain = deps('ask', { memoryAccessDecision: realGate, requestMemoryWriteApproval: asker })
+    await expect(executeTool(ctx(), 'writeMemory', { content: 'x' }, plain)).rejects.toThrow(MEMORY_WRITE_NOT_APPROVED)
     expect(plain.memory.write).not.toHaveBeenCalled()
+    expect(asker).toHaveBeenCalledTimes(1)
   })
 
   it('keeps two channels apart: each binding writes to its own store', async () => {
     // One warm host serves every channel, so a per-agent cached session would reuse
     // the FIRST channel's pinned scope for all later channels.
-    const d = deps(true)
+    const d = deps('allow')
     const bind = (channelKey: string): SessionContext => ({
       agentId: 'bot-a',
       platform: 'distill',
@@ -181,7 +283,7 @@ describe('the distillation binding is its own authorization', () => {
     await executeTool(bind('chan-A'), 'writeMemory', { path: 'a.md', content: '- from A' }, d)
     await executeTool(bind('chan-B'), 'writeMemory', { path: 'b.md', content: '- from B' }, d)
 
-    const calls = (d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const calls = (d.memory.write as unknown as WriteCalls).mock.calls
     expect((calls[0]![0] as { channelKey?: string }).channelKey).toBe('chan-A')
     expect((calls[1]![0] as { channelKey?: string }).channelKey).toBe('chan-B')
   })
@@ -205,15 +307,15 @@ describe('a dream-bound session writing its staged store', () => {
   })
 
   it('writes to the pinned staged store, recorded as `dream`', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     await executeTool(dreamCtx(), 'writeMemory', { path: 'deploys.md', content: '- x' }, d)
-    const [scope, , , , source] = (d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!
+    const [scope, , , , source] = (d.memory.write as unknown as WriteCalls).mock.calls[0]!
     expect((scope as { root?: unknown }).root).toEqual({ key: 'staged' })
     expect(source).toBe('dream')
   })
 
   it('keeps the lowercase-kebab filename rule the proposal format used to enforce', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     await expect(executeTool(dreamCtx(), 'writeMemory', { path: 'Bad_Name.md', content: 'x' }, d)).rejects.toThrow(
       /invalid memory path/
     )
@@ -221,7 +323,7 @@ describe('a dream-bound session writing its staged store', () => {
   })
 
   it('caps DISTINCT topics, while letting one topic be rewritten freely', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     const ctx = dreamCtx()
     await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a' }, d)
     await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a2' }, d) // same topic, fine
@@ -229,11 +331,11 @@ describe('a dream-bound session writing its staged store', () => {
     await expect(executeTool(ctx, 'writeMemory', { path: 'three.md', content: 'c' }, d)).rejects.toThrow(
       /topic limit reached/
     )
-    expect((d.memory.write as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(3)
+    expect((d.memory.write as unknown as WriteCalls).mock.calls).toHaveLength(3)
   })
 
   it('reports the topics it wrote, which is what the dream stages against', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     const ctx = dreamCtx()
     await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a' }, d)
     await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a2' }, d)
@@ -244,7 +346,7 @@ describe('a dream-bound session writing its staged store', () => {
     // The store rejects the write (a subdirectory path, an oversized body). The name must
     // not enter the provenance record, or a dream could claim a topic through the tool and
     // then put the actual bytes there with the runtime's own file tool.
-    const d = deps(true)
+    const d = deps('allow')
     const ctx = dreamCtx()
     ;(d.memory.write as unknown as { mockRejectedValueOnce(e: Error): void }).mockRejectedValueOnce(
       new Error('memory is a flat directory')
@@ -259,7 +361,7 @@ describe('a dream-bound session writing its staged store', () => {
   })
 
   it('leaves an unbound turn unconstrained', async () => {
-    const d = deps(true)
+    const d = deps('allow')
     await executeTool(ctx(), 'writeMemory', { path: 'Any_Name.md', content: 'x' }, d)
     expect(d.memory.write).toHaveBeenCalled()
   })

--- a/packages/daemon/test/memory-write-session-grant.test.ts
+++ b/packages/daemon/test/memory-write-session-grant.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The daemon half of the private-session memory write (session-visibility.md §5.1), driven end to
+ * end through `executeTool`: the gate asks, the webchat card answers, and "Allow for this session"
+ * is remembered for THAT session's later writes and no other's.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { agentHostKey } from '../src/acp/host-key.js'
+import { Daemon } from '../src/daemon.js'
+import { executeTool, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+import { MEMORY_WRITE_NO_APPROVER, MEMORY_WRITE_NOT_APPROVED } from '../src/memory/tools.js'
+import { sessionKey } from '../src/store/local-store.js'
+import { pendingTurnKey } from '../src/daemon/turn-types.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+
+const AGENT = 'bot-a'
+const OWNER = agentHostKey(AGENT)
+
+function ctx(channel: string, over: Partial<SessionContext> = {}): SessionContext {
+  return { agentId: AGENT, platform: 'webchat', channel, thread: channel, isDm: true, tools: [], ...over }
+}
+
+/** A daemon with one live webchat turn on `conv-1`, whose store calls every session private. */
+function world(excluded = true) {
+  const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+  daemon.store = {
+    isCaptureExcluded: vi.fn(async () => excluded),
+    getSessionByAcpIdForAgent: async () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: async () => new Map<string, string>(),
+    upsertElicit: vi.fn(async () => {})
+  }
+  const sink = { output: vi.fn(), done: vi.fn() }
+  const pending = {
+    plan: {
+      sessionKey: sessionKey('webchat', 'conv-1', 'conv-1', AGENT),
+      agentId: AGENT,
+      agentName: 'Butler',
+      platform: 'webchat',
+      channel: 'conv-1',
+      statusThread: 'conv-1',
+      requesterId: 'user-1',
+      approvalSurfaceSuppressed: false
+    },
+    approval: { waitMs: 0, depth: 0 },
+    acpSessionId: 's1',
+    hostKey: OWNER,
+    outwardSessionId: 'outward-1',
+    builtinSystemToolCallIds: new Set<string>(),
+    entry: { msg: { text: 'remember this' } },
+    webchat: {
+      conversationId: 'conv-1',
+      turnId: 'turn-1',
+      sink,
+      index: 0,
+      replyText: '',
+      heldText: '',
+      messageEmitted: false
+    }
+  }
+  daemon.pending.set(pendingTurnKey(OWNER, 's1'), pending)
+  const deps = {
+    memory: { read: vi.fn(async () => ({ content: '' })), write: vi.fn(async () => ({ ok: true })) },
+    memoryAccessDecision: (c: SessionContext, m: 'read' | 'write') => daemon.memoryAccessDecisionFor(c, m),
+    requestMemoryWriteApproval: (c: SessionContext, a: unknown) => daemon.requestMemoryWriteApprovalFor(c, a)
+  } as unknown as OpsDeps
+  const cards = (): any[] => sink.output.mock.calls.map(([o]: any[]) => o.event).filter((e) => e.kind === 'elicitation')
+  const answer = async (value: string | null) => {
+    await vi.waitFor(() => expect(cards().length).toBeGreaterThan(0))
+    const { requestId } = cards().at(-1)!
+    await daemon.permissions.handleElicitChoice({ requestId, value, webchatConversationId: 'conv-1' })
+  }
+  return { daemon, deps, cards, answer }
+}
+
+describe('"Allow for this session" on a private webchat session', () => {
+  it('asks once, then lets the rest of that session write without asking', async () => {
+    const w = world()
+    const first = executeTool(ctx('conv-1'), 'writeMemory', { path: 'deploys.md', content: '- ship' }, w.deps)
+    await w.answer('allow_session')
+    await first
+    await executeTool(ctx('conv-1'), 'writeMemory', { path: 'deploys.md', content: '- ship v2' }, w.deps)
+    expect(w.deps.memory.write).toHaveBeenCalledTimes(2)
+    expect(w.cards()).toHaveLength(1)
+  })
+
+  it('does not carry over to another session, which has no live turn here and so nobody to ask', async () => {
+    const w = world()
+    const first = executeTool(ctx('conv-1'), 'writeMemory', { path: 'deploys.md', content: '- ship' }, w.deps)
+    await w.answer('allow_session')
+    await first
+    await expect(executeTool(ctx('conv-2'), 'writeMemory', { content: 'x' }, w.deps)).rejects.toThrow(
+      MEMORY_WRITE_NO_APPROVER
+    )
+    expect(w.deps.memory.write).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('"Allow once" and Deny on the same session', () => {
+  it('allows exactly the approved call and asks again for the next one', async () => {
+    const w = world()
+    const first = executeTool(ctx('conv-1'), 'writeMemory', { path: 'a.md', content: 'one' }, w.deps)
+    await w.answer('allow_once')
+    await first
+    const second = executeTool(ctx('conv-1'), 'writeMemory', { path: 'b.md', content: 'two' }, w.deps)
+    await vi.waitFor(() => expect(w.cards()).toHaveLength(2))
+    await w.answer('deny')
+    await expect(second).rejects.toThrow(MEMORY_WRITE_NOT_APPROVED)
+    expect(w.deps.memory.write).toHaveBeenCalledTimes(1)
+    expect(w.cards()[1].message).toContain('writeMemory → b.md')
+  })
+})
+
+describe('what never asks', () => {
+  it('a read, an org-visible session, and a daemon-minted memory binding', async () => {
+    const w = world()
+    await executeTool(ctx('conv-1'), 'readMemory', {}, w.deps)
+    expect(w.deps.memory.read).toHaveBeenCalled()
+    const bound = ctx('conv-1', { memoryBinding: { source: 'distill', scope: { agentId: AGENT } } })
+    await executeTool(bound, 'writeMemory', { path: 'p.md', content: 'x' }, w.deps)
+    const open = world(false)
+    await executeTool(ctx('conv-1'), 'writeMemory', { path: 'p.md', content: 'x' }, open.deps)
+    expect(w.cards()).toEqual([])
+    expect(open.cards()).toEqual([])
+    expect(w.deps.memory.write).toHaveBeenCalledTimes(1)
+    expect(open.deps.memory.write).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What happened

In a console Playground session marked Private, the user asked the agent to delete a memory file. `writeMemory` was refused with "Shared agent memory is unavailable in this session" while reads kept working. The session-isolation gate (#653, `session-visibility.md` §5.1) blocks every explicit memory write from a capture-excluded session, and the wording did not match what the gate actually does (reads are fine; writes are the concern).

The product decision: the human in a private session owns that content, so an explicit approval from them is consent to put it in shared memory. The daemon should ask, not refuse.

## Fix

**Gate becomes a decision.** `MemoryOpsDeps.memoryAccessDecision(ctx, mode)` returns `'allow' | 'deny' | 'ask'` (replacing the boolean `memoryAccessAllowed`). For `ask`, `executeTool` calls `requestMemoryWriteApproval(ctx, memoryWriteAsk(name, args))` and awaits it inline before dispatch, so the approval covers exactly that call's path and payload — nothing is cached except the explicit session grant. Scope is unchanged: only the `'write'` entries of `MEMORY_TOOL_ACCESS_MODES`; reads, the `ctx.memoryBinding` bypass, post-turn distillation and dream capture are untouched.

**One card, existing surfaces.** `PermissionCoordinator.askMemoryWriteApproval(owner, sessionId, ask)` builds a synthetic single-select elicitation (`permissions/memory-write-approval.ts`) whose message is the question plus `tool → target` and a bounded summary (first ~200 chars of the content, or what an edit/delete/clear does), with three options: **Allow once**, **Allow for this session**, **Deny**. It rides the coordinator's existing paths, so no second card system and no protocol/web change:

- webchat (Playground / session view): the in-stream elicitation card, answered by the person in the conversation;
- a platform with an elicitation-card facet (Slack, Telegram): the in-thread button row, answered by position token;
- otherwise (Discord, Feishu, a webchat continuation, ...): the Agent-editor queue — console Approval requests and the Slack approval DM. An editor Allow is "allow once"; the DM card carries all three buttons.

**No approver, no hang.** No live turn, a suppressed turn, a headless run (`msg.headless`), an A2A child (`callMeta` or an `a2a:` channel) returns `no_approver` at once. Turn cancellation settles a pending ask as a decline through the existing `releaseElicits` / `releaseEditorPermissions`. No new timer scheme.

**Session grant.** "Allow for this session" is recorded in `Daemon.memoryWriteGrants` keyed by the logical session key: later writes from that session skip the ask; other sessions still ask. It is in-memory (lost on daemon restart, as decided) and dropped when the session row is deleted.

**Accurate refusals.** `MEMORY_ACCESS_BLOCKED` is replaced by `MEMORY_WRITE_NOT_APPROVED` ("This session is private, so the agent's shared memory is read-only here. The user did not approve saving this; keep the information in this conversation and do not retry.") and `MEMORY_WRITE_NO_APPROVER` (same lead, "No one could be asked to approve this write").

**Docs.** `docs/designs/session-visibility.md` §5.1 gains one paragraph naming the exception, the three choices, and the no-approver rule.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean (src + test).
- `vitest run test/memory-write-gate.test.ts test/memory-write-approval.test.ts test/memory-write-session-grant.test.ts` — 45 tests pass:
  - gate: approve → write proceeds; deny → refusal text, nothing written; no approver → refusal without hanging; reads never ask; non-excluded session never asks; `memoryBinding` never asks; the ask summary for full/edit/remove/clear writes and record tools.
  - coordinator: webchat card content (head line, `tool → target`, summary, exactly the three options); each choice maps to its outcome; an unoffered value or another conversation's answer is refused and the card stays open; turn cancellation settles as a decline with a `cancelled` resolved event; the wait is billed as human-approval time; the Slack-style facet path reads a tapped position back; the editor-queue fallback records the request and resolves on editor Allow/Deny or turn end; five no-approver shapes answer immediately.
  - daemon: "Allow for this session" asks once then lets later writes through, does not carry to another session; "Allow once" covers one call and the next one asks again.
- `eslint` and `prettier --check` on every changed file — clean.
- Not run locally: the full daemon suite (CI).

## Judgment calls

- The editor queue is the fallback for a chat with no elicitation card, mirroring how a runtime permission prompt behaves there. This means an Agent editor (not necessarily the requester) can approve on those platforms; on webchat, Slack and Telegram the ask goes to the person in the conversation.
- `Deny` is offered as an explicit option even though every card also carries Dismiss; both settle as a decline.
- A Slack card's settled label echoes the option value (`allow_session`), as every enum elicitation card does today; the transcript row carries the human label. Left as is rather than changing shared card behavior here.
- The grant is released only when the session row is deleted (the one `deleteSession` call site); there is no per-session "closed" hook to attach to, and a grant on a live but idle session is the intended semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
