### PR TITLE
fix(web): an elicitation card stays where the agent asked it

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.elicit-transcript.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicit-transcript.test.tsx
@@ -240,6 +240,26 @@ describe('a recorded elicitation card on the session page', () => {
     for (const label of ['main', 'develop', 'Dismiss']) expect(buttonNamed(label)?.disabled).toBe(true)
   })
 
+  it('keeps the card where it was asked, not above the turn that asked it', async () => {
+    // The agent explains itself and THEN asks. Both rows belong to one turn, and the card used
+    // to be hoisted to the head of it — so a reader met the form before the sentence that set
+    // it up, and the acknowledgement of an earlier round read as an answer to this one.
+    wire.messages = [
+      row({ seq: 1, sender: 'agent-1', kind: 'text', text: 'Before I cut it, one question.' }),
+      elicitRow(CARD),
+      row({ seq: 3, sender: 'agent-1', kind: 'text', text: 'Standing by for your pick.' })
+    ]
+    await render()
+
+    const shown = text()
+    const preamble = shown.indexOf('Before I cut it')
+    const question = shown.indexOf('Which branch should I cut from?')
+    const after = shown.indexOf('Standing by for your pick.')
+    expect(preamble).toBeGreaterThanOrEqual(0)
+    expect(question).toBeGreaterThan(preamble)
+    expect(after).toBeGreaterThan(question)
+  })
+
   it('says an ask nothing could show was not answerable here', async () => {
     wire.messages = [elicitRow({ ...CARD, options: [], outcome: 'unrenderable' })]
     await render()

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -231,6 +231,25 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(live.answered[1]).toEqual(['session-1', 'agent-1', 'elicit-1', null, 'conv-1'])
   })
 
+  it('asks where it asked — after the words that set the question up, not above them', async () => {
+    // One live turn that speaks and THEN asks. The card used to be hoisted to the head of its
+    // turn, so the reader met the form before the sentence explaining it, and an earlier round's
+    // acknowledgement below the card read as an answer to this one.
+    live.steps = [
+      { kind: 'done', turnId: 'turn-1', agentId: 'agent-1', boundary: true, text: 'Before I cut it, one question.' },
+      CARD
+    ]
+    await render()
+
+    const shown = text()
+    const said = shown.indexOf('Before I cut it')
+    const asked = shown.indexOf('Which branch should I cut from?')
+    expect(said).toBeGreaterThanOrEqual(0)
+    expect(asked).toBeGreaterThan(said)
+    // And it is still the answerable card, not a record of one.
+    expect(buttonNamed('main')?.disabled).toBe(false)
+  })
+
   it('toggles a multi-select and answers with the list only on Confirm', async () => {
     live.steps = [
       { ...CARD, text: 'Which checks should I run?', elicit: { ...CARD.elicit, multi: { minItems: 1, maxItems: 2 } } }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -4931,16 +4931,15 @@ export default function SessionDetailView() {
                             // collapsed work. A turn carries at most one (the row is upserted), but
                             // a merged conversation interleaves turns from several sources.
                             const planSteps = turn.steps.filter((s) => s.lane === PLAN_LANE)
-                            // The agent's in-band questions — their own block, above the answer,
-                            // because they are addressed to the reader rather than spoken at them.
-                            const elicitSteps = turn.steps.filter((s) => s.lane === ELICIT_LANE)
-                            const textSteps = turn.steps.filter(
-                              (s) =>
-                                !WORK_LANES.has(s.lane) &&
-                                s.lane !== NOTICE_LANE &&
-                                s.lane !== PLAN_LANE &&
-                                s.lane !== ELICIT_LANE
+                            // What the turn SAID, in the order it said it: spoken bubbles and the
+                            // agent's in-band question cards interleaved. A card gets its own
+                            // block rather than a bubble — it is addressed to the reader, not
+                            // spoken at them — but it stays where it was asked, since an agent
+                            // that explains itself and then asks must not read as asking first.
+                            const saidSteps = turn.steps.filter(
+                              (s) => !WORK_LANES.has(s.lane) && s.lane !== NOTICE_LANE && s.lane !== PLAN_LANE
                             )
+                            const textSteps = saidSteps.filter((s) => s.lane !== ELICIT_LANE)
                             const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
                             // Reasoning steps / tool commands / edited FILES (distinct paths across
                             // EDIT rows, since one EDIT row can touch several files).
@@ -5030,7 +5029,7 @@ export default function SessionDetailView() {
                                   </div>
                                   {noticeSteps.length > 0 && (
                                     <div
-                                      className={`flex min-w-0 flex-col gap-[3px] ${textSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
+                                      className={`flex min-w-0 flex-col gap-[3px] ${saidSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
                                     >
                                       {noticeSteps.map((st, si) => (
                                         <span
@@ -5044,20 +5043,21 @@ export default function SessionDetailView() {
                                   )}
                                   {planSteps.length > 0 && (
                                     <div
-                                      className={`flex min-w-0 flex-col gap-2 ${textSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
+                                      className={`flex min-w-0 flex-col gap-2 ${saidSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
                                     >
                                       {planSteps.map((st, si) => (
                                         <PlanBlock key={`p:${si}`} step={st} />
                                       ))}
                                     </div>
                                   )}
-                                  {elicitSteps.length > 0 && (
-                                    <div
-                                      className={`flex min-w-0 flex-col gap-2 ${textSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
-                                    >
-                                      {elicitSteps.map((st, si) => (
+                                  {/* One bubble per text step: a turn that answers in two chunks
+                            arrives as two delivered messages, so one wrapper around the set
+                            would merge messages the platform kept apart. A question card sits
+                            between them wherever the agent asked it. */}
+                                  {saidSteps.map((st, si) =>
+                                    st.lane === ELICIT_LANE ? (
+                                      <div key={`e:${st.elicit?.requestId ?? si}`} className={si > 0 ? 'mt-2' : ''}>
                                         <ElicitationCard
-                                          key={`e:${st.elicit?.requestId ?? si}`}
                                           step={st}
                                           {...(answerElicitation
                                             ? {
@@ -5066,29 +5066,25 @@ export default function SessionDetailView() {
                                               }
                                             : {})}
                                         />
-                                      ))}
-                                    </div>
+                                      </div>
+                                    ) : (
+                                      <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
+                                        {st.image && (
+                                          <img
+                                            src={`data:${st.image.mimeType};base64,${st.image.data}`}
+                                            alt={st.image.name}
+                                            className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
+                                          />
+                                        )}
+                                        {st.text && (
+                                          <div className="whitespace-pre-wrap">
+                                            <MessageText text={st.text} platform={st.platform} />
+                                          </div>
+                                        )}
+                                        <StepExtras step={st} sessionId={toolSid} />
+                                      </div>
+                                    )
                                   )}
-                                  {/* One bubble per text step: a turn that answers in two chunks
-                            arrives as two delivered messages, so one wrapper around the set
-                            would merge messages the platform kept apart. */}
-                                  {textSteps.map((st, si) => (
-                                    <div key={si} className={`${AGENT_BUBBLE} ${si > 0 ? 'mt-2' : ''}`}>
-                                      {st.image && (
-                                        <img
-                                          src={`data:${st.image.mimeType};base64,${st.image.data}`}
-                                          alt={st.image.name}
-                                          className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
-                                        />
-                                      )}
-                                      {st.text && (
-                                        <div className="whitespace-pre-wrap">
-                                          <MessageText text={st.text} platform={st.platform} />
-                                        </div>
-                                      )}
-                                      <StepExtras step={st} sessionId={toolSid} />
-                                    </div>
-                                  ))}
                                   {workSteps.length > 0 && (
                                     <>
                                       {/* One row: the work toggle, with the bubble's copy button at


### PR DESCRIPTION
## What

A turn's elicitation card is rendered where the agent asked it, instead of above
everything the turn said.

`SessionDetailView` partitioned a turn's steps by lane and emitted the `ELICIT`
block unconditionally before the text bubbles. So an agent that explained itself
and *then* asked put the form first, and the bubbles that fell below the card
included the acknowledgement of the **previous** round — which then read as an
answer to the card sitting above it.

The turn's spoken part is now one ordered pass (`saidSteps`): text bubbles and
question cards interleaved in arrival order. A card still gets its own block
rather than sitting inside a bubble — it is addressed to the reader, not spoken
at them — it just stays in place. `NOTICE` and `PLAN` keep their position above
all of it; their bottom-margin condition now counts cards too, so a turn whose
only spoken content is a card still gets the gap.

Both card sources are covered:

- a persisted `elicit` transcript row sits at its `seq`;
- a live streamed card appends to the tail of its turn, which is where a pending
  ask belongs.

## Verification

- Two new tests, one per source — `SessionDetailView.elicit-transcript.test.tsx`
  (persisted row between two agent lines) and
  `SessionDetailView.elicitation.test.tsx` (live `done` step then live card,
  asserting the card is still answerable). Both were checked to **fail against
  the pre-fix file** and pass with it, so they pin the regression rather than
  the current output.
- `pnpm --filter @agentconnect.md/web test` — 215 files / 2443 tests pass.
- `typecheck`, `eslint`, `prettier` clean.

No daemon, protocol, or control-plane code is touched.

## Not in this PR

The same session surfaced a second, unrelated elicitation bug: a runtime whose
AskUserQuestion bridge marks its custom-answer box with neither
`_meta._askUserQuestionCustomAnswer` nor `_meta.codex.isOtherAnswer` has that
box asked as a question of its own titled "Other". That fix lives in the daemon's
shared elicitation scan and is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
