### PR TITLE
feat(daemon): a Telegram question that must be typed gets a box

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6658,6 +6658,25 @@ export class Daemon {
     this.seenMsgIds.add(seenMsgId)
     if (this.seenMsgIds.size > 2000) this.seenMsgIds.clear()
 
+    // A typed elicitation answer is an ANSWER, never a prompt: a reply to the box one of this
+    // conversation's live cards opened settles that card and stops here, before thread
+    // canonicalization would read it as continuing the session and before command parsing would
+    // read `!stop` typed into the box as a control. No-op on every surface that asks for no typing.
+    // Human traffic only: an agent bot replying in the same chat takes its own ladder below, and
+    // an agent answering another agent's question is not what "anyone who can see it" meant.
+    if (
+      !agentAuthored &&
+      (await this.permissions.claimElicitReply({
+        channel: msg.channel,
+        ...(msg.replyTo !== undefined ? { replyTo: msg.replyTo } : {}),
+        text: msg.text,
+        actor: { userId: msg.sender.id }
+      }))
+    ) {
+      this.log.debug(`routing: ${msg.msgId} answered an elicitation card`)
+      return { kind: 'rejected', reason: 'suppressed' }
+    }
+
     // Telegram reply-based session threading: derive the session thread from the reply
     // chain BEFORE command parsing / routing, so both see the canonical thread (an
     // @mention opens a fresh session; a reply to any message already in a session

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6667,7 +6667,9 @@ export class Daemon {
     if (
       !agentAuthored &&
       (await this.permissions.claimElicitReply({
-        channel: msg.channel,
+        // Qualified by the receiving bot, or a reply in one person's DM with bot B could settle a
+        // card bot A is holding — those two DMs share a chat id and its message numbers.
+        conversation: transcriptChannelKey(msg.channel, msg.transportScope),
         ...(msg.replyTo !== undefined ? { replyTo: msg.replyTo } : {}),
         text: msg.text,
         actor: { userId: msg.sender.id }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -121,7 +121,14 @@ interface ClosedGate {
  *  appends a second stream event. The chat arm names no platform — the facet does, and the
  *  handle's three fields are the coordinates BOTH chat surfaces identify a posted card by. */
 type PendingElicitSurface =
-  | ({ surface: 'chat'; facet: ElicitCardFacet } & ElicitCardHandle)
+  | ({
+      surface: 'chat'
+      facet: ElicitCardFacet
+      /** The conversation a typed answer must have been written in, qualified by the bot that owns
+       *  the card (`plan.transcriptChannel`). `channel` is the bare platform channel a rewrite is
+       *  addressed to, which cannot tell two bots apart in one person's DMs. */
+      answerConv: string
+    } & ElicitCardHandle)
   | { surface: 'webchat'; wc: NonNullable<Pending['webchat']> }
 
 /** What the surface a card was posted to renders — re-deriving its target has to ask the same
@@ -1500,6 +1507,7 @@ export class PermissionCoordinator {
       facet,
       conn: p.conn,
       channel: p.plan.channel,
+      answerConv: p.plan.transcriptChannel,
       // An MCP approval keeps its durable record in `permission_requests` and its own console
       // surface, so it is not also a transcript card.
       ...(isApproval
@@ -1953,7 +1961,11 @@ export class PermissionCoordinator {
   async claimElicitReply(reply: ElicitCardReply & { actor?: InteractionActor }): Promise<boolean> {
     if (reply.replyTo === undefined) return false
     for (const [requestId, rec] of this.pendingElicits) {
-      if (rec.surface !== 'chat' || !rec.facet.claimReply || !rec.form || rec.channel !== reply.channel) continue
+      if (rec.surface !== 'chat' || !rec.facet.claimReply || !rec.form) continue
+      // Matched on the BOT-QUALIFIED conversation, never the bare channel: a person's DMs with two
+      // Telegram bots share one chat id and one message-number sequence, so a bare channel would
+      // let a reply to bot B's prompt settle bot A's card — and suppress B's own delivery with it.
+      if (rec.answerConv !== reply.conversation) continue
       const form = this.cardForm(rec)
       if (!form) continue
       const claimed = rec.facet.claimReply(rec, { requestId, params: rec.params, form }, reply)

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -32,6 +32,7 @@ import type {
   ElicitCardHandle,
   ElicitCardHost,
   ElicitCardMark,
+  ElicitCardReply,
   ElicitCardSettlement
 } from '../platforms/elicit-card.js'
 import {
@@ -1935,6 +1936,36 @@ export class PermissionCoordinator {
     }
     if (folded.kind === 'pending') return
     await this.submitElicitForm({ requestId: a.requestId, fields: folded.fields, ...actor })
+  }
+
+  /**
+   * Offer one typed message to the live cards of its own conversation, answering the first that
+   * claims it. True ⇒ it WAS an answer and must never also reach the agent as a prompt.
+   *
+   * A surface with no typed control claims nothing, so this is a no-op on every chat but the one
+   * that asked someone to type. Where it does claim, the reply is validated by the same
+   * {@link submitElicitForm} a Confirm goes through — a number that is not a number, a string
+   * breaking its own `pattern`, are refused with the field's own words and the card left live.
+   *
+   * The claim is per CARD, never per person: anyone who can see a card may answer it, which is the
+   * same rule its buttons follow. What keeps one answer to one card is the message it replies TO.
+   */
+  async claimElicitReply(reply: ElicitCardReply & { actor?: InteractionActor }): Promise<boolean> {
+    if (reply.replyTo === undefined) return false
+    for (const [requestId, rec] of this.pendingElicits) {
+      if (rec.surface !== 'chat' || !rec.facet.claimReply || !rec.form || rec.channel !== reply.channel) continue
+      const form = this.cardForm(rec)
+      if (!form) continue
+      const claimed = rec.facet.claimReply(rec, { requestId, params: rec.params, form }, reply)
+      if (!claimed || claimed.kind !== 'submit') continue
+      await this.submitElicitForm({
+        requestId,
+        fields: claimed.fields,
+        ...(reply.actor ? { actor: reply.actor } : {})
+      })
+      return true
+    }
+    return false
   }
 
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -137,6 +137,16 @@ export interface ElicitCardTapTarget {
   readonly form: readonly ElicitTarget[]
 }
 
+/** One typed answer as core offers it to a card: the conversation it was written in, the message
+ *  it was written as a reply to, and its words. A surface matches it against whatever it asked the
+ *  reader to reply TO — which is how one answer reaches exactly one card. */
+export interface ElicitCardReply {
+  readonly channel: string
+  /** The message this reply answers, in the surface's own dialect. Absent ⇒ not a reply at all. */
+  readonly replyTo?: string
+  readonly text: string
+}
+
 /** One chat surface's elicitation-card facet. Registered on that platform's
  *  {@link TurnOutputSurface}; absent ⇒ the surface cannot collect an answer and core declines the
  *  ask with the in-channel notice. */
@@ -167,6 +177,11 @@ export interface ElicitCardFacet {
    *  `form` is re-derived by core from the card's own params, so it is the very field list the
    *  card rendered. Null ⇒ the tap named nothing this card offers, and core refuses it aloud. */
   tap?(handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null
+  /** Whether this typed message answers THIS card, and with what. Absent ⇒ the surface collects no
+   *  typed answer and every message in its chats is a prompt, which is what a Slack card's is.
+   *  Null ⇒ not this card's answer, and core keeps looking. The fields are keyed as a Confirm's
+   *  are, so a typed answer is validated by the same re-derivation every other answer is. */
+  claimReply?(handle: ElicitCardHandle, card: ElicitCardTapTarget, reply: ElicitCardReply): ElicitCardTap | null
   /** The namespace a tapping actor's id is scoped to on this surface, recorded beside an approval
    *  resolver so it is globally unique. Absent where the surface's user ids already are — a
    *  Telegram user id names one account across every chat, a Slack one only within its workspace. */

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -141,7 +141,11 @@ export interface ElicitCardTapTarget {
  *  it was written as a reply to, and its words. A surface matches it against whatever it asked the
  *  reader to reply TO — which is how one answer reaches exactly one card. */
 export interface ElicitCardReply {
-  readonly channel: string
+  /** The conversation, QUALIFIED BY THE BOT THAT RECEIVED IT — `transcriptChannelKey`, the same
+   *  identity the transcript and the ingress dedup use. Not the bare channel: two Telegram bots
+   *  DM'd by one person share that person's chat id AND its message numbers, so a bare channel
+   *  would let a reply to bot B's message id settle bot A's card. */
+  readonly conversation: string
   /** The message this reply answers, in the surface's own dialect. Absent ⇒ not a reply at all. */
   readonly replyTo?: string
   readonly text: string

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -36,6 +36,7 @@ import type {
   ElicitCardHandle,
   ElicitCardHost,
   ElicitCardMark,
+  ElicitCardReply,
   ElicitCardSettlement,
   ElicitCardTap,
   ElicitCardTapTarget,
@@ -47,6 +48,7 @@ import type { TelegramTurnState } from './turn-output.js'
 import {
   clampTo,
   elicitCardShape,
+  elicitFieldExpectation,
   elicitFormFieldHint,
   elicitOptionToken,
   type ElicitKind,
@@ -83,6 +85,10 @@ const TELEGRAM_ELICIT_DISMISS = 'x'
  *  for the same reason Dismiss is not: it names no option, it names the set of them. */
 const TELEGRAM_ELICIT_CONFIRM = 'ok'
 
+/** The token the button that OPENS A PROMPT carries — the one control a keyboard has for a field
+ *  that must be typed. It names no option either: it asks for the box, it does not answer. */
+const TELEGRAM_ELICIT_PROMPT = 'ed'
+
 /** How an assembled card draws one option's checkbox. Literal emoji, as the marks are. */
 const TELEGRAM_ELICIT_CHECKED = '\u2611\ufe0f'
 const TELEGRAM_ELICIT_UNCHECKED = '\u2b1c\ufe0f'
@@ -112,13 +118,16 @@ const TELEGRAM_ELICIT_MARK: Record<ElicitCardMark, string> = {
 }
 
 /**
- * What a Telegram elicitation card can render AND collect: the two kinds one TAP answers, plus the
- * multi-select a keyboard of checkboxes assembles over several taps. A typed box is still absent —
- * nothing in a keyboard accepts characters — so `text` and `number`, and therefore every form
- * carrying one, stay declined rather than posted as a control that cannot take an answer.
+ * What a Telegram elicitation card can render AND collect: the two kinds one TAP answers, the
+ * multi-select a keyboard of checkboxes assembles over several taps, and — since a `force_reply`
+ * IS the Bot API's input box — a typed one. A keyboard accepts no characters, so the card carries
+ * a button that opens the box instead, and the reply comes back naming the message it answers.
+ *
+ * A form of SEVERAL questions is still declined: one prompt at a time is a state machine across
+ * fields, and a reader who walks away mid-way would leave half a form standing.
  */
 export const TELEGRAM_ELICIT_SURFACE: ElicitSurface = {
-  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum']),
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
   optionLimits: {
     enum: { maxOptions: TELEGRAM_ELICIT_MAX_BUTTONS },
     // A checkbox keyboard is the SAME keyboard, one row longer for its Confirm — so it is bounded
@@ -201,11 +210,31 @@ export function telegramElicitFormText(message: string, target: ElicitTarget): s
   return `${telegramElicitText(clampTo(message, Math.max(0, TELEGRAM_ELICIT_MESSAGE_CAP - hint.length - 1)))}\n${hint}`
 }
 
-/** The one field an assembled Telegram card renders, or null when this form is not one — today
- *  exactly a lone multi-select, the only kind a keyboard can assemble without a typed box. Pure. */
+/** The one field an assembled Telegram card renders, or null when this form is not one — a LONE
+ *  multi-select, which the keyboard ticks, or a lone typed field, which a prompt collects. Several
+ *  questions are not one of these: they would need a prompt per field. Pure. */
 export function telegramAssembledField(form: readonly ElicitTarget[]): ElicitTarget | null {
   const only = form.length === 1 ? form[0]! : null
-  return only && only.kind === 'multi-enum' ? only : null
+  if (!only) return null
+  return only.kind === 'multi-enum' || only.kind === 'text' || only.kind === 'number' ? only : null
+}
+
+/** The keyboard under a card whose answer must be TYPED: the button that opens the box, and
+ *  Dismiss. There is no Confirm — the reply IS the submission, so a second tap would only be a
+ *  chance to lose it. Pure. */
+export function telegramElicitPromptButtons(requestId: string): InlineButton[][] {
+  return [
+    [
+      { text: 'Answer', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_PROMPT) },
+      { text: 'Dismiss', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_DISMISS) }
+    ]
+  ]
+}
+
+/** What the prompt message says above the reader's own compose box: the question again, because a
+ *  reply box on Telegram quotes only a snippet and the card may have scrolled away. Pure. */
+export function telegramElicitPromptText(message: string, target: ElicitTarget): string {
+  return telegramElicitFormText(message, target)
 }
 
 /** Telegram's per-turn elicitation draft: the message and the keyboard under it. */
@@ -220,6 +249,9 @@ interface TelegramElicitDraft {
  *  record, so a card that ends without a Confirm leaves nothing behind. */
 interface TelegramElicitCardState {
   chosen: Set<number>
+  /** The open `force_reply` prompt's own message id, which is what a reply to it names. Absent
+   *  until the reader asks for the box, and again once the prompt has been answered. */
+  promptTs?: string
 }
 
 function cardStateOf(handle: ElicitCardHandle): TelegramElicitCardState {
@@ -241,16 +273,24 @@ export const telegramElicitCards: ElicitCardFacet = {
     const assembled = oneTap ? null : telegramAssembledField(ask.form)
     if (!oneTap && !assembled) return null
     const target = assembled ?? ask.form[0]!
-    if (!target.options.length || !telegramElicitDataFits(ask.requestId, target.options.length)) return null
-    const draft: TelegramElicitDraft = assembled
+    // A typed field offers no options at all; every other card's widest button must fit 64 bytes.
+    const typed = target.kind === 'text' || target.kind === 'number'
+    if (!typed && (!target.options.length || !telegramElicitDataFits(ask.requestId, target.options.length))) return null
+    if (typed && !telegramElicitDataFits(ask.requestId, 1)) return null
+    const draft: TelegramElicitDraft = typed
       ? {
-          text: telegramElicitFormText(ask.message, assembled),
-          buttons: telegramElicitCheckboxes(ask.requestId, assembled.options, new Set())
+          text: telegramElicitFormText(ask.message, target),
+          buttons: telegramElicitPromptButtons(ask.requestId)
         }
-      : {
-          text: telegramElicitText(ask.message),
-          buttons: telegramElicitButtons(ask.requestId, target.options)
-        }
+      : assembled
+        ? {
+            text: telegramElicitFormText(ask.message, assembled),
+            buttons: telegramElicitCheckboxes(ask.requestId, assembled.options, new Set())
+          }
+        : {
+            text: telegramElicitText(ask.message),
+            buttons: telegramElicitButtons(ask.requestId, target.options)
+          }
     return draft
   },
 
@@ -289,6 +329,25 @@ export const telegramElicitCards: ElicitCardFacet = {
     const target = telegramAssembledField(card.form)
     if (!target) return null
     const state = cardStateOf(handle)
+    const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
+    // A typed field is answered in a box, never on the keyboard: the one button it has asks for
+    // that box. Opening it is not an answer, so the card stays exactly as open as it was.
+    if (target.kind === 'text' || target.kind === 'number') {
+      if (token !== TELEGRAM_ELICIT_PROMPT || !Number.isInteger(messageId)) return null
+      const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+      // The prompt REPLIES to the card, which is also what keeps it inside a forum topic: Telegram
+      // places a reply where the message it answers is, so no thread coordinate is re-derived here.
+      void (handle.conn as TelegramConnection)
+        .postPrompt(handle.channel, telegramElicitPromptText(message, target), {
+          replyTo: messageId,
+          placeholder: elicitFieldExpectation(target)
+        })
+        .then((ts) => {
+          if (ts !== undefined) state.promptTs = ts
+        })
+        .catch(() => {})
+      return { kind: 'pending' }
+    }
     if (token === TELEGRAM_ELICIT_CONFIRM) {
       const picked = [...state.chosen].sort((a, b) => a - b).map(elicitOptionToken)
       return { kind: 'submit', fields: { [elicitFormBlockId(0)]: picked } }
@@ -299,7 +358,6 @@ export const telegramElicitCards: ElicitCardFacet = {
     // submit are ONE fact here — unlike Slack, where the message itself holds the reader's half-
     // filled state — so a card with no addressable message refuses the tap instead of remembering
     // a selection its own boxes still show unticked.
-    const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
     if (!Number.isInteger(messageId)) return null
     if (state.chosen.has(index)) state.chosen.delete(index)
     else state.chosen.add(index)
@@ -317,6 +375,29 @@ export const telegramElicitCards: ElicitCardFacet = {
     return { kind: 'pending' }
   },
 
+  /**
+   * Claim a typed reply for this card: it answers only the PROMPT this card opened, matched by the
+   * message the reply names. That is the whole of the scoping — anyone who can see the card may
+   * answer it, exactly as its buttons allow, and one prompt belongs to one card, so an answer can
+   * never land on a question its writer never saw (#1828's rule, kept).
+   *
+   * The words go back as the field's own carried value, which for a typed field IS the text: core
+   * then validates it the way it validates a Confirm, so a number that is not a number and a
+   * string breaking its own `pattern` are refused with the field's own words.
+   */
+  claimReply(handle: ElicitCardHandle, card: ElicitCardTapTarget, reply: ElicitCardReply): ElicitCardTap | null {
+    const target = telegramAssembledField(card.form)
+    if (!target || (target.kind !== 'text' && target.kind !== 'number')) return null
+    const state = handle.cardState as TelegramElicitCardState | undefined
+    if (!state?.promptTs || state.promptTs !== reply.replyTo) return null
+    const text = reply.text.trim()
+    if (!text) return null
+    // The prompt is deliberately NOT spent here. An accepted answer settles the card, and a card
+    // that is gone claims nothing more; a REFUSED one is still open, and the reader who has just
+    // been told what was wrong is typing into the very box that should still take their retry.
+    return { kind: 'submit', fields: { [elicitFormBlockId(0)]: text } }
+  },
+
   settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void {
     if (handle.ts === undefined) return
     const messageId = Number(handle.ts)
@@ -331,5 +412,11 @@ export const telegramElicitCards: ElicitCardFacet = {
     const text = clampTo(`${telegramElicitText(message)}\n${decision}`, TELEGRAM_MESSAGE_LIMIT)
     // An empty keyboard is what drops the buttons; the answered card stays readable in the chat.
     void (handle.conn as TelegramConnection).editCard(handle.channel, messageId, text, []).catch(() => {})
+    // And a prompt still standing would keep offering a box for a question that is over. Editing
+    // it is what drops its `force_reply`, so no reader is left typing into a closed card.
+    const promptTs = (handle.cardState as TelegramElicitCardState | undefined)?.promptTs
+    const promptId = promptTs === undefined ? NaN : Number(promptTs)
+    if (Number.isInteger(promptId))
+      void (handle.conn as TelegramConnection).editCard(handle.channel, promptId, decision, []).catch(() => {})
   }
 }

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -249,15 +249,17 @@ interface TelegramElicitDraft {
  *  record, so a card that ends without a Confirm leaves nothing behind. */
 interface TelegramElicitCardState {
   chosen: Set<number>
-  /** The open `force_reply` prompt's own message id, which is what a reply to it names. Absent
-   *  until the reader asks for the box, and again once the prompt has been answered. */
-  promptTs?: string
+  /** EVERY `force_reply` prompt this card has posted, by message id — which is what a reply to one
+   *  names. All of them stay answerable until the card settles: each tap of Answer posts its own
+   *  box, so two readers can be typing at once (or one reader can tap twice), and a box still on
+   *  screen must not have stopped working because a later one appeared. */
+  prompts: Set<string>
 }
 
 function cardStateOf(handle: ElicitCardHandle): TelegramElicitCardState {
   const existing = handle.cardState as TelegramElicitCardState | undefined
   if (existing) return existing
-  const fresh: TelegramElicitCardState = { chosen: new Set<number>() }
+  const fresh: TelegramElicitCardState = { chosen: new Set<number>(), prompts: new Set<string>() }
   handle.cardState = fresh
   return fresh
 }
@@ -343,7 +345,7 @@ export const telegramElicitCards: ElicitCardFacet = {
           placeholder: elicitFieldExpectation(target)
         })
         .then((ts) => {
-          if (ts !== undefined) state.promptTs = ts
+          if (ts !== undefined) state.prompts.add(ts)
         })
         .catch(() => {})
       return { kind: 'pending' }
@@ -389,7 +391,7 @@ export const telegramElicitCards: ElicitCardFacet = {
     const target = telegramAssembledField(card.form)
     if (!target || (target.kind !== 'text' && target.kind !== 'number')) return null
     const state = handle.cardState as TelegramElicitCardState | undefined
-    if (!state?.promptTs || state.promptTs !== reply.replyTo) return null
+    if (reply.replyTo === undefined || !state?.prompts.has(reply.replyTo)) return null
     const text = reply.text.trim()
     if (!text) return null
     // The prompt is deliberately NOT spent here. An accepted answer settles the card, and a card
@@ -412,11 +414,11 @@ export const telegramElicitCards: ElicitCardFacet = {
     const text = clampTo(`${telegramElicitText(message)}\n${decision}`, TELEGRAM_MESSAGE_LIMIT)
     // An empty keyboard is what drops the buttons; the answered card stays readable in the chat.
     void (handle.conn as TelegramConnection).editCard(handle.channel, messageId, text, []).catch(() => {})
-    // And a prompt still standing would keep offering a box for a question that is over. Editing
-    // it is what drops its `force_reply`, so no reader is left typing into a closed card.
-    const promptTs = (handle.cardState as TelegramElicitCardState | undefined)?.promptTs
-    const promptId = promptTs === undefined ? NaN : Number(promptTs)
-    if (Number.isInteger(promptId))
-      void (handle.conn as TelegramConnection).editCard(handle.channel, promptId, decision, []).catch(() => {})
+    // Every prompt still standing would keep offering a box for a question that is over, so each
+    // is DELETED rather than edited: Telegram edits only a message carrying no markup or an inline
+    // keyboard, so an edit aimed at a `force_reply` is refused and the box would simply remain.
+    const prompts = (handle.cardState as TelegramElicitCardState | undefined)?.prompts
+    for (const promptTs of prompts ?? [])
+      void (handle.conn as TelegramConnection).deleteMessage(handle.channel, promptTs).catch(() => {})
   }
 }

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -168,6 +168,7 @@ export interface TelegramApi {
     text: string,
     opts?: { parse_mode?: string; reply_markup?: InlineKeyboardMarkup }
   ): Promise<unknown>
+  deleteMessage(chatId: number | string, messageId: number): Promise<unknown>
   /** The two outbound file forms. An image previews inline through sendPhoto; sendDocument
    *  takes everything else and is the only form that preserves the bytes exactly. */
   sendPhoto(
@@ -552,6 +553,27 @@ export class TelegramConnection implements PlatformConnection {
       } catch (err) {
         this.deps.log?.debug(`telegram: sendMessage (prompt) failed (ch=${channel}): ${(err as Error).message}`)
         return undefined
+      }
+    })
+  }
+
+  /**
+   * Retire one of the bot's own messages ({@link PlatformConnection.deleteMessage}). The only
+   * supported way to take back a `force_reply`: Telegram edits only messages carrying no markup or
+   * an inline keyboard, so an edit aimed at a prompt is refused — and a refused edit leaves a
+   * reader typing into a question that is over. Best-effort: false when the API refused it, which
+   * a message past its own delete window will.
+   */
+  async deleteMessage(channel: string, ts: string): Promise<boolean> {
+    const messageId = Number(ts)
+    if (!Number.isInteger(messageId)) return false
+    return await this.queue.enqueue(async () => {
+      try {
+        await this.bot.api.deleteMessage(channel, messageId)
+        return true
+      } catch (err) {
+        this.deps.log?.debug(`telegram: deleteMessage failed (ch=${channel} id=${ts}): ${(err as Error).message}`)
+        return false
       }
     })
   }

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -123,6 +123,12 @@ export interface TelegramDeps {
 /** grammY's `InlineKeyboardMarkup` slice we build. */
 type InlineKeyboardMarkup = { inline_keyboard: { text: string; callback_data: string }[][] }
 
+/** grammY's `ForceReply`: the client opens its compose box already aimed at this message, so the
+ *  reader types straight into it and the reply carries `reply_to_message` back. It is the closest
+ *  thing a Bot API chat has to an input box, and it is a `reply_markup` of its own — a message
+ *  carries a keyboard OR a force-reply, never both. */
+type ForceReply = { force_reply: true; input_field_placeholder?: string }
+
 /** The raw grammY `callback_query` slice the connection reads. */
 export interface TelegramCallbackQuery {
   id: string
@@ -153,7 +159,7 @@ export interface TelegramApi {
       message_thread_id?: number
       parse_mode?: string
       reply_parameters?: { message_id: number; allow_sending_without_reply?: boolean }
-      reply_markup?: InlineKeyboardMarkup
+      reply_markup?: InlineKeyboardMarkup | ForceReply
     }
   ): Promise<{ message_id: number }>
   editMessageText(
@@ -514,6 +520,38 @@ export class TelegramConnection implements PlatformConnection {
         this.deps.log?.debug(
           `telegram: editMessageText (card) failed (ch=${channel} id=${messageId}): ${(err as Error).message}`
         )
+      }
+    })
+  }
+
+  /**
+   * Post a message the reader answers by TYPING: a `force_reply`, which opens their compose box
+   * aimed at it, so the reply comes back carrying this message's id. The nearest thing a Telegram
+   * chat has to an input box. Best-effort; returns the new message id so the prompt can be closed
+   * once it has been answered.
+   */
+  async postPrompt(
+    channel: string,
+    text: string,
+    opts: { threadTs?: string; replyTo?: number; placeholder?: string } = {}
+  ): Promise<string | undefined> {
+    const thread = opts.threadTs != null && /^\d+$/.test(opts.threadTs) ? Number(opts.threadTs) : undefined
+    return this.queue.enqueue(async () => {
+      try {
+        const res = await this.bot.api.sendMessage(channel, text, {
+          ...(thread !== undefined ? { message_thread_id: thread } : {}),
+          ...(opts.replyTo !== undefined
+            ? { reply_parameters: { message_id: opts.replyTo, allow_sending_without_reply: true } }
+            : {}),
+          reply_markup: {
+            force_reply: true,
+            ...(opts.placeholder ? { input_field_placeholder: opts.placeholder } : {})
+          }
+        })
+        return res?.message_id != null ? String(res.message_id) : undefined
+      } catch (err) {
+        this.deps.log?.debug(`telegram: sendMessage (prompt) failed (ch=${channel}): ${(err as Error).message}`)
+        return undefined
       }
     })
   }

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -73,16 +73,16 @@ describe("the wire a Telegram tap comes back on — 64 bytes, so it carries the 
 })
 
 describe('what Telegram declares it can collect, and what it declines', () => {
-  it('claims the two kinds one tap answers, plus the multi-select a keyboard assembles', () => {
-    expect([...TELEGRAM_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum', 'multi-enum'])
+  it('claims every kind a keyboard can answer, a typed one included', () => {
+    expect([...TELEGRAM_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum', 'multi-enum', 'number', 'text'])
   })
 
-  it('reduces an enum, a boolean and a multi-select, but nothing that has to be TYPED', () => {
+  it('reduces each kind to the control that collects it', () => {
     expect(elicitTarget(form(BRANCH), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('enum')
     expect(elicitTarget(form({ ok: { type: 'boolean' } }), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('boolean')
     expect(elicitTarget(form(CHECKS), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('multi-enum')
-    for (const prop of [{ note: { type: 'string' } }, { count: { type: 'integer' } }])
-      expect(elicitForm(form(prop, Object.keys(prop)), TELEGRAM_ELICIT_SURFACE)).toBeNull()
+    expect(elicitTarget(form({ note: { type: 'string' } }), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('text')
+    expect(elicitTarget(form({ count: { type: 'integer' } }), TELEGRAM_ELICIT_SURFACE)?.kind).toBe('number')
   })
 
   it('declines an option list past what one keyboard holds, rather than showing part of it', () => {
@@ -134,11 +134,12 @@ interface Harness {
   daemon: any
   conn: any
   cards: { text: string; buttons: InlineButton[][]; opts: { threadTs?: string; replyTo?: number } }[]
-  edits: { text: string; buttons: InlineButton[][] }[]
+  edits: { text: string; buttons: InlineButton[][]; id?: number }[]
   acked: string[]
   notices: () => string[]
   /** Hold the next card post's response, so a tap can be made to beat its own send. */
   holdPost: (release: Promise<void>) => void
+  prompts: { text: string; opts: { replyTo?: number; placeholder?: string } }[]
 }
 
 /** @param turn the turn's THREAD coordinate and its Telegram reply anchor — a plain supergroup
@@ -151,7 +152,8 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
     upsertElicit: vi.fn(async () => {})
   }
   const cards: { text: string; buttons: InlineButton[][]; opts: { threadTs?: string; replyTo?: number } }[] = []
-  const edits: { text: string; buttons: InlineButton[][] }[] = []
+  const edits: { text: string; buttons: InlineButton[][]; id?: number }[] = []
+  const prompts: { text: string; opts: { replyTo?: number; placeholder?: string } }[] = []
   const acked: string[] = []
   const conn = Object.create(TelegramConnection.prototype)
   let held: Promise<void> | undefined
@@ -165,8 +167,12 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
     if (held) await held
     return '4242'
   }
-  conn.editCard = async (_c: string, _id: number, text: string, buttons: InlineButton[][]) => {
-    edits.push({ text, buttons })
+  conn.editCard = async (_c: string, id: number, text: string, buttons: InlineButton[][]) => {
+    edits.push({ text, buttons, id })
+  }
+  conn.postPrompt = async (_c: string, text: string, opts: { replyTo?: number; placeholder?: string } = {}) => {
+    prompts.push({ text, opts })
+    return '5150'
   }
   conn.answerCallback = async (id: string) => void acked.push(id)
   daemon.pending.set(JSON.stringify(['agent-1', 's1']), {
@@ -206,7 +212,8 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
     edits,
     acked,
     notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string),
-    holdPost: (release: Promise<void>) => void (held = release)
+    holdPost: (release: Promise<void>) => void (held = release),
+    prompts
   }
 }
 
@@ -270,9 +277,11 @@ describe('a Telegram turn posts an elicitation card and settles it in place', ()
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 
-  it('declines a kind Telegram has no control for, and says so in the chat', async () => {
+  it('declines an ask Telegram has no card for, and says so in the chat', async () => {
     const h = telegramTurn()
-    const req = form({ note: { type: 'string' } }, ['note'])
+    // Several questions: one prompt at a time is a state machine across fields, and a reader who
+    // walks away mid-way leaves half a form standing.
+    const req = form({ note: { type: 'string' }, count: { type: 'integer' } }, ['note', 'count'])
     await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
     expect(h.cards).toEqual([])
     expect(h.notices()[0]).toContain("this chat can't collect an answer for")
@@ -468,5 +477,95 @@ describe('a Telegram multi-select is assembled on the keyboard and submitted by 
     expect(h.edits).toEqual([])
     expect(h.notices()).toEqual(["That answer wasn't accepted — the question is still open."])
     expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+  })
+})
+
+describe('a Telegram typed answer is written into a force-reply box', () => {
+  async function tap(h: Harness, requestId: string, token: string): Promise<void> {
+    await h.daemon.handleTelegramCallback(
+      { id: `cb-${token}`, data: telegramElicitData(requestId, token), channel: '-100', messageId: 4242, userId: '77' },
+      h.conn
+    )
+  }
+  const reply = (text: string, replyTo?: string) => ({ channel: '-100', text, ...(replyTo ? { replyTo } : {}) })
+
+  it('offers a box rather than a control that cannot take characters, and takes what is typed', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form({ note: { type: 'string' } }, ['note']))
+    expect(h.cards[0]!.buttons).toEqual([
+      [
+        { text: 'Answer', callbackData: telegramElicitData(requestId, 'ed') },
+        { text: 'Dismiss', callbackData: telegramElicitData(requestId, 'x') }
+      ]
+    ])
+    // Opening the box is not an answer: the card is exactly as open as it was.
+    await tap(h, requestId, 'ed')
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    // The prompt REPLIES to the card, which is also what keeps it inside a forum topic.
+    expect(h.prompts).toHaveLength(1)
+    expect(h.prompts[0]!.opts.replyTo).toBe(4242)
+
+    expect(await h.daemon.permissions.claimElicitReply(reply('ship it', '5150'))).toBe(true)
+    await expect(result).resolves.toEqual({ action: 'accept', content: { note: 'ship it' } })
+    // Both the card and the prompt stop offering anything: no reader is left typing into a
+    // question that is over.
+    expect(h.edits.map((e) => e.id)).toEqual([4242, 5150])
+    expect(h.edits[0]!.text).toContain('✅ note: ship it')
+  })
+
+  it('answers only the prompt it opened — never a reply to anything else', async () => {
+    const h = telegramTurn()
+    const { requestId } = await raise(h, form({ note: { type: 'string' } }, ['note']))
+    // Before the box is even asked for, nothing in this chat is an answer.
+    expect(await h.daemon.permissions.claimElicitReply(reply('ship it', '5150'))).toBe(false)
+    await tap(h, requestId, 'ed')
+    // A message that replies to nothing, and one replying to some other message, are both prompts.
+    expect(await h.daemon.permissions.claimElicitReply(reply('ship it'))).toBe(false)
+    expect(await h.daemon.permissions.claimElicitReply(reply('ship it', '4242'))).toBe(false)
+    // Another conversation's reply cannot reach this card either.
+    expect(await h.daemon.permissions.claimElicitReply({ channel: '-200', text: 'x', replyTo: '5150' })).toBe(false)
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+  })
+
+  it('takes the first answer and nothing after it, because the answered card is gone', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form({ note: { type: 'string' } }, ['note']))
+    await tap(h, requestId, 'ed')
+    expect(await h.daemon.permissions.claimElicitReply(reply('first', '5150'))).toBe(true)
+    expect(await h.daemon.permissions.claimElicitReply(reply('second', '5150'))).toBe(false)
+    await expect(result).resolves.toEqual({ action: 'accept', content: { note: 'first' } })
+  })
+
+  it('keeps the SAME box open after a refusal, so the retry goes where the reader is typing', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form({ count: { type: 'integer' } }, ['count']))
+    await tap(h, requestId, 'ed')
+    expect(await h.daemon.permissions.claimElicitReply(reply('nope', '5150'))).toBe(true)
+    expect(h.prompts).toHaveLength(1)
+    expect(await h.daemon.permissions.claimElicitReply(reply('7', '5150'))).toBe(true)
+    await expect(result).resolves.toEqual({ action: 'accept', content: { count: 7 } })
+  })
+
+  it('gives a number field a real number, and refuses words with the field’s own message', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form({ count: { type: 'integer', minimum: 1 } }, ['count']))
+    await tap(h, requestId, 'ed')
+    expect(await h.daemon.permissions.claimElicitReply(reply('not a number', '5150'))).toBe(true)
+    // Claimed but refused: the words were an answer to THIS card, and a bad one leaves it live.
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain('Enter')
+
+    await tap(h, requestId, 'ed')
+    expect(await h.daemon.permissions.claimElicitReply(reply('42', '5150'))).toBe(true)
+    await expect(result).resolves.toEqual({ action: 'accept', content: { count: 42 } })
+  })
+
+  it('still reads Dismiss as the decline it is on every card', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form({ note: { type: 'string' } }, ['note']))
+    await tap(h, requestId, 'ed')
+    await tap(h, requestId, 'x')
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(h.edits[0]!.text).toContain('🚫 Dismissed')
   })
 })

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -140,6 +140,7 @@ interface Harness {
   /** Hold the next card post's response, so a tap can be made to beat its own send. */
   holdPost: (release: Promise<void>) => void
   prompts: { text: string; opts: { replyTo?: number; placeholder?: string } }[]
+  deleted: string[]
 }
 
 /** @param turn the turn's THREAD coordinate and its Telegram reply anchor — a plain supergroup
@@ -154,6 +155,7 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
   const cards: { text: string; buttons: InlineButton[][]; opts: { threadTs?: string; replyTo?: number } }[] = []
   const edits: { text: string; buttons: InlineButton[][]; id?: number }[] = []
   const prompts: { text: string; opts: { replyTo?: number; placeholder?: string } }[] = []
+  const deleted: string[] = []
   const acked: string[] = []
   const conn = Object.create(TelegramConnection.prototype)
   let held: Promise<void> | undefined
@@ -170,9 +172,14 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
   conn.editCard = async (_c: string, id: number, text: string, buttons: InlineButton[][]) => {
     edits.push({ text, buttons, id })
   }
+  // A DISTINCT id per send, as Telegram gives: a fixed one hides a card holding two open boxes.
   conn.postPrompt = async (_c: string, text: string, opts: { replyTo?: number; placeholder?: string } = {}) => {
     prompts.push({ text, opts })
-    return '5150'
+    return String(5150 + prompts.length - 1)
+  }
+  conn.deleteMessage = async (_c: string, ts: string) => {
+    deleted.push(ts)
+    return true
   }
   conn.answerCallback = async (id: string) => void acked.push(id)
   daemon.pending.set(JSON.stringify(['agent-1', 's1']), {
@@ -182,7 +189,7 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
       sessionKey: 'k1',
       requesterId: 'turn-user',
       channel: '-100',
-      transcriptChannel: '-100',
+      transcriptChannel: '-100\u001ftelegram:bot-a',
       statusThread: 'T1',
       agentName: 'agent',
       isDm: false,
@@ -213,7 +220,8 @@ function telegramTurn(turn: { thread?: string; replyTo?: number } = {}): Harness
     acked,
     notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string),
     holdPost: (release: Promise<void>) => void (held = release),
-    prompts
+    prompts,
+    deleted
   }
 }
 
@@ -487,7 +495,12 @@ describe('a Telegram typed answer is written into a force-reply box', () => {
       h.conn
     )
   }
-  const reply = (text: string, replyTo?: string) => ({ channel: '-100', text, ...(replyTo ? { replyTo } : {}) })
+  const CONV = '-100\u001ftelegram:bot-a'
+  const reply = (text: string, replyTo?: string, conversation = CONV) => ({
+    conversation,
+    text,
+    ...(replyTo ? { replyTo } : {})
+  })
 
   it('offers a box rather than a control that cannot take characters, and takes what is typed', async () => {
     const h = telegramTurn()
@@ -507,10 +520,12 @@ describe('a Telegram typed answer is written into a force-reply box', () => {
 
     expect(await h.daemon.permissions.claimElicitReply(reply('ship it', '5150'))).toBe(true)
     await expect(result).resolves.toEqual({ action: 'accept', content: { note: 'ship it' } })
-    // Both the card and the prompt stop offering anything: no reader is left typing into a
-    // question that is over.
-    expect(h.edits.map((e) => e.id)).toEqual([4242, 5150])
+    // The card stops offering anything, and the prompt is DELETED rather than edited: Telegram
+    // edits only a message carrying no markup or an inline keyboard, so an edit aimed at a
+    // `force_reply` is refused and the box would simply remain.
+    expect(h.edits.map((e) => e.id)).toEqual([4242])
     expect(h.edits[0]!.text).toContain('✅ note: ship it')
+    expect(h.deleted).toEqual(['5150'])
   })
 
   it('answers only the prompt it opened — never a reply to anything else', async () => {
@@ -522,9 +537,27 @@ describe('a Telegram typed answer is written into a force-reply box', () => {
     // A message that replies to nothing, and one replying to some other message, are both prompts.
     expect(await h.daemon.permissions.claimElicitReply(reply('ship it'))).toBe(false)
     expect(await h.daemon.permissions.claimElicitReply(reply('ship it', '4242'))).toBe(false)
-    // Another conversation's reply cannot reach this card either.
-    expect(await h.daemon.permissions.claimElicitReply({ channel: '-200', text: 'x', replyTo: '5150' })).toBe(false)
+    // Another conversation's reply cannot reach this card, and neither can the SAME chat id
+    // reached through a different bot — one person's DMs with two bots share their message
+    // numbers, so the bot is part of the identity.
+    expect(await h.daemon.permissions.claimElicitReply(reply('x', '5150', '-200\u001ftelegram:bot-a'))).toBe(false)
+    expect(await h.daemon.permissions.claimElicitReply(reply('x', '5150', '-100\u001ftelegram:bot-b'))).toBe(false)
+    expect(await h.daemon.permissions.claimElicitReply(reply('x', '5150', '-100'))).toBe(false)
     expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+  })
+
+  it('keeps EVERY box it opened answerable, so a second tap does not break the first', async () => {
+    // Two readers can be typing at once, and one reader can tap twice. A box still on screen must
+    // not have stopped working because a later one appeared.
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form({ note: { type: 'string' } }, ['note']))
+    await tap(h, requestId, 'ed')
+    await tap(h, requestId, 'ed')
+    expect(h.prompts).toHaveLength(2)
+    expect(await h.daemon.permissions.claimElicitReply(reply('from the first box', '5150'))).toBe(true)
+    await expect(result).resolves.toEqual({ action: 'accept', content: { note: 'from the first box' } })
+    // And both boxes are retired, not just the one that was answered.
+    expect(h.deleted.sort()).toEqual(['5150', '5151'])
   })
 
   it('takes the first answer and nothing after it, because the answered card is gone', async () => {
@@ -555,7 +588,6 @@ describe('a Telegram typed answer is written into a force-reply box', () => {
     expect(h.daemon.permissions.pendingElicits.size).toBe(1)
     expect(h.notices().at(-1)).toContain('Enter')
 
-    await tap(h, requestId, 'ed')
     expect(await h.daemon.permissions.claimElicitReply(reply('42', '5150'))).toBe(true)
     await expect(result).resolves.toEqual({ action: 'accept', content: { count: 42 } })
   })


### PR DESCRIPTION
## What was missing

A `text` or `number` question was declined on Telegram, because the one control a Bot API
keyboard has — a button — accepts no characters. #1901 fixed the multi-select by discovering
that a button can also *toggle*; this fixes the typed case by using the control Telegram has
for typing and we were not using.

## `force_reply` is the input box

`reply_markup: { force_reply: true }` opens the reader's own compose box aimed at one message,
and their reply comes back carrying `reply_to_message.message_id`. That is both an input box
*and* a per-card answer channel by construction — the property #1828 wanted from Slack's thread
route and could not guarantee.

```
💬 What should the release be called?
Enter text.
┌──────────────────────┐
│ Answer     Dismiss   │      ← tap Answer
└──────────────────────┘
        ↓
💬 What should the release be called?     ← force_reply, replying to the card
Enter text.
   ┌────────────────────────────────┐
   │ [compose box, already aimed]   │
   └────────────────────────────────┘
        ↓  reader types "v2.4.0"
💬 What should the release be called?
✅ note: v2.4.0                            ← both card and prompt stop offering anything
```

No Confirm: the reply IS the submission, and a second tap would only be a chance to lose it.
The prompt **replies to the card**, which is also what keeps it inside a forum topic — Telegram
places a reply where the message it answers is, so no thread coordinate is re-derived here.

## One validation, again

The typed words go back as the field's own carried value under the same `elicitFormBlockId(0)` a
Confirm uses, so a typed answer runs through the SAME re-derivation (#1815) every other answer
does. A number that is not a number, a string breaking its own `pattern`, `format`, `minLength`
— each is refused with the field's own words and the card is left live. The box stays open on a
refusal: the reader who was just told what was wrong is typing into it.

## The seam

One optional member, `ElicitCardFacet.claimReply(handle, card, reply)`. Core offers each typed
human message to the live cards of its own conversation:

- **before** thread canonicalization would read it as continuing the session,
- **before** command parsing would read `!stop` typed into the box as a control,
- **never** for agent-authored traffic — "anyone who can see the card may answer it" is about
  people, and an agent answering another agent's question is not that.

A surface that asks nobody to type claims nothing, which is what Slack's does — so this is a
no-op everywhere except the chat that opened a box.

## Still declined on Telegram

A form of several questions: one prompt at a time is a state machine across fields, and a reader
who walks away mid-way leaves half a form standing. The select-with-Other companion needs the
same machinery plus the record semantics of a form answer. Both are #1794's next Telegram items.

## Verification

- `telegram-elicit-card.test.ts` — 32 tests. All 8 new/changed assertions confirmed **red** on
  `main` before the change.
- New coverage: the card offers a box rather than a dead control; opening it is not an answer;
  the prompt replies to the card; only the prompt this card opened is claimed (not a bare
  message, not a reply to another message, not another conversation's); the answered card is
  gone so nothing after it lands; the same box survives a refusal for the retry; a number field
  gets a real number and words are refused with the field's own message; Dismiss unchanged.
- Full daemon suite: the 10 red files are the known load-flaky set (skills / sandbox / scheduler
  / inbox) plus the pre-existing `evaluation-runner` baseline; all pass in isolation, and no
  routing or elicitation file is among them.
- `pnpm eval:gates` 192/193 (that same pre-existing failure). typecheck / eslint / prettier clean.

Refs #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
