### PR TITLE
fix(daemon): a custom-answer box is folded into its question however the bridge spells it

### DIFF
--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1106,10 +1106,15 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
   // The unmarked pair, read by name off the questions that OFFER options — the shape only says
   // "box for that question" where the question has choices this box is an alternative to.
   const selects = new Set(found.filter((t) => t.kind === 'enum' || t.kind === 'multi-enum').map((t) => t.propName))
+  const required = new Set(elicitRequiredProps(params))
   const bound = found.map((t) => {
     if (t.customAnswerFor) return questions.has(t.customAnswerFor) ? t : dropCustomAnswerFor(t)
-    // Only where the property claimed no marker namespace of its own.
-    if (t.kind !== 'text' || speaksCustomAnswerMarker(p.requestedSchema?.properties?.[t.propName] ?? {})) return t
+    // Only where the property claimed no marker namespace of its own, and only where it is
+    // OPTIONAL: a companion is an alternative to a pick, so a REQUIRED text property is a
+    // question in its own right whatever it is named, and folding it would place a field the
+    // answer cannot omit behind a chip that discloses it.
+    if (t.kind !== 'text' || required.has(t.propName)) return t
+    if (speaksCustomAnswerMarker(p.requestedSchema?.properties?.[t.propName] ?? {})) return t
     const owner = suffixedCustomAnswerOwner(t.propName, selects)
     return owner ? { ...t, customAnswerFor: owner } : t
   })

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -963,19 +963,59 @@ const CODEX_CUSTOM_ANSWER_META_KEY = 'codex'
 /** The longest question text a card carries under a field's label. */
 const ELICIT_DESCRIPTION_MAX = 300
 
+/** The marker namespaces above, each with the flag that binds a box inside its question. */
+const CUSTOM_ANSWER_MARKERS = [
+  [CUSTOM_ANSWER_META_KEY, 'isCustomAnswer'],
+  [CODEX_CUSTOM_ANSWER_META_KEY, 'isOtherAnswer']
+] as const
+
 /** The question a property's `_meta` claims this free-text box answers, or undefined when it
  *  claims none — an unmarked property is a question in its own right. */
 function customAnswerOwner(prop: Record<string, unknown>): string | undefined {
   const meta = prop._meta as Record<string, unknown> | undefined
-  for (const [key, flag] of [
-    [CUSTOM_ANSWER_META_KEY, 'isCustomAnswer'],
-    [CODEX_CUSTOM_ANSWER_META_KEY, 'isOtherAnswer']
-  ] as const) {
+  for (const [key, flag] of CUSTOM_ANSWER_MARKERS) {
     const marker = meta?.[key] as Record<string, unknown> | undefined
     const owner = marker?.questionId
     if (marker?.[flag] === true && typeof owner === 'string' && owner) return owner
   }
   return undefined
+}
+
+/** Whether a property speaks a marker namespace at all, flag or no flag. A producer that speaks
+ *  one has already said what the box is, so its silence is a statement and not shape to guess at. */
+function speaksCustomAnswerMarker(prop: Record<string, unknown>): boolean {
+  const meta = prop._meta as Record<string, unknown> | undefined
+  return CUSTOM_ANSWER_MARKERS.some(([key]) => !!meta?.[key])
+}
+
+// What a bridge appends to a question's property name when it adds that question's own box:
+// `question_0_custom`, `need_type__other`. Read as the marker of LAST resort, so a bridge that
+// marks nothing (DeepSeek Harness spells the pair by name alone) still folds its box inside the
+// question instead of asking "Other" as a question of its own.
+const CUSTOM_ANSWER_SUFFIXES = ['_custom', '_other', '-custom', '-other'] as const
+
+/** The select question this property name is the free-text box OF, by shape alone: another
+ *  rendered question's name plus a custom-answer suffix, with a doubled separator (`__other`)
+ *  read the same as a single one. Undefined when the name claims no question on this card. */
+function suffixedCustomAnswerOwner(propName: string, questions: Set<string>): string | undefined {
+  const lower = propName.toLowerCase()
+  for (const suffix of CUSTOM_ANSWER_SUFFIXES) {
+    if (!lower.endsWith(suffix)) continue
+    const stem = propName.slice(0, propName.length - suffix.length)
+    for (const owner of [stem, stem.slice(0, -1)]) if (owner && questions.has(owner)) return owner
+  }
+  return undefined
+}
+
+/** A target whose {@link ElicitTarget.defaultValue} still names one of its own options — the
+ *  seed of a control that lost an option must not be a value the control cannot show. */
+function withoutStaleDefault(target: ElicitTarget): ElicitTarget {
+  const values = new Set(target.options.map((o) => o.value))
+  const raw = target.defaultValue
+  const stale = Array.isArray(raw) ? raw.some((v) => !values.has(v)) : typeof raw === 'string' && !values.has(raw)
+  if (!stale) return target
+  const { defaultValue: _dropped, ...rest } = target
+  return rest
 }
 
 /**
@@ -1063,11 +1103,36 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
   // A companion whose question this surface did not render has nothing to sit inside, so it
   // stands as a field of its own rather than pointing at a control that is not on the card.
   const questions = new Set(found.filter((t) => !t.customAnswerFor).map((t) => t.propName))
-  return found.map((t) => {
-    if (!t.customAnswerFor || questions.has(t.customAnswerFor)) return t
-    const { customAnswerFor: _orphan, ...rest } = t
-    return rest
+  // The unmarked pair, read by name off the questions that OFFER options — the shape only says
+  // "box for that question" where the question has choices this box is an alternative to.
+  const selects = new Set(found.filter((t) => t.kind === 'enum' || t.kind === 'multi-enum').map((t) => t.propName))
+  const bound = found.map((t) => {
+    if (t.customAnswerFor) return questions.has(t.customAnswerFor) ? t : dropCustomAnswerFor(t)
+    // Only where the property claimed no marker namespace of its own.
+    if (t.kind !== 'text' || speaksCustomAnswerMarker(p.requestedSchema?.properties?.[t.propName] ?? {})) return t
+    const owner = suffixedCustomAnswerOwner(t.propName, selects)
+    return owner ? { ...t, customAnswerFor: owner } : t
   })
+  // A question whose box the card offers ITSELF must not also offer that box as a choice: a
+  // bridge that appends an "Other" option to the enum means "type below", but picking it answers
+  // the question with a value the agent reads as no answer at all. Matched against the
+  // companion's own label rather than any word, and never down to an empty list of options.
+  const companionLabel = new Map<string, string>()
+  for (const t of bound)
+    if (t.customAnswerFor)
+      companionLabel.set(t.customAnswerFor, elicitFieldLabel(params, t.propName).trim().toLowerCase())
+  return bound.map((t) => {
+    const label = companionLabel.get(t.propName)
+    if (label === undefined || !t.options.length) return t
+    const options = t.options.filter((o) => o.label.trim().toLowerCase() !== label)
+    return options.length && options.length < t.options.length ? withoutStaleDefault({ ...t, options }) : t
+  })
+}
+
+/** The same target with no owning question — a companion that turned out to point at nothing. */
+function dropCustomAnswerFor(target: ElicitTarget): ElicitTarget {
+  const { customAnswerFor: _orphan, ...rest } = target
+  return rest
 }
 
 /** The elicitation's URL-mode target (ACP `ElicitationUrlMode`), or null when this is not a

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -2391,6 +2391,23 @@ describe('elicitation card', () => {
     expect(elicitForm(typedOwner, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
   })
 
+  it("never reads a REQUIRED text property as another question's box", () => {
+    // A companion is an ALTERNATIVE to a pick, so it is optional by construction. A required
+    // property named like one is a question of its own: folded, it would sit behind its
+    // question's disclosure chip while the schema still refuses any answer that omits it.
+    const req0 = req(
+      { question_0: { type: 'string', enum: ['a'] }, question_0_custom: { type: 'string', title: 'Other' } },
+      ['question_0_custom']
+    )
+    expect(elicitForm(req0, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
+    // The question's OWN requiredness says nothing about the box, which still folds.
+    const reqOwner = req(
+      { question_0: { type: 'string', enum: ['a'] }, question_0_custom: { type: 'string', title: 'Other' } },
+      ['question_0']
+    )
+    expect(elicitForm(reqOwner, WEBCHAT_ELICIT_SURFACE)?.[1]?.customAnswerFor).toBe('question_0')
+  })
+
   it('keeps an option that is a real answer, and never empties a question', () => {
     // "Other" here is one of the agent's OWN choices, and the only one: dropping it would leave
     // a question with nothing to pick, so the list stands as offered.

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -2335,6 +2335,87 @@ describe('elicitation card', () => {
     ])
   })
 
+  // A bridge that marks NOTHING is still readable from the schema's shape: DeepSeek Harness
+  // (@openma/deepseek-harness-acp) names the pair `question_0` / `question_0_custom` and adds an
+  // "Other" choice to the enum, with no `_meta` on either. Read as a question of its own, the box
+  // was asked twice per question and the choice answered with a value the harness reads as blank.
+  it('folds an UNMARKED custom-answer box into the question its name belongs to', () => {
+    const asked = req(
+      {
+        question_0: {
+          type: 'string',
+          title: 'GitHub App',
+          oneOf: [
+            { const: 'option_0', title: 'Installed' },
+            { const: 'option_1', title: 'Not installed' },
+            { const: 'custom_0', title: 'Other' }
+          ]
+        },
+        question_0_custom: { type: 'string', title: 'Other', description: 'Type a custom answer.' },
+        question_1: {
+          type: 'array',
+          title: 'Formats',
+          items: { anyOf: [{ const: 'option_0' }, { const: 'custom_1', title: 'Other' }] }
+        },
+        question_1_custom: { type: 'string', title: 'Other', description: 'Type a custom answer.' }
+      },
+      []
+    )
+    const form = elicitForm(asked, WEBCHAT_ELICIT_SURFACE)
+    expect(form?.map((t) => [t.propName, t.customAnswerFor])).toEqual([
+      ['question_0', undefined],
+      ['question_0_custom', 'question_0'],
+      ['question_1', undefined],
+      ['question_1_custom', 'question_1']
+    ])
+    // The enum's own "Other" is that same box under another name — the card offers the box, so
+    // the choice goes, and only the choices the agent actually meant are left.
+    expect(form?.[0]?.options.map((o) => o.value)).toEqual(['option_0', 'option_1'])
+    expect(form?.[2]?.options.map((o) => o.value)).toEqual(['option_0'])
+  })
+
+  it('reads a doubled separator the same way, and only where nothing was marked', () => {
+    const unmarked = req(
+      { need_type: { type: 'string', enum: ['a'] }, need_type__other: { type: 'string', title: 'Other' } },
+      []
+    )
+    expect(elicitForm(unmarked, WEBCHAT_ELICIT_SURFACE)?.map((t) => t.customAnswerFor)).toEqual([
+      undefined,
+      'need_type'
+    ])
+    // A name that matches nothing on the card is a question of its own, as it always was.
+    const stray = req({ pick: { type: 'string', enum: ['a'] }, note_custom: { type: 'string' } }, [])
+    expect(elicitForm(stray, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
+    // And a box named for a question that offers NO choices is not an alternative to anything.
+    const typedOwner = req({ name: { type: 'string' }, name_custom: { type: 'string' } }, [])
+    expect(elicitForm(typedOwner, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
+  })
+
+  it('keeps an option that is a real answer, and never empties a question', () => {
+    // "Other" here is one of the agent's OWN choices, and the only one: dropping it would leave
+    // a question with nothing to pick, so the list stands as offered.
+    const only = req(
+      { q: { type: 'string', oneOf: [{ const: 'x', title: 'Other' }] }, q_custom: { type: 'string', title: 'Other' } },
+      []
+    )
+    expect(elicitForm(only, WEBCHAT_ELICIT_SURFACE)?.[0]?.options.map((o) => o.value)).toEqual(['x'])
+  })
+
+  it('drops a default the deduped option list no longer offers', () => {
+    const seeded = req(
+      {
+        q: {
+          type: 'string',
+          default: 'custom_0',
+          oneOf: [{ const: 'option_0' }, { const: 'custom_0', title: 'Other' }]
+        },
+        q_custom: { type: 'string', title: 'Other' }
+      },
+      []
+    )
+    expect(elicitForm(seeded, WEBCHAT_ELICIT_SURFACE)?.[0]?.defaultValue).toBeUndefined()
+  })
+
   it('ignores a codex marker that claims no question', () => {
     // `isOtherAnswer` absent (or false) makes the box a question of its own, exactly as an
     // unmarked property is — the flag, not the namespace, is what binds it.
@@ -2358,6 +2439,27 @@ describe('elicitation card', () => {
     // A marker on something that is not a typed box claims nothing.
     const notText = req({ a: { type: 'string', enum: ['x'] }, b: { ...custom('a'), type: 'boolean' } }, [])
     expect(elicitForm(notText, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
+  })
+
+  it('counts an UNMARKED pair as one question against the cap too', () => {
+    // The cap counts QUESTIONS. Before the pair was read by name an unmarked bridge's boxes each
+    // counted as one, so a 6-question ask (12 properties) blew a 10-question cap and the whole
+    // card was DECLINED — the reader got "couldn't be answered here" rather than a long form.
+    const unmarked = (n: number) =>
+      Object.fromEntries(
+        Array.from({ length: n }, (_, i) => [
+          [`question_${i}`, { type: 'string', title: `Q${i}`, oneOf: [{ const: 'option_0', title: 'a' }] }],
+          [`question_${i}_custom`, { type: 'string', title: 'Other', description: 'Type a custom answer.' }]
+        ]).flat() as [string, unknown][]
+      )
+    const six = elicitForm(req(unmarked(6), []), WEBCHAT_ELICIT_SURFACE)
+    expect(six).toHaveLength(12)
+    expect(six?.filter((t) => !t.customAnswerFor)).toHaveLength(6)
+    // At the cap it still renders; one question past it the card declines, as it should.
+    expect(elicitForm(req(unmarked(ELICIT_FORM_FIELD_CAP), []), WEBCHAT_ELICIT_SURFACE)).toHaveLength(
+      ELICIT_FORM_FIELD_CAP * 2
+    )
+    expect(elicitForm(req(unmarked(ELICIT_FORM_FIELD_CAP + 1), []), WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   it('counts questions, not their custom-answer boxes, against the form cap', () => {

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -159,9 +159,10 @@ export const ElicitField = z.object({
   description: z.string().max(300).optional(),
   /** Set on a select question's free-text companion: the property whose question this box types
    *  an answer for. The card renders it INSIDE that question rather than as a question of its
-   *  own, and never numbers or counts it. Which `_meta` marker said so (ACP
-   *  `_askUserQuestionCustomAnswer`, or Codex's `_meta.codex.isOtherAnswer`) is the daemon's to
-   *  read: the raw schema never crosses this wire, so a reader has only this field. */
+   *  own, and never numbers or counts it. What said so — an ACP `_askUserQuestionCustomAnswer`
+   *  marker, Codex's `_meta.codex.isOtherAnswer`, or, for a bridge that marks nothing, the pair's
+   *  own property names — is the daemon's to read: the raw schema never crosses this wire, so a
+   *  reader has only this field. */
   customAnswerFor: z.string().min(1).max(200).optional(),
   options: ElicitOptions,
   multi: ElicitMulti.optional(),

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -232,6 +232,19 @@ describe('foldCustomAnswers', () => {
     expect(foldCustomAnswers(bound)[1]?.customAnswerFor).toBe('a')
   })
 
+  it('never folds a REQUIRED field, which the daemon may have kept standalone on purpose', () => {
+    // An absent `customAnswerFor` can also be the daemon's deliberate refusal — a property with
+    // a known `_meta` namespace whose binding flag is off. Folded, a REQUIRED one hides behind
+    // its question's chip and the card enables Submit for an answer the daemon then rejects,
+    // because nothing on this side reports the omission. A companion is optional by
+    // construction, so requiredness is the signal that this is a question of its own.
+    const standalone = [q('a', 'enum', ['x']), { ...box('a__other'), required: true }]
+    expect(foldCustomAnswers(standalone).every((f) => f.customAnswerFor === undefined)).toBe(true)
+    // The QUESTION being required says nothing about the box, which still folds.
+    const requiredOwner = [{ ...q('a', 'enum', ['x']), required: true }, box('a_custom')]
+    expect(foldCustomAnswers(requiredOwner)[1]?.customAnswerFor).toBe('a')
+  })
+
   it('never empties a question, and drops a default its options no longer offer', () => {
     // "Other" as the ONLY choice is a real answer: dropping it would leave nothing to pick.
     const only = foldCustomAnswers([q('q', 'enum', ['Other']), box('q_custom')])

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  foldCustomAnswers,
   PLAN_LANE,
   WORK_LANES,
   planEntries,
@@ -191,5 +192,51 @@ describe('PLAN_LANE', () => {
   it('is not a work lane, and does not collide with the playground live PLAN lane', () => {
     expect(WORK_LANES.has(PLAN_LANE)).toBe(false)
     expect(PLAN_LANE).not.toBe('PLAN')
+  })
+})
+
+describe('foldCustomAnswers', () => {
+  // The shape a bridge that marks NOTHING sends: the pair named by convention alone, plus an
+  // "Other" CHOICE on the enum whose only meaning is "type below".
+  const q = (propName: string, kind: 'enum' | 'multi-enum', labels: string[]) => ({
+    propName,
+    label: propName,
+    kind,
+    options: labels.map((label) => ({ value: label, label }))
+  })
+  const box = (propName: string) => ({ propName, label: 'Other', kind: 'text' as const, options: [] })
+
+  it('folds a box named for its question, and drops the choice that duplicates it', () => {
+    const folded = foldCustomAnswers([q('question_0', 'enum', ['Installed', 'Other']), box('question_0_custom')])
+    expect(folded.map((f) => f.customAnswerFor)).toEqual([undefined, 'question_0'])
+    expect(folded[0]?.options.map((o) => o.label)).toEqual(['Installed'])
+  })
+
+  it('reads a doubled separator, a hyphen, and a multi-select the same way', () => {
+    for (const name of ['need_type__other', 'need_type-custom', 'need_type_other']) {
+      expect(foldCustomAnswers([q('need_type', 'enum', ['a']), box(name)])[1]?.customAnswerFor).toBe('need_type')
+    }
+    const multi = foldCustomAnswers([q('formats', 'multi-enum', ['brief', 'Other']), box('formats_custom')])
+    expect(multi[1]?.customAnswerFor).toBe('formats')
+    expect(multi[0]?.options.map((o) => o.label)).toEqual(['brief'])
+  })
+
+  it('leaves alone what it cannot claim', () => {
+    // A name matching no question on the card is a question of its own, as it always was.
+    expect(foldCustomAnswers([q('pick', 'enum', ['a']), box('note_custom')])[1]?.customAnswerFor).toBeUndefined()
+    // A box named for a question that offers NO choices is not an alternative to anything.
+    const typedOwner = [{ propName: 'name', label: 'Name', kind: 'text' as const, options: [] }, box('name_custom')]
+    expect(foldCustomAnswers(typedOwner).every((f) => f.customAnswerFor === undefined)).toBe(true)
+    // And a binding the daemon already made passes through untouched.
+    const bound = [q('a', 'enum', ['x']), { ...box('a_custom'), customAnswerFor: 'a' }]
+    expect(foldCustomAnswers(bound)[1]?.customAnswerFor).toBe('a')
+  })
+
+  it('never empties a question, and drops a default its options no longer offer', () => {
+    // "Other" as the ONLY choice is a real answer: dropping it would leave nothing to pick.
+    const only = foldCustomAnswers([q('q', 'enum', ['Other']), box('q_custom')])
+    expect(only[0]?.options.map((o) => o.label)).toEqual(['Other'])
+    const seeded = foldCustomAnswers([{ ...q('q', 'enum', ['keep', 'Other']), defaultValue: 'Other' }, box('q_custom')])
+    expect(seeded[0]?.defaultValue).toBeUndefined()
   })
 })

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -118,13 +118,18 @@ function withoutStaleDefault(field: ElicitFieldSpec): ElicitFieldSpec {
  * itself that choice goes. Matched on the companion's own label rather than any word, and never
  * down to an empty option list.
  *
- * Only fields the daemon left unbound are read this way, so a newer daemon that already folded
- * them passes through untouched. Pure.
+ * Only OPTIONAL fields the daemon left unbound are read this way, so a newer daemon that already
+ * folded them passes through untouched, and a field the daemon deliberately kept standalone and
+ * REQUIRED is never folded out of sight. Pure.
  */
 export function foldCustomAnswers(fields: ElicitFieldSpec[]): ElicitFieldSpec[] {
   const selects = new Set(fields.filter((f) => f.kind === 'enum' || f.kind === 'multi-enum').map((f) => f.propName))
   const bound = fields.map((f) => {
-    if (f.customAnswerFor || f.kind !== 'text') return f
+    // A REQUIRED field is never a box read this way: a companion is an optional alternative to
+    // a pick, so a required one is a question in its own right whatever it is named. Folding it
+    // would hide it behind its question's chip, where nothing can report that the answer the
+    // card is about to send leaves a required field out.
+    if (f.customAnswerFor || f.kind !== 'text' || f.required) return f
     const owner = suffixedCustomAnswerOwner(f.propName, selects)
     return owner ? { ...f, customAnswerFor: owner } : f
   })

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -1,5 +1,5 @@
 import type { PlanBody } from '@/lib/api'
-import type { ElicitBody } from '@/lib/data'
+import type { ElicitBody, ElicitFieldSpec } from '@/lib/data'
 
 // 2b chat style: an agent turn shows its spoken answer (MSG/DONE lanes) as plain
 // text and collapses its "work" — reasoning (THINK/PLAN), tool calls (TOOL), and
@@ -75,6 +75,69 @@ export function elicitCard(body: string | undefined): ElicitBody | null {
 /** One elicitation card's identity across the two places it can be rendered from: the agent that
  *  owns the request, and the request itself. A uuid request id could stand alone, but identity
  *  here is (owner, request) and saying so keeps a future non-unique id from silently colliding. */
+// What a bridge appends to a question's property name when it adds that question's own
+// free-text box: `question_0_custom`, `need_type__other`. The daemon binds a box to its
+// question from the elicitation schema's `_meta` marker, which never crosses this wire — so
+// where that binding arrives unset, the pair's NAMES are all this side has to read it from.
+const CUSTOM_ANSWER_SUFFIXES = ['_custom', '_other', '-custom', '-other']
+
+/** The select question a field name is the free-text box OF: another field's name plus one of
+ *  the suffixes above, with a doubled separator (`need_type__other`) read like a single one.
+ *  Undefined when the name claims no question that offers choices. */
+function suffixedCustomAnswerOwner(propName: string, selects: Set<string>): string | undefined {
+  const lower = propName.toLowerCase()
+  for (const suffix of CUSTOM_ANSWER_SUFFIXES) {
+    if (!lower.endsWith(suffix)) continue
+    const stem = propName.slice(0, propName.length - suffix.length)
+    for (const owner of [stem, stem.slice(0, -1)]) if (owner && selects.has(owner)) return owner
+  }
+  return undefined
+}
+
+/** A field whose `defaultValue` still names one of its own options — the seed of a control
+ *  that just lost an option must not be a value that control can no longer show. */
+function withoutStaleDefault(field: ElicitFieldSpec): ElicitFieldSpec {
+  const values = new Set(field.options.map((o) => o.value))
+  const raw = field.defaultValue
+  const stale = Array.isArray(raw) ? raw.some((v) => !values.has(v)) : typeof raw === 'string' && !values.has(raw)
+  if (!stale) return field
+  const { defaultValue: _dropped, ...rest } = field
+  return rest
+}
+
+/**
+ * A form card's fields with every UNBOUND custom-answer box folded into the question it
+ * belongs to, read from the pair's names.
+ *
+ * An AskUserQuestion bridge gives each select question its own free-text box, and says so with
+ * a `_meta` marker the daemon turns into `customAnswerFor`. A bridge that marks nothing leaves
+ * it unset, and the box then reads as a question of its own titled "Other" — asked once per
+ * real question, numbered and counted among them. Such a bridge also tends to append an
+ * "Other" CHOICE to the enum whose only meaning is "type below": picking it answers the
+ * question with a value the agent reads as no answer at all, so where the card offers the box
+ * itself that choice goes. Matched on the companion's own label rather than any word, and never
+ * down to an empty option list.
+ *
+ * Only fields the daemon left unbound are read this way, so a newer daemon that already folded
+ * them passes through untouched. Pure.
+ */
+export function foldCustomAnswers(fields: ElicitFieldSpec[]): ElicitFieldSpec[] {
+  const selects = new Set(fields.filter((f) => f.kind === 'enum' || f.kind === 'multi-enum').map((f) => f.propName))
+  const bound = fields.map((f) => {
+    if (f.customAnswerFor || f.kind !== 'text') return f
+    const owner = suffixedCustomAnswerOwner(f.propName, selects)
+    return owner ? { ...f, customAnswerFor: owner } : f
+  })
+  const companionLabel = new Map<string, string>()
+  for (const f of bound) if (f.customAnswerFor) companionLabel.set(f.customAnswerFor, f.label.trim().toLowerCase())
+  return bound.map((f) => {
+    const label = companionLabel.get(f.propName)
+    if (label === undefined || !f.options.length) return f
+    const options = f.options.filter((o) => o.label.trim().toLowerCase() !== label)
+    return options.length && options.length < f.options.length ? withoutStaleDefault({ ...f, options }) : f
+  })
+}
+
 export function elicitStepKey(agentId: string | undefined, requestId: string): string {
   return `${agentId ?? ''}\u0000${requestId}`
 }

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -568,6 +568,90 @@ describe('the agent’s elicitation card on the session page', () => {
     ])
   })
 
+  it('folds a box a bridge marked with nothing, off the pair’s names alone', async () => {
+    // The wire shape a bridge that sets no `_meta` marker sends — the DeepSeek Harness one, and
+    // what an older daemon that read no marker forwards: `customAnswerFor` unset on the box, and
+    // an "Other" CHOICE on the enum whose only meaning is "type below". Unfolded, the box was a
+    // question of its own titled "Other", asked once per real question, and picking that choice
+    // answered with a value the agent reads as blank.
+    const other = { value: 'custom_0', label: 'Other' }
+    live.steps = [
+      {
+        ...CARD,
+        text: 'The agent needs your input.',
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            {
+              propName: 'question_0',
+              label: 'GitHub App',
+              kind: 'enum',
+              options: [{ value: 'option_0', label: 'Installed' }, other]
+            },
+            {
+              propName: 'question_0_custom',
+              label: 'Other',
+              description: 'Type a custom answer.',
+              kind: 'text',
+              options: []
+            },
+            {
+              propName: 'question_1',
+              label: 'Runtime',
+              kind: 'enum',
+              options: [
+                { value: 'option_0', label: 'Claude' },
+                { ...other, value: 'custom_1' }
+              ]
+            },
+            {
+              propName: 'question_1_custom',
+              label: 'Other',
+              description: 'Type a custom answer.',
+              kind: 'text',
+              options: []
+            }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    // Two questions, 01 and 02 — not four, and no row titled "Other".
+    const numbers = [...(container?.querySelectorAll('span.font-mono') ?? [])]
+      .map((n) => n.textContent ?? '')
+      .filter((t) => /^\d\d$/.test(t))
+    expect(numbers).toEqual(['01', '02'])
+    expect(text()).toContain('0/2 answered')
+    expect(text()).not.toContain('Type a custom answer.')
+    // The duplicate CHOICE is gone; the box is offered as the card's own disclosure instead.
+    expect(buttonsNamed('Other')).toHaveLength(0)
+    expect(buttonsNamed('Other…')).toHaveLength(2)
+    expect(buttonNamed('Installed')?.disabled).toBe(false)
+
+    // And the box answers its question: typed, it counts, and it submits under its own property.
+    await openOther()
+    await typeInto(inputNamed('GitHub App — Other')!, 'installed org-wide')
+    expect(text()).toContain('1/2')
+    await act(async () => {
+      buttonNamed('Claude')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(text()).toContain('2/2')
+    await act(async () => {
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([
+      [
+        'session-1',
+        'agent-1',
+        'elicit-1',
+        { question_0_custom: 'installed org-wide', question_1: 'option_0' },
+        'conv-1'
+      ]
+    ])
+  })
+
   it('closes a question’s box back up, and answers with the options rather than a hidden draft', async () => {
     live.steps = [
       {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -104,6 +104,7 @@ import {
   elicitCard,
   ELICIT_LANE,
   elicitStepKey,
+  foldCustomAnswers,
   liveElicitKeys,
   NOTICE_LANE,
   PLAN_LANE,
@@ -1038,16 +1039,19 @@ const ELICIT_ACTIONS = 'flex flex-wrap items-center gap-[8px] border-t border-(-
  *  Without `onAnswer` — a reader with no live socket to answer over — the same card renders
  *  as a plain record of the ask, controls inert rather than missing. */
 function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value: ElicitAnswerValue) => void }) {
+  // A custom-answer box the daemon could not bind — a bridge that marks the pair with no
+  // `_meta`, or an older daemon that read no marker — is folded into its question HERE, off
+  // the pair's names, so the box is never asked as a question of its own titled "Other".
+  const fields = step.elicit?.fields?.length ? foldCustomAnswers(step.elicit.fields) : undefined
   const [picked, setPicked] = useState<string[]>(() => pickedDefaults(step.elicit))
   const [draft, setDraft] = useState<string>(() => typedDraft(step.elicit))
-  const [drafts, setDrafts] = useState<Record<string, string>>(() => formDrafts(step.elicit?.fields))
-  const [picks, setPicks] = useState<Record<string, string[]>>(() => formPicks(step.elicit?.fields))
-  const [others, setOthers] = useState<Record<string, boolean>>(() => formOthers(step.elicit?.fields))
+  const [drafts, setDrafts] = useState<Record<string, string>>(() => formDrafts(fields))
+  const [picks, setPicks] = useState<Record<string, string[]>>(() => formPicks(fields))
+  const [others, setOthers] = useState<Record<string, boolean>>(() => formOthers(fields))
   const elicit = step.elicit
   const multi = elicit?.multi
   const consentUrl = elicit?.url
   const consent = consentUrl ? readConsentUrl(consentUrl) : null
-  const fields = elicit?.fields?.length ? elicit.fields : undefined
   // The card's QUESTIONS: a select question's free-text companion is part of the question it
   // names, not one of its own, so it is never numbered, counted, or asked twice.
   const rows = fields?.filter((f) => !f.customAnswerFor)


### PR DESCRIPTION
## What

A select question's free-text "Other" box is folded into the question it belongs
to whatever the ACP bridge calls it — and if the bridge marks it not at all.

The shared elicitation scan bound that box to its question from one of exactly
two `_meta` markers: ACP's `_askUserQuestionCustomAnswer` and Codex's
`_meta.codex.isOtherAnswer`. A bridge that speaks neither had its box read as a
question in its own right — titled "Other", numbered and counted among the real
questions, once per question. Reading a third marker only moves the problem to
the fourth bridge, so the pair is now read from the **shape** of the schema: a
bare text property named for another *select* property plus a `_custom` /
`_other` suffix (a doubled separator read like a single one) is that question's
box. A property that *does* speak a marker namespace is still bound only by its
flag, so a producer that speaks the protocol and deliberately left the flag off
keeps its current meaning.

Two consequences fall out of the same bug:

- **The cap counted the box as a question.** `ELICIT_FORM_FIELD_CAP` is 10
  questions, and an unmarked pair counted as two — so a 6-question ask arrived
  as 12 properties, blew the cap, and the card was **declined outright**. The
  reader got "couldn't be answered here" instead of a form. Measured before and
  after; now pinned by a test.
- **The duplicate choice.** Such a bridge also appends an `Other` *option* to
  the enum whose only meaning is "type below" — picking it answers the question
  with a value the agent reads as no answer at all. Where the card offers the
  box itself, that option is dropped: matched on the companion's own label
  rather than any hardcoded word, never down to an empty option list, and a
  `default` naming a dropped option goes with it.

Fixed in the one scan behind every surface, so the web console, Slack,
Telegram, the CLI, and the persisted card record all agree.

## Why the second commit

The daemon resolves this from the raw `requestedSchema`, which never crosses the
wire — but `propName`, `label`, `kind` and `options` do, so the console can read
the same shape one layer later. That is not redundant: daemons are deployed and
upgraded independently of the console, so the web fold is what fixes the card
for a session served by a daemon nobody has upgraded yet. Only fields that
arrive *unbound* are read this way, so a daemon that already folded them passes
through untouched and the two compose rather than fight.

## Verification

- `packages/daemon/test/render.test.ts` — 5 new cases: the unmarked pair,
  separator variants, a box whose question offers no choices (claims nothing),
  a real `Other` answer that must survive, a stale default, and the cap
  (6 questions → 12 fields / 6 questions, at the cap renders, one past declines).
- `packages/web/src/components/console/session-work.test.ts` — 4 cases on the
  pure helper.
- `SessionDetailView.elicitation.test.tsx` — the wire shape end to end: 4 fields
  render as 2 questions numbered 01/02, no row titled "Other", the duplicate
  chip replaced by the card's own disclosure, and the typed box submitting under
  its own property. Checked to fail without the fold.
- daemon `render` / `slack-elicit-form` / `telegram-elicit-card`: 250 pass.
  Full web suite 215 files / 2454 tests. `typecheck`, `eslint`, `prettier` clean.

Follow-up, not required by this PR: the bridge in question would ideally emit
`_meta._askUserQuestionCustomAnswer` and drop its synthetic enum choice. The
shape read makes us correct without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
