### PR TITLE
fix(daemon): derive VM runtime candidates from stored logins

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -179,6 +179,9 @@ record. Configuration directories, empty stores, and an executable in the image
 do not establish that the operator configured a login.
 
 The daemon probes each candidate on the host to learn its models and capabilities.
+These metadata probes use host SRT when available and otherwise run on the host;
+they do not submit a model turn. With microsandbox selected, `requireSandbox`
+continues to require VM isolation for agent sessions, without requiring host SRT.
 The image table supplies the guest command and binary version. A candidate missing
 from that table remains visible with **Binary not installed in image**. An image
 runtime without a discovered host login does not appear in the candidate list.

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -170,6 +170,28 @@ with `--k8s` is rejected as conflicting configuration; an omitted/default local
 backend has no effect on pool execution. Sharing an image does not mean nesting
 microsandbox inside every pool pod.
 
+### Runtime discovery
+
+A microsandbox daemon derives its runtime candidates from the stored credential
+sources used to prepare runtime authentication. Discovery checks the specific
+authentication file and, for a shared provider store, the corresponding provider
+record. Configuration directories, empty stores, and an executable in the image
+do not establish that the operator configured a login.
+
+The daemon probes each candidate on the host to learn its models and capabilities.
+The image table supplies the guest command and binary version. A candidate missing
+from that table remains visible with **Binary not installed in image**. An image
+runtime without a discovered host login does not appear in the candidate list.
+
+Stored credentials indicate configuration, not current validity. Expired logins
+remain visible; an authentication failure from the host probe or a real turn
+produces the existing **Login required** status independently of image availability.
+
+File and database discovery currently covers Claude, Codex, Qoder, OMP, Grok, pi,
+OpenCode, DSH, Hermes, Auggie, Cline, Amp, and Gemini/Qwen/Kimi OAuth. Keyring-only
+logins and credential formats without a shared discovery descriptor are not
+detected; those runtimes stay out of the microsandbox candidate list.
+
 ## 2. Selecting the backend
 
 The choice favors session development workflows over maximum hardening.

--- a/packages/control-plane/prisma/migrations/20260928000000_runtime_image_availability/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260928000000_runtime_image_availability/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runtime_profile" ADD COLUMN "unavailableReason" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -649,6 +649,7 @@ model RuntimeProfile {
   modelCatalog       Json?      @db.JsonB // wire RuntimeModelCatalog verbatim (runtime-model-catalog.md §5); null ⇒ no catalog reported
   modelsSource       String? // provenance of models[]: 'cached' | 'probed'; null ⇒ older daemon (probed semantics)
   authRequired       Boolean    @default(false) // last probe hit ACP auth-required (-32000): installed but needs a login on the daemon host
+  unavailableReason  String? // image-binary-missing; null means no reported sandbox restriction
   observedAt         DateTime   @default(now()) @db.Timestamptz(6)
 
   daemon Daemon @relation(fields: [daemonId], references: [id], onDelete: Cascade)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -157,6 +157,7 @@ export const RuntimeProfileDto = z.object({
   // runtime is installed but needs a login on the daemon host. Drives the
   // console's per-runtime "Login required" warning.
   authRequired: z.boolean(),
+  unavailableReason: z.literal('image-binary-missing').nullable().optional(),
   // ISO-8601 — when the daemon last reported this profile.
   observedAt: z.string().nullable()
 })

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4953,6 +4953,7 @@ export interface RuntimeProfileRecord {
   /** The daemon's last probe was rejected with the ACP auth-required error
    *  (-32000): installed but needing a login on the daemon host. */
   authRequired: boolean
+  unavailableReason?: 'image-binary-missing' | null
   /** When the daemon last reported this profile. */
   observedAt: Date
 }

--- a/packages/control-plane/src/persistence/repositories/runtime-profile.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/runtime-profile.repo.ts
@@ -26,6 +26,7 @@ function toRecord(p: RuntimeProfile): RuntimeProfileRecord {
     modelCatalog: (p.modelCatalog as RuntimeProfileRecord['modelCatalog']) ?? null,
     modelsSource: (p.modelsSource as RuntimeProfileRecord['modelsSource']) ?? null,
     authRequired: p.authRequired,
+    unavailableReason: p.unavailableReason as RuntimeProfileRecord['unavailableReason'],
     observedAt: p.observedAt
   }
 }
@@ -58,6 +59,7 @@ export class PgRuntimeProfileRepo implements RuntimeProfileRepo {
         modelCatalog: f.modelCatalog ?? Prisma.DbNull,
         modelsSource: f.modelsSource ?? null,
         authRequired: f.authRequired ?? false,
+        unavailableReason: f.unavailableReason ?? null,
         observedAt: at
       },
       update: {
@@ -73,6 +75,7 @@ export class PgRuntimeProfileRepo implements RuntimeProfileRepo {
         modelsSource: f.modelsSource ?? null,
         // Absent ⇒ no login warning — clear rather than keep a stale flag.
         authRequired: f.authRequired ?? false,
+        unavailableReason: f.unavailableReason ?? null,
         observedAt: at
       }
     })

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -214,6 +214,7 @@ export interface DaemonRuntimeProfile {
    *  (-32000): the runtime is installed but needs a login on the daemon host.
    *  Drives the console's per-runtime login warning. */
   authRequired: boolean
+  unavailableReason?: 'image-binary-missing' | null
   /** When the daemon last reported this profile. */
   observedAt: Date
 }

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -60,6 +60,7 @@ function toProfileView(p: RuntimeProfileRecord): DaemonRuntimeProfile {
     modelCatalog: p.modelCatalog,
     modelsSource: p.modelsSource,
     authRequired: p.authRequired,
+    unavailableReason: p.unavailableReason ?? null,
     observedAt: p.observedAt
   }
 }

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -98,6 +98,7 @@ type DaemonDto = {
     } | null
     modelsSource: string | null
     authRequired: boolean
+    unavailableReason?: 'image-binary-missing' | null
     observedAt: string | null
   }[]
   mcpServers: {
@@ -259,9 +260,10 @@ describe('GET /daemons — live-status overlay', () => {
     expect(d.runtimeProfiles[0]!.modelsSource).toBeNull()
     // No login warning reported ⇒ explicit false (older daemons never send it).
     expect(d.runtimeProfiles[0]!.authRequired).toBe(false)
+    expect(d.runtimeProfiles[0]!.unavailableReason).toBeNull()
   })
 
-  it('surfaces the per-runtime authRequired login warning', async () => {
+  it('retains auth and missing-image warnings in capability and detail reads', async () => {
     await seedDaemon()
     await new PgRuntimeProfileRepo(prisma).record(
       DaemonId(DAEMON),
@@ -271,12 +273,24 @@ describe('GET /daemons — live-status overlay', () => {
         models: [],
         acpSupport: 'full',
         toolCalling: true,
-        authRequired: true
+        authRequired: true,
+        unavailableReason: 'image-binary-missing'
       },
       new Date()
     )
     running = buildHttpApp(prisma)
-    expect((await listCapabilities()).find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]!.authRequired).toBe(true)
+    expect((await listCapabilities()).find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]).toMatchObject({
+      runtime: 'claude',
+      authRequired: true,
+      unavailableReason: 'image-binary-missing'
+    })
+    const response = await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${DAEMON}` })
+    expect(response.statusCode).toBe(200)
+    expect((response.json() as DaemonDto).runtimeProfiles[0]).toMatchObject({
+      runtime: 'claude',
+      authRequired: true,
+      unavailableReason: 'image-binary-missing'
+    })
   })
 
   it('serves the reported modelCatalog, modelsSource and observedAt per runtime profile', async () => {

--- a/packages/control-plane/test/protocol/daemon-runtimes.handler.test.ts
+++ b/packages/control-plane/test/protocol/daemon-runtimes.handler.test.ts
@@ -172,7 +172,7 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     expect(stub.lastSent('error')).toBeUndefined()
   })
 
-  it('persists the per-runtime authRequired login warning and clears it when a later snapshot omits it', async () => {
+  it('keeps auth and missing-image warnings independent and clears omitted status', async () => {
     const h = buildWsHarness(prisma)
     const { stub } = await connectReady(h)
     const repo = new PgRuntimeProfileRepo(prisma)
@@ -180,17 +180,23 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     // The probe was rejected with ACP auth-required: the runtime stays listed
     // (installed) but carries the login warning.
     stub.inject('facts/daemon-runtimes', {
-      runtimes: [{ ...profile('claude-acp'), authRequired: true }]
+      runtimes: [{ ...profile('claude-acp'), authRequired: true, unavailableReason: 'image-binary-missing' }]
     })
     await vi.waitFor(async () => {
-      expect((await repo.forDaemon(DaemonId(DAEMON)))[0]?.authRequired).toBe(true)
+      expect((await repo.forDaemon(DaemonId(DAEMON)))[0]).toMatchObject({
+        authRequired: true,
+        unavailableReason: 'image-binary-missing'
+      })
     })
 
     // Logged in meanwhile: the next snapshot omits the flag (a successful probe
     // never sends it) — the stored warning must clear, never stay stale.
     stub.inject('facts/daemon-runtimes', { runtimes: [profile('claude-acp')] })
     await vi.waitFor(async () => {
-      expect((await repo.forDaemon(DaemonId(DAEMON)))[0]?.authRequired).toBe(false)
+      expect((await repo.forDaemon(DaemonId(DAEMON)))[0]).toMatchObject({
+        authRequired: false,
+        unavailableReason: null
+      })
     })
     expect(stub.lastSent('error')).toBeUndefined()
   })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2444,7 +2444,9 @@ export class Daemon {
    *  after boot. The store memoizes, so this resolves once for the runtime and never once per spawn. */
   private async ensureRuntimeInstalled(runtimeId: string, local = false): Promise<void> {
     if (local && this.localRuntimeCatalog) {
-      this.localRuntimeCatalog = await this.installManagedRuntimePackages(this.localRuntimeCatalog, [runtimeId])
+      const installed = await this.installManagedRuntimePackages(this.localRuntimeCatalog, [runtimeId])
+      if (!installed.entries[runtimeId]) throw new Error(this.runtimeUnavailableMessage(runtimeId))
+      this.localRuntimeCatalog = installed
       return
     }
     const entry = this.runtimeCatalog.entries[runtimeId]

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -18309,7 +18309,8 @@ export class Daemon {
         fakeHosts: this.opts.hostFactory !== undefined,
         ...(this.opts.probeRuntimes ? { probe: this.opts.probeRuntimes } : {}),
         ...(this.sandboxMechanism ? { sandboxMechanism: this.sandboxMechanism } : {}),
-        requireSandbox: this.cfg.security.requireSandbox,
+        // Required VM isolation applies to sessions; host metadata probes use SRT when available.
+        requireSandbox: this.cfg.sandbox.backend === 'srt' && this.cfg.security.requireSandbox,
         daemonRoot: this.root,
         agentsRoot: this.cfg.agentsDir,
         isolateAccountApps: this.cfg.security.isolateAccountApps

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -271,6 +271,7 @@ import {
   RuntimeCommandsCache
 } from './runtimes/runtime-commands.js'
 import { installedRuntimeCatalog, installedRuntimes, resolveCommandPath } from './runtimes/probe.js'
+import { discoverRuntimeCredentials } from './runtimes/runtime-credential-discovery.js'
 import { startK8sRuntimePlane, type K8sRuntimePlane } from './k8s/runtime-plane.js'
 import {
   declaredRuntimeCatalog,
@@ -2300,47 +2301,61 @@ export class Daemon {
     })
   }
 
-  /** Phase 13 — resolve the runtime catalog and narrow it to what is actually installed (declared, under --k8s). */
+  /** Phase 13 — resolve host candidates and the image's separate executable catalog. */
   private async discoverRuntimes(root: string, cfg: Config, discoveredAgents: LoadedAgent[]): Promise<void> {
     const resolvedCatalog = await (this.opts.resolveCatalog ?? resolveRuntimeCatalog)(cfg, root, {
       neededRuntimes: discoveredAgents.map((a) => a.runtime),
       mode: 'cache-first'
     })
-    // Advertise (and launch) only runtimes actually installed on this host — the
-    // registry lists every known agent, but most aren't present here. Under --k8s
-    // there is nothing to discover locally: the sandbox image declares what it ships
-    // (k8s-runtimes.ts), so presence is a declaration rather than a probe.
-    const installedCatalog = this.opts.installed
-      ? (() => {
-          const runtimes = this.opts.installed!(resolvedCatalog.runtimes)
-          return {
-            runtimes,
-            entries: Object.fromEntries(
-              Object.entries(resolvedCatalog.entries).filter(([id]) => runtimes[id] !== undefined)
+    // VM candidates come from the same stored auth sources that prepare their private HOME.
+    const credentialEntries =
+      cfg.sandbox.backend === 'microsandbox'
+        ? Object.fromEntries(
+            Object.entries(resolvedCatalog.entries).filter(
+              ([id, entry]) => discoverRuntimeCredentials(id, entry.runtime).paths.length > 0
             )
-          }
-        })()
-      : this.k8s
-        ? this.declaredPoolCatalog(root, resolvedCatalog)
-        : installedRuntimeCatalog(resolvedCatalog)
+          )
+        : undefined
+    const installedCatalog = credentialEntries
+      ? {
+          entries: credentialEntries,
+          runtimes: Object.fromEntries(Object.entries(credentialEntries).map(([id, entry]) => [id, entry.runtime]))
+        }
+      : this.opts.installed
+        ? (() => {
+            const runtimes = this.opts.installed!(resolvedCatalog.runtimes)
+            return {
+              runtimes,
+              entries: Object.fromEntries(
+                Object.entries(resolvedCatalog.entries).filter(([id]) => runtimes[id] !== undefined)
+              )
+            }
+          })()
+        : this.k8s
+          ? this.declaredPoolCatalog(root, resolvedCatalog)
+          : installedRuntimeCatalog(resolvedCatalog)
     // Only what this daemon's agents actually run: a runtime assigned later is installed before its
     // first host start instead, so a host with six logged-in harnesses does not fetch all six here.
     const storedCatalog = await this.installManagedRuntimePackages(
       installedCatalog,
       discoveredAgents.filter((agent) => !this.usesMicrosandbox(agent)).map((agent) => agent.runtime)
     )
-    const { runtimes: installed, entries: installedEntries } = storedCatalog
-    this.localRuntimeCatalog = cfg.sandbox.backend === 'microsandbox' ? storedCatalog : undefined
+    this.localRuntimeCatalog = credentialEntries
+      ? {
+          entries: { ...installedCatalog.entries, ...storedCatalog.entries },
+          runtimes: { ...installedCatalog.runtimes, ...storedCatalog.runtimes }
+        }
+      : undefined
+    const localCatalog = this.localRuntimeCatalog ?? storedCatalog
+    const { runtimes: installed, entries: installedEntries } = localCatalog
     if (this.microsandboxTable) {
-      const declared = declaredRuntimeCatalog(resolvedCatalog, this.microsandboxTable)
+      const declared = declaredRuntimeCatalog(installedCatalog, this.microsandboxTable)
       this.microsandboxCatalog = declared.catalog
-      this.k8sDeclaredModels = declared.models
-      this.k8sDeclaredAcp = declared.acp
       this.runtimeCatalog = {
-        entries: { ...storedCatalog.entries, ...declared.catalog.entries },
-        runtimes: { ...storedCatalog.runtimes, ...declared.catalog.runtimes }
+        entries: { ...localCatalog.entries, ...declared.catalog.entries },
+        runtimes: { ...localCatalog.runtimes, ...declared.catalog.runtimes }
       }
-    } else this.runtimeCatalog = storedCatalog
+    } else this.runtimeCatalog = localCatalog
     this.refreshAdmittedRuntimes()
     this.runtimeFacts.setInstalled(installedEntries)
     if (this.microsandboxCatalog) this.runtimeFacts.noteImageCatalog(this.microsandboxCatalog.entries)
@@ -2348,7 +2363,10 @@ export class Daemon {
     const pendingCurated = Object.keys(installed).filter((id) => installedEntries[id]?.source === 'curated')
     if (pendingCurated.length) this.log.info(`runtimes pending ACP admission: ${pendingCurated.join(', ')}`)
     const skipped = Object.keys(resolvedCatalog.runtimes).filter((id) => !installed[id])
-    if (skipped.length) this.log.info(`runtimes not installed (skipped): ${skipped.join(', ')}`)
+    if (skipped.length) {
+      const reason = credentialEntries ? 'without stored credentials' : 'not installed'
+      this.log.info(`runtimes ${reason} (skipped): ${skipped.join(', ')}`)
+    }
   }
 
   // Sources whose launch spec the daemon itself supplies. Explicit `user` config is the operator's
@@ -2526,8 +2544,7 @@ export class Daemon {
     // Model-catalog cache: synchronous last-good hydrate BEFORE the CP client
     // starts, so the register-time facts snapshot already carries models + the
     // capability matrix instead of blanking the CP until the sweep completes.
-    // Image runtimes must not inherit model catalogs cached by a previous host execution.
-    await this.runtimeFacts.hydrateFromCache(new Set(Object.keys(this.microsandboxCatalog?.entries ?? {})))
+    await this.runtimeFacts.hydrateFromCache()
     // The image's declared models are the fresher truth than any cached row, and stay
     // `cached` provenance: no live probe confirmed them, so model gates remain permissive.
     this.runtimeFacts.applyDeclaredFacts(this.k8sDeclaredModels, this.k8sDeclaredAcp)
@@ -2561,10 +2578,7 @@ export class Daemon {
       }),
       onUpdated: async (runtimeId) => {
         await this.runtimeFacts.rebuildCatalog(runtimeId)
-        this.cpClient?.emitDaemonRuntimes?.(
-          this.admittedRuntimeIds().map((id) => this.runtimeFacts.profileFor(id)),
-          this.mcpServerFactsFromDefs()
-        )
+        this.runtimeFacts.emitFacts()
       }
     })
   }
@@ -18266,8 +18280,9 @@ export class Daemon {
       draining: () => this.draining,
       catalog: () => this.runtimeCatalog,
       localProbeCatalog: () => this.localRuntimeCatalog ?? this.runtimeCatalog,
-      executionLocation: (runtimeId) =>
-        this.k8s || this.microsandboxCatalog?.entries[runtimeId] !== undefined ? 'sandbox' : 'host',
+      imageVersion: (runtimeId) => this.microsandboxCatalog?.entries[runtimeId]?.version,
+      unavailableReason: (runtimeId) =>
+        this.microsandboxTable && !this.microsandboxCatalog?.entries[runtimeId] ? 'image-binary-missing' : undefined,
       admittedRuntimes: () => this.runtimes,
       refreshAdmitted: () => this.refreshAdmittedRuntimes(),
       reportedRuntimeIds: () => this.reportedRuntimeIds(),
@@ -18277,16 +18292,13 @@ export class Daemon {
       mcpServerFacts: () => this.mcpServerFactsFromDefs(),
       noteCatalogProbe: (input) => void this.modelCatalogSvc?.noteProbe(input),
       localizeRuntime: async (runtimeId) => {
-        await this.ensureRuntimeInstalled(runtimeId)
-        // Host-only installs must stay current in the separate local launch catalog.
+        await this.ensureRuntimeInstalled(runtimeId, this.localRuntimeCatalog !== undefined)
+        // Keep host launch commands current without replacing the image's executable.
         if (this.localRuntimeCatalog && !this.microsandboxCatalog?.entries[runtimeId]) {
-          const entry = this.runtimeCatalog.entries[runtimeId]
+          const entry = this.localRuntimeCatalog.entries[runtimeId]
           if (entry) {
-            this.localRuntimeCatalog.entries[runtimeId] = entry
-            this.localRuntimeCatalog.runtimes[runtimeId] = entry.runtime
-          } else {
-            delete this.localRuntimeCatalog.entries[runtimeId]
-            delete this.localRuntimeCatalog.runtimes[runtimeId]
+            this.runtimeCatalog.entries[runtimeId] = entry
+            this.runtimeCatalog.runtimes[runtimeId] = entry.runtime
           }
         }
       },
@@ -18636,12 +18648,9 @@ export class Daemon {
     return Object.keys(this.runtimes)
   }
 
-  /** Runtime ids the facts snapshot reports: the admitted set PLUS curated
-   *  candidates whose fresh probe was an auth-required rejection. Those are
-   *  installed but logged out — they must be visible to the console (with the
-   *  login warning) even though admission keeps them unlaunchable until a
-   *  probe succeeds. */
+  /** Keep VM credential candidates visible through missing binaries and failed or expired logins. */
   private reportedRuntimeIds(): string[] {
+    if (this.localRuntimeCatalog) return Object.keys(this.runtimeCatalog.entries)
     const ids = this.admittedRuntimeIds()
     const admitted = new Set(ids)
     return [

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -62,8 +62,8 @@ export interface RuntimeFactsHost {
   draining(): boolean
   catalog(): ResolvedRuntimeCatalog
   localProbeCatalog(): ResolvedRuntimeCatalog
-  // The advertised runtime's execution location; a same-ID host install may also exist.
-  executionLocation(runtimeId: string): 'host' | 'sandbox'
+  imageVersion(runtimeId: string): string | undefined
+  unavailableReason(runtimeId: string): FactsRuntimeProfile['unavailableReason']
   admittedRuntimes(): Record<string, RuntimeDef>
   refreshAdmitted(): void
   reportedRuntimeIds(): string[]
@@ -162,10 +162,8 @@ export class RuntimeFactsRegistry {
   profileFor(id: string): FactsRuntimeProfile {
     return {
       runtime: id,
-      // Prefer the probed adapter version (the actual running release, learned at the
-      // last probe's `initialize`) over the registry's declared version; fall back to
-      // the declared version when a runtime hasn't been probed / reported none.
-      version: this.probedVersions.get(id) || this.versions[id] || '',
+      // VM versions come from the image; a host probe supplies models and capabilities only.
+      version: this.host.imageVersion(id) || this.probedVersions.get(id) || this.versions[id] || '',
       models: this.models.get(id) ?? [],
       acpSupport: 'full',
       acpProtocolVersion: this.acpVersions.get(id),
@@ -175,6 +173,7 @@ export class RuntimeFactsRegistry {
       // Capability matrix rides every frame it exists for — including probe-failure
       // rounds where models[] empties (advertisement ≠ capability knowledge).
       modelCatalog: this.catalogs.get(id),
+      ...(this.host.unavailableReason(id) ? { unavailableReason: this.host.unavailableReason(id) } : {}),
       ...(this.authRequired.has(id) || this.authRequiredLive.has(id) ? { authRequired: true } : {})
     }
   }
@@ -250,10 +249,10 @@ export class RuntimeFactsRegistry {
    *  runtime may only be temporarily unresolved); rows older than 30 days are
    *  garbage-collected. The store reads only this member's rows, so a member can
    *  never boot advertising models a peer's image runs and its own does not. */
-  async hydrateFromCache(excludedRuntimeIds: ReadonlySet<string> = new Set()): Promise<void> {
+  async hydrateFromCache(): Promise<void> {
     try {
       for (const meta of await this.host.store().listRuntimeCatalogMetas()) {
-        if (excludedRuntimeIds.has(meta.runtimeId) || !this.host.catalog().entries[meta.runtimeId]) continue
+        if (!this.host.catalog().entries[meta.runtimeId]) continue
         await this.rebuildCatalog(meta.runtimeId)
         const cachedModels = (await this.host.store().listRuntimeModelCaps(meta.runtimeId)).map((r) => r.modelId)
         if (cachedModels.length > 0 && (this.models.get(meta.runtimeId) ?? []).length === 0) {
@@ -275,7 +274,7 @@ export class RuntimeFactsRegistry {
       this.catalogs.delete(id)
       return
     }
-    const rt = this.host.catalog().entries[id]?.runtime
+    const rt = (this.host.localProbeCatalog().entries[id] ?? this.host.catalog().entries[id])?.runtime
     const claude = rt ? isClaudeRuntimeDef(rt) : false
     const models = (await this.host.store().listRuntimeModelCaps(id)).map((r) => ({
       id: r.modelId,
@@ -301,7 +300,7 @@ export class RuntimeFactsRegistry {
    * continuously connected daemon rechecks curated winners on the same TTL. */
   armProbeRefresh(): void {
     if (this.host.draining() || this.probeTimer !== undefined) return
-    if (!Object.values(this.host.catalog().entries).some((entry) => entry.source === 'curated')) return
+    if (!Object.values(this.host.localProbeCatalog().entries).some((entry) => entry.source === 'curated')) return
     this.probeTimer = this.host.clock().setTimeout(() => {
       this.probeTimer = undefined
       if (this.host.draining()) return
@@ -369,7 +368,7 @@ export class RuntimeFactsRegistry {
         ? {}
         : Object.fromEntries(
             Object.entries(catalog.entries)
-              .filter(([id, entry]) => entry.source !== 'curated' && this.host.executionLocation(id) === 'host')
+              .filter(([, entry]) => entry.source !== 'curated')
               .map(([id, entry]) => [id, entry.runtime])
           )
     const probeCount = Object.keys(ordinaryRuntimes).length + Object.keys(curatedCandidates).length
@@ -397,11 +396,6 @@ export class RuntimeFactsRegistry {
       const onResult = async (result: RuntimeProbeResult): Promise<void> => {
         if (applied.has(result.runtime)) return
         applied.add(result.runtime)
-        // A same-ID host runtime needs admission, but its probe must not replace the image's facts.
-        if (this.host.executionLocation(result.runtime) !== 'host') {
-          if (catalog.entries[result.runtime]?.source === 'curated') this.host.curatedAdmission().record(result)
-          return
-        }
         await this.applyProbeResult(result)
         this.emitFacts()
         emitted = true
@@ -539,7 +533,7 @@ export class RuntimeFactsRegistry {
   /** Fold one probe result into admission, advertised models/caps and the model
    *  catalog. Called per result so a slow runtime delays only itself. */
   private async applyProbeResult(r: RuntimeProbeResult): Promise<void> {
-    if (this.host.catalog().entries[r.runtime]?.source === 'curated') this.host.curatedAdmission().record(r)
+    if (this.host.localProbeCatalog().entries[r.runtime]?.source === 'curated') this.host.curatedAdmission().record(r)
     this.host.refreshAdmitted()
     // Successful probes (including empty selectors) and auth failures are
     // authoritative. Preserve a non-empty cache-hydrated list across other
@@ -579,7 +573,7 @@ export class RuntimeFactsRegistry {
    *  the last-good catalog is never cleared. */
   private async seedCatalogFromProbe(r: RuntimeProbeResult): Promise<void> {
     if (!r.ok) return
-    const entry = this.host.catalog().entries[r.runtime]
+    const entry = this.host.localProbeCatalog().entries[r.runtime] ?? this.host.catalog().entries[r.runtime]
     if (!entry || this.host.admittedRuntimes()[r.runtime] === undefined) return // curated candidates pre-admission stay out
     const store = this.host.store()
     try {
@@ -647,8 +641,8 @@ export class RuntimeFactsRegistry {
         }
         await this.rebuildCatalog(r.runtime)
       }
-      // Phase 2 uses host executables, so image runtimes stop at the sandbox's phase-1 facts.
-      if (this.host.executionLocation(r.runtime) === 'host') {
+      // Self-hosted model discovery always uses host executables, including for VM sessions.
+      if (!this.host.launch().k8s) {
         this.host.noteCatalogProbe({
           runtimeId: r.runtime,
           rt: entry.runtime,

--- a/packages/daemon/src/runtimes/omp-credentials.ts
+++ b/packages/daemon/src/runtimes/omp-credentials.ts
@@ -22,6 +22,37 @@ function rowBytes(row: Record<string, SQLInputValue>): number {
   return Object.values(row).reduce<number>((total, value) => total + valueBytes(value), 0)
 }
 
+/** Query provider names only; expired or disabled logins remain discoverable for reauthentication. */
+export function discoverOmpCredentialProviders(sourcePath: string): string[] {
+  let source: DatabaseSync | undefined
+  try {
+    if (!lstatSync(sourcePath).isFile()) return []
+    source = new DatabaseSync(sourcePath, { readOnly: true })
+    return source
+      .prepare(
+        `
+      SELECT DISTINCT provider FROM auth_credentials
+      WHERE typeof(provider) = 'text' AND length(trim(provider)) > 0
+        AND length(data) <= ${MAX_ROW_BYTES}
+        AND CASE WHEN json_valid(data) THEN
+          (credential_type = 'api_key' AND json_type(data, '$.key') = 'text'
+            AND length(trim(json_extract(data, '$.key'))) > 0)
+          OR (credential_type = 'oauth' AND (
+            (json_type(data, '$.access') = 'text' AND length(trim(json_extract(data, '$.access'))) > 0)
+            OR (json_type(data, '$.refresh') = 'text' AND length(trim(json_extract(data, '$.refresh'))) > 0)))
+        ELSE 0 END
+      ORDER BY provider
+    `
+      )
+      .all()
+      .map((row) => String(row.provider))
+  } catch {
+    return []
+  } finally {
+    source?.close()
+  }
+}
+
 /**
  * Copy only OMP's credential schema and rows into a fresh private database.
  * Reviewed against can1357/oh-my-pi b0d04e517335ada4e00ef8dc93aad9f4d1be8d21.

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -1,10 +1,12 @@
 import { accessSync, constants, existsSync } from 'node:fs'
-import { basename, delimiter, join } from 'node:path'
+import { basename, delimiter, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { CURATED_RUNTIME_CATALOG } from './curated.js'
 import { parseArchiveLaunch } from './archive-store.js'
 import type { ResolvedRuntimeCatalog } from './registry.js'
+import type { SeededCredentialFile } from './runtime-seeded-credentials.js'
+import { resolveClaudeConfigSources, resolveOmpCredentialSource } from './runtime-credential-sources.js'
 
 /**
  * Host-availability probing for runtimes.
@@ -104,6 +106,8 @@ export type RuntimeProbe = (env: NodeJS.ProcessEnv) => boolean
 /** Host runtime state that can initialize an agent's private runtime HOME. */
 export interface RuntimeStateLocation {
   source: string
+  /** Exact credential files shared by private-HOME seeding and opt-in credential discovery. */
+  credentialFiles?: readonly SeededCredentialFile[]
   /** Path relative to the private runtime HOME. */
   destination: string
   /**
@@ -149,10 +153,19 @@ function state(
   source: string | undefined,
   destination: string,
   seedFiles?: readonly string[],
-  seedJsonKeys?: readonly string[]
+  seedJsonKeys?: readonly string[],
+  credentialFiles?: readonly SeededCredentialFile[]
 ): RuntimeStateLocation[] {
   return source
-    ? [{ source, destination, ...(seedFiles ? { seedFiles } : {}), ...(seedJsonKeys ? { seedJsonKeys } : {}) }]
+    ? [
+        {
+          source,
+          destination,
+          ...(seedFiles ? { seedFiles } : {}),
+          ...(seedJsonKeys ? { seedJsonKeys } : {}),
+          ...(credentialFiles ? { credentialFiles } : {})
+        }
+      ]
     : []
 }
 
@@ -174,28 +187,33 @@ const QODER_SEED = (brand: string): readonly string[] => [
   'mcp-oauth-tokens.json',
   'a2a-oauth-tokens.json'
 ]
-const CLAUDE_MODEL_CACHE_KEYS = ['additionalModelOptionsCache'] as const
+const CLAUDE_GLOBAL_SEED_KEYS = ['additionalModelOptionsCache', 'primaryApiKey'] as const
 /** DeepSeek Harness auth: the managed 0600 credential store plus its .env fallback. */
-const DSH_SEED = ['.credentials.yaml', '.env'] as const
+const DSH_CREDENTIALS = [
+  { path: '.credentials.yaml', format: 'dsh' },
+  { path: '.env', format: 'dsh-env' }
+] as const
 /** Antigravity login inputs: the ACP server's auth.type selection, the CLI's OAuth token, and the install identity. */
 const ANTIGRAVITY_SEED = ['settings.json', 'antigravity-oauth-token', 'installation_id'] as const
 /** OpenClaw acp bridge inputs: gateway address + token config and its .env fallback. */
 const OPENCLAW_SEED = ['openclaw.json', '.env'] as const
 
 export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
-  // Anthropic Claude Code — seed only the rollout-model cache from ~/.claude.json.
-  // The daemon pins CLAUDE_CONFIG_DIR=<private-home>/.claude (RUNTIME_PRIVATE_ENV),
-  // and Claude Code reads additionalModelOptionsCache from that directory on its first
-  // session. Projecting that one field preserves rollout models (e.g. Fable 5) without
-  // copying host MCP, project, account, or machine state. Host settings are daemon input
-  // and credentials are shared separately through CLAUDE_SECURESTORAGE_CONFIG_DIR.
-  // The HOME-root copy stays for Claude versions that ignore the config-dir env.
-  'claude-acp': (env) => [
-    ...state(env.CLAUDE_CONFIG_DIR, '.claude', ['.claude.json'], CLAUDE_MODEL_CACHE_KEYS),
-    ...state(join(home(env), '.claude'), '.claude', ['.claude.json'], CLAUDE_MODEL_CACHE_KEYS),
-    ...state(join(home(env), '.claude.json'), '.claude.json', undefined, CLAUDE_MODEL_CACHE_KEYS),
-    ...state(join(home(env), '.claude.json'), join('.claude', '.claude.json'), undefined, CLAUDE_MODEL_CACHE_KEYS)
-  ],
+  // Project only the active global file's saved API key and rollout cache; session and MCP state stay private.
+  'claude-acp': (env) => {
+    const { configDir, globalConfigFile } = resolveClaudeConfigSources(env)
+    if (dirname(globalConfigFile) === configDir) {
+      return [
+        ...state(configDir, '.claude', [basename(globalConfigFile)], CLAUDE_GLOBAL_SEED_KEYS),
+        ...state(join(home(env), '.claude.json'), '.claude.json', undefined, ['additionalModelOptionsCache'])
+      ]
+    }
+    return [
+      ...state(globalConfigFile, '.claude.json', undefined, CLAUDE_GLOBAL_SEED_KEYS),
+      ...state(globalConfigFile, join('.claude', '.claude.json'), undefined, CLAUDE_GLOBAL_SEED_KEYS),
+      ...state(configDir, '.claude', [])
+    ]
+  },
 
   // OpenAI Codex CLI — ~/.codex (honors $CODEX_HOME).
   'codex-acp': (env) => [...state(env.CODEX_HOME, '.codex'), ...state(join(home(env), '.codex'), '.codex')],
@@ -206,13 +224,22 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // seeds nothing.
   gemini: (env) => [
     ...state(join(home(env), '.gemini', 'settings.json'), join('.gemini', 'settings.json')),
-    ...state(join(home(env), '.gemini', 'oauth_creds.json'), join('.gemini', 'oauth_creds.json')),
+    ...state(
+      join(home(env), '.gemini', 'oauth_creds.json'),
+      join('.gemini', 'oauth_creds.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'oauth', provider: 'google' }]
+    ),
     ...state(join(home(env), '.gemini', 'google_accounts.json'), join('.gemini', 'google_accounts.json')),
     ...state(join(home(env), '.gemini', 'tmp'), join('.gemini', 'tmp'), [])
   ],
 
   // Qwen Code (Gemini-CLI fork) — ~/.qwen.
-  'qwen-code': (env) => state(join(home(env), '.qwen'), '.qwen'),
+  'qwen-code': (env) =>
+    state(join(home(env), '.qwen'), '.qwen', undefined, undefined, [
+      { path: 'oauth_creds.json', format: 'oauth', provider: 'qwen' }
+    ]),
 
   // GitHub Copilot CLI — ~/.copilot (honors $COPILOT_HOME).
   'github-copilot-cli': (env) => [
@@ -235,23 +262,40 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // when opencode is run from home, so accept it as a fallback signal.
   opencode: (env) => [
     ...state(join(xdgConfigHome(env), 'opencode'), join('.config', 'opencode')),
-    ...state(join(xdgDataHome(env), 'opencode', 'auth.json'), join('.local', 'share', 'opencode', 'auth.json')),
+    ...state(
+      join(xdgDataHome(env), 'opencode', 'auth.json'),
+      join('.local', 'share', 'opencode', 'auth.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'opencode' }]
+    ),
     ...state(join(home(env), '.opencode'), '.opencode')
   ],
 
   // pi (svkozak pi-acp npx adapter) — auth/settings live below the agent dir;
   // sessions, downloaded binaries, and adapter state must remain agent-private.
   'pi-acp': (env) => [
-    ...state(env.PI_CODING_AGENT_DIR, join('.pi', 'agent'), ['auth.json', 'settings.json']),
-    ...state(join(home(env), '.pi'), '.pi', [join('agent', 'auth.json'), join('agent', 'settings.json')])
+    ...state(
+      join(env.PI_CODING_AGENT_DIR || join(home(env), '.pi', 'agent'), 'auth.json'),
+      join('.pi', 'agent', 'auth.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'pi' }]
+    ),
+    ...state(env.PI_CODING_AGENT_DIR, join('.pi', 'agent'), ['settings.json']),
+    ...state(join(home(env), '.pi'), '.pi', [join('agent', 'settings.json')])
   ],
 
   // Nous Research Hermes — ~/.hermes (honors $HERMES_HOME, which relocates the
   // whole home dir). Keep both the canonical proposed registry id and the legacy
   // AgentConnect alias on the same reviewed allowlist.
   'hermes-agent': (env) => [
-    ...state(env.HERMES_HOME, '.hermes', ['.env', 'config.yaml', '.anthropic_oauth.json', 'auth.json']),
-    ...state(join(home(env), '.hermes'), '.hermes', ['.env', 'config.yaml', '.anthropic_oauth.json', 'auth.json'])
+    ...state(env.HERMES_HOME || join(home(env), '.hermes'), '.hermes', ['.env', 'config.yaml'], undefined, [
+      { path: 'auth.json', format: 'hermes' },
+      { path: '.anthropic_oauth.json', format: 'claude-oauth', provider: 'anthropic' },
+      { path: '.env', format: 'dsh-env' }
+    ]),
+    ...state(join(home(env), '.hermes'), '.hermes', ['.env', 'config.yaml'])
   ],
   hermes: (env) => RUNTIME_STATE_LOCATIONS['hermes-agent']!(env),
 
@@ -285,10 +329,7 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
 
   // Oh My Pi — agent.db is handled by the structured credential extractor in
   // runtime-home.ts; the ordinary file seeder copies config only.
-  omp: (env) => [
-    ...state(env.PI_CODING_AGENT_DIR, join('.omp', 'agent'), ['config.yml']),
-    ...state(join(home(env), '.omp', 'agent'), join('.omp', 'agent'), ['config.yml'])
-  ],
+  omp: (env) => state(dirname(resolveOmpCredentialSource(env)), join('.omp', 'agent'), ['config.yml']),
 
   // Qoder CLI (a Gemini-CLI fork) — global config dir defaults to ~/.qoder, but
   // $QODER_CONFIG_DIR overrides it outright and $QODER_CLI_HOME / $GEMINI_CLI_HOME
@@ -325,6 +366,13 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // Sourcegraph Amp — $XDG_CONFIG_HOME/amp (honors $AMP_SETTINGS_FILE).
   'amp-acp': (env) => [
     ...state(
+      join(xdgDataHome(env), 'amp', 'secrets.json'),
+      join('.local', 'share', 'amp', 'secrets.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'amp' }]
+    ),
+    ...state(
       env.AMP_SETTINGS_FILE,
       join('.config', 'amp', env.AMP_SETTINGS_FILE ? basename(env.AMP_SETTINGS_FILE) : 'settings.json')
     ),
@@ -332,23 +380,49 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   ],
 
   // Augment auggie — ~/.augment.
-  auggie: (env) => state(join(home(env), '.augment'), '.augment'),
+  auggie: (env) =>
+    state(join(home(env), '.augment'), '.augment', undefined, undefined, [{ path: 'session.json', format: 'auggie' }]),
 
   // Cline CLI — provider credentials live in <data-dir>/settings/providers.json.
   // CLINE_DATA_DIR names the data dir itself (normally ~/.cline/data), not ~/.cline.
   cline: (env) => [
-    ...state(env.CLINE_PROVIDER_SETTINGS_PATH, join('.cline', 'data', 'settings', 'providers.json')),
-    ...state(env.CLINE_DATA_DIR, join('.cline', 'data'), [join('settings', 'providers.json')]),
-    ...state(env.CLINE_DIR, '.cline', [join('data', 'settings', 'providers.json')]),
-    ...state(join(home(env), '.cline'), '.cline', [join('data', 'settings', 'providers.json')])
+    ...state(
+      env.CLINE_PROVIDER_SETTINGS_PATH?.trim() ||
+        join(
+          env.CLINE_DATA_DIR?.trim() || join(env.CLINE_DIR?.trim() || join(home(env), '.cline'), 'data'),
+          'settings',
+          'providers.json'
+        ),
+      join('.cline', 'data', 'settings', 'providers.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'cline' }]
+    ),
+    ...state(env.CLINE_DATA_DIR, join('.cline', 'data'), []),
+    ...state(env.CLINE_DIR, '.cline', []),
+    ...state(join(home(env), '.cline'), '.cline', [])
   ],
 
-  // xAI Grok CLI — ~/.grok.
-  'grok-build': (env) => state(join(home(env), '.grok'), '.grok'),
+  // Grok's exact login source precedes its ordinary config files when seeding the private HOME.
+  'grok-build': (env) => [
+    ...state(
+      env.GROK_AUTH_PATH || join(env.GROK_HOME || join(home(env), '.grok'), 'auth.json'),
+      join('.grok', 'auth.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'grok' }]
+    ),
+    ...state(env.GROK_HOME || join(home(env), '.grok'), '.grok')
+  ],
 
   // Moonshot Kimi CLI — ~/.kimi (legacy) or ~/.kimi-code (newer, honors $KIMI_CODE_HOME).
   kimi: (env) => [
-    ...state(env.KIMI_CODE_HOME, '.kimi-code'),
+    ...state(env.KIMI_CODE_HOME || join(home(env), '.kimi-code'), '.kimi-code', undefined, undefined, [
+      { path: join('credentials', 'kimi-code.json'), format: 'oauth', provider: 'kimi-code' }
+    ]),
+    ...state(env.KIMI_SHARE_DIR || join(home(env), '.kimi'), '.kimi', undefined, undefined, [
+      { path: join('credentials', 'kimi-code.json'), format: 'oauth', provider: 'kimi-code' }
+    ]),
     ...state(join(home(env), '.kimi'), '.kimi'),
     ...state(join(home(env), '.kimi-code'), '.kimi-code')
   ],
@@ -359,7 +433,10 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // DeepSeek Harness (via the dsh-acp adapter) — $DSH_HOME, default ~/.dsh. Seed
   // only the managed credential store and its .env fallback; sessions and logs
   // in the same directory stay agent-private.
-  'dsh-acp': (env) => [...state(env.DSH_HOME, '.dsh', DSH_SEED), ...state(join(home(env), '.dsh'), '.dsh', DSH_SEED)],
+  'dsh-acp': (env) => [
+    ...state(env.DSH_HOME || join(home(env), '.dsh'), '.dsh', [], undefined, DSH_CREDENTIALS),
+    ...state(join(home(env), '.dsh'), '.dsh', [])
+  ],
 
   // OpenClaw — ~/.openclaw, relocatable via $OPENCLAW_STATE_DIR (the dir itself),
   // $OPENCLAW_HOME (the home base), or $OPENCLAW_CONFIG_PATH (the config file

--- a/packages/daemon/src/runtimes/runtime-credential-discovery.ts
+++ b/packages/daemon/src/runtimes/runtime-credential-discovery.ts
@@ -1,0 +1,24 @@
+import type { RuntimeDef } from '../config/config-schema.js'
+import {
+  discoverSharedRuntimeCredentials,
+  resolveOmpCredentialSource,
+  sharedCredentialProfile,
+  type RuntimeCredentialDiscovery
+} from './runtime-credential-sources.js'
+import { discoverSeededRuntimeCredentials } from './runtime-seeded-credentials.js'
+import { discoverOmpCredentialProviders } from './omp-credentials.js'
+
+export function discoverRuntimeCredentials(
+  runtimeId: string,
+  runtime?: RuntimeDef,
+  hostEnv: NodeJS.ProcessEnv = process.env
+): RuntimeCredentialDiscovery {
+  const profile = sharedCredentialProfile(runtimeId, runtime)
+  if (profile) return discoverSharedRuntimeCredentials(profile, hostEnv)
+  if (runtimeId === 'omp') {
+    const path = resolveOmpCredentialSource(hostEnv)
+    const providers = discoverOmpCredentialProviders(path)
+    return { paths: providers.length > 0 ? [path] : [], providers }
+  }
+  return discoverSeededRuntimeCredentials(runtimeId, hostEnv)
+}

--- a/packages/daemon/src/runtimes/runtime-credential-sources.ts
+++ b/packages/daemon/src/runtimes/runtime-credential-sources.ts
@@ -1,0 +1,193 @@
+import { existsSync, lstatSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { isAbsolute, join, resolve, sep } from 'node:path'
+import type { RuntimeDef } from '../config/config-schema.js'
+
+export type SharedCredentialProfile = 'claude' | 'codex' | 'qoder' | 'qoder-cn'
+
+export interface RuntimeCredentialDiscovery {
+  paths: string[]
+  providers: string[]
+}
+
+function signature(runtime: RuntimeDef | undefined, pattern: RegExp): boolean {
+  return runtime ? [runtime.command, ...runtime.args].some((part) => pattern.test(part.toLowerCase())) : false
+}
+
+export function sharedCredentialProfile(runtimeId: string, runtime?: RuntimeDef): SharedCredentialProfile | undefined {
+  if (runtimeId === 'claude-acp' || signature(runtime, /(?:^|[\\/@])claude(?:-[a-z-]+)?(?:@[^\\/]*)?$/)) return 'claude'
+  if (runtimeId === 'codex-acp' || signature(runtime, /(?:^|[\\/])codex-acp(?:@[^\\/]*)?$/)) return 'codex'
+  if (runtimeId === 'qoder-cli-cn' || signature(runtime, /(?:^|[\\/@])qoderclicn(?:@[^\\/]*)?$/)) return 'qoder-cn'
+  if (runtimeId === 'qoder-cli' || signature(runtime, /(?:^|[\\/@])qodercli(?:@[^\\/]*)?$/)) return 'qoder'
+  return undefined
+}
+
+function hostHome(env: NodeJS.ProcessEnv): string {
+  return (process.platform === 'win32' ? env.USERPROFILE || env.HOME : env.HOME) || homedir()
+}
+
+function absoluteConfiguredPath(raw: string, env: NodeJS.ProcessEnv, label: string): string {
+  const expanded = raw === '~' ? hostHome(env) : raw.startsWith('~/') ? join(hostHome(env), raw.slice(2)) : raw
+  if (!isAbsolute(expanded) || resolve(expanded) === sep) throw new Error(`unsafe ${label}: ${raw}`)
+  return resolve(expanded)
+}
+
+export function resolveClaudeConfigSources(env: NodeJS.ProcessEnv): {
+  configDir: string
+  globalConfigFile: string
+} {
+  const configDir = absoluteConfiguredPath(
+    env.CLAUDE_CONFIG_DIR || join(hostHome(env), '.claude'),
+    env,
+    'host CLAUDE_CONFIG_DIR'
+  )
+  const legacyConfig = join(configDir, '.config.json')
+  return {
+    configDir,
+    globalConfigFile: existsSync(legacyConfig)
+      ? legacyConfig
+      : join(env.CLAUDE_CONFIG_DIR ? configDir : hostHome(env), '.claude.json')
+  }
+}
+
+/** Resolve only; discovery must not create directories or migrate an operator's login. */
+export function resolveClaudeCredentialSources(env: NodeJS.ProcessEnv): {
+  configDir: string
+  credentialDir: string
+  credentialFile: string
+  globalConfigFile: string
+} {
+  const config = resolveClaudeConfigSources(env)
+  const { configDir } = config
+  let configuredSecureDir = env.CLAUDE_SECURESTORAGE_CONFIG_DIR
+  if (!configuredSecureDir) {
+    const settingsPath = join(configDir, 'settings.json')
+    const settings = existsSync(settingsPath) ? (JSON.parse(readFileSync(settingsPath, 'utf8')) as unknown) : {}
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      throw new Error(`Claude settings must contain a JSON object: ${settingsPath}`)
+    }
+    const rawSettingsEnv = (settings as Record<string, unknown>).env
+    if (
+      rawSettingsEnv !== undefined &&
+      (!rawSettingsEnv || typeof rawSettingsEnv !== 'object' || Array.isArray(rawSettingsEnv))
+    ) {
+      throw new Error(`Claude settings.env must contain a JSON object: ${settingsPath}`)
+    }
+    const setting = (rawSettingsEnv as Record<string, unknown> | undefined)?.CLAUDE_SECURESTORAGE_CONFIG_DIR
+    if (setting !== undefined && typeof setting !== 'string') {
+      throw new Error(`Claude settings env.CLAUDE_SECURESTORAGE_CONFIG_DIR must be a string: ${settingsPath}`)
+    }
+    configuredSecureDir = setting
+  }
+  const credentialDir = absoluteConfiguredPath(
+    configuredSecureDir || configDir,
+    env,
+    'Claude secure credential directory'
+  )
+  return {
+    ...config,
+    credentialDir,
+    credentialFile: join(credentialDir, '.credentials.json')
+  }
+}
+
+export function resolveCodexCredentialSources(env: NodeJS.ProcessEnv): { configDir: string; credentialFile: string } {
+  const configDir = absoluteConfiguredPath(env.CODEX_HOME || join(hostHome(env), '.codex'), env, 'host CODEX_HOME')
+  return { configDir, credentialFile: join(configDir, 'auth.json') }
+}
+
+export function resolveOmpCredentialSource(env: NodeJS.ProcessEnv): string {
+  return join(env.PI_CODING_AGENT_DIR || join(hostHome(env), '.omp', 'agent'), 'agent.db')
+}
+
+export function resolveQoderCredentialSources(
+  profile: 'qoder' | 'qoder-cn',
+  env: NodeJS.ProcessEnv
+): {
+  configDir: string
+  credentialDir: string
+  credentialFile: string
+} {
+  const cn = profile === 'qoder-cn'
+  const configured = cn ? env.QODERCN_CONFIG_DIR : env.QODER_CONFIG_DIR
+  const base = (cn ? env.QODERCN_CLI_HOME : env.QODER_CLI_HOME) || env.GEMINI_CLI_HOME
+  const name = (
+    (cn ? env.QODERCN_CONFIG_DIR_NAME : env.QODER_CONFIG_DIR_NAME) || (cn ? '.qoder-cn' : '.qoder')
+  ).normalize('NFC')
+  const configDir = absoluteConfiguredPath(configured || join(base || hostHome(env), name), env, `${profile} config`)
+  const credentialDir = join(configDir, '.auth')
+  return { configDir, credentialDir, credentialFile: join(credentialDir, 'user') }
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function hasText(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function credentialFilePresent(path: string, followSymlinks = true): boolean {
+  try {
+    const stat = followSymlinks ? statSync(path) : lstatSync(path)
+    return stat.isFile() && stat.size > 0 && stat.size <= 2 * 1024 * 1024
+  } catch {
+    return false
+  }
+}
+
+function credentialObject(path: string, followSymlinks = true): Record<string, unknown> {
+  try {
+    return credentialFilePresent(path, followSymlinks) ? object(JSON.parse(readFileSync(path, 'utf8'))) : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Report stored credential records without checking expiration or returning their contents. */
+export function discoverSharedRuntimeCredentials(
+  profile: SharedCredentialProfile,
+  env: NodeJS.ProcessEnv
+): RuntimeCredentialDiscovery {
+  const paths: string[] = []
+  const providers: string[] = []
+  try {
+    if (profile === 'claude') {
+      const source = resolveClaudeCredentialSources(env)
+      const oauth = object(credentialObject(source.credentialFile).claudeAiOauth)
+      if (hasText(oauth.accessToken) || hasText(oauth.refreshToken)) paths.push(source.credentialFile)
+      if (hasText(credentialObject(source.globalConfigFile, false).primaryApiKey)) paths.push(source.globalConfigFile)
+      if (paths.length > 0) providers.push('anthropic')
+    } else if (profile === 'codex') {
+      const source = resolveCodexCredentialSources(env)
+      const auth = credentialObject(source.credentialFile)
+      const tokens = object(auth.tokens)
+      const identity = object(auth.agent_identity)
+      if (
+        hasText(auth.OPENAI_API_KEY) ||
+        hasText(tokens.access_token) ||
+        hasText(tokens.refresh_token) ||
+        hasText(auth.personal_access_token) ||
+        hasText(auth.agent_identity) ||
+        (hasText(identity.agent_runtime_id) && hasText(identity.agent_private_key))
+      )
+        providers.push('openai')
+      const bedrock = object(auth.bedrock_access_keys)
+      if (
+        hasText(object(auth.bedrock_api_key).api_key) ||
+        (hasText(bedrock.access_key_id) && hasText(bedrock.secret_access_key))
+      )
+        providers.push('amazon-bedrock')
+      if (providers.length > 0) paths.push(source.credentialFile)
+    } else {
+      const source = resolveQoderCredentialSources(profile, env)
+      if (credentialFilePresent(source.credentialFile)) {
+        paths.push(source.credentialFile)
+        providers.push(profile)
+      }
+    }
+  } catch {
+    // An unreadable or malformed source is not evidence of a stored login.
+  }
+  return { paths, providers }
+}

--- a/packages/daemon/src/runtimes/runtime-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-credentials.ts
@@ -16,11 +16,15 @@ import {
   symlinkSync,
   unlinkSync
 } from 'node:fs'
-import { homedir } from 'node:os'
-import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import type { RuntimeDef } from '../config/config-schema.js'
-
-export type SharedCredentialProfile = 'claude' | 'codex' | 'qoder' | 'qoder-cn'
+import {
+  resolveClaudeCredentialSources,
+  resolveCodexCredentialSources,
+  resolveQoderCredentialSources,
+  sharedCredentialProfile
+} from './runtime-credential-sources.js'
+export { sharedCredentialProfile, type SharedCredentialProfile } from './runtime-credential-sources.js'
 
 export interface SharedRuntimeCredentialAccess {
   env: Record<string, string>
@@ -30,38 +34,6 @@ export interface SharedRuntimeCredentialAccess {
   seedExclusions: string[]
   /** Finish migration/linking after the private runtime HOME exists. */
   preparePrivateHome: (runtimeHome: string) => void
-}
-
-function signature(runtime: RuntimeDef | undefined, pattern: RegExp): boolean {
-  return runtime ? [runtime.command, ...runtime.args].some((part) => pattern.test(part.toLowerCase())) : false
-}
-
-/** Runtime identity is daemon/registry-owned; an agent can select an id but
- * cannot declare a credential profile or filesystem path. */
-export function sharedCredentialProfile(runtimeId: string, runtime?: RuntimeDef): SharedCredentialProfile | undefined {
-  if (runtimeId === 'claude-acp' || signature(runtime, /(?:^|[\\/@])claude(?:-[a-z-]+)?(?:@[^\\/]*)?$/)) {
-    return 'claude'
-  }
-  if (runtimeId === 'codex-acp' || signature(runtime, /(?:^|[\\/])codex-acp(?:@[^\\/]*)?$/)) {
-    return 'codex'
-  }
-  if (runtimeId === 'qoder-cli-cn' || signature(runtime, /(?:^|[\\/@])qoderclicn(?:@[^\\/]*)?$/)) {
-    return 'qoder-cn'
-  }
-  if (runtimeId === 'qoder-cli' || signature(runtime, /(?:^|[\\/@])qodercli(?:@[^\\/]*)?$/)) {
-    return 'qoder'
-  }
-  return undefined
-}
-
-function hostHome(env: NodeJS.ProcessEnv): string {
-  return env.HOME || homedir()
-}
-
-function absoluteConfiguredPath(raw: string, env: NodeJS.ProcessEnv, label: string): string {
-  const expanded = raw === '~' ? hostHome(env) : raw.startsWith('~/') ? join(hostHome(env), raw.slice(2)) : raw
-  if (!isAbsolute(expanded) || resolve(expanded) === sep) throw new Error(`unsafe ${label}: ${raw}`)
-  return resolve(expanded)
 }
 
 function ensureOwnedDirectory(path: string, label: string): string {
@@ -103,14 +75,6 @@ function secureCredentialFile(path: string): void {
   }
 }
 
-function jsonObject(path: string): Record<string, unknown> {
-  const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`Claude settings must contain a JSON object: ${path}`)
-  }
-  return parsed as Record<string, unknown>
-}
-
 function sameFileContents(a: string, b: string): boolean {
   const left = readFileSync(a)
   const right = readFileSync(b)
@@ -137,33 +101,9 @@ function claudeCredentialGeneration(path: string): number | undefined {
 }
 
 function prepareClaudeCredentials(env: NodeJS.ProcessEnv): SharedRuntimeCredentialAccess {
-  const configured = env.CLAUDE_CONFIG_DIR || join(hostHome(env), '.claude')
-  const configDir = ensureOwnedDirectory(
-    absoluteConfiguredPath(configured, env, 'host CLAUDE_CONFIG_DIR'),
-    'host Claude config directory'
-  )
-  let configuredSecureDir = env.CLAUDE_SECURESTORAGE_CONFIG_DIR
-  if (!configuredSecureDir) {
-    const settingsPath = join(configDir, 'settings.json')
-    const settings = existsSync(settingsPath) ? jsonObject(settingsPath) : {}
-    const rawSettingsEnv = settings.env
-    if (
-      rawSettingsEnv !== undefined &&
-      (!rawSettingsEnv || typeof rawSettingsEnv !== 'object' || Array.isArray(rawSettingsEnv))
-    ) {
-      throw new Error(`Claude settings.env must contain a JSON object: ${settingsPath}`)
-    }
-    const settingsEnv = (rawSettingsEnv ?? {}) as Record<string, unknown>
-    const setting = settingsEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR
-    if (setting !== undefined && typeof setting !== 'string') {
-      throw new Error(`Claude settings env.CLAUDE_SECURESTORAGE_CONFIG_DIR must be a string: ${settingsPath}`)
-    }
-    configuredSecureDir = setting
-  }
-  const credentialDir = ensureOwnedDirectory(
-    absoluteConfiguredPath(configuredSecureDir || configDir, env, 'Claude secure credential directory'),
-    'Claude secure credential directory'
-  )
+  const source = resolveClaudeCredentialSources(env)
+  ensureOwnedDirectory(source.configDir, 'host Claude config directory')
+  const credentialDir = ensureOwnedDirectory(source.credentialDir, 'Claude secure credential directory')
   const destination = join(credentialDir, '.credentials.json')
   if (existsSync(destination)) secureCredentialFile(existingFileTarget(destination))
 
@@ -236,8 +176,8 @@ function refreshTimestamp(path: string): number | undefined {
 }
 
 function prepareCodexCredentials(env: NodeJS.ProcessEnv): SharedRuntimeCredentialAccess {
-  const configured = env.CODEX_HOME || join(hostHome(env), '.codex')
-  const codexHome = ensureOwnedDirectory(absoluteConfiguredPath(configured, env, 'host CODEX_HOME'), 'host CODEX_HOME')
+  const source = resolveCodexCredentialSources(env)
+  const codexHome = ensureOwnedDirectory(source.configDir, 'host CODEX_HOME')
   const hostAuth = join(codexHome, 'auth.json')
   if (existsSync(hostAuth)) secureCredentialFile(existingFileTarget(hostAuth))
   const writablePaths = existsSync(hostAuth) ? [existingFileTarget(hostAuth)] : []
@@ -383,26 +323,11 @@ function migratePrivateQoderAuth(privateAuth: string, sharedAuth: string, label:
   rmdirSync(privateAuth)
 }
 
-function qoderConfigDirectory(profile: 'qoder' | 'qoder-cn', env: NodeJS.ProcessEnv): string {
-  const cn = profile === 'qoder-cn'
-  const configured = cn ? env.QODERCN_CONFIG_DIR : env.QODER_CONFIG_DIR
-  const base = (cn ? env.QODERCN_CLI_HOME : env.QODER_CLI_HOME) || env.GEMINI_CLI_HOME
-  const name = (
-    (cn ? env.QODERCN_CONFIG_DIR_NAME : env.QODER_CONFIG_DIR_NAME) || (cn ? '.qoder-cn' : '.qoder')
-  ).normalize('NFC')
-  return ensureOwnedDirectory(
-    absoluteConfiguredPath(
-      configured || (base ? join(base, name) : join(hostHome(env), name)),
-      env,
-      `${profile} config`
-    ),
-    `host ${profile} config directory`
-  )
-}
-
 function prepareQoderCredentials(profile: 'qoder' | 'qoder-cn', env: NodeJS.ProcessEnv): SharedRuntimeCredentialAccess {
   const configName = profile === 'qoder-cn' ? '.qoder-cn' : '.qoder'
-  const sharedAuth = ensureOwnedDirectory(join(qoderConfigDirectory(profile, env), '.auth'), `host ${profile} auth`)
+  const source = resolveQoderCredentialSources(profile, env)
+  const configDir = ensureOwnedDirectory(source.configDir, `host ${profile} config directory`)
+  const sharedAuth = ensureOwnedDirectory(join(configDir, '.auth'), `host ${profile} auth`)
   return {
     env: {},
     writablePaths: [sharedAuth],

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -13,8 +13,8 @@ import {
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { home as hostHomeDir, runtimeStateLocations } from './probe.js'
 import { extractOmpCredentials } from './omp-credentials.js'
+import { MAX_SEED_FILE_BYTES } from './runtime-seeded-credentials.js'
 
-const MAX_SEED_FILE_BYTES = 2 * 1024 * 1024
 const LEGACY_RUNTIME_STATE: Record<string, string[]> = {
   'claude-acp': ['.claude'],
   'codex-acp': ['.codex']
@@ -89,6 +89,29 @@ function copySeedFile(
   if (existsSync(destination)) {
     if (lstatSync(destination).isSymbolicLink()) {
       throw new Error(`runtime HOME destination contains a symlink: ${destination}`)
+    }
+    if (seedJsonKeys?.includes('primaryApiKey')) {
+      try {
+        const sourceStat = lstatSync(source)
+        if (!sourceStat.isFile() || sourceStat.size > MAX_SEED_FILE_BYTES) return
+        const projected = JSON.parse(projectedJson(source, ['primaryApiKey']) ?? '{}') as Record<string, unknown>
+        const existing: unknown = JSON.parse(readFileSync(destination, 'utf8'))
+        if (
+          existing &&
+          typeof existing === 'object' &&
+          !Array.isArray(existing) &&
+          !Object.hasOwn(existing, 'primaryApiKey') &&
+          typeof projected.primaryApiKey === 'string' &&
+          projected.primaryApiKey.trim()
+        ) {
+          writeFileSync(destination, `${JSON.stringify({ ...existing, primaryApiKey: projected.primaryApiKey })}\n`, {
+            encoding: 'utf8',
+            mode: 0o600
+          })
+        }
+      } catch {
+        // Existing private config remains authoritative when either projection is unreadable.
+      }
     }
     return
   }
@@ -181,6 +204,9 @@ export function prepareRuntimeHome(
   ensurePrivateDir(home)
   const excluded = new Set(excludedDestinations.map((destination) => containedDestination(home, destination)))
   const locations = runtimeStateLocations(runtimeId, hostEnv)
+  const credentialDestinations = locations.flatMap((location) =>
+    (location.credentialFiles ?? []).map((file) => containedDestination(home, join(location.destination, file.path)))
+  )
   // rc.6-era native memory supported Claude and Codex and lived directly under
   // the agent root. Move only those historical paths before host seeding.
   if (!targetHome) {
@@ -197,7 +223,13 @@ export function prepareRuntimeHome(
   for (const location of locations) {
     const destination = containedDestination(home, location.destination)
     assertNoDestinationSymlink(home, destination)
-    seedLocation(home, location.source, destination, excluded, location.seedFiles, location.seedJsonKeys)
+    const locationExcluded = new Set([...excluded, ...credentialDestinations])
+    seedLocation(home, location.source, destination, locationExcluded, location.seedFiles, location.seedJsonKeys)
+    for (const file of location.credentialFiles ?? []) {
+      const credentialDestination = join(destination, file.path)
+      assertNoDestinationSymlink(home, credentialDestination)
+      seedLocation(home, join(location.source, file.path), credentialDestination, excluded)
+    }
     if (runtimeId === 'omp') {
       extractOmpCredentials(join(location.source, 'agent.db'), join(destination, 'agent.db'))
     }
@@ -225,10 +257,13 @@ const AMBIENT_STATE_ENV = new Set([
   'ZEROCLAW_DATA_DIR',
   'AMP_SETTINGS_FILE',
   'PI_CODING_AGENT_DIR',
+  'GROK_HOME',
+  'GROK_AUTH_PATH',
   'CLINE_DIR',
   'CLINE_DATA_DIR',
   'CLINE_PROVIDER_SETTINGS_PATH',
   'KIMI_CODE_HOME',
+  'KIMI_SHARE_DIR',
   // Qoder (a Gemini-CLI fork) resolves its config + agents dirs from these; drop
   // the host values so the child falls back to the private HOME. Covers both the
   // international and CN brands plus the shared Gemini fallback.
@@ -304,6 +339,7 @@ const RUNTIME_PRIVATE_ENV: Record<string, RuntimePrivateEnv> = {
   'qoder-cli-cn': (home) => ({ QODERCN_CONFIG_DIR: join(home, '.qoder-cn') }),
   omp: (home) => ({ PI_CODING_AGENT_DIR: join(home, '.omp', 'agent') }),
   'pi-acp': (home) => ({ PI_CODING_AGENT_DIR: join(home, '.pi', 'agent') }),
+  'grok-build': (home) => ({ GROK_HOME: join(home, '.grok'), GROK_AUTH_PATH: join(home, '.grok', 'auth.json') }),
   cline: (home) => ({
     CLINE_DIR: join(home, '.cline'),
     CLINE_DATA_DIR: join(home, '.cline', 'data')
@@ -320,6 +356,7 @@ const RUNTIME_PRIVATE_ENV: Record<string, RuntimePrivateEnv> = {
   kimi: (home, hostEnv) => {
     const env: Record<string, string> = {}
     if (hostEnv.KIMI_CODE_HOME) env.KIMI_CODE_HOME = join(home, '.kimi-code')
+    if (hostEnv.KIMI_SHARE_DIR) env.KIMI_SHARE_DIR = join(home, '.kimi')
     return env
   }
 }

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -13,9 +13,9 @@ import {
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import type { McpTransportCapabilities } from '@agentconnect.md/protocol'
+import { HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED, type McpTransportCapabilities } from '@agentconnect.md/protocol'
 import type { SessionConfigOption } from '@agentclientprotocol/sdk'
-import type { ModelOptions } from '../acp/acp-host.js'
+import { turnFailureCode, type ModelOptions } from '../acp/acp-host.js'
 import type { AcpProbeClient } from '../acp/probe-client.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
@@ -622,7 +622,8 @@ export async function probeRuntime(
   } catch (err) {
     const error = sanitizeProbeDiagnostic(err, opts.hostEnv ?? process.env, redactValues)
     opts.log?.warn(`probe: ${id} failed — ${error}`)
-    return { runtime: id, ok: false, models: [], error, ...(isAuthRequiredError(err) ? { authRequired: true } : {}) }
+    const authRequired = isAuthRequiredError(err) || turnFailureCode(err) === HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED
+    return { runtime: id, ok: false, models: [], error, ...(authRequired ? { authRequired: true } : {}) }
   } finally {
     if (timer) clearTimeout(timer)
     if (onAbort) signal?.removeEventListener('abort', onAbort)

--- a/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
@@ -1,0 +1,192 @@
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseEnv } from 'node:util'
+import { parse as parseYaml } from 'yaml'
+import { runtimeStateLocations } from './probe.js'
+
+export const MAX_SEED_FILE_BYTES = 2 * 1024 * 1024
+
+export interface SeededCredentialFile {
+  /** Relative to the state source; an empty path denotes an exact-file source. */
+  path: string
+  format:
+    'grok' | 'pi' | 'opencode' | 'oauth' | 'claude-oauth' | 'hermes' | 'dsh' | 'dsh-env' | 'auggie' | 'cline' | 'amp'
+  provider?: string
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function nonempty(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function oauth(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.access === 'string' &&
+    typeof value.refresh === 'string' &&
+    (nonempty(value.access) || nonempty(value.refresh)) &&
+    typeof value.expires === 'number' &&
+    Number.isFinite(value.expires)
+  )
+}
+
+function credentialProviders(data: unknown, format: SeededCredentialFile['format']): string[] {
+  const entries = record(data)
+  if (!entries) return []
+  return Object.entries(entries).flatMap(([provider, raw]) => {
+    const value = record(raw)
+    if (!provider || !value) return []
+    if (format === 'grok') {
+      const issuerScope =
+        nonempty(value.oidc_issuer) && nonempty(value.oidc_client_id)
+          ? `${value.oidc_issuer.replace(/\/+$/, '')}::${value.oidc_client_id}`
+          : undefined
+      const knownScope =
+        provider === 'xai::api_key' || provider === 'https://accounts.x.ai/sign-in' || provider === issuerScope
+      return knownScope &&
+        nonempty(value.key) &&
+        ['web_login', 'grok', 'oidc', 'external', 'api_key'].includes(String(value.auth_mode))
+        ? ['xai']
+        : []
+    }
+    if (value.type === 'oauth') return oauth(value) ? [provider] : []
+    if (format === 'pi') {
+      const env = record(value.env)
+      return value.type === 'api_key' && (nonempty(value.key) || (env && Object.values(env).some(nonempty)))
+        ? [provider]
+        : []
+    }
+    if (value.type === 'api' && nonempty(value.key)) return [provider]
+    if (value.type === 'wellknown' && typeof value.key === 'string' && nonempty(value.token)) return [provider]
+    return []
+  })
+}
+
+const DSH_PROVIDER_REFS: Record<string, string> = {
+  DEEPSEEK_API_KEY: 'deepseek',
+  OPENAI_API_KEY: 'openai',
+  ANTHROPIC_API_KEY: 'anthropic',
+  GEMINI_API_KEY: 'google',
+  GOOGLE_API_KEY: 'google',
+  XAI_API_KEY: 'xai',
+  OPENROUTER_API_KEY: 'openrouter'
+}
+
+function hermesCredentialProviders(data: unknown): string[] {
+  const auth = record(data) ?? {}
+  const hasToken = (raw: unknown): boolean => {
+    const value = record(raw) ?? {}
+    return nonempty(value.access_token) || nonempty(value.refresh_token) || nonempty(value.agent_key)
+  }
+  const providers = Object.entries(record(auth.credential_pool) ?? {}).flatMap(([provider, entries]) =>
+    provider && Array.isArray(entries) && entries.some(hasToken) ? [provider] : []
+  )
+  const singletons = record(auth.providers) ?? {}
+  for (const provider of ['nous', 'openai-codex', 'xai-oauth', 'qwen-oauth', 'minimax-oauth']) {
+    const value = record(singletons[provider])
+    if (hasToken(value) || hasToken(value?.tokens)) providers.push(provider)
+  }
+  return providers
+}
+
+function credentialsInFile(text: string, file: SeededCredentialFile): { present: boolean; providers: string[] } {
+  if (file.format === 'dsh' || file.format === 'dsh-env') {
+    const data = record(file.format === 'dsh' ? parseYaml(text) : parseEnv(text))
+    if (!data) return { present: false, providers: [] }
+    const refs = record(data.version === 1 ? data.refs : data) ?? {}
+    const stored = Object.entries(refs).filter(
+      ([name, value]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) && nonempty(value)
+    )
+    const providers = stored.flatMap(([name]) => (DSH_PROVIDER_REFS[name] ? [DSH_PROVIDER_REFS[name]!] : []))
+    for (const [name, raw] of Object.entries(record(data.records) ?? {})) {
+      const value = record(raw)
+      const env = record(value?.env)
+      if (
+        name.startsWith('llm-pi-ai/') &&
+        value &&
+        ((value.kind === 'api-key' && (nonempty(value.key) || (env && Object.values(env).some(nonempty)))) ||
+          (value.kind === 'grant' && oauth(record(value.payload) ?? {})))
+      ) {
+        providers.push(name.slice('llm-pi-ai/'.length))
+      }
+    }
+    return { present: providers.length > 0, providers }
+  }
+  const data: unknown = JSON.parse(text.replace(/^\uFEFF/, ''))
+  if (file.format === 'auggie') {
+    const value = record(data) ?? {}
+    const present = nonempty(value.accessToken) && nonempty(value.tenantURL) && Array.isArray(value.scopes)
+    return { present, providers: present ? ['augment'] : [] }
+  }
+  if (file.format === 'amp') {
+    const present = Object.entries(record(data) ?? {}).some(([key, value]) => {
+      if (!key.startsWith('apiKey@') || !nonempty(value)) return false
+      try {
+        return ['https:', 'http:'].includes(new URL(key.slice('apiKey@'.length)).protocol)
+      } catch {
+        return false
+      }
+    })
+    return { present, providers: present ? ['amp'] : [] }
+  }
+  if (file.format === 'cline') {
+    const stored = record(data) ?? {}
+    const providers =
+      stored.version === 1
+        ? Object.values(record(stored.providers) ?? {}).flatMap((entry) => {
+            const settings = record(record(entry)?.settings) ?? {}
+            const auth = record(settings.auth) ?? {}
+            const aws = record(settings.aws) ?? {}
+            return nonempty(settings.provider) &&
+              (nonempty(settings.apiKey) ||
+                nonempty(auth.apiKey) ||
+                nonempty(auth.accessToken) ||
+                nonempty(auth.refreshToken) ||
+                (nonempty(aws.accessKey) && nonempty(aws.secretKey)))
+              ? [settings.provider]
+              : []
+          })
+        : []
+    return { present: providers.length > 0, providers }
+  }
+  if (file.format === 'oauth' || file.format === 'claude-oauth') {
+    const value = record(data)
+    const camelCase = file.format === 'claude-oauth'
+    const present =
+      !!value &&
+      (nonempty(value[camelCase ? 'accessToken' : 'access_token']) ||
+        nonempty(value[camelCase ? 'refreshToken' : 'refresh_token']))
+    return { present, providers: present && file.provider ? [file.provider] : [] }
+  }
+  const providers = file.format === 'hermes' ? hermesCredentialProviders(data) : credentialProviders(data, file.format)
+  return { present: providers.length > 0, providers }
+}
+
+/** Enumerate stored credentials without resolving keys, refreshing tokens, or exposing their values. */
+export function discoverSeededRuntimeCredentials(
+  runtimeId: string,
+  env: NodeJS.ProcessEnv
+): { paths: string[]; providers: string[] } {
+  const paths = new Set<string>()
+  const providers = new Set<string>()
+  for (const location of runtimeStateLocations(runtimeId, env)) {
+    for (const file of location.credentialFiles ?? []) {
+      const source = join(location.source, file.path)
+      try {
+        const stat = lstatSync(source)
+        if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) continue
+        const found = credentialsInFile(readFileSync(source, 'utf8'), file)
+        if (!found.present) continue
+        paths.add(source)
+        for (const provider of found.providers) providers.add(provider)
+      } catch {
+        // Unreadable or malformed login state is not a discoverable credential source.
+      }
+    }
+  }
+  return { paths: [...paths], providers: [...providers] }
+}

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
+import { ConfigSchema } from '../src/config/config-schema.js'
 import { CuratedRuntimeAdmission } from '../src/runtimes/curated-admission.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import { FakeClock } from './cp/fake-clock.js'
@@ -276,7 +277,7 @@ describe('daemon curated runtime admission', () => {
     const daemon = new Daemon({ clock, probeRuntimes: probe as never, sandboxMechanism: null })
 
     try {
-      ;(daemon as any).cfg = { security: { isolateAccountApps: true } }
+      ;(daemon as any).cfg = ConfigSchema.parse({ version: 1 })
       ;(daemon as any).root = '/tmp/curated-admission-ttl-test'
       ;(daemon as any).runtimeCatalog = catalog()
       ;(daemon as any).refreshAdmittedRuntimes()
@@ -312,7 +313,7 @@ describe('daemon curated runtime admission', () => {
     })
 
     try {
-      ;(daemon as any).cfg = { security: { isolateAccountApps: true } }
+      ;(daemon as any).cfg = ConfigSchema.parse({ version: 1 })
       ;(daemon as any).root = '/tmp/curated-admission-test'
       ;(daemon as any).runtimeCatalog = catalog()
       ;(daemon as any).refreshAdmittedRuntimes()
@@ -352,7 +353,7 @@ describe('daemon curated runtime admission', () => {
       return Object.keys(runtimes).map((runtime) => ({ runtime, ok: true, models: [] }))
     })
     const daemon = new Daemon({ probeRuntimes: probe as never, sandboxMechanism: null })
-    ;(daemon as any).cfg = { security: { isolateAccountApps: true } }
+    ;(daemon as any).cfg = ConfigSchema.parse({ version: 1 })
     ;(daemon as any).root = '/tmp/curated-admission-queue-test'
     ;(daemon as any).runtimeCatalog = catalog()
     ;(daemon as any).refreshAdmittedRuntimes()

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -552,10 +552,14 @@ describe('one pod per session on the plane (git-workspace-model §11)', () => {
     expect(cluster.claims.has(plane.driver.claimName(session))).toBe(true)
     served.length = 0
 
-    // The read names the session's directory, so it waits for the SESSION pod's channel and refuses
-    // when none arrives — it is never answered by the agent pod, which is the whole bug.
+    // The session read must time out without falling back to the agent pod.
     const placement = plane.workspaceFsFor('agent-a')!
-    await expect(placement.fs.stat(sessionPath)).rejects.toThrow(`no shim channel bound for ${session} in time`)
+    // Clock rounding can surface either the binder's timeout or the dialer's underlying timeout.
+    await expect(placement.fs.stat(sessionPath)).rejects.toThrow(
+      new RegExp(
+        `^(?:no shim channel bound for ${session} in time|could not connect to sandbox shim: binding timed out after 250ms)$`
+      )
+    )
     expect(served).toEqual([])
     // Waking it is a resume of the claim the cluster already holds, never a new one.
     expect([...cluster.claims.keys()].sort()).toEqual(['agent-agent-a', plane.driver.claimName(session)].sort())

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -10,7 +10,7 @@ import { LocalStore } from '../src/store/local-store.js'
 import { catalogFingerprint } from '../src/runtimes/model-catalog.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
-import type { RuntimeProbeResult } from '../src/runtimes/runtime-prober.js'
+import { preparedProbeLaunch, type ProbeOptions, type RuntimeProbeResult } from '../src/runtimes/runtime-prober.js'
 import { FakeClock } from './cp/fake-clock.js'
 
 /** Daemon-level integration tests for the runtime-model-catalog wiring
@@ -258,12 +258,16 @@ describe('microsandbox runtime facts', () => {
       const clock = new FakeClock()
       clock.advance(10_000)
       let catalog = catalogOf({})
-      const probe = vi.fn(async (runtimes: Record<string, RuntimeDef>): Promise<RuntimeProbeResult[]> =>
-        Object.keys(runtimes).map((runtime) =>
-          runtime === 'pi-acp'
-            ? { runtime, ok: false, models: [], authRequired: true, error: 'Authentication required' }
-            : { runtime, ok: true, models: ['host-model'], probedVersion: 'host-version', acpProtocolVersion: 1 }
-        )
+      const probe = vi.fn(
+        async (runtimes: Record<string, RuntimeDef>, options: ProbeOptions): Promise<RuntimeProbeResult[]> =>
+          Object.entries(runtimes).map(([runtime, definition]) => {
+            const cwd = join(dir, 'probes', runtime, 'workspace')
+            mkdirSync(cwd, { recursive: true })
+            expect(preparedProbeLaunch(runtime, definition, cwd, options)).toBeDefined()
+            return runtime === 'pi-acp'
+              ? { runtime, ok: false, models: [], authRequired: true, error: 'Authentication required' }
+              : { runtime, ok: true, models: ['host-model'], probedVersion: 'host-version', acpProtocolVersion: 1 }
+          })
       )
       const daemon = new Daemon({
         root: dir,
@@ -289,6 +293,7 @@ describe('microsandbox runtime facts', () => {
         catalog.entries['pi-acp']!.source = 'curated'
         const d = daemon as any
         d.cfg.sandbox.backend = 'microsandbox'
+        d.cfg.security.requireSandbox = true
         d.microsandboxTable = {
           runtimes: ['codex-acp', ...(expiredInImage ? ['pi-acp'] : []), 'opencode'].map((id) => ({
             id,

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { SessionConfigOption } from '@agentclientprotocol/sdk'
@@ -235,101 +235,125 @@ describe('daemon activation gate provenance rule', () => {
 })
 
 describe('microsandbox runtime facts', () => {
-  it('probes host definitions while preserving image facts and same-ID host admission', async () => {
-    const dir = root()
-    await seedCache(
-      dir,
-      ['local', 'shared', 'guest-only'].map((runtimeId) => ({
-        runtimeId,
-        models: [{ id: 'old-host-model', caps: { fastMode: true } }]
-      }))
-    )
-    const clock = new FakeClock()
-    clock.advance(10_000)
-    let catalog = catalogOf({ local: FAKE_RT })
-    const probe = vi.fn(async (runtimes: Record<string, RuntimeDef>): Promise<RuntimeProbeResult[]> =>
-      Object.keys(runtimes).map((runtime) => ({
-        runtime,
-        ok: true,
-        models: ['host-model'],
-        probedVersion: 'host-version',
-        acpProtocolVersion: 1
-      }))
-    )
-    const daemon = new Daemon({
-      root: dir,
-      clock,
-      resolveCatalog: async () => catalog,
-      installed: (runtimes) => Object.fromEntries(Object.entries(runtimes).filter(([id]) => id !== 'guest-only')),
-      probeRuntimes: probe,
-      hostFactory: () => ({}) as never,
-      sandboxMechanism: null
-    })
-
-    try {
-      await daemon.start()
-      catalog = catalogOf({ local: FAKE_RT, shared: FAKE_RT, 'guest-only': FAKE_RT })
-      catalog.entries.shared!.source = 'curated'
-      const d = daemon as any
-      d.cfg.sandbox.backend = 'microsandbox'
-      d.microsandboxTable = {
-        runtimes: ['shared', 'guest-only'].map((id) => ({
-          id,
-          command: `/image/bin/${id}`,
-          args: ['acp'],
-          version: 'image-version',
-          models: ['image-model'],
-          acp: { protocolVersion: 9 }
-        }))
+  it.each([true, false])(
+    'retains stored logins through host probes and model refreshes (expired runtime in image: %s)',
+    async (expiredInImage) => {
+      const dir = root()
+      const hostHome = join(dir, 'host-home')
+      for (const part of ['.codex', '.grok', '.pi/agent', '.local/share/opencode']) {
+        mkdirSync(join(hostHome, part), { recursive: true })
       }
-      const install = vi.spyOn(d, 'installManagedRuntimePackages')
-      const agents = [
-        { runtime: 'shared', runInSandbox: true },
-        { runtime: 'local', runInSandbox: false }
-      ]
-      await d.discoverRuntimes(dir, d.cfg, agents)
-      expect(install.mock.calls[0]![1]).toEqual(['local'])
-      d.cfg.security.requireSandbox = true
-      await d.discoverRuntimes(dir, d.cfg, agents)
-      expect(install.mock.calls[1]![1]).toEqual([])
-      d.cfg.security.requireSandbox = false
-      await d.hydrateRuntimeCaches()
-      expect(d.runtimeFacts.profileFor('local').modelCatalog.models[0].id).toBe('old-host-model')
-      const noteProbe = stubCatalogSvc(daemon)
-      const emitted = captureEmits(daemon)
-
-      await d.runtimeFacts.probeAndEmit(true)
-
-      expect(probe.mock.calls.map(([runtimes]) => runtimes)).toEqual([{ local: FAKE_RT }, { shared: FAKE_RT }])
-      expect(noteProbe).toHaveBeenCalledOnce()
-      expect(noteProbe.mock.calls[0]![0]).toMatchObject({ runtimeId: 'local', rt: FAKE_RT })
-      expect(() => d.curatedRuntimeAdmission.assertLaunch('shared', 'curated')).not.toThrow()
-      for (const id of ['shared', 'guest-only']) {
-        expect(d.runtimeFacts.profileFor(id)).toMatchObject({
-          runtime: id,
-          version: 'image-version',
-          models: ['image-model'],
-          modelsSource: 'cached',
-          acpProtocolVersion: 9
+      writeFileSync(join(hostHome, '.codex', 'auth.json'), JSON.stringify({ OPENAI_API_KEY: 'fixture-key' }))
+      writeFileSync(
+        join(hostHome, '.grok', 'auth.json'),
+        JSON.stringify({ 'xai::api_key': { key: 'fixture-key', auth_mode: 'api_key' } })
+      )
+      writeFileSync(
+        join(hostHome, '.pi', 'agent', 'auth.json'),
+        JSON.stringify({
+          anthropic: { type: 'oauth', access: 'fixture-access', refresh: 'fixture-refresh', expires: 1 }
         })
-        expect(d.runtimeFacts.profileFor(id).modelCatalog).toBeUndefined()
-        expect(await d.store.getRuntimeCatalogMeta(id)).toMatchObject({ fingerprint: 'fp-cache' })
-      }
-      expect(d.localRuntimeCatalog.runtimes.shared.command).toBe('fake-agent')
-      expect(d.microsandboxCatalog.runtimes.shared.command).toBe('/image/bin/shared')
+      )
+      writeFileSync(join(hostHome, '.local', 'share', 'opencode', 'auth.json'), '{}')
+      const clock = new FakeClock()
+      clock.advance(10_000)
+      let catalog = catalogOf({})
+      const probe = vi.fn(async (runtimes: Record<string, RuntimeDef>): Promise<RuntimeProbeResult[]> =>
+        Object.keys(runtimes).map((runtime) =>
+          runtime === 'pi-acp'
+            ? { runtime, ok: false, models: [], authRequired: true, error: 'Authentication required' }
+            : { runtime, ok: true, models: ['host-model'], probedVersion: 'host-version', acpProtocolVersion: 1 }
+        )
+      )
+      const daemon = new Daemon({
+        root: dir,
+        clock,
+        resolveCatalog: async () => catalog,
+        installed: (runtimes) => runtimes,
+        probeRuntimes: probe,
+        hostFactory: () => ({}) as never,
+        sandboxMechanism: null
+      })
 
-      d.localRuntimeCatalog = catalogOf({})
-      clock.advance(5 * 60_000)
-      probe.mockClear()
-      emitted.length = 0
-      await d.runtimeFacts.probeAndEmit(true)
-      expect(probe).not.toHaveBeenCalled()
-      expect(emitted).toHaveLength(1)
-      expect(emitted[0]!.find((profile) => profile.runtime === 'shared')?.models).toEqual(['image-model'])
-    } finally {
-      await daemon.stop()
+      try {
+        await daemon.start()
+        vi.stubEnv('HOME', hostHome)
+        vi.stubEnv('USERPROFILE', hostHome)
+        vi.stubEnv('CODEX_HOME', join(hostHome, '.codex'))
+        vi.stubEnv('GROK_HOME', join(hostHome, '.grok'))
+        vi.stubEnv('GROK_AUTH_PATH', join(hostHome, '.grok', 'auth.json'))
+        vi.stubEnv('PI_CODING_AGENT_DIR', join(hostHome, '.pi', 'agent'))
+        vi.stubEnv('XDG_DATA_HOME', join(hostHome, '.local', 'share'))
+        catalog = catalogOf({ 'grok-build': FAKE_RT, 'codex-acp': FAKE_RT, 'pi-acp': FAKE_RT, opencode: FAKE_RT })
+        catalog.entries['codex-acp']!.source = 'curated'
+        catalog.entries['pi-acp']!.source = 'curated'
+        const d = daemon as any
+        d.cfg.sandbox.backend = 'microsandbox'
+        d.microsandboxTable = {
+          runtimes: ['codex-acp', ...(expiredInImage ? ['pi-acp'] : []), 'opencode'].map((id) => ({
+            id,
+            command: `/image/bin/${id}`,
+            args: ['acp'],
+            version: 'image-version',
+            models: ['image-model'],
+            acp: { protocolVersion: 9 }
+          }))
+        }
+        await d.discoverRuntimes(dir, d.cfg, [])
+        expect(d.reportedRuntimeIds().sort()).toEqual(['codex-acp', 'grok-build', 'pi-acp'])
+        expect(d.microsandboxCatalog.entries.opencode).toBeUndefined()
+        await d.hydrateRuntimeCaches()
+        expect(d.runtimeFacts.profileFor('codex-acp').models).toEqual([])
+        const onCatalogUpdated = d.modelCatalogSvc.deps.onUpdated
+        const noteProbe = stubCatalogSvc(daemon)
+        const emitted = captureEmits(daemon)
+
+        await d.runtimeFacts.probeAndEmit(true)
+
+        expect(probe.mock.calls.map(([runtimes]) => Object.keys(runtimes))).toEqual([
+          ['grok-build'],
+          ['codex-acp', 'pi-acp']
+        ])
+        expect(noteProbe.mock.calls.map(([input]) => input.runtimeId).sort()).toEqual(['codex-acp', 'grok-build'])
+        expect(d.runtimeFacts.profileFor('codex-acp')).toMatchObject({
+          runtime: 'codex-acp',
+          version: 'image-version',
+          models: ['host-model'],
+          modelsSource: 'probed',
+          acpProtocolVersion: 1
+        })
+        expect(d.runtimeFacts.profileFor('codex-acp').unavailableReason).toBeUndefined()
+        expect(d.runtimeFacts.profileFor('grok-build')).toMatchObject({
+          models: ['host-model'],
+          unavailableReason: 'image-binary-missing'
+        })
+        expect(d.runtimeFacts.profileFor('pi-acp')).toMatchObject({ authRequired: true })
+        expect(d.runtimeFacts.profileFor('pi-acp').unavailableReason).toBe(
+          expiredInImage ? undefined : 'image-binary-missing'
+        )
+        expect(d.curatedRuntimeAdmission.status('codex-acp', 'curated')).toBe('verified')
+        expect(d.curatedRuntimeAdmission.status('pi-acp', 'curated')).toBe('failed')
+        expect(d.reportedRuntimeIds().sort()).toEqual(['codex-acp', 'grok-build', 'pi-acp'])
+        expect(d.localRuntimeCatalog.runtimes['codex-acp'].command).toBe('fake-agent')
+        expect(d.microsandboxCatalog.runtimes['codex-acp'].command).toBe('/image/bin/codex-acp')
+        await onCatalogUpdated('codex-acp')
+        expect(
+          emitted
+            .at(-1)
+            ?.map((profile) => profile.runtime)
+            .sort()
+        ).toEqual(['codex-acp', 'grok-build', 'pi-acp'])
+        probe.mockClear()
+        d.runtimeFacts.armProbeRefresh()
+        clock.advance(5 * 60_000)
+        await vi.waitFor(() => expect(probe).toHaveBeenCalledOnce())
+        expect(Object.keys(probe.mock.calls[0]![0])).toEqual(['codex-acp', 'pi-acp'])
+      } finally {
+        vi.unstubAllEnvs()
+        await daemon.stop()
+      }
     }
-  })
+  )
 })
 
 describe('daemon last-good advertisement fallback', () => {

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -11,8 +11,11 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
 import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
+import { discoverRuntimeCredentials } from '../src/runtimes/runtime-credential-discovery.js'
+import { resolveQoderCredentialSources } from '../src/runtimes/runtime-credential-sources.js'
 
 const roots: string[] = []
 
@@ -35,6 +38,151 @@ function fixture(): { root: string; daemonRoot: string; hostHome: string; scopeD
 function settings(path: string): { filesystem: { allowWrite: string[] } } {
   return JSON.parse(readFileSync(path, 'utf8')) as { filesystem: { allowWrite: string[] } }
 }
+
+describe('stored runtime credential discovery', () => {
+  it('finds only stored OMP provider records in the configured database, including expired login', () => {
+    const { hostHome } = fixture()
+    const configDir = join(hostHome, 'custom-omp')
+    mkdirSync(configDir)
+    const sourcePath = join(configDir, 'agent.db')
+    const db = new DatabaseSync(sourcePath)
+    db.exec(`
+      CREATE TABLE auth_credentials(provider TEXT, credential_type TEXT, data TEXT, disabled_cause TEXT);
+      CREATE TABLE history(payload BLOB);
+      INSERT INTO history VALUES (zeroblob(3145728));
+      INSERT INTO auth_credentials VALUES
+        ('anthropic', 'oauth', '{"access":"synthetic-expired","refresh":"synthetic-refresh","expires":1}', 'expired'),
+        ('openai', 'api_key', '{"key":"synthetic-key"}', NULL),
+        ('invalid', 'api_key', 'not-json', NULL),
+        ('empty', 'api_key', '{"key":""}', NULL);
+    `)
+    db.close()
+    expect(discoverRuntimeCredentials('omp', undefined, { HOME: hostHome })).toEqual({ paths: [], providers: [] })
+    expect(discoverRuntimeCredentials('omp', undefined, { HOME: hostHome, PI_CODING_AGENT_DIR: configDir })).toEqual({
+      paths: [sourcePath],
+      providers: ['anthropic', 'openai']
+    })
+  })
+
+  it('does not create login directories or mistake config files for credentials', () => {
+    const { hostHome } = fixture()
+    const env = { HOME: hostHome }
+    for (const id of ['claude-acp', 'codex-acp', 'qoder-cli', 'qoder-cli-cn']) {
+      expect(discoverRuntimeCredentials(id, undefined, env)).toEqual({ paths: [], providers: [] })
+    }
+    expect(existsSync(join(hostHome, '.claude'))).toBe(false)
+    expect(existsSync(join(hostHome, '.codex'))).toBe(false)
+    expect(existsSync(join(hostHome, '.qoder'))).toBe(false)
+    mkdirSync(join(hostHome, '.claude'))
+    writeFileSync(join(hostHome, '.claude', 'settings.json'), '{"theme":"dark"}')
+    mkdirSync(join(hostHome, '.codex'))
+    writeFileSync(join(hostHome, '.codex', 'auth.json'), '{"last_refresh":"2020-01-01"}')
+    expect(discoverRuntimeCredentials('claude-acp', undefined, env).paths).toEqual([])
+    expect(discoverRuntimeCredentials('codex-acp', undefined, env).paths).toEqual([])
+  })
+
+  it('uses the same Claude secure-storage selection as launch without excluding expired OAuth', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+    const configDir = join(hostHome, '.claude')
+    const settingsDir = join(configDir, 'settings-auth')
+    const environmentDir = join(configDir, 'environment-auth')
+    mkdirSync(settingsDir, { recursive: true })
+    mkdirSync(environmentDir)
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: settingsDir } })
+    )
+    const credentials = JSON.stringify({ claudeAiOauth: { accessToken: 'synthetic-expired', expiresAt: 1 } })
+    writeFileSync(join(settingsDir, '.credentials.json'), credentials)
+    writeFileSync(join(environmentDir, '.credentials.json'), credentials)
+    expect(discoverRuntimeCredentials('claude-acp', undefined, { HOME: hostHome })).toEqual({
+      paths: [join(settingsDir, '.credentials.json')],
+      providers: ['anthropic']
+    })
+    const env = { HOME: hostHome, CLAUDE_SECURESTORAGE_CONFIG_DIR: environmentDir }
+    expect(discoverRuntimeCredentials('claude-acp', undefined, env)).toEqual({
+      paths: [join(environmentDir, '.credentials.json')],
+      providers: ['anthropic']
+    })
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      scopeDir,
+      cwd,
+      daemonRoot,
+      runInSandbox: true,
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      hostEnv: env
+    })
+    expect(launch.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(realpathSync(environmentDir))
+  })
+
+  it('recognizes saved Claude API-key login only in the active global config', () => {
+    const { hostHome } = fixture()
+    const defaultConfig = join(hostHome, '.claude.json')
+    writeFileSync(defaultConfig, '{"primaryApiKey":"synthetic-key"}')
+    expect(discoverRuntimeCredentials('claude-acp', undefined, { HOME: hostHome })).toEqual({
+      paths: [defaultConfig],
+      providers: ['anthropic']
+    })
+    const configDir = join(hostHome, 'custom-claude')
+    mkdirSync(configDir)
+    const env = { HOME: hostHome, CLAUDE_CONFIG_DIR: configDir }
+    expect(discoverRuntimeCredentials('claude-acp', undefined, env).paths).toEqual([])
+    writeFileSync(join(configDir, '.claude.json'), '{"primaryApiKey":"synthetic-key"}')
+    expect(discoverRuntimeCredentials('claude-acp', undefined, env).paths).toEqual([join(configDir, '.claude.json')])
+    writeFileSync(join(configDir, '.config.json'), '{"additionalModelOptionsCache":[]}')
+    expect(discoverRuntimeCredentials('claude-acp', undefined, env).paths).toEqual([])
+    writeFileSync(join(configDir, '.config.json'), '{"primaryApiKey":"synthetic-key"}')
+    expect(discoverRuntimeCredentials('claude-acp', undefined, env).paths).toEqual([join(configDir, '.config.json')])
+  })
+
+  it('recognizes Codex file login and respects CODEX_HOME without falling back to another login', () => {
+    const { hostHome } = fixture()
+    const defaultDir = join(hostHome, '.codex')
+    mkdirSync(defaultDir)
+    writeFileSync(join(defaultDir, 'auth.json'), '{"OPENAI_API_KEY":"synthetic-key"}')
+    expect(discoverRuntimeCredentials('codex-acp', undefined, { HOME: hostHome })).toEqual({
+      paths: [join(defaultDir, 'auth.json')],
+      providers: ['openai']
+    })
+    const configDir = join(hostHome, 'custom-codex')
+    mkdirSync(configDir)
+    const env = { HOME: hostHome, CODEX_HOME: configDir }
+    expect(discoverRuntimeCredentials('codex-acp', undefined, env).paths).toEqual([])
+    writeFileSync(
+      join(configDir, 'auth.json'),
+      '{"tokens":{"refresh_token":"synthetic-expired"},"last_refresh":"2020-01-01"}'
+    )
+    expect(discoverRuntimeCredentials('custom-codex', { command: 'codex-acp', args: [], env: [] }, env)).toEqual({
+      paths: [join(configDir, 'auth.json')],
+      providers: ['openai']
+    })
+    writeFileSync(join(configDir, 'auth.json'), 'not-json')
+    expect(discoverRuntimeCredentials('codex-acp', undefined, env).paths).toEqual([])
+  })
+
+  it.each(['qoder', 'qoder-cn'] as const)(
+    'requires the configured %s user login rather than machine identity',
+    (profile) => {
+      const { hostHome } = fixture()
+      const configDir = join(hostHome, 'custom-qoder')
+      const env = { HOME: hostHome, [profile === 'qoder' ? 'QODER_CONFIG_DIR' : 'QODERCN_CONFIG_DIR']: configDir }
+      const source = resolveQoderCredentialSources(profile, env)
+      const id = profile === 'qoder' ? 'qoder-cli' : 'qoder-cli-cn'
+      mkdirSync(source.credentialDir, { recursive: true })
+      writeFileSync(join(source.credentialDir, 'machine_id'), 'synthetic-machine')
+      expect(discoverRuntimeCredentials(id, undefined, env).paths).toEqual([])
+      writeFileSync(source.credentialFile, 'synthetic-encrypted-login')
+      expect(discoverRuntimeCredentials(id, undefined, env)).toEqual({
+        paths: [source.credentialFile],
+        providers: [profile]
+      })
+      writeFileSync(source.credentialFile, '')
+      expect(discoverRuntimeCredentials(id, undefined, env).paths).toEqual([])
+    }
+  )
+})
 
 describe('Linux shared runtime login', () => {
   it('opens only the canonical Git metadata directory to the inner Codex agent', () => {

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -6,6 +6,7 @@ import { createHash } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
 import { hostPackageCacheEnv, prepareRuntimeHome, runtimeHomeEnvironment } from '../src/runtimes/runtime-home.js'
 import { extractOmpCredentials } from '../src/runtimes/omp-credentials.js'
+import { discoverSeededRuntimeCredentials } from '../src/runtimes/runtime-seeded-credentials.js'
 
 function fixture(): { root: string; hostHome: string; scopeDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'ac-runtime-home-'))
@@ -56,6 +57,228 @@ describe('private runtime HOME', () => {
     const home = prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
     expect(existsSync(join(home, '.claude.json'))).toBe(false)
     expect(existsSync(join(home, '.claude', '.claude.json'))).toBe(false)
+  })
+
+  it('projects the active Claude file-login API key without host account or MCP state', () => {
+    const { hostHome, scopeDir } = fixture()
+    const config = join(hostHome, '.claude')
+    writeFileSync(
+      join(config, '.config.json'),
+      JSON.stringify({ primaryApiKey: 'synthetic-key', oauthAccount: { id: 'private' }, mcpServers: { private: {} } })
+    )
+    writeFileSync(join(hostHome, '.claude.json'), JSON.stringify({ primaryApiKey: 'ignored-key' }))
+    const home = prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
+    expect(JSON.parse(readFileSync(join(home, '.claude', '.config.json'), 'utf8'))).toEqual({
+      primaryApiKey: 'synthetic-key'
+    })
+    expect(existsSync(join(home, '.claude.json'))).toBe(false)
+  })
+
+  it('fills a missing saved Claude API key in retained private config without replacing private settings', () => {
+    const { hostHome, scopeDir } = fixture()
+    const hostConfig = join(hostHome, '.claude.json')
+    writeFileSync(hostConfig, JSON.stringify({ additionalModelOptionsCache: ['initial'] }))
+    const home = prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
+    const privateConfig = join(home, '.claude', '.claude.json')
+    writeFileSync(privateConfig, JSON.stringify({ additionalModelOptionsCache: ['private'], localSetting: true }))
+    writeFileSync(hostConfig, JSON.stringify({ primaryApiKey: 'synthetic-key', additionalModelOptionsCache: [] }))
+    prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
+    expect(JSON.parse(readFileSync(privateConfig, 'utf8'))).toEqual({
+      additionalModelOptionsCache: ['private'],
+      localSetting: true,
+      primaryApiKey: 'synthetic-key'
+    })
+    writeFileSync(hostConfig, JSON.stringify({ primaryApiKey: 'another-synthetic-key' }))
+    prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
+    expect(JSON.parse(readFileSync(privateConfig, 'utf8')).primaryApiKey).toBe('synthetic-key')
+  })
+
+  it.each([
+    {
+      runtime: 'grok-build',
+      path: join('.grok', 'auth.json'),
+      credential: {
+        'xai::api_key': { key: 'synthetic-key', auth_mode: 'api_key', expires_at: '2000-01-01T00:00:00Z' }
+      },
+      provider: 'xai'
+    },
+    {
+      runtime: 'pi-acp',
+      path: join('.pi', 'agent', 'auth.json'),
+      credential: {
+        anthropic: { type: 'oauth', access: 'synthetic-access', refresh: 'synthetic-refresh', expires: 1 }
+      },
+      provider: 'anthropic'
+    },
+    {
+      runtime: 'opencode',
+      path: join('.local', 'share', 'opencode', 'auth.json'),
+      credential: { openai: { type: 'oauth', access: 'synthetic-access', refresh: 'synthetic-refresh', expires: 1 } },
+      provider: 'openai'
+    },
+    {
+      runtime: 'auggie',
+      path: join('.augment', 'session.json'),
+      credential: { accessToken: 'synthetic', tenantURL: 'https://tenant.example.test', scopes: [] },
+      provider: 'augment'
+    },
+    {
+      runtime: 'amp-acp',
+      path: join('.local', 'share', 'amp', 'secrets.json'),
+      credential: { 'apiKey@https://amp.example.test': 'synthetic' },
+      provider: 'amp'
+    },
+    {
+      runtime: 'cline',
+      path: join('.cline', 'data', 'settings', 'providers.json'),
+      credential: {
+        version: 1,
+        providers: { custom: { settings: { provider: 'anthropic', auth: { accessToken: 'synthetic', expiresAt: 1 } } } }
+      },
+      provider: 'anthropic'
+    },
+    {
+      runtime: 'hermes-agent',
+      path: join('.hermes', 'auth.json'),
+      credential: { providers: { 'openai-codex': { tokens: { access_token: 'synthetic', expires_at: 1 } } } },
+      provider: 'openai-codex'
+    },
+    {
+      runtime: 'hermes-agent',
+      path: join('.hermes', '.anthropic_oauth.json'),
+      credential: { refreshToken: 'synthetic', expiresAt: 1 },
+      provider: 'anthropic'
+    },
+    {
+      runtime: 'kimi',
+      path: join('.kimi-code', 'credentials', 'kimi-code.json'),
+      credential: { access_token: 'synthetic', expires_at: 1 },
+      provider: 'kimi-code'
+    },
+    {
+      runtime: 'kimi',
+      path: join('.kimi', 'credentials', 'kimi-code.json'),
+      credential: { refresh_token: 'synthetic', expires_at: 1 },
+      provider: 'kimi-code'
+    }
+  ])(
+    'discovers $runtime records from the same exact file seeded into HOME without checking expiry',
+    ({ runtime, path, credential, provider }) => {
+      const { hostHome, scopeDir } = fixture()
+      const source = join(hostHome, path)
+      mkdirSync(join(source, '..'), { recursive: true })
+      expect(discoverSeededRuntimeCredentials(runtime, { HOME: hostHome })).toEqual({ paths: [], providers: [] })
+      writeFileSync(source, '{}')
+      expect(discoverSeededRuntimeCredentials(runtime, { HOME: hostHome })).toEqual({ paths: [], providers: [] })
+      writeFileSync(source, JSON.stringify(credential))
+      expect(discoverSeededRuntimeCredentials(runtime, { HOME: hostHome })).toEqual({
+        paths: [source],
+        providers: [provider]
+      })
+      const home = prepareRuntimeHome(runtime, scopeDir, { HOME: hostHome })
+      expect(JSON.parse(readFileSync(join(home, path), 'utf8'))).toEqual(credential)
+    }
+  )
+
+  it('uses Grok file and home overrides for both discovery and the private runtime', () => {
+    const { root, hostHome, scopeDir } = fixture()
+    const grokHome = join(root, 'grok-state')
+    const source = join(root, 'grok-login.json')
+    mkdirSync(grokHome)
+    writeFileSync(join(grokHome, 'auth.json'), JSON.stringify({ default: { key: 'ignored-key', auth_mode: 'oidc' } }))
+    writeFileSync(
+      source,
+      JSON.stringify({
+        'https://issuer.example.test::public-client': {
+          key: 'synthetic-key',
+          auth_mode: 'oidc',
+          oidc_issuer: 'https://issuer.example.test/',
+          oidc_client_id: 'public-client'
+        }
+      })
+    )
+    const hostEnv = { HOME: hostHome, GROK_HOME: grokHome, GROK_AUTH_PATH: source }
+    expect(discoverSeededRuntimeCredentials('grok-build', hostEnv)).toEqual({ paths: [source], providers: ['xai'] })
+    const home = prepareRuntimeHome('grok-build', scopeDir, hostEnv)
+    expect(readFileSync(join(home, '.grok', 'auth.json'), 'utf8')).toContain('synthetic-key')
+    const env = runtimeHomeEnvironment('grok-build', home, {}, hostEnv)
+    expect(env.GROK_HOME).toBe(join(home, '.grok'))
+    expect(env.GROK_AUTH_PATH).toBe(join(home, '.grok', 'auth.json'))
+  })
+
+  it.each([
+    {
+      runtime: 'pi-acp',
+      path: join('.pi', 'agent', 'auth.json'),
+      override: 'PI_CODING_AGENT_DIR',
+      credential: { anthropic: { type: 'api_key', key: 'ignored-key' } }
+    },
+    {
+      runtime: 'grok-build',
+      path: join('.grok', 'auth.json'),
+      override: 'GROK_AUTH_PATH',
+      credential: { 'xai::api_key': { key: 'ignored-key', auth_mode: 'api_key' } }
+    }
+  ])(
+    'keeps $runtime auth absent when its effective override has no login',
+    ({ runtime, path, override, credential }) => {
+      const { root, hostHome, scopeDir } = fixture()
+      const source = join(hostHome, path)
+      mkdirSync(join(source, '..'), { recursive: true })
+      writeFileSync(source, JSON.stringify(credential))
+      const env = { HOME: hostHome, [override]: join(root, 'empty-override') }
+      expect(discoverSeededRuntimeCredentials(runtime, env)).toEqual({ paths: [], providers: [] })
+      const home = prepareRuntimeHome(runtime, scopeDir, env)
+      expect(existsSync(join(home, path))).toBe(false)
+    }
+  )
+
+  it('discovers model credentials in both DSH layouts and ignores unrelated service keys', () => {
+    const { hostHome, scopeDir } = fixture()
+    const dsh = join(hostHome, '.dsh')
+    mkdirSync(dsh)
+    const source = join(dsh, '.credentials.yaml')
+    writeFileSync(source, 'MCP_SERVER_TOKEN: synthetic-service-key\n')
+    writeFileSync(join(dsh, '.env'), 'DEEPSEEK_BASE_URL=https://provider.example.test\n')
+    expect(discoverSeededRuntimeCredentials('dsh-acp', { HOME: hostHome }).paths).toEqual([])
+    writeFileSync(source, 'version: 1\nrecords:\n  llm-pi-ai/openai:\n    kind: api-key\n')
+    expect(discoverSeededRuntimeCredentials('dsh-acp', { HOME: hostHome }).paths).toEqual([])
+    for (const text of [
+      'DEEPSEEK_API_KEY: synthetic-key\n',
+      'version: 1\nrefs:\n  DEEPSEEK_API_KEY: synthetic-key\n'
+    ]) {
+      writeFileSync(source, text)
+      expect(discoverSeededRuntimeCredentials('dsh-acp', { HOME: hostHome })).toEqual({
+        paths: [source],
+        providers: ['deepseek']
+      })
+    }
+    const home = prepareRuntimeHome('dsh-acp', scopeDir, { HOME: hostHome })
+    expect(readFileSync(join(home, '.dsh', '.credentials.yaml'), 'utf8')).toContain('synthetic-key')
+  })
+
+  it.each([
+    {
+      runtime: 'grok-build',
+      path: join('.grok', 'auth.json'),
+      value: { unrelated: { key: 'synthetic', auth_mode: 'oidc' } }
+    },
+    {
+      runtime: 'hermes-agent',
+      path: join('.hermes', 'auth.json'),
+      value: { providers: { spotify: { access_token: 'synthetic' } } }
+    },
+    {
+      runtime: 'amp-acp',
+      path: join('.local', 'share', 'amp', 'secrets.json'),
+      value: { 'github-access-token@https://example.test': 'synthetic' }
+    }
+  ])('ignores unrelated records in the $runtime shared auth store', ({ runtime, path, value }) => {
+    const { hostHome } = fixture()
+    const source = join(hostHome, path)
+    mkdirSync(join(source, '..'), { recursive: true })
+    writeFileSync(source, JSON.stringify(value))
+    expect(discoverSeededRuntimeCredentials(runtime, { HOME: hostHome })).toEqual({ paths: [], providers: [] })
   })
 
   it('seeds only Pi auth/settings from its nested agent directory', () => {

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -174,18 +174,19 @@ describe('probeRuntime', () => {
     expect(onStop).toHaveBeenCalledOnce()
   })
 
-  it('flags an ACP auth-required rejection (-32000) as authRequired', async () => {
+  it.each([
+    [-32000, 'Authentication required'],
+    [-32603, 'OAuth session expired and could not be refreshed']
+  ])('flags an ACP login rejection (%s) as authRequired', async (code, message) => {
     const host = fakeHost({
-      // Exactly what claude-acp / codex-acp reject session/new with when logged
-      // out: the SDK's RequestError.authRequired (JSON-RPC -32000).
       newSession: async () => {
-        throw Object.assign(new Error('Authentication required'), { code: -32000 })
+        throw Object.assign(new Error(message), { code })
       }
     })
     const res = await probeRuntime('codex-acp', rt, '/tmp/x', { hostFactory: () => host })
     expect(res.ok).toBe(false)
     expect(res.authRequired).toBe(true)
-    expect(res.error).toContain('Authentication required')
+    expect(res.error).toContain(message)
   })
 
   it('keeps other JSON-RPC failures (e.g. -32603) out of authRequired', async () => {

--- a/packages/daemon/test/runtime-store-daemon.test.ts
+++ b/packages/daemon/test/runtime-store-daemon.test.ts
@@ -110,6 +110,31 @@ describe('daemon-owned adapter store', () => {
     await daemon.stop()
   })
 
+  it('retains a VM host-probe candidate after a failed install so a later probe can retry', async () => {
+    const root = scaffold()
+    const { tree: dir, bin } = tree(root)
+    let attempts = 0
+    const daemon = daemonWith(root, async () => {
+      if (++attempts === 1) throw new Error('package registry unavailable')
+      return { tree: dir, version: '1.4.2', bin }
+    })
+    await daemon.start()
+    const local = daemon as unknown as {
+      localRuntimeCatalog: ResolvedRuntimeCatalog
+      ensureRuntimeInstalled(id: string, local: boolean): Promise<void>
+    }
+    try {
+      local.localRuntimeCatalog = catalog()
+      await expect(local.ensureRuntimeInstalled('codex-acp', true)).rejects.toThrow('no daemon-owned install')
+      expect(local.localRuntimeCatalog.runtimes['codex-acp']).toEqual(RUNTIME)
+      await local.ensureRuntimeInstalled('codex-acp', true)
+      expect(attempts).toBe(2)
+      expect(local.localRuntimeCatalog.runtimes['codex-acp']!.args).toEqual([bin])
+    } finally {
+      await daemon.stop()
+    }
+  })
+
   it('keeps that refusal to one line with no absolute path, however the failure was thrown', async () => {
     const root = scaffold('codex-acp')
     const { tree: dir } = tree(root)

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -327,6 +327,8 @@ export const FactsRuntimeProfile = z.object({
   // before sessions can start. Cleared (absent) once a probe succeeds; absent
   // also for older daemons that don't report it.
   authRequired: z.boolean().optional(),
+  // The host runtime remains discoverable when its binary is absent from the selected sandbox image.
+  unavailableReason: z.literal('image-binary-missing').optional(),
   // Discovered model × config capability matrix (last-good; survives probe
   // failures — advertisement (`models`) empties on failure, capability
   // knowledge does not). Absent = this daemon has no catalog for the runtime.

--- a/packages/web/src/components/console/FleetDetail.test.ts
+++ b/packages/web/src/components/console/FleetDetail.test.ts
@@ -68,6 +68,18 @@ describe('runtime aggregation carries model display metadata', () => {
     expect(intersectRuntimes([member(), opus48, member()])[0]!.modelInfo).toEqual({})
   })
 
+  it('preserves a member image restriction without dropping host model knowledge', () => {
+    const members = [member(), member({ unavailableReason: 'image-binary-missing', authRequired: true })]
+    for (const aggregate of [unionRuntimes, intersectRuntimes]) {
+      expect(aggregate(members)[0]).toMatchObject({
+        runtime: 'claude',
+        models: ['opus[1m]', 'haiku'],
+        unavailableReason: 'image-binary-missing',
+        authRequired: true
+      })
+    }
+  })
+
   it('carries them through the intersection too', () => {
     const [rt] = intersectRuntimes([member(), member()])
     expect(rt!.modelInfo?.['opus[1m]']?.description).toBe('Opus 5 with 1M context')

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -19,6 +19,7 @@ import {
   agentModelDisplay,
   effectiveAgentStatus,
   runtimeLabel,
+  IMAGE_BINARY_MISSING_LABEL,
   status,
   type Agent,
   type DaemonRow
@@ -51,6 +52,7 @@ export interface FleetRuntime {
    *  a set whose members resolve one alias differently has no single answer to quote. */
   modelInfo?: Record<string, { name?: string; description?: string }>
   authRequired: boolean
+  unavailableReason?: 'image-binary-missing' | null
 }
 
 /** The set's answer for each model id: what every member that describes it agrees on, and
@@ -111,13 +113,15 @@ export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
           runtime: rt.runtime,
           version: rt.version,
           models: [...rt.models],
-          authRequired: rt.authRequired === true
+          authRequired: rt.authRequired === true,
+          unavailableReason: rt.unavailableReason
         })
         continue
       }
       if (!prev.version) prev.version = rt.version
       for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
       prev.authRequired ||= rt.authRequired === true
+      prev.unavailableReason ??= rt.unavailableReason
     }
   }
   for (const rt of byId.values()) rt.modelInfo = consensusModelInfo(described.get(rt.runtime) ?? [])
@@ -155,7 +159,8 @@ export function intersectRuntimes(members: readonly DaemonRow[]): FleetRuntime[]
       // Sticky, as in the union: one member needing a login qualifies the set's promise, so the
       // row is MARKED. Not withdrawn — placement is deliberately independent of login readiness
       // (preset-agents.md §3.2), which is why this does not exclude the runtime.
-      authRequired: all.some((peer) => peer.authRequired === true)
+      authRequired: all.some((peer) => peer.authRequired === true),
+      unavailableReason: all.find((peer) => peer.unavailableReason)?.unavailableReason
     })
   }
   return out
@@ -456,6 +461,12 @@ export function FleetRuntimesCard({
                     className={hasModels ? 'flex-none' : 'invisible flex-none'}
                   />
                 </button>
+                {rt.unavailableReason === 'image-binary-missing' && (
+                  <div className="flex items-center gap-[6px] bg-(--status-paused-soft) px-[13px] py-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--amber-500)">
+                    <Icon name="triangle-alert" size={12} className="flex-none" />
+                    {IMAGE_BINARY_MISSING_LABEL}
+                  </div>
+                )}
                 {rt.authRequired && (
                   <button
                     type="button"

--- a/packages/web/src/components/console/RuntimeSelect.test.tsx
+++ b/packages/web/src/components/console/RuntimeSelect.test.tsx
@@ -49,6 +49,15 @@ const CLAUDE = 0
 const CODEX = 1
 
 describe('RuntimeSelect', () => {
+  it('keeps an empty reported list unselected and closed', async () => {
+    const onChange = vi.fn()
+    await mount(<RuntimeSelect value="" options={[]} onChange={onChange} />)
+    expect(trigger().disabled).toBe(true)
+    expect(trigger().textContent).toContain('Select runtime')
+    expect(options()).toHaveLength(0)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('marks a logged-out runtime without taking the choice away', async () => {
     await mount(<Harness needsLogin={['codex']} />)
 
@@ -64,6 +73,24 @@ describe('RuntimeSelect', () => {
 
     expect(trigger().textContent).toContain('Codex')
     expect(options()).toHaveLength(0)
+  })
+
+  it('keeps a missing image binary visible alongside its independent login warning', async () => {
+    const onChange = vi.fn()
+    await mount(
+      <RuntimeSelect
+        value="claude"
+        options={['claude', 'codex']}
+        needsLogin={['codex']}
+        imageBinaryMissing={['codex']}
+        onChange={onChange}
+      />
+    )
+    const codex = options()[CODEX]!
+    expect(codex.textContent).toContain('Binary not installed in image')
+    expect(codex.textContent).toContain('Login required')
+    await act(async () => codex.click())
+    expect(onChange).toHaveBeenCalledWith('codex')
   })
 
   it('leaves a signed-in runtime unmarked', async () => {

--- a/packages/web/src/components/console/RuntimeSelect.tsx
+++ b/packages/web/src/components/console/RuntimeSelect.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
 import { AgentMark } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
-import { runtimeLabel } from '@/lib/data'
+import { IMAGE_BINARY_MISSING_LABEL, runtimeLabel } from '@/lib/data'
 
 const LOGIN_HINT = 'Not signed in on this daemon — you can still pick it, then sign in on the daemon host'
 
@@ -10,6 +10,7 @@ export function RuntimeSelect({
   value,
   options,
   needsLogin,
+  imageBinaryMissing,
   onChange,
   ariaLabel = 'Runtime'
 }: {
@@ -20,6 +21,7 @@ export function RuntimeSelect({
    *  an agent on a logged-out runtime is a supported state — creation and placement
    *  deliberately don't gate on readiness (docs/designs/preset-agents.md §3.2). */
   needsLogin?: readonly string[]
+  imageBinaryMissing?: readonly string[]
   onChange: (value: string) => void
   ariaLabel?: string
 }) {
@@ -27,7 +29,8 @@ export function RuntimeSelect({
   const rows = options.map((id) => ({
     id,
     label: runtimeLabel(id, acpRuntime(registry, id)?.name),
-    needsLogin: !!needsLogin?.includes(id)
+    needsLogin: !!needsLogin?.includes(id),
+    imageBinaryMissing: !!imageBinaryMissing?.includes(id)
   }))
   const selectedIndex = Math.max(
     0,
@@ -99,6 +102,7 @@ export function RuntimeSelect({
       <button
         ref={triggerRef}
         type="button"
+        disabled={rows.length === 0}
         className={`inp relative w-full cursor-pointer text-left outline-none transition-[background-color,border-color,box-shadow] ${
           open
             ? 'border-(--border-focus) ring-[3px] ring-(--brand-ring)'
@@ -123,8 +127,11 @@ export function RuntimeSelect({
               <span className="truncate">{selected?.label ?? value}</span>
               {/* The field is a 1/3 column, too narrow for the menu's text tag — carry
                   the same warning as a mark so the state survives the menu closing. */}
-              {selected?.needsLogin && (
-                <span className="flex-none" title={LOGIN_HINT}>
+              {(selected?.needsLogin || selected?.imageBinaryMissing) && (
+                <span
+                  className="flex-none"
+                  title={selected.imageBinaryMissing ? IMAGE_BINARY_MISSING_LABEL : LOGIN_HINT}
+                >
                   <Icon name="triangle-alert" size={13} color="var(--status-paused)" />
                 </span>
               )}
@@ -152,10 +159,8 @@ export function RuntimeSelect({
             tabIndex={-1}
             aria-label={ariaLabel}
             aria-activedescendant={`${listboxId}-option-${activeIndex}`}
-            // Size to the widest option (never truncate a runtime name), with the
-            // trigger width as the floor — the Runtime field is a 1/3 column now,
-            // too narrow to clip "Claude Code" against.
-            className="fmenu left-0 z-40 w-max min-w-full rounded-lg p-2 shadow-(--shadow-xl) outline-none"
+            // Keep names and wrapped status text readable within the viewport.
+            className="fmenu left-0 z-40 w-max min-w-full max-w-[calc(100vw-64px)] rounded-lg p-2 shadow-(--shadow-xl) outline-none"
             onKeyDown={onListKeyDown}
           >
             {rows.map((row, index) => {
@@ -169,7 +174,7 @@ export function RuntimeSelect({
                   role="option"
                   tabIndex={-1}
                   aria-selected={isSelected}
-                  title={row.needsLogin ? LOGIN_HINT : undefined}
+                  title={row.imageBinaryMissing ? IMAGE_BINARY_MISSING_LABEL : row.needsLogin ? LOGIN_HINT : undefined}
                   className={`fopt min-h-10 gap-3 rounded-md px-2 py-[6px] text-[13px] ${
                     isSelected
                       ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
@@ -183,13 +188,25 @@ export function RuntimeSelect({
                   <span className="imark h-7 w-7 flex-none rounded-md">
                     <AgentMark model={row.id} />
                   </span>
-                  <span className="flex-1 whitespace-nowrap">{row.label}</span>
-                  {row.needsLogin && (
-                    <span className="flex flex-none items-center gap-[4px] font-sans text-[11px] font-medium leading-normal text-(--status-paused)">
-                      <Icon name="triangle-alert" size={11} className="flex-none" />
-                      Login required
-                    </span>
-                  )}
+                  <span className="flex min-w-0 flex-1 flex-col items-start gap-1">
+                    <span>{row.label}</span>
+                    {(row.imageBinaryMissing || row.needsLogin) && (
+                      <span className="flex flex-wrap gap-x-3 gap-y-1 font-sans text-[11px] font-medium leading-normal text-(--status-paused)">
+                        {row.imageBinaryMissing && (
+                          <span className="flex items-start gap-[4px]">
+                            <Icon name="triangle-alert" size={11} className="mt-[2px] flex-none" />
+                            <span>{IMAGE_BINARY_MISSING_LABEL}</span>
+                          </span>
+                        )}
+                        {row.needsLogin && (
+                          <span className="flex items-start gap-[4px]">
+                            <Icon name="triangle-alert" size={11} className="mt-[2px] flex-none" />
+                            <span>Login required</span>
+                          </span>
+                        )}
+                      </span>
+                    )}
+                  </span>
                   {isSelected && <Icon name="check" size={16} color="var(--brand)" className="flex-none" />}
                 </button>
               )

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -12,6 +12,7 @@ import {
   poolLabel,
   poolTagline,
   groupPlacementValue,
+  imageBinaryMissingRuntimeIds,
   loginRequiredRuntimeIds,
   agentSlugFinalize,
   agentSlugSanitize,
@@ -329,16 +330,18 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     sandboxSupported,
     sandboxRequired
   })
-  // Runtime ids come from the selected daemon's reported profiles — the registry ids
-  // that round-trip back to the launch key — so a created agent actually resolves.
-  // No daemon (or none reported) ⇒ the static fallback list.
-  const runtimeIds = daemon?.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  // A selected daemon's reported profiles are authoritative, including an empty list.
+  const runtimeIds = daemon ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
   // Runtimes the daemon reports as logged out. Marked in the picker, never blocked —
   // creating on one is a supported state (docs/designs/preset-agents.md §3.2).
   const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
+  const runtimesMissingImageBinary = imageBinaryMissingRuntimeIds(daemon)
   // …but the DEFAULT prefers a signed-in one, mirroring how auto-placement picks a
   // preset's runtime. Falls through to the first reported id when all are logged out.
-  const defaultRuntime = runtimeIds.find((id) => !runtimesNeedingLogin.includes(id)) ?? runtimeIds[0] ?? ''
+  const defaultRuntime =
+    runtimeIds.find((id) => !runtimesNeedingLogin.includes(id) && !runtimesMissingImageBinary.includes(id)) ??
+    runtimeIds[0] ??
+    ''
   // `runtime` is '' until the user picks one, so the default above applies to a fresh
   // form while an explicit choice — logged out or not — always survives.
   const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
@@ -618,6 +621,10 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     }
     if (!daemon) {
       setErr('No daemon available — start a daemon first.')
+      return
+    }
+    if (!effectiveRuntime) {
+      setErr('No runtime available on this daemon.')
       return
     }
     if (usingPicker && !ghRepo) {
@@ -910,6 +917,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                     value={effectiveRuntime}
                     options={runtimeIds}
                     needsLogin={runtimesNeedingLogin}
+                    imageBinaryMissing={runtimesMissingImageBinary}
                     onChange={(nextRuntime) => {
                       setRuntime(nextRuntime)
                       setEffort('')
@@ -1438,7 +1446,10 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        <Button disabled={busy || (memoryProvider === 'external' && !externalMemory.connectionId)} onClick={submit}>
+        <Button
+          disabled={busy || !effectiveRuntime || (memoryProvider === 'external' && !externalMemory.connectionId)}
+          onClick={submit}
+        >
           <Icon name="bot" size={15} />
           {busy ? 'Creating…' : 'Create'}
         </Button>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -6,6 +6,7 @@ import {
   effortField,
   effortLabel,
   FALLBACK_RUNTIME_IDS,
+  imageBinaryMissingRuntimeIds,
   loginRequiredRuntimeIds,
   fastModeAvailableFor,
   modelCapability,
@@ -468,17 +469,15 @@ export default function EditAgentModal({
   const forceMove = daemonChanged && !initialPlacement && sourceOffline && moveReady(daemon)
   const sourceBlocksSafeMove = daemonChanged && sourceUnavailable && !forceMove
 
-  // Runtime options come from the SELECTED daemon's reported profiles (same source as
-  // the Add-agent picker); fall back to the static runtime list when the daemon reports
-  // none. Keep the agent's current runtime selectable so changing placement never
-  // silently rewrites it.
+  // Preserve the configured runtime while keeping the selected daemon's reported choices authoritative.
   const reportedRuntimeIds = daemon?.runtimeModels.map((r) => r.runtime) ?? []
-  const runtimeIds = reportedRuntimeIds.length ? reportedRuntimeIds : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon ? reportedRuntimeIds : FALLBACK_RUNTIME_IDS
   const runtimeOptions = runtime && !runtimeIds.includes(runtime) ? [runtime, ...runtimeIds] : runtimeIds
   // Runtimes the daemon reports as logged out — marked in the picker, never blocked.
   // An agent may legitimately sit on one (docs/designs/preset-agents.md §3.2), so this
   // surfaces the state on the choice rather than taking the choice away.
   const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
+  const runtimesMissingImageBinary = imageBinaryMissingRuntimeIds(daemon)
   const runtimeMeta = acpRuntime(acpRegistry, runtime)
   // Models are only what the daemon reports for this runtime — advertised ids
   // verbatim, never a synthesized "Default" entry: an agent without an explicit
@@ -804,6 +803,7 @@ export default function EditAgentModal({
                       value={runtime}
                       options={runtimeOptions}
                       needsLogin={runtimesNeedingLogin}
+                      imageBinaryMissing={runtimesMissingImageBinary}
                       onChange={onRuntimeChange}
                     />
                   </div>

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -16,6 +16,7 @@ import {
   platName,
   presentedDaemonStatus,
   runtimeLabel,
+  IMAGE_BINARY_MISSING_LABEL,
   status
 } from '@/lib/data'
 import { creatorLabel } from '@/lib/api'
@@ -118,9 +119,7 @@ export default function DaemonDetailView() {
   const canUpgrade = canRestart && daemon.availableVersions.some((v) => v !== daemon.version)
 
   const hosted = agents.filter((a) => a.daemon === daemon.daemonId)
-  const runtimes: FleetRuntime[] = daemon.runtimeModels.length
-    ? unionRuntimes([daemon])
-    : daemon.caps.runtimes.map((runtime) => ({ runtime, version: '', models: [], authRequired: false }))
+  const runtimes: FleetRuntime[] = unionRuntimes([daemon])
   const seen = daemon.uptime === '—' ? 'never connected' : `last seen ${daemon.uptime} ago`
   // `conns` is the daemon's agent ceiling; <= 0 is its UNBOUNDED sentinel, not a ceiling of zero.
   // Its numerator is the daemon's OWN heartbeat count, never `hosted`: a group duty this member
@@ -275,8 +274,7 @@ export default function DaemonDetailView() {
               )
               const usage = users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'
               const version = rt.version ? `v${rt.version.replace(/^v/, '')}` : null
-              // Expandable when the runtime reported models; the fallback rows
-              // built from caps.runtimes carry none.
+              // Expand only runtimes that reported models.
               const hasDetail = rt.models.length > 0
               const open = hasDetail && expandedRuntimes.has(rt.runtime)
               const rowCls = `box-border flex w-full items-center gap-[10px] border-0 bg-(--surface-card) px-4 py-[11px] text-left ${
@@ -318,6 +316,12 @@ export default function DaemonDetailView() {
                     </button>
                   ) : (
                     <div className={rowCls}>{rowInner}</div>
+                  )}
+                  {rt.unavailableReason === 'image-binary-missing' && (
+                    <div className="flex items-center gap-[6px] bg-(--status-paused-soft) px-4 py-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--amber-500)">
+                      <Icon name="triangle-alert" size={12} className="flex-none" />
+                      {IMAGE_BINARY_MISSING_LABEL}
+                    </div>
                   )}
                   {rt.authRequired && (
                     <button
@@ -379,7 +383,7 @@ export default function DaemonDetailView() {
             })
           ) : (
             <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-              No runtimes reported — this daemon hasn&apos;t advertised its runtime profiles yet.
+              No runtimes reported by this daemon.
             </div>
           )}
         </div>
@@ -725,7 +729,7 @@ export default function DaemonDetailView() {
         title="Runtimes"
         runtimes={runtimes}
         agents={hosted}
-        empty="No runtimes reported — this daemon hasn't advertised its runtime profiles yet."
+        empty="No runtimes reported by this daemon."
         daemonName={daemon.name}
       />
 

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -353,6 +353,25 @@ describe('HomeView readiness gate', () => {
     expect(host.textContent).toContain('No AI runtime is signed in')
   })
 
+  it.each([true, false])('requires the image binary only for sandboxed sessions (%s)', async (runInSandbox) => {
+    mocks.agents = [agent({ runInSandbox })]
+    mocks.daemons = [
+      daemon({
+        runtimeModels: [
+          {
+            runtime: 'claude',
+            models: ['claude-sonnet-4-5'],
+            modelCatalog: claudeCatalog,
+            unavailableReason: 'image-binary-missing'
+          }
+        ]
+      })
+    ]
+    await render()
+    expect(host.textContent?.includes('Binary not installed in image')).toBe(runInSandbox)
+    expect(host.textContent).not.toContain('No AI runtime is signed in')
+  })
+
   it('shows no banner when the selected agent’s daemon is healthy but ANOTHER daemon is not', async () => {
     mocks.agents = [agent()]
     mocks.daemons = [

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -32,6 +32,7 @@ import { useProfile } from '@/lib/profile'
 import { featureFlagEnabled, type FeatureFlagId } from '@/lib/feature-flags'
 import {
   agentCapabilitySource,
+  IMAGE_BINARY_MISSING_LABEL,
   agentDaemonLabel,
   agentLabel,
   agentPlacementKind,
@@ -137,7 +138,11 @@ export default function HomeView() {
   // looking one up found nothing and every such agent read as signed in (never blocked, never fixed).
   const authRequiredFor = (a: Agent) =>
     !!agentCapabilitySource(a, daemons, memberSets)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
-  const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a)
+  const imageBinaryMissingFor = (a: Agent) =>
+    (a.runInSandbox || a.sandboxRequired) &&
+    agentCapabilitySource(a, daemons, memberSets)?.runtimeModels.find((r) => r.runtime === a.runtime)
+      ?.unavailableReason === 'image-binary-missing'
+  const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a) && !imageBinaryMissingFor(a)
 
   // Preferred default agent: the "agentconnect" preset when it's READY, else the
   // first READY one, else the preset, else the first. Readiness outranks the preset:
@@ -314,13 +319,15 @@ export default function HomeView() {
   }))
 
   // Why the composer can't start a session for the selected agent (null ⇒ it can).
-  const blocked: 'offline' | 'auth' | null = !agent
+  const blocked: 'offline' | 'auth' | 'image' | null = !agent
     ? null
     : !agentOnline
       ? 'offline'
-      : authRequiredFor(agent)
-        ? 'auth'
-        : null
+      : imageBinaryMissingFor(agent)
+        ? 'image'
+        : authRequiredFor(agent)
+          ? 'auth'
+          : null
   // A multi-agent create needs every roster pick startable — the "+" menu only
   // OFFERS ready agents, but the @mention picker (unlike it) also lists unready
   // ones dimmed (so a typed name still resolves to a real candidate), and
@@ -448,7 +455,9 @@ export default function HomeView() {
           ? 'Add to this conversation'
           : !isOnline(a)
             ? `${agentLabel(a)} is offline — its daemon isn't serving`
-            : `${agentLabel(a)} has no AI runtime signed in`,
+            : imageBinaryMissingFor(a)
+              ? IMAGE_BINARY_MISSING_LABEL
+              : `${agentLabel(a)} has no AI runtime signed in`,
         leading: (
           <span className="av h-[18px] w-[18px] flex-none rounded-xs">
             <AgentIconView icon={a.icon} runtime={a.runtime} size={18} />
@@ -748,13 +757,17 @@ export default function HomeView() {
             title={
               blocked === 'offline'
                 ? `${agentLabel(agent!)} is offline — can't start a session`
-                : blocked === 'auth'
-                  ? `No AI runtime is signed in on ${placementName || 'the daemon'} — can't start a session`
-                  : notReadyMember
-                    ? !isOnline(notReadyMember)
-                      ? `${agentLabel(notReadyMember)} is offline — can't start a session`
-                      : `${agentLabel(notReadyMember)} has no AI runtime signed in — can't start a session`
-                    : 'Send'
+                : blocked === 'image'
+                  ? IMAGE_BINARY_MISSING_LABEL
+                  : blocked === 'auth'
+                    ? `No AI runtime is signed in on ${placementName || 'the daemon'} — can't start a session`
+                    : notReadyMember
+                      ? !isOnline(notReadyMember)
+                        ? `${agentLabel(notReadyMember)} is offline — can't start a session`
+                        : imageBinaryMissingFor(notReadyMember)
+                          ? IMAGE_BINARY_MISSING_LABEL
+                          : `${agentLabel(notReadyMember)} has no AI runtime signed in — can't start a session`
+                      : 'Send'
             }
           >
             <Icon name="arrow-up" size={15} color="#fff" />
@@ -774,6 +787,8 @@ export default function HomeView() {
                 <span className="font-semibold">{agentLabel(agent!)}</span>
                 {' is offline — you can’t start a session until its daemon reconnects.'}
               </>
+            ) : blocked === 'image' ? (
+              IMAGE_BINARY_MISSING_LABEL
             ) : (
               <>
                 {'No AI runtime is signed in'}

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -334,6 +334,16 @@ describe('onboarding — daemon online: configure + finish', () => {
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: null })
   })
 
+  it('keeps the runtime empty when the connected daemon reports no credential candidates', async () => {
+    mocks.daemons = [{ ...mocks.daemons[0], runtimeModels: [] }]
+    await render()
+    expect(host.textContent).not.toContain('runtime-claude')
+    expect(button('Finish').disabled).toBe(true)
+    await click('Finish')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+  })
+
   it('hides the pickers only when the org has no built-in agent at all', async () => {
     mocks.agents = []
     await render()

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -19,6 +19,7 @@ import {
   modelOptionsFor,
   poolLabel,
   preferredModelFor,
+  imageBinaryMissingRuntimeIds,
   loginRequiredRuntimeIds
 } from '@/lib/data'
 import type { DaemonRow } from '@/lib/data'
@@ -486,10 +487,14 @@ function WhereStep({
 // daemon's reported profiles (else the static fallback), models from the chosen
 // runtime's profile.
 function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model?: string }) {
-  const runtimeIds = daemon?.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
   // Logged-out runtimes are marked, not blocked; the default just prefers a signed-in one.
   const runtimesNeedingLogin = daemon ? loginRequiredRuntimeIds(daemon) : []
-  const defaultRuntime = runtimeIds.find((id) => !runtimesNeedingLogin.includes(id)) ?? runtimeIds[0] ?? ''
+  const runtimesMissingImageBinary = imageBinaryMissingRuntimeIds(daemon)
+  const defaultRuntime =
+    runtimeIds.find((id) => !runtimesNeedingLogin.includes(id) && !runtimesMissingImageBinary.includes(id)) ??
+    runtimeIds[0] ??
+    ''
   // Seeded from the agent's current config (a pool-born preset has one); '' = untouched.
   const [runtime, setRuntime] = useState(initial?.runtime ?? '')
   const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
@@ -500,6 +505,7 @@ function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model
   return {
     runtimeIds,
     runtimesNeedingLogin,
+    runtimesMissingImageBinary,
     effectiveRuntime,
     models,
     selectedModel,
@@ -518,6 +524,7 @@ function RuntimeModelFields({ rm }: { rm: ReturnType<typeof useRuntimeModel> }) 
           value={rm.effectiveRuntime}
           options={rm.runtimeIds}
           needsLogin={rm.runtimesNeedingLogin}
+          imageBinaryMissing={rm.runtimesMissingImageBinary}
           onChange={(next) => {
             rm.setRuntime(next)
             rm.setModel('')

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1064,6 +1064,7 @@ export interface RuntimeProfileDto {
   // runtime is installed but needs a login on the daemon host. Absent (older
   // CP) ⇒ no warning.
   authRequired?: boolean
+  unavailableReason?: 'image-binary-missing' | null
 }
 
 // One daemon-configured MCP server (name + transport), reported in the
@@ -2177,7 +2178,8 @@ export function withDaemonCapability(row: DaemonRow, cap: DaemonCapabilityDto | 
       acpProtocolVersion: p.acpProtocolVersion,
       mcpCapabilities: p.mcpCapabilities ?? null,
       modelCatalog: p.modelCatalog ?? null,
-      authRequired: p.authRequired ?? false
+      authRequired: p.authRequired ?? false,
+      unavailableReason: p.unavailableReason ?? null
     })),
     mcpServers: cap.mcpServers
   }
@@ -2224,7 +2226,8 @@ export function daemonFromDto(
       acpProtocolVersion: p.acpProtocolVersion,
       mcpCapabilities: p.mcpCapabilities ?? null,
       modelCatalog: p.modelCatalog ?? null,
-      authRequired: p.authRequired ?? false
+      authRequired: p.authRequired ?? false,
+      unavailableReason: p.unavailableReason ?? null
     })),
     mcpServers: d.mcpServers ?? [],
     activeSessions: String(d.activeSessions),

--- a/packages/web/src/lib/daemon-read-split.test.ts
+++ b/packages/web/src/lib/daemon-read-split.test.ts
@@ -59,7 +59,8 @@ const capability: DaemonCapabilityDto = {
         source: 'acp',
         observedAt: '2026-08-30T00:00:00.000Z'
       },
-      authRequired: true
+      authRequired: true,
+      unavailableReason: 'image-binary-missing'
     }
   ],
   mcpServers: [{ name: 'github', transport: 'stdio' }]
@@ -86,6 +87,7 @@ describe('daemon read split', () => {
     expect(row.runtimeModels[0]!.mcpCapabilities).toEqual({ http: true, sse: true })
     // The login warning is fleet-wide information, so it survives the split.
     expect(row.runtimeModels[0]!.authRequired).toBe(true)
+    expect(row.runtimeModels[0]!.unavailableReason).toBe('image-binary-missing')
     // The runtime-level answers survive, so the read-only model/permission labels resolve
     // for every agent; the per-model matrix is empty until `useDaemonDetail` reads one daemon.
     expect(row.runtimeModels[0]!.modelCatalog!.defaultModel).toBe('sonnet')
@@ -101,7 +103,14 @@ describe('daemon read split', () => {
 
 describe('mergeDaemonCatalogs — the detail read owns catalogs, the fleet row owns the rest', () => {
   const fleet = [
-    { runtime: 'claude-acp', version: '0.70.0', models: ['opus'], authRequired: true, modelCatalog: null }
+    {
+      runtime: 'claude-acp',
+      version: '0.70.0',
+      models: ['opus'],
+      authRequired: true,
+      unavailableReason: 'image-binary-missing',
+      modelCatalog: null
+    }
   ] as DaemonRow['runtimeModels']
   const detail = [
     {
@@ -120,6 +129,7 @@ describe('mergeDaemonCatalogs — the detail read owns catalogs, the fleet row o
     // A slower detail response must not resurrect a stale runtime inventory or login state.
     expect(merged!.models).toEqual(['opus'])
     expect(merged!.authRequired).toBe(true)
+    expect(merged!.unavailableReason).toBe('image-binary-missing')
   })
 
   it('never adds a runtime the fleet row no longer reports', () => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -884,6 +884,14 @@ export function loginRequiredRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'>
   return (daemon?.runtimeModels ?? []).filter((r) => r.authRequired).map((r) => r.runtime)
 }
 
+export const IMAGE_BINARY_MISSING_LABEL = 'Binary not installed in image'
+
+export function imageBinaryMissingRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'> | undefined): string[] {
+  return (daemon?.runtimeModels ?? [])
+    .filter((r) => r.unavailableReason === 'image-binary-missing')
+    .map((r) => r.runtime)
+}
+
 /** One rendered effort choice; `description` (when the runtime provides one)
  *  goes on the control's title attribute. */
 export interface EffortChoice {
@@ -2231,6 +2239,7 @@ export interface DaemonRow {
      *  the runtime needs a login on the daemon host (drives the warning strip
      *  on the daemon detail page). Absent ⇒ no warning. */
     authRequired?: boolean
+    unavailableReason?: 'image-binary-missing' | null
   }[]
   /** Daemon-configured MCP servers (name + transport, facts/daemon-runtimes). */
   mcpServers: McpServerInfo[]


### PR DESCRIPTION
Microsandbox previously combined host configuration-directory detection with every runtime shipped by the image. This advertised unconfigured runtimes and prevented host probes from supplying the models for runtimes that also existed in the image.

Build candidates from the credential sources used by authentication preparation. Check exact files and provider records, retain expired credentials, probe the corresponding host runtime for models and capabilities, and use the image table for guest commands and versions. A configured runtime missing from the image remains visible with **Binary not installed in image**; its login status is reported independently. Empty candidate lists stay empty in the Console.

Credential source resolution is shared with native auth preparation and private-HOME seeding. Source overrides remain authoritative. Default SRT discovery, interactive first-time login, and pool runtime discovery keep their existing behavior. Under microsandbox, host inventory probes use SRT when available without requiring a second host sandbox; required VM isolation still applies to agent sessions.

File/database discovery currently covers Claude, Codex, Qoder, OMP, Grok, pi, OpenCode, DSH, Hermes, Auggie, Cline, Amp, and Gemini/Qwen/Kimi OAuth. Keyring-only logins and other unimplemented credential formats are not candidates.

Validation:

- Synthetic credential fixtures cover exact-file/provider discovery, expired records, configured-source precedence, and private-HOME preparation.
- Daemon integration checks exercise host model discovery, image-only omission, missing-image status, and expired-login visibility, and retry after a failed host adapter install.
- PostgreSQL/HTTP round trips cover the nullable availability field and clearing stale reports; Console tests cover status propagation and runtime selection.
- 259 daemon tests pass (1 skipped); 67 PostgreSQL/HTTP tests and 73 Console tests pass.
- The session-routing timeout assertion accepts both existing timeout paths, avoiding clock-rounding flakes while preserving the no-fallback checks; 60 related K8s tests pass.
- Daemon, protocol, Control Plane, and Console typechecks pass. Full-repository lint/format checks and the daemon self-contained bundle build pass. No live daemon was changed.

Created by Codex . GPT-6
