### PR TITLE
feat(daemon): steer a mid-turn message into the running turn over ACP _session/steering

### DIFF
--- a/docs/designs/turn-final-context-refresh.md
+++ b/docs/designs/turn-final-context-refresh.md
@@ -336,6 +336,17 @@ A message addressed to another agent is not in this agent's queue. It remains a 
 activation for that other agent while also serving as thread context that can
 invalidate this agent's candidate.
 
+**Steering precedes queueing (#1847).** When the same-agent arrival reaches the gate while
+`session/prompt` is awaiting a runtime that advertised `_meta.steering.supported`, the
+daemon first offers it to the live turn over `_session/steering` with
+`idleBehavior: promptRequired`. An `injected` outcome settles the entry exactly like a
+coalesced one (`steered_into_turn`), and its transcript `ts` is recorded as absorbed and
+claimed at steer time, so neither the start fence nor the final refresh presents that row
+again and a late admission cannot coalesce it twice. `failed`, an RPC error, a spent
+per-turn budget (`MAX_STEERS_PER_TURN`), or a runtime without the capability falls through
+to the queue path described above; `!queue`, hook, scheduler, and agent-to-agent entries
+never steer.
+
 ## 6. Proposed Interfaces and State
 
 The names below are illustrative; the separation of responsibilities is normative.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -215,9 +215,11 @@ no second answer, and the message is never re-asked once the turn ends.
 
 The visible acknowledgement follows the delivery, not the queue. A surface that
 would have said "queued behind the current task" says the message was added to the
-running task instead; a console conversation sees the follow-up settle into the
-turn that is already streaming. The running turn's own status and reactions are
-unchanged.
+running task instead. In the console, a message typed while a steerable turn
+streams leaves the composer at once, appears in the conversation marked as steered
+into the running reply, and the reply that follows it continues below it; only when
+the runtime cannot take it does the message wait in the composer's queue, where it
+can still be cancelled. The running turn's own status and reactions are unchanged.
 
 Steering is for ordinary human messages on chat platforms and the console. The
 explicit `!queue` command still parks its text until the agent is idle; scheduled

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -204,6 +204,30 @@ nothing and the turn is unaffected, and origins with no inbound message to point
 at — a schedule, another agent's wake, a session opened in the console — do not
 acknowledge anything.
 
+## A message sent during a running turn steers that turn
+
+Someone who writes to an agent while it is still working is usually correcting or
+adding to the work in progress, not opening a second request. When the agent's
+runtime supports mid-turn steering (both managed runtimes, Claude and Codex, do),
+the message is delivered into the running turn: the agent reads it as it works,
+and the answer it is already streaming continues in place. There is no second turn,
+no second answer, and the message is never re-asked once the turn ends.
+
+The visible acknowledgement follows the delivery, not the queue. A surface that
+would have said "queued behind the current task" says the message was added to the
+running task instead; a console conversation sees the follow-up settle into the
+turn that is already streaming. The running turn's own status and reactions are
+unchanged.
+
+Steering is for ordinary human messages on chat platforms and the console. The
+explicit `!queue` command still parks its text until the agent is idle; scheduled
+wakes, code-host events, and agent-to-agent calls always run as their own turns.
+When the runtime cannot steer — it lacks the capability, it declined because the
+turn was ending as the message arrived, the per-turn steering budget is spent, or
+the operator turned the `sessionSteering` feature off — the message waits behind
+the turn exactly as before. `!cancel` remains the way to abandon the work in
+progress rather than redirect it.
+
 ## Slack message attribution footer
 
 The attribution footer for an agent response must be attached to the final Slack

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -42,6 +42,8 @@ import {
 import type { HostKey } from './host-key.js'
 import type { Logger } from '../log.js'
 import { accountAppIsolation } from './account-apps.js'
+import { STEERING_METHOD, parseSteeringOutcome, steeringRequestParams, steeringSupported } from './steering.js'
+import type { SteeringIdleBehavior, SteeringOutcome } from './steering.js'
 
 // The raw session config-option shapes (from the ACP SDK), re-exported so
 // sessionConfigOptions() consumers can type the option tree without importing
@@ -158,6 +160,7 @@ export interface SessionConfigPrefs {
 // The launch shape lives with the driver that consumes it; re-exported here because
 // this module is where callers have always imported it from.
 export type { AcpSandboxLaunch, SpawnDriver, SpawnedRuntime } from './spawn-driver.js'
+export type { SteeringIdleBehavior, SteeringOutcome } from './steering.js'
 
 /** The `session/set_config_option` call that applies a desired value, or the reason none is needed. */
 export type ConfigSelectionPlan = { configId: string; value: string } | { skip: string }
@@ -509,6 +512,8 @@ export class AcpHost {
   // This is capability-gated because older ACP adapters reject the field.
   private canUseAdditionalDirectories = false
   private canDelete = false
+  // whether the agent advertised mid-turn steering (`_meta.steering.supported`) at initialize.
+  private canSteer = false
   // prompt content-block variants the agent opted into at initialize. text +
   // resource_link are always baseline; image/audio/embeddedContext are gated.
   private promptCaps: { image?: boolean; audio?: boolean; embeddedContext?: boolean } = {}
@@ -824,6 +829,7 @@ export class AcpHost {
     this.canUseAdditionalDirectories = init.agentCapabilities?.sessionCapabilities?.additionalDirectories != null
     this.canDelete = init.agentCapabilities?.sessionCapabilities?.delete != null
     this.promptCaps = init.agentCapabilities?.promptCapabilities ?? {}
+    this.canSteer = steeringSupported(init._meta)
     const mcp = init.agentCapabilities?.mcpCapabilities
     this.mcpCaps = {
       http: mcp?.http ?? false,
@@ -838,7 +844,7 @@ export class AcpHost {
         }
       : undefined
     this.opts.log?.debug(
-      `acp: agent initialized (${this.agentInfo?.name ?? 'agent'}${this.agentInfo?.version ? ` v${this.agentInfo.version}` : ''}, loadSession=${this.canLoad}, additionalDirectories=${this.canUseAdditionalDirectories}, prompt caps: image=${!!this.promptCaps.image} audio=${!!this.promptCaps.audio} embeddedContext=${!!this.promptCaps.embeddedContext}, mcp: http=${this.mcpCaps.http} sse=${this.mcpCaps.sse})`
+      `acp: agent initialized (${this.agentInfo?.name ?? 'agent'}${this.agentInfo?.version ? ` v${this.agentInfo.version}` : ''}, loadSession=${this.canLoad}, additionalDirectories=${this.canUseAdditionalDirectories}, steering=${this.canSteer}, prompt caps: image=${!!this.promptCaps.image} audio=${!!this.promptCaps.audio} embeddedContext=${!!this.promptCaps.embeddedContext}, mcp: http=${this.mcpCaps.http} sse=${this.mcpCaps.sse})`
     )
   }
 
@@ -1192,6 +1198,29 @@ export class AcpHost {
 
   async cancel(sessionId: string): Promise<void> {
     await this.conn!.agent.notify(methods.agent.session.cancel, { sessionId })
+  }
+
+  /** Whether the runtime accepts `_session/steering` — read once from `initialize`. */
+  steeringSupported(): boolean {
+    return this.canSteer
+  }
+
+  /** Inject `blocks` into a session's RUNNING turn over `_session/steering`. `failed` when the
+   *  runtime never advertised steering or the session is not live here, otherwise the runtime's
+   *  own outcome; a transport error propagates so the caller can fall back to queueing. */
+  async steer(
+    sessionId: string,
+    blocks: ContentBlock[],
+    opts: { idleBehavior?: SteeringIdleBehavior } = {}
+  ): Promise<SteeringOutcome> {
+    if (!this.canSteer || !this.live.has(sessionId)) return 'failed'
+    const res = await this.conn!.agent.request<unknown>(
+      STEERING_METHOD,
+      steeringRequestParams(sessionId, blocks, opts.idleBehavior)
+    )
+    const outcome = parseSteeringOutcome(res)
+    this.opts.log?.debug(`acp: steer into ${sessionId} → ${outcome}`)
+    return outcome
   }
 
   /** Delete persisted adapter state when supported, then release local ownership. */

--- a/packages/daemon/src/acp/probe-client.ts
+++ b/packages/daemon/src/acp/probe-client.ts
@@ -20,6 +20,7 @@ export interface AcpProbeClient {
   acpProtocolVersion(): number | undefined
   acpAgentInfo?(): { name: string; title?: string; version?: string } | undefined
   mcpCapabilities?(): McpTransportCapabilities | null
+  steeringSupported?(): boolean
   stop(deadlineMs?: number): Promise<void>
 }
 

--- a/packages/daemon/src/acp/steering.ts
+++ b/packages/daemon/src/acp/steering.ts
@@ -1,0 +1,42 @@
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+
+// Mid-turn steering over the `_session/steering` ACP extension shipped by codex-acp (#309) and
+// claude-agent-acp. Upstream is standardising the same behaviour as `session/inject`; when that
+// lands, this module and AcpHost.steer() are the only places that change.
+export const STEERING_METHOD = '_session/steering'
+
+/** The runtime's verdict: `injected` into the running turn, `startedNewTurn` because the session
+ *  was idle, or `failed` — anything else the wire carries is read as `failed`. */
+export type SteeringOutcome = 'injected' | 'startedNewTurn' | 'failed'
+
+/** `promptRequired` makes an idle session reject the steer instead of opening a turn the daemon
+ *  never admitted; `startNewTurn` is the runtimes' own default. */
+export type SteeringIdleBehavior = 'promptRequired' | 'startNewTurn'
+
+/** Whether an `initialize` response advertised steering (`_meta.steering.supported === true`). */
+export function steeringSupported(initMeta: unknown): boolean {
+  if (typeof initMeta !== 'object' || initMeta === null) return false
+  const steering = (initMeta as { steering?: unknown }).steering
+  if (typeof steering !== 'object' || steering === null) return false
+  return (steering as { supported?: unknown }).supported === true
+}
+
+/** The `_session/steering` request body for one steer. */
+export function steeringRequestParams(
+  sessionId: string,
+  prompt: ContentBlock[],
+  idleBehavior?: SteeringIdleBehavior
+): Record<string, unknown> {
+  return {
+    sessionId,
+    prompt,
+    ...(idleBehavior ? { _meta: { steering: { idleBehavior } } } : {})
+  }
+}
+
+/** Read the runtime's `outcome`; an absent or unknown value is a failed steer. */
+export function parseSteeringOutcome(response: unknown): SteeringOutcome {
+  if (typeof response !== 'object' || response === null) return 'failed'
+  const outcome = (response as { outcome?: unknown }).outcome
+  return outcome === 'injected' || outcome === 'startedNewTurn' ? outcome : 'failed'
+}

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -227,9 +227,11 @@ export const ConfigSchema = z.object({
    * never negotiated through the control plane or placed on the message hot path. */
   features: z
     .object({
-      turnFinalContextRefresh: z.boolean().default(true)
+      turnFinalContextRefresh: z.boolean().default(true),
+      // Steer a message into the live turn over `_session/steering` instead of queueing it.
+      sessionSteering: z.boolean().default(true)
     })
-    .default({ turnFinalContextRefresh: true }),
+    .default({ turnFinalContextRefresh: true, sessionSteering: true }),
   sessions: z
     .object({
       // Local-DB retention for FINISHED sessions (issue #485): a session untouched

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8477,14 +8477,16 @@ export class Daemon {
           msg.remoteMcp,
           op.mentions,
           op.post,
-          op.worktree
+          op.worktree,
+          op.steer
         )
         return {
           msgId: msg.msgId,
           accepted: ack.accepted,
           turnId: ack.turnId,
           ...(ack.reason ? { reason: ack.reason } : {}),
-          ...(ack.detail ? { detail: ack.detail } : {})
+          ...(ack.detail ? { detail: ack.detail } : {}),
+          ...(ack.steered ? { steered: true } : {})
         }
       }
       case 'context': {
@@ -10191,6 +10193,9 @@ export class Daemon {
     callMeta?: CallMeta,
     opts?: {
       isQueueCmd?: boolean
+      /** Steer into the live turn or refuse `busy` — never queue. For a caller that keeps its own
+       *  queue (the console composer) and must learn the verdict from the admission ACK. */
+      steerOnly?: boolean
       /** Recovery of a row whose loop-guard admission was already counted. */
       replay?: boolean
       /** A startup replay may wait for an interrupt safety drain instead of being dropped. */
@@ -10508,6 +10513,14 @@ export class Daemon {
             // queue below is the fallback for everything the runtime or the policy declines.
             if (await this.steerIntoLiveTurn(key, entry)) {
               await settleAdmission({ accepted: true, steered: true })
+              return
+            }
+            // A steer-only delivery is refused rather than parked: its caller still holds the
+            // message and re-sends it when the turn ends. The durable row must not outlive it.
+            if (opts?.steerOnly) {
+              await this.removeInbox(entry).catch(() => undefined)
+              await settleAdmission({ accepted: false, reason: 'busy' })
+              resolve(null)
               return
             }
             // Place the entry BEFORE the revision plan's interrupts: those await, and a gate that
@@ -13657,6 +13670,10 @@ export class Daemon {
           }
         : {}),
       ...(allowRuntimeChangesInChat && fast ? { fastModeAvailable: true } : {}),
+      // Steerable while this host owns the live session and advertised `_session/steering`.
+      ...(this.cfg.features.sessionSteering && modelSessionIsLive && host?.steeringSupported?.() === true
+        ? { steerable: true }
+        : {}),
       // The console deep-links from this, so it is the session's outward id (§1.1), not the hop's.
       ...(outwardSessionId ? { sessionId: outwardSessionId } : {})
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -68,6 +68,12 @@ import {
   type ThreadContextSnapshot
 } from './session/thread-context.js'
 import { defaultTurnOutputMetrics } from './session/turn-output-metrics.js'
+import {
+  selectSteerTarget,
+  steerEligibleEntry,
+  steerPromptBlocks,
+  steeredTranscriptText
+} from './daemon/steering-admission.js'
 import { recallQueryFromBlocks } from './memory/recall.js'
 import { maskableSecrets, maskSecretsDeep } from './session/secret-mask.js'
 import { monotonicTs } from './store/monotonic-ts.js'
@@ -7404,7 +7410,7 @@ export class Daemon {
       ...(ingress?.receiptId ? { receiptId: ingress.receiptId(normalized) } : {}),
       onAdmission: async (result) => {
         trace.stage = 'admitted'
-        if (result.accepted && !result.duplicate) await onAdmitted(msg, normalized, busy)
+        if (result.accepted && !result.duplicate) await onAdmitted(msg, normalized, busy, result.steered === true)
         // A durability refusal is the ONE outcome the provider must send again: nothing was
         // recorded, so nothing will replay it either. Every other non-acceptance is a
         // deliberate local gate — paused, draining, loop protection — whose delivery is
@@ -7448,7 +7454,7 @@ export class Daemon {
       ): Promise<'dispatch' | 'settled' | 'refused'>
       /** Run once, INSIDE dispatch's durable admission fence, the first time this delivery is
        *  admitted. Rejecting refuses the delivery — nothing runs that could not be recorded. */
-      onAdmitted?(msg: RdMsgIm, normalized: NormalizedMessage, busy: boolean): Promise<void>
+      onAdmitted?(msg: RdMsgIm, normalized: NormalizedMessage, busy: boolean, steered: boolean): Promise<void>
       /** Refuse the delivery when the durable row cannot be written, rather than running it
        *  best-effort — for a platform whose admission hook USES that row as its dedup. */
       requireDurable?: boolean
@@ -7461,7 +7467,7 @@ export class Daemon {
       'linear',
       {
         prepare: async (msg, normalized, trace) => await this.prepareLinearDelivery(msg, normalized, trace),
-        onAdmitted: async (msg, normalized, busy) => this.onLinearAdmitted(msg, normalized, busy),
+        onAdmitted: async (msg, normalized, busy, steered) => this.onLinearAdmitted(msg, normalized, busy, steered),
         requireDurable: true,
         receiptId: (normalized) => linearDeliveryReceiptId(stableMessageId(normalized))
       }
@@ -7648,7 +7654,7 @@ export class Daemon {
    * before this can run, and a losing copy of the delivery never reaches it at all — which is
    * also what keeps a redelivered `created` from moving the issue twice.
    */
-  private onLinearAdmitted(msg: RdMsgIm, normalized: NormalizedMessage, busy: boolean): void {
+  private onLinearAdmitted(msg: RdMsgIm, normalized: NormalizedMessage, busy: boolean, steered = false): void {
     const conn = this.lnConnByIntegration.get(msg.integrationId)
     const ext = readLinearExt(normalized)
     if (!conn || !ext) return
@@ -7667,7 +7673,7 @@ export class Daemon {
       if (mode === 'none') return
       await conn.postActivity(ext.agentSessionId, {
         type: 'thought',
-        body: linearAckBody(agentName, ext, { queued: busy }),
+        body: linearAckBody(agentName, ext, steered ? { steered: true } : { queued: busy }),
         ephemeral: true
       })
       // The session opened on this delivery: the issue moves to "started" once the ack is OUT —
@@ -8827,13 +8833,17 @@ export class Daemon {
   /** Settle one activation whose message a live turn's prompt already carries: the row is
    *  upgraded to a delivery for this agent, the durable row is released, and the turn is
    *  reported cancelled rather than run a second time. */
-  private async coalesceEntryIntoTurn(entry: QueueEntry, sessionId: string | null): Promise<void> {
+  private async coalesceEntryIntoTurn(
+    entry: QueueEntry,
+    sessionId: string | null,
+    reason: 'coalesced_into_turn' | 'steered_into_turn' = 'coalesced_into_turn'
+  ): Promise<void> {
     if (entry.webchat && !entry.webchat.doneSent) {
       entry.webchat.doneSent = true
       entry.webchat.sink.done({
         conversationId: entry.webchat.conversationId,
         turnId: entry.webchat.turnId,
-        stopReason: 'coalesced_into_turn'
+        stopReason: reason
       })
     }
     const { thread, ts } = transcriptCoords(entry.msg)
@@ -8860,8 +8870,46 @@ export class Daemon {
       turnId: this.evaluationTurnIdFor(entry.agentId, entry.msg),
       platform: entry.msg.platform,
       channel: entry.msg.channel,
-      data: { reason: 'coalesced_into_turn' }
+      data: { reason }
     })
+  }
+
+  /** Steer an arrival into the live turn for its session key over `_session/steering` (#1847)
+   *  instead of queueing it. True when the runtime took it: the entry is settled exactly like a
+   *  coalesced one and its row is marked absorbed so neither fence regenerates for it. False —
+   *  no eligible live prompt, no capability, budget spent, the runtime declined, or the RPC
+   *  failed — leaves the caller on today's queue path. */
+  private async steerIntoLiveTurn(key: string, entry: QueueEntry): Promise<boolean> {
+    if (!this.cfg.features.sessionSteering || !steerEligibleEntry(entry)) return false
+    const target = selectSteerTarget(this.pending.values(), key)
+    if (!target) return false
+    const host = target.selectedHost?.host ?? this.hostForOwner(target.hostKey)
+    if (!host?.steeringSupported?.()) return false
+    // Attempts, not successes: a runtime that keeps declining is not asked without bound.
+    target.steerCount = (target.steerCount ?? 0) + 1
+    let outcome: Awaited<ReturnType<AcpHost['steer']>>
+    try {
+      // `promptRequired`: a steer that races the turn end is declined, never a turn we did not admit.
+      outcome = await host.steer(target.acpSessionId, steerPromptBlocks(entry.msg), {
+        idleBehavior: 'promptRequired'
+      })
+    } catch (err) {
+      this.log.warn(`steer: ${key} failed, queueing instead — ${(err as Error).message}`)
+      return false
+    }
+    if (outcome === 'failed') return false
+    if (outcome === 'startedNewTurn') {
+      this.log.warn(`steer: runtime opened a new turn for ${key} despite promptRequired; treating as admitted`)
+    }
+    // The live prompt now carries this row: remember it as absorbed AND already settled, so the
+    // final fence does not regenerate for it and a late admission cannot coalesce it twice.
+    const { ts } = transcriptCoords(entry.msg)
+    this.noteAbsorbedContext(key, new Map([[ts, steeredTranscriptText(entry.msg)]]))
+    this.claimAbsorbedContext(key, ts)
+    await this.coalesceEntryIntoTurn(entry, target.acpSessionId, 'steered_into_turn')
+    defaultTurnOutputMetrics.queueSteered(entry.msg.platform, 1)
+    this.log.info(`steer: delivered 1 message into the live turn for ${key} (${outcome})`)
+    return true
   }
 
   /** Start/regeneration fence queue mutation. The caller has already decided that
@@ -10168,7 +10216,13 @@ export class Daemon {
        * any turn can start. AWAITED, and a rejection REFUSES the delivery — the caller's own
        * durable bookkeeping is part of the same fence `requireDurable` protects, so work it
        * could not record is never run. */
-      onAdmission?: (result: { accepted: boolean; reason?: string; duplicate?: boolean }) => void | Promise<void>
+      onAdmission?: (result: {
+        accepted: boolean
+        reason?: string
+        duplicate?: boolean
+        /** The delivery rode the running turn over `_session/steering`; no queue entry exists. */
+        steered?: boolean
+      }) => void | Promise<void>
       /** Hold an admitted entry before execution; false drops only that entry. */
       admissionWait?: Promise<boolean>
       /** Delay observed-inbound persistence until admissionWait succeeds. */
@@ -10212,6 +10266,7 @@ export class Daemon {
           accepted: boolean
           reason?: string
           duplicate?: boolean
+          steered?: boolean
         }): Promise<void> => {
           if (admissionSettled) return
           admissionSettled = true
@@ -10447,6 +10502,12 @@ export class Daemon {
             // yet, so settle it as coalesced now instead of prompting the same message twice.
             if (await this.coalesceLateAdmission(key, entry)) {
               await settleAdmission({ accepted: true })
+              return
+            }
+            // A running prompt takes the message directly when the runtime can steer (#1847); the
+            // queue below is the fallback for everything the runtime or the policy declines.
+            if (await this.steerIntoLiveTurn(key, entry)) {
+              await settleAdmission({ accepted: true, steered: true })
               return
             }
             // Place the entry BEFORE the revision plan's interrupts: those await, and a gate that
@@ -12082,8 +12143,13 @@ export class Daemon {
       )
       // Start-fence linearization: no await occurs between queue coalescing above
       // (or the prior regeneration decision) and initiating this ACP request.
-      const promptPromise = host.prompt(sessionId, promptBlocks)
-      const result = await promptPromise
+      p.promptInFlight = true
+      let result: PromptResult
+      try {
+        result = await host.prompt(sessionId, promptBlocks)
+      } finally {
+        p.promptInFlight = false
+      }
       // The runtime's notifications are handled off the prompt call, so drain this
       // session's update chain before the turn reads what they wrote.
       await this.acpUpdateChains.get(acpUpdateChainKey(p.hostKey, sessionId))

--- a/packages/daemon/src/daemon/constants.ts
+++ b/packages/daemon/src/daemon/constants.ts
@@ -3,6 +3,8 @@ import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 // Cap per-session `!queue` depth so a hung turn or a user spamming `!queue` can't
 // grow `queued` without bound. Past the cap we reject with a clear message.
 export const MAX_QUEUED_PER_SESSION = 10
+// Cap on `_session/steering` calls one running turn may absorb; past it, arrivals queue as before.
+export const MAX_STEERS_PER_TURN = 10
 export const MAX_TURN_CONTEXT_REGENERATIONS = 3
 /** Updates the live renderer flushes buffered text on. A staged turn commits its current
  *  segment ahead of one of these, so interleaved "say → work → say more" posts as it

--- a/packages/daemon/src/daemon/steering-admission.ts
+++ b/packages/daemon/src/daemon/steering-admission.ts
@@ -1,0 +1,55 @@
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import type { NormalizedMessage } from '../messages/normalized.js'
+import { attachmentMention } from '../session/attachment-block.js'
+import { MAX_STEERS_PER_TURN } from './constants.js'
+import type { Pending, QueueEntry } from './turn-types.js'
+
+// Pure decisions behind "steer instead of queue" (issue #1847): which arrivals may ride the live
+// turn, which turn they ride, and what the runtime receives. dispatch() owns the side effects.
+
+type SteerCandidate = Pick<
+  QueueEntry,
+  'msg' | 'isQueueCmd' | 'hookContext' | 'callMeta' | 'admissionWait' | 'coordinationWait'
+>
+
+/** Only an ordinary human chat message may be steered. `!queue`, code-host hooks, scheduler
+ *  wakes, agent→agent calls, and entries holding an admission barrier stay serialised. */
+export function steerEligibleEntry(entry: SteerCandidate): boolean {
+  return (
+    entry.msg.source === 'user' &&
+    entry.isQueueCmd !== true &&
+    entry.hookContext === undefined &&
+    entry.callMeta === undefined &&
+    entry.admissionWait === undefined &&
+    entry.coordinationWait === undefined
+  )
+}
+
+/** The turn a same-key arrival can be steered into: its prompt is awaiting the runtime, its output
+ *  is not suppressed, and it still has steering budget. Undefined ⇒ queue as before. */
+export function selectSteerTarget(
+  pendings: Iterable<Pending>,
+  sessionKey: string,
+  cap: number = MAX_STEERS_PER_TURN
+): Pending | undefined {
+  for (const pending of pendings) {
+    if (pending.plan.sessionKey !== sessionKey) continue
+    if (pending.promptInFlight !== true || pending.outputSuppressed !== undefined) return undefined
+    return (pending.steerCount ?? 0) < cap ? pending : undefined
+  }
+  return undefined
+}
+
+/** The text the message's transcript row carries — what the fences compare against. */
+export function steeredTranscriptText(msg: NormalizedMessage): string {
+  const mention = attachmentMention(msg.attachments)
+  return mention ? `${msg.text}\n${mention}`.trim() : msg.text
+}
+
+/** What the running turn receives: the same `[sender] text` shape as a trigger prompt, with the
+ *  attachment marker the agent needs to forward a file by name. Attachment bytes are not sent. */
+export function steerPromptBlocks(msg: NormalizedMessage): ContentBlock[] {
+  const text = `[${msg.sender.id}] ${msg.turnBody?.prompt ?? msg.text}`
+  const mention = attachmentMention(msg.attachments)
+  return [{ type: 'text', text: mention ? `${text}\n${mention}` : text }]
+}

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -575,6 +575,11 @@ export interface Pending {
   acpSessionId: string
   /** The host that minted `acpSessionId` — the other half of the `this.pending` key. */
   hostKey: HostKey
+  /** True only while a `session/prompt` for this turn is awaiting the runtime — the window a
+   *  same-session arrival can be steered into instead of queued. */
+  promptInFlight?: boolean
+  /** `_session/steering` calls this turn has absorbed, bounded by MAX_STEERS_PER_TURN. */
+  steerCount?: number
   /** The same session's OUTWARD id (session-concept.md §1.1) — what the console knows it by, so
    *  every deep link and status payload this turn produces addresses a row the CP actually has.
    *  Stamped once here because most of those producers are synchronous. */

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -318,9 +318,14 @@ export function buildLinearPromptText(
  * It opens with the acting agent's name because every agent posts through the one deployment
  * app, so content is the only place identity can appear (§5).
  */
-export function linearAckBody(agentName: string, ext: LinearAdapterExt, opts: { queued?: boolean } = {}): string {
+export function linearAckBody(
+  agentName: string,
+  ext: LinearAdapterExt,
+  opts: { queued?: boolean; steered?: boolean } = {}
+): string {
   const subject = ext.issueIdentifier?.trim() ?? ext.agentSessionId
   const name = sanitizeTitle(agentName) || 'agent'
+  if (opts.steered) return `**${name}** · added to the running task`
   return opts.queued ? `**${name}** · queued behind the current task` : `**${name}** · reading ${subject} …`
 }
 

--- a/packages/daemon/src/runtimes/cluster-probe.ts
+++ b/packages/daemon/src/runtimes/cluster-probe.ts
@@ -212,6 +212,7 @@ const ProbeResultSchema = z.object({
   acpProtocolVersion: z.number().int().optional(),
   probedVersion: z.string().optional(),
   mcpCapabilities: z.object({ http: z.boolean(), sse: z.boolean() }).optional(),
+  steering: z.boolean().optional(),
   configOptions: z.array(z.unknown()).optional(),
   error: z.string().optional(),
   authRequired: z.boolean().optional(),

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -130,6 +130,9 @@ export interface RuntimeProbeResult {
   /** Optional MCP transports advertised at `initialize` (stdio is baseline).
    *  Undefined if the probe failed — callers then assume stdio-only. */
   mcpCapabilities?: McpTransportCapabilities
+  /** Whether the agent advertised mid-turn steering (`_meta.steering.supported`) at
+   *  `initialize`. Undefined if the probe failed or the host predates the accessor. */
+  steering?: boolean
   /** RAW session config options of the probe session (unaugmented, as the agent
    *  advertised them at `session/new`) — seeds the model-catalog cache with the
    *  default model's effort/fast caps and the runtime-level permission modes.
@@ -603,10 +606,11 @@ export async function probeRuntime(
     const mcpCapabilities = activeHost.mcpCapabilities?.() ?? undefined
     const info = activeHost.acpAgentInfo?.()
     const probedVersion = info?.version
+    const steering = activeHost.steeringSupported?.()
     const configOptions =
       probeSessionId !== undefined ? (activeHost.sessionConfigOptions?.(probeSessionId) ?? undefined) : undefined
     opts.log?.info(
-      `probe: ${id} ok (${info?.name ?? 'agent'}${info?.version ? ` v${info.version}` : ''}, models: ${models.length ? models.join(', ') : 'none advertised'})`
+      `probe: ${id} ok (${info?.name ?? 'agent'}${info?.version ? ` v${info.version}` : ''}, models: ${models.length ? models.join(', ') : 'none advertised'}, steering: ${steering === undefined ? 'unknown' : steering ? 'yes' : 'no'})`
     )
     return {
       runtime: id,
@@ -616,6 +620,7 @@ export async function probeRuntime(
       acpProtocolVersion,
       mcpCapabilities,
       probedVersion,
+      ...(steering !== undefined ? { steering } : {}),
       configOptions
     }
   } catch (err) {

--- a/packages/daemon/src/session/turn-output-metrics.ts
+++ b/packages/daemon/src/session/turn-output-metrics.ts
@@ -17,6 +17,7 @@ export interface TurnOutputMetrics {
   generations(count: number): void
   candidateDiscarded(reason: 'context_changed' | 'context_churn' | 'interrupted' | 'failed'): void
   queueCoalesced(platform: Platform, count: number): void
+  queueSteered(platform: Platform, count: number): void
   contextChurnExhausted(platform: Platform): void
 }
 
@@ -28,6 +29,7 @@ const generations = meter.createHistogram('turn_regeneration_generations', { uni
 const candidateDiscarded = meter.createCounter('turn_candidate_discarded_total')
 const snapshotDuration = meter.createHistogram('turn_context_snapshot_duration_ms', { unit: 'ms' })
 const queueCoalesced = meter.createCounter('turn_queue_coalesced_total')
+const queueSteered = meter.createCounter('turn_queue_steered_total')
 const churnExhausted = meter.createCounter('turn_context_churn_exhausted_total')
 
 export const defaultTurnOutputMetrics: TurnOutputMetrics = {
@@ -55,6 +57,9 @@ export const defaultTurnOutputMetrics: TurnOutputMetrics = {
   },
   queueCoalesced(platform, count) {
     if (count > 0) queueCoalesced.add(count, { platform })
+  },
+  queueSteered(platform, count) {
+    if (count > 0) queueSteered.add(count, { platform })
   },
   contextChurnExhausted(platform) {
     churnExhausted.add(1, { platform })

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -411,6 +411,8 @@ export interface StatusBarInfo {
   /** Selectable session presets; may include the synthetic Codex Auto value. */
   permissionModes?: string[]
   fastModeAvailable?: boolean
+  /** A message sent during this turn can be steered into it (webchat status only). */
+  steerable?: boolean
   // Current Slack output verbosity (daemon-side minimal/low/medium/high). Modal-only selector;
   // the level set is a fixed enum, so there's no "available" list. renderStatusBar ignores it.
   outputMode?: 'none' | 'minimal' | 'low' | 'medium' | 'high'

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -71,8 +71,10 @@ export interface WebchatDispatchOptions {
   requireDurable?: boolean
   /** Stable target-scoped inbox id for one physical event delivered to several local agents. */
   deliveryId?: string
+  /** Steer into the live turn or refuse `busy`; never queue (#1847). */
+  steerOnly?: boolean
   /** Synchronous admission barrier, settled before any turn can start. */
-  onAdmission?: (result: { accepted: boolean; reason?: string; duplicate?: boolean }) => void
+  onAdmission?: (result: { accepted: boolean; reason?: string; duplicate?: boolean; steered?: boolean }) => void
   /** Hold an admitted entry before execution; false drops only that entry. */
   admissionWait?: Promise<boolean>
   /** Delay observed-inbound persistence until admissionWait succeeds. */
@@ -171,7 +173,8 @@ export class WebchatTransport {
     remoteMcp?: WebchatRemoteMcpEntitlement,
     mentions?: string[],
     post?: { postId: string; at: number },
-    requestedWorktree?: boolean
+    requestedWorktree?: boolean,
+    steer?: boolean
   ): Promise<WebchatAck> {
     const turnId = requestedTurnId ?? randomUUID()
     // Route directly to the named agent (bypasses arbitration); null when it isn't a
@@ -283,7 +286,11 @@ export class WebchatTransport {
     // generation already in flight for this agent can see it at the final fence
     // and coalesce the queued activation. The identical later append from
     // SessionManager.handle dedups in place (same canonical ts, sender, text).
-    if (post && this.host.turnFinalContextRefresh()) {
+    // A steer-only turn writes no row of its own: steered, the live turn's settlement appends it
+    // as a delivery; refused, nothing must remain for the final fence to regenerate over — the
+    // browser re-sends the same text later as an ordinary turn. It still needs the canonical ts.
+    if (post && steer) msg.transcriptTs = String(post.at)
+    if (post && this.host.turnFinalContextRefresh() && !steer) {
       const observedMention = attachmentMention(msg.attachments)
       // The bounded inline image must ride the ADMISSION write: it wins the slot,
       // and SessionManager's later identical append dedups via INSERT OR IGNORE —
@@ -315,11 +322,40 @@ export class WebchatTransport {
       // separate turn after the regeneration already answered it.
       msg.transcriptTs = observedTs
     }
+    if (steer) return await this.dispatchSteerOnly(result.agentId, msg, stream)
     void this.host.dispatch(result.agentId, msg, undefined, stream).catch((err) => {
       if (!(err instanceof LifecycleCleanupBlockedError))
         this.host.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)
     })
     return { accepted: true, turnId }
+  }
+
+  /** A browser that queues locally sent this while a turn ran (#1847): the ACK waits for the
+   *  admission verdict — `steered` into the live turn, admitted as its own turn because that turn
+   *  had ended, or refused `busy` so the browser keeps the message in its own queue. */
+  private async dispatchSteerOnly(
+    agentId: string,
+    msg: NormalizedMessage,
+    stream: WebchatTurnStream
+  ): Promise<WebchatAck> {
+    let settle!: (verdict: { accepted: boolean; reason?: string; steered?: boolean }) => void
+    const admission = new Promise<{ accepted: boolean; reason?: string; steered?: boolean }>((r) => (settle = r))
+    void this.host
+      .dispatch(agentId, msg, undefined, stream, undefined, { steerOnly: true, onAdmission: (r) => settle(r) })
+      .catch((err) => {
+        if (!(err instanceof LifecycleCleanupBlockedError))
+          this.host.error(`webchat steer dispatch failed for agent "${agentId}": ${formatErr(err)}`)
+        settle({ accepted: false, reason: 'busy' })
+      })
+    const verdict = await admission
+    if (!verdict.accepted) {
+      this.removeWebchatStream(this.webchatStreamKey(stream.turnId, agentId), stream)
+      this.host.info(
+        `webchat: steer for ${stream.turnId} refused (${verdict.reason ?? 'busy'}) — browser keeps it queued`
+      )
+      return { accepted: false, turnId: stream.turnId, reason: verdict.reason === 'paused' ? 'paused' : 'busy' }
+    }
+    return { accepted: true, turnId: stream.turnId, ...(verdict.steered ? { steered: true } : {}) }
   }
 
   /** The live platform transport a chat-origin continuation mirrors through, plus the bot identity

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -265,7 +265,11 @@ export class WebchatTransport {
       return { accepted: false, turnId, reason: 'busy' }
     }
     this.pruneWebchatStreams()
-    if (this.webchatStreams.has(this.webchatStreamKey(turnId, result.agentId))) {
+    const existingStream = this.webchatStreams.get(this.webchatStreamKey(turnId, result.agentId))
+    if (existingStream) {
+      // A browser that lost the ack re-sends its steer on reconnect (same turnId): a copy of one
+      // this daemon already steered is confirmed again, never queued or refused as a duplicate.
+      if (steer && this.streamEndedSteered(existingStream)) return { accepted: true, turnId, steered: true }
       return { accepted: false, turnId, reason: 'busy' }
     }
     const initialRuntime =
@@ -328,6 +332,15 @@ export class WebchatTransport {
         this.host.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)
     })
     return { accepted: true, turnId }
+  }
+
+  private streamEndedSteered(stream: WebchatTurnStream): boolean {
+    return stream.replay.some(
+      (buffered) =>
+        buffered.event.kind === 'done' &&
+        (buffered.event.done.stopReason === 'steered_into_turn' ||
+          buffered.event.done.stopReason === 'coalesced_into_turn')
+    )
   }
 
   /** A browser that queues locally sent this while a turn ran (#1847): the ACK waits for the

--- a/packages/daemon/src/webchat/transport.ts
+++ b/packages/daemon/src/webchat/transport.ts
@@ -134,6 +134,8 @@ export interface WebchatHost {
 export class WebchatTransport {
   /** Bounded, ephemeral reconnect state keyed by (turnId, agentId). */
   private readonly webchatStreams = new Map<string, WebchatTurnStream>()
+  /** Steer-only admissions still awaiting their verdict, by stream key — a reconnect copy joins them. */
+  private readonly pendingSteerAdmissions = new Map<string, Promise<WebchatAck>>()
 
   constructor(private readonly host: WebchatHost) {}
 
@@ -265,11 +267,19 @@ export class WebchatTransport {
       return { accepted: false, turnId, reason: 'busy' }
     }
     this.pruneWebchatStreams()
-    const existingStream = this.webchatStreams.get(this.webchatStreamKey(turnId, result.agentId))
+    const streamKey = this.webchatStreamKey(turnId, result.agentId)
+    const existingStream = this.webchatStreams.get(streamKey)
     if (existingStream) {
-      // A browser that lost the ack re-sends its steer on reconnect (same turnId): a copy of one
-      // this daemon already steered is confirmed again, never queued or refused as a duplicate.
-      if (steer && this.streamEndedSteered(existingStream)) return { accepted: true, turnId, steered: true }
+      // A browser that lost the ack re-sends its steer on reconnect (same turnId). The copy is
+      // never a second delivery: it joins an admission still deciding, is confirmed for a stream
+      // that already ended steered, and is reported accepted for one that became its own turn —
+      // `busy` stays the DEFINITE refusal the browser may requeue on.
+      if (steer) {
+        const pending = this.pendingSteerAdmissions.get(streamKey)
+        if (pending) return await pending
+        if (this.streamEndedSteered(existingStream)) return { accepted: true, turnId, steered: true }
+        return { accepted: true, turnId }
+      }
       return { accepted: false, turnId, reason: 'busy' }
     }
     const initialRuntime =
@@ -326,7 +336,15 @@ export class WebchatTransport {
       // separate turn after the regeneration already answered it.
       msg.transcriptTs = observedTs
     }
-    if (steer) return await this.dispatchSteerOnly(result.agentId, msg, stream)
+    if (steer) {
+      const verdict = this.dispatchSteerOnly(result.agentId, msg, stream)
+      this.pendingSteerAdmissions.set(streamKey, verdict)
+      try {
+        return await verdict
+      } finally {
+        this.pendingSteerAdmissions.delete(streamKey)
+      }
+    }
     void this.host.dispatch(result.agentId, msg, undefined, stream).catch((err) => {
       if (!(err instanceof LifecycleCleanupBlockedError))
         this.host.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -790,3 +790,47 @@ describe('AcpHost elicitation capabilities', () => {
     await host.stop()
   })
 })
+
+describe('AcpHost steering (`_session/steering` against the fake agent)', () => {
+  it('reads the capability from initialize `_meta` and never calls a runtime that lacks it', async () => {
+    const host = new AcpHost({ command: process.execPath, args: [fakeAgent], env: [] }, { onUpdate: () => {} })
+    await host.start()
+    expect(host.steeringSupported()).toBe(false)
+    const sessionId = await host.newSession('/tmp')
+    // The fixture answers the method with "not found" when steering is off; the host must not send it.
+    await expect(host.steer(sessionId, [{ type: 'text', text: 'x' }])).resolves.toBe('failed')
+    await host.stop()
+  })
+
+  it('reports the runtime outcome: declined on an idle session under promptRequired, injected into a running turn', async () => {
+    const chunks: string[] = []
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      {
+        onUpdate: (_sid, update) => {
+          if (update.sessionUpdate === 'agent_message_chunk' && (update as any).content?.type === 'text')
+            chunks.push((update as any).content.text)
+        },
+        env: { AC_STEERING: '1', AC_STEER_HOLD_PROMPT: '1' }
+      }
+    )
+    await host.start()
+    expect(host.steeringSupported()).toBe(true)
+    const sessionId = await host.newSession('/tmp')
+    // Idle session: `promptRequired` makes the runtime decline instead of opening a turn.
+    await expect(
+      host.steer(sessionId, [{ type: 'text', text: 'early' }], { idleBehavior: 'promptRequired' })
+    ).resolves.toBe('failed')
+    // A session this host does not own is declined locally.
+    await expect(host.steer('not-mine', [{ type: 'text', text: 'x' }])).resolves.toBe('failed')
+
+    // Running turn: the fixture holds the prompt open until a steer lands in it.
+    const turn = host.prompt(sessionId, [{ type: 'text', text: 'start' }])
+    await expect(
+      host.steer(sessionId, [{ type: 'text', text: 'and also this' }], { idleBehavior: 'promptRequired' })
+    ).resolves.toBe('injected')
+    await expect(turn).resolves.toMatchObject({ stopReason: 'end_turn' })
+    expect(chunks).toContain('steer:and also this')
+    await host.stop()
+  })
+})

--- a/packages/daemon/test/acp-steering.test.ts
+++ b/packages/daemon/test/acp-steering.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { parseSteeringOutcome, steeringRequestParams, steeringSupported } from '../src/acp/steering.js'
+import {
+  selectSteerTarget,
+  steerEligibleEntry,
+  steerPromptBlocks,
+  steeredTranscriptText
+} from '../src/daemon/steering-admission.js'
+import type { NormalizedMessage } from '../src/messages/normalized.js'
+import type { Pending } from '../src/daemon/turn-types.js'
+
+const msg = (over: Partial<NormalizedMessage> = {}): NormalizedMessage => ({
+  msgId: 'slack:C1:100.2',
+  traceId: '100.2',
+  source: 'user',
+  platform: 'slack',
+  channel: 'C1',
+  thread: 'T1',
+  sender: { id: 'U1', isBot: false },
+  text: 'use the staging database instead',
+  mentionedBots: [],
+  isDm: true,
+  trigger: 'dm',
+  ...over
+})
+
+describe('_session/steering wire helpers', () => {
+  it('reads the capability only from an explicit `_meta.steering.supported: true`', () => {
+    expect(steeringSupported({ steering: { supported: true } })).toBe(true)
+    expect(steeringSupported({ steering: { supported: 'true' } })).toBe(false)
+    expect(steeringSupported({ steering: {} })).toBe(false)
+    expect(steeringSupported({})).toBe(false)
+    expect(steeringSupported(undefined)).toBe(false)
+    expect(steeringSupported(null)).toBe(false)
+  })
+
+  it('shapes the request with the prompt and the idle behaviour under `_meta.steering`', () => {
+    const blocks = [{ type: 'text' as const, text: 'hi' }]
+    expect(steeringRequestParams('s1', blocks, 'promptRequired')).toEqual({
+      sessionId: 's1',
+      prompt: blocks,
+      _meta: { steering: { idleBehavior: 'promptRequired' } }
+    })
+    expect(steeringRequestParams('s1', blocks)).toEqual({ sessionId: 's1', prompt: blocks })
+  })
+
+  it('reads only the three known outcomes; anything else is a failed steer', () => {
+    expect(parseSteeringOutcome({ outcome: 'injected' })).toBe('injected')
+    expect(parseSteeringOutcome({ outcome: 'startedNewTurn' })).toBe('startedNewTurn')
+    expect(parseSteeringOutcome({ outcome: 'failed' })).toBe('failed')
+    expect(parseSteeringOutcome({ outcome: 'queued' })).toBe('failed')
+    expect(parseSteeringOutcome({})).toBe('failed')
+    expect(parseSteeringOutcome(null)).toBe('failed')
+  })
+})
+
+describe('steer admission policy', () => {
+  it('steers only an ordinary human chat message', () => {
+    expect(steerEligibleEntry({ msg: msg() })).toBe(true)
+    expect(steerEligibleEntry({ msg: msg(), isQueueCmd: true })).toBe(false)
+    expect(steerEligibleEntry({ msg: msg({ source: 'cron' }) })).toBe(false)
+    expect(steerEligibleEntry({ msg: msg({ source: 'agent' }) })).toBe(false)
+    expect(steerEligibleEntry({ msg: msg(), hookContext: {} as never })).toBe(false)
+    expect(steerEligibleEntry({ msg: msg(), callMeta: {} as never })).toBe(false)
+    expect(steerEligibleEntry({ msg: msg(), admissionWait: Promise.resolve(true) })).toBe(false)
+    expect(steerEligibleEntry({ msg: msg(), coordinationWait: Promise.resolve() })).toBe(false)
+  })
+
+  const pending = (over: Partial<Pending> = {}): Pending =>
+    ({ plan: { sessionKey: 'slack:C1:T1:bot-a' }, promptInFlight: true, ...over }) as unknown as Pending
+
+  it('targets the live prompt of the same key, and nothing else', () => {
+    const live = pending()
+    expect(selectSteerTarget([pending({ plan: { sessionKey: 'other' } as never }), live], 'slack:C1:T1:bot-a')).toBe(
+      live
+    )
+    expect(selectSteerTarget([live], 'slack:C1:T1:bot-b')).toBeUndefined()
+    // Between prompts (final fence, regeneration decision) there is nothing to steer into.
+    expect(selectSteerTarget([pending({ promptInFlight: false })], 'slack:C1:T1:bot-a')).toBeUndefined()
+    // A paused or loop-tripped turn takes no more input.
+    expect(selectSteerTarget([pending({ outputSuppressed: 'pause' })], 'slack:C1:T1:bot-a')).toBeUndefined()
+  })
+
+  it('stops steering once the per-turn budget is spent', () => {
+    expect(selectSteerTarget([pending({ steerCount: 2 })], 'slack:C1:T1:bot-a', 3)).toBeDefined()
+    expect(selectSteerTarget([pending({ steerCount: 3 })], 'slack:C1:T1:bot-a', 3)).toBeUndefined()
+  })
+
+  it('prompts the running turn in the trigger shape and names attachments without sending them', () => {
+    expect(steerPromptBlocks(msg())).toEqual([{ type: 'text', text: '[U1] use the staging database instead' }])
+    const withFile = msg({
+      attachments: [{ id: 'F1', name: 'plan.md', mimeType: 'text/markdown', size: 12, sourceUrl: 'https://x.test/f' }]
+    })
+    const [block] = steerPromptBlocks(withFile)
+    expect(block).toMatchObject({ type: 'text' })
+    expect((block as { text: string }).text.startsWith('[U1] use the staging database instead\n')).toBe(true)
+    expect((block as { text: string }).text).toContain('plan.md')
+    // The transcript row text is the same text the observed-inbound row carries.
+    expect(steeredTranscriptText(msg())).toBe('use the staging database instead')
+    expect(steeredTranscriptText(withFile)).toContain('plan.md')
+  })
+})

--- a/packages/daemon/test/daemon-session-steering.test.ts
+++ b/packages/daemon/test/daemon-session-steering.test.ts
@@ -1,0 +1,250 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+import { MAX_STEERS_PER_TURN } from '../src/daemon/constants.js'
+import type { NormalizedMessage } from '../src/messages/normalized.js'
+import { sessionKey } from '../src/store/local-store.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { WAIT } from './wait-support.js'
+
+// Issue #1847: a message for a session whose turn is still running is steered into that turn
+// over `_session/steering` when the runtime can take it, and queued exactly as before when it
+// cannot. These drive `dispatch` directly with a host whose prompt blocks until released.
+
+function scaffold(features: Record<string, boolean> = {}): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-steer-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { turnFinalContextRefresh: true, ...features },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const agentDir = join(root, 'agents', 'bot-a')
+  mkdirSync(agentDir, { recursive: true })
+  writeFileSync(
+    join(agentDir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(agentDir, 'workspace') },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+  )
+  return root
+}
+
+const msg = (ts: string, body: string, over: Partial<NormalizedMessage> = {}): NormalizedMessage => ({
+  msgId: `slack:C1:${ts}`,
+  traceId: ts,
+  source: 'user' as const,
+  platform: 'slack' as const,
+  channel: 'C1',
+  thread: 'T1',
+  sender: { id: 'U1', isBot: false },
+  text: body,
+  mentionedBots: [] as string[],
+  isDm: true,
+  trigger: 'dm' as const,
+  ...over
+})
+
+/** A host whose prompts block until released, with steering wired through `steer`. */
+function steeringHost(opts: { supported?: boolean; steer?: () => Promise<string> } = {}) {
+  const releases: Array<() => void> = []
+  const prompts: string[] = []
+  const host = {
+    start: vi.fn(async () => {}),
+    newSession: vi.fn(async () => 'acp-1'),
+    hasSession: vi.fn(() => true),
+    prompt: vi.fn(async (_sid: string, blocks: { text?: string }[]) => {
+      prompts.push(blocks.map((b) => b.text ?? '').join('\n'))
+      await new Promise<void>((r) => releases.push(r))
+      return { stopReason: 'end_turn' }
+    }),
+    cancel: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    ...(opts.supported === false
+      ? {}
+      : {
+          steeringSupported: vi.fn(() => true),
+          steer: vi.fn(opts.steer ?? (async () => 'injected'))
+        })
+  }
+  return { host, prompts, releaseOne: () => releases.shift()?.() }
+}
+
+async function boot(host: unknown, features?: Record<string, boolean>) {
+  const daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
+    root: scaffold(features),
+    hostFactory: () => host as any
+  })
+  await daemon.start()
+  return daemon
+}
+
+const keyFor = (first: NormalizedMessage) => sessionKey('slack', 'C1', 'T1', 'bot-a', first.transportScope)
+
+/** Keep releasing blocked prompts until every dispatch has settled — a queued follow-up may run
+ *  as its own turn or be folded into a regeneration of the head, and both block on the host. */
+async function settleAll(h: ReturnType<typeof steeringHost>, promises: Promise<unknown>[]): Promise<unknown[]> {
+  let settled = false
+  const all = Promise.all(promises).finally(() => (settled = true))
+  while (!settled) {
+    h.releaseOne()
+    await new Promise((r) => setTimeout(r, 20))
+  }
+  return all
+}
+
+describe('mid-turn session steering', () => {
+  it('steers a same-session arrival into the running prompt instead of queueing it', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const first = msg('100.1', 'original request')
+    const p1 = (daemon as any).dispatch('bot-a', first, 'int-a')
+    await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledOnce(), WAIT)
+    const key = keyFor(first)
+
+    const p2 = (daemon as any).dispatch('bot-a', msg('100.2', 'use the staging database instead'), 'int-a')
+    // The follow-up settles while the first prompt is STILL blocked — it rode the live turn.
+    await expect(p2).resolves.toBe('acp-1')
+    expect(h.host.steer).toHaveBeenCalledOnce()
+    const [sessionId, blocks, steerOpts] = (h.host.steer as any).mock.calls[0]
+    expect(sessionId).toBe('acp-1')
+    expect(blocks).toEqual([{ type: 'text', text: '[U1] use the staging database instead' }])
+    expect(steerOpts).toEqual({ idleBehavior: 'promptRequired' })
+    // No queue entry and no durable row survive; the turn keeps its gate.
+    expect((daemon as any).serialQueue.has(key)).toBe(false)
+    const inbox = await (daemon as any).store.listInboxBySessionKeyFifo()
+    expect(inbox.map((row: { id: string }) => row.id)).toEqual(['slack:C1:100.1'])
+    expect((daemon as any).inflight.has(key)).toBe(true)
+    expect(h.host.prompt).toHaveBeenCalledOnce()
+
+    // The steered row is already in the ACP session: the final fence must not regenerate for it.
+    h.releaseOne()
+    await expect(p1).resolves.toBe('acp-1')
+    await vi.waitFor(() => expect((daemon as any).inflight.has(key)).toBe(false), WAIT)
+    expect(h.host.prompt).toHaveBeenCalledOnce()
+    await daemon.stop()
+  })
+
+  it('falls back to the queue when the runtime declines, the call fails, or the runtime cannot steer', async () => {
+    for (const variant of ['declined', 'threw', 'unsupported'] as const) {
+      const h =
+        variant === 'unsupported'
+          ? steeringHost({ supported: false })
+          : steeringHost({
+              steer:
+                variant === 'declined'
+                  ? async () => 'failed'
+                  : async () => {
+                      throw new Error('transport closed')
+                    }
+            })
+      const daemon = await boot(h.host)
+      const first = msg('100.1', 'original request')
+      const p1 = (daemon as any).dispatch('bot-a', first, 'int-a')
+      await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledOnce(), WAIT)
+      const key = keyFor(first)
+
+      const p2 = (daemon as any).dispatch('bot-a', msg('100.2', 'follow-up'), 'int-a')
+      await vi.waitFor(() => expect((daemon as any).serialQueue.get(key)).toHaveLength(1), WAIT)
+      if (variant !== 'unsupported') expect(h.host.steer).toHaveBeenCalledOnce()
+      // Queued as before: it runs (or is folded into a regeneration) only after the head settles.
+      await expect(settleAll(h, [p1, p2])).resolves.toEqual(['acp-1', 'acp-1'])
+      expect(h.host.prompt).toHaveBeenCalledTimes(2)
+      await daemon.stop()
+    }
+  })
+
+  it('keeps `!queue`, scheduler wakes, and the feature switch on the serial queue', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const first = msg('100.1', 'original request')
+    const p1 = (daemon as any).dispatch('bot-a', first, 'int-a')
+    await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledOnce(), WAIT)
+    const key = keyFor(first)
+
+    const queued = (daemon as any).dispatch('bot-a', msg('100.2', 'park this'), 'int-a', undefined, undefined, {
+      isQueueCmd: true
+    })
+    const cron = (daemon as any).dispatch('bot-a', msg('100.3', 'scheduled check', { source: 'cron' }), 'int-a')
+    await vi.waitFor(() => expect((daemon as any).serialQueue.get(key)).toHaveLength(2), WAIT)
+    expect(h.host.steer).not.toHaveBeenCalled()
+
+    await expect(settleAll(h, [p1, queued, cron])).resolves.toEqual(['acp-1', 'acp-1', 'acp-1'])
+    expect(h.host.steer).not.toHaveBeenCalled()
+    await daemon.stop()
+
+    const off = steeringHost()
+    const disabled = await boot(off.host, { sessionSteering: false })
+    const head = msg('100.1', 'original request')
+    const d1 = (disabled as any).dispatch('bot-a', head, 'int-a')
+    await vi.waitFor(() => expect(off.host.prompt).toHaveBeenCalledOnce(), WAIT)
+    const d2 = (disabled as any).dispatch('bot-a', msg('100.2', 'follow-up'), 'int-a')
+    await vi.waitFor(() => expect((disabled as any).serialQueue.get(keyFor(head))).toHaveLength(1), WAIT)
+    await expect(settleAll(off, [d1, d2])).resolves.toEqual(['acp-1', 'acp-1'])
+    expect(off.host.steer).not.toHaveBeenCalled()
+    await disabled.stop()
+  })
+
+  it('queues once a turn has spent its steering budget', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const first = msg('100.1', 'original request')
+    const p1 = (daemon as any).dispatch('bot-a', first, 'int-a')
+    await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledOnce(), WAIT)
+    const key = keyFor(first)
+    const [live] = [...(daemon as any).pending.values()]
+    live.steerCount = MAX_STEERS_PER_TURN
+
+    const p2 = (daemon as any).dispatch('bot-a', msg('100.2', 'one too many'), 'int-a')
+    await vi.waitFor(() => expect((daemon as any).serialQueue.get(key)).toHaveLength(1), WAIT)
+    expect(h.host.steer).not.toHaveBeenCalled()
+    await expect(settleAll(h, [p1, p2])).resolves.toEqual(['acp-1', 'acp-1'])
+    expect(h.host.prompt).toHaveBeenCalledTimes(2)
+    await daemon.stop()
+  })
+
+  it('steers while the turn is parked on session/request_permission — the runtime holds it', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const first = msg('100.1', 'original request')
+    const p1 = (daemon as any).dispatch('bot-a', first, 'int-a')
+    await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledOnce(), WAIT)
+    const key = keyFor(first)
+
+    // The prompt is awaiting the runtime, which is awaiting the human.
+    const approval = (daemon as any).permissions.onAcpPermission('bot-a', 'acp-1', {
+      sessionId: 'acp-1',
+      options: [
+        { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+        { optionId: 'deny', name: 'Deny', kind: 'reject_once' }
+      ],
+      toolCall: { toolCallId: 'tc-1', title: 'Bash' }
+    })
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(1), WAIT)
+
+    const p2 = (daemon as any).dispatch('bot-a', msg('100.2', 'skip the migration step'), 'int-a')
+    await expect(p2).resolves.toBe('acp-1')
+    expect(h.host.steer).toHaveBeenCalledOnce()
+    expect((daemon as any).serialQueue.has(key)).toBe(false)
+
+    const [requestId] = (daemon as any).permissions.pendingEditorPermissions.keys()
+    await (daemon as any).permissions.decideEditorPermission({ agentId: 'bot-a', requestId, decision: 'allow' })
+    await approval
+    h.releaseOne()
+    await expect(p1).resolves.toBe('acp-1')
+    expect(h.host.prompt).toHaveBeenCalledOnce()
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/fixtures/fake-acp-agent.mjs
+++ b/packages/daemon/test/fixtures/fake-acp-agent.mjs
@@ -108,6 +108,12 @@ const configOptions = (sessionId) => {
 let clientCapabilities
 let requestCounter = 1000
 let pendingElicit
+// `AC_STEERING=1` advertises `_meta.steering.supported` and serves `_session/steering`.
+// `AC_STEER_HOLD_PROMPT=1` additionally keeps each session/prompt open until a steer arrives,
+// which is the only way a test observes an `injected` outcome from the agent's own side.
+const steeringEnabled = process.env.AC_STEERING === '1'
+const holdPromptForSteer = process.env.AC_STEER_HOLD_PROMPT === '1'
+const heldPrompts = new Map()
 rl.on('line', async (line) => {
   if (!line.trim()) return
   const msg = JSON.parse(line)
@@ -133,7 +139,38 @@ rl.on('line', async (line) => {
   }
   if (method === 'initialize') {
     clientCapabilities = params?.clientCapabilities
-    send({ jsonrpc: '2.0', id, result: { protocolVersion: 1, agentCapabilities: agentCapabilities() } })
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        protocolVersion: 1,
+        agentCapabilities: agentCapabilities(),
+        ...(steeringEnabled ? { _meta: { steering: { supported: true } } } : {})
+      }
+    })
+  } else if (method === '_session/steering') {
+    if (!steeringEnabled) {
+      send({ jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } })
+      return
+    }
+    const text = (params.prompt ?? []).map((b) => b.text ?? '').join('')
+    const held = heldPrompts.get(params.sessionId)
+    if (held) {
+      heldPrompts.delete(params.sessionId)
+      send({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: params.sessionId,
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: `steer:${text}` } }
+        }
+      })
+      send({ jsonrpc: '2.0', id, result: { outcome: 'injected' } })
+      send({ jsonrpc: '2.0', id: held, result: { stopReason: 'end_turn' } })
+      return
+    }
+    const idleBehavior = params._meta?.steering?.idleBehavior
+    send({ jsonrpc: '2.0', id, result: { outcome: idleBehavior === 'promptRequired' ? 'failed' : 'startedNewTurn' } })
   } else if (method === 'session/new') {
     if (!acceptsAdditionalDirectories(id, params)) return
     if (!acceptsMcpServers(id, params)) return
@@ -177,6 +214,10 @@ rl.on('line', async (line) => {
     send({ jsonrpc: '2.0', id, result: {} })
   } else if (method === 'session/prompt') {
     const text = (params.prompt ?? []).map((b) => b.text ?? '').join('')
+    if (holdPromptForSteer) {
+      heldPrompts.set(params.sessionId, id)
+      return
+    }
     // `AC_ECHO_CLIENT_CAPS=1` replies with what the client advertised at initialize, which is
     // the only way a test sees the capability declaration from the agent's own side.
     if (process.env.AC_ECHO_CLIENT_CAPS === '1') {

--- a/packages/daemon/test/webchat-steering.test.ts
+++ b/packages/daemon/test/webchat-steering.test.ts
@@ -119,6 +119,10 @@ describe('webchat steer-only turns', () => {
     expect((h.host.steer as any).mock.calls[0][1]).toEqual([{ type: 'text', text: '[owner] use the staging database' }])
     const done = steerEvents.find((e) => e.kind === 'done')
     expect(done).toMatchObject({ kind: 'done', done: { turnId: STEER_TURN, stopReason: 'steered_into_turn' } })
+    // A browser that lost the ack re-sends the same steer on reconnect: confirmed again, not steered twice.
+    const again = await (daemon as any).handleRelayMsg(steerOp('use the staging database'), () => {})
+    expect(again).toEqual({ msgId: 'm-2', accepted: true, turnId: STEER_TURN, steered: true })
+    expect(h.host.steer).toHaveBeenCalledOnce()
     // Nothing waits behind the turn, and the first prompt is the only one.
     expect([...(daemon as any).serialQueue.values()].flat()).toHaveLength(0)
     h.releaseOne()

--- a/packages/daemon/test/webchat-steering.test.ts
+++ b/packages/daemon/test/webchat-steering.test.ts
@@ -1,0 +1,172 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+import type { RdChatEvent, RdMsgWebchat } from '@agentconnect.md/protocol'
+import { WAIT } from './wait-support.js'
+
+// #547 on top of #1847: a console composer that queues locally sends a `steer: true` turn while
+// the agent's turn runs. The daemon answers the admission verdict in the ACK — `steered` into
+// the live turn, refused `busy` (the browser keeps it queued), or admitted as its own turn.
+
+const AGENT_ID = 'bot-a'
+const CONV = '88888888-8888-4888-8888-888888888888'
+const TURN = '77777777-7777-4777-8777-777777777777'
+const STEER_TURN = '66666666-6666-4666-8666-666666666666'
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-wc-steer-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { turnFinalContextRefresh: true },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', AGENT_ID)
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: AGENT_ID,
+      name: AGENT_ID,
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' }
+    })
+  )
+  return root
+}
+
+const rd = (payload: RdMsgWebchat['payload'], over: Partial<RdMsgWebchat> = {}): RdMsgWebchat => ({
+  source: 'webchat',
+  agentId: AGENT_ID,
+  sessionKey: CONV,
+  msgId: 'm-1',
+  chatId: CONV,
+  payload,
+  ...over
+})
+
+function steeringHost(steer?: () => Promise<string>) {
+  const releases: Array<() => void> = []
+  const host = {
+    start: vi.fn(async () => {}),
+    newSession: vi.fn(async () => 'acp-wc-1'),
+    hasSession: vi.fn(() => true),
+    prompt: vi.fn(async () => {
+      await new Promise<void>((r) => releases.push(r))
+      return { stopReason: 'end_turn' }
+    }),
+    cancel: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    steeringSupported: vi.fn(() => true),
+    steer: vi.fn(steer ?? (async () => 'injected'))
+  }
+  return { host, releaseOne: () => releases.shift()?.() }
+}
+
+async function boot(host: unknown) {
+  const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+  await daemon.start()
+  ;(daemon as any).cpClient = {
+    emitUsageReport: vi.fn(),
+    emitSessionActivity: vi.fn(),
+    organizationScope: () => 'connection' as const,
+    stop: vi.fn(async () => {})
+  }
+  ;(daemon as any).relays = { stop: vi.fn(async () => {}), sendWebchatPost: vi.fn() }
+  return daemon
+}
+
+async function startTurn(daemon: Daemon, host: { prompt: ReturnType<typeof vi.fn> }, events: RdChatEvent[]) {
+  const ack = await (daemon as any).handleRelayMsg(
+    rd({ op: 'turn', text: 'original request', user: 'owner', turnId: TURN, post: { postId: TURN, at: 1_000 } }),
+    (event: RdChatEvent) => events.push(event)
+  )
+  expect(ack).toMatchObject({ accepted: true, turnId: TURN })
+  await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
+}
+
+const steerOp = (text: string) =>
+  rd(
+    { op: 'turn', text, user: 'owner', turnId: STEER_TURN, post: { postId: STEER_TURN, at: 2_000 }, steer: true },
+    { msgId: 'm-2' }
+  )
+
+describe('webchat steer-only turns', () => {
+  it('acks `steered` once the live turn took the message, and ends that turn stream at once', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const events: RdChatEvent[] = []
+    await startTurn(daemon, h.host, events)
+    // The running turn's status frame tells the composer it may steer.
+    await vi.waitFor(() =>
+      expect(events.some((e) => e.kind === 'output' && e.output.status?.steerable === true)).toBe(true)
+    )
+
+    const steerEvents: RdChatEvent[] = []
+    const ack = await (daemon as any).handleRelayMsg(steerOp('use the staging database'), (event: RdChatEvent) =>
+      steerEvents.push(event)
+    )
+    expect(ack).toEqual({ msgId: 'm-2', accepted: true, turnId: STEER_TURN, steered: true })
+    expect(h.host.steer).toHaveBeenCalledOnce()
+    expect((h.host.steer as any).mock.calls[0][1]).toEqual([{ type: 'text', text: '[owner] use the staging database' }])
+    const done = steerEvents.find((e) => e.kind === 'done')
+    expect(done).toMatchObject({ kind: 'done', done: { turnId: STEER_TURN, stopReason: 'steered_into_turn' } })
+    // Nothing waits behind the turn, and the first prompt is the only one.
+    expect([...(daemon as any).serialQueue.values()].flat()).toHaveLength(0)
+    h.releaseOne()
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    expect(h.host.prompt).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  it('refuses `busy` instead of queueing when the runtime declines, leaving no stream or row behind', async () => {
+    const h = steeringHost(async () => 'failed')
+    const daemon = await boot(h.host)
+    const events: RdChatEvent[] = []
+    await startTurn(daemon, h.host, events)
+
+    const steerEvents: RdChatEvent[] = []
+    const ack = await (daemon as any).handleRelayMsg(steerOp('follow-up'), (event: RdChatEvent) =>
+      steerEvents.push(event)
+    )
+    expect(ack).toEqual({ msgId: 'm-2', accepted: false, turnId: STEER_TURN, reason: 'busy' })
+    expect(steerEvents).toEqual([])
+    expect([...(daemon as any).serialQueue.values()].flat()).toHaveLength(0)
+    const inbox = await (daemon as any).store.listInboxBySessionKeyFifo()
+    expect(inbox.map((row: { id: string }) => row.id)).not.toContain(STEER_TURN)
+    // The refused stream is gone: a resume for it finds nothing.
+    expect((daemon as any).webchatTransport.webchatStreams.has(`${STEER_TURN}:${AGENT_ID}`)).toBe(false)
+    h.releaseOne()
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    expect(h.host.prompt).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  it('admits a steer whose turn had already ended as an ordinary turn, without `steered`', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const events: RdChatEvent[] = []
+    await startTurn(daemon, h.host, events)
+    h.releaseOne()
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+
+    const steerEvents: RdChatEvent[] = []
+    const ack = await (daemon as any).handleRelayMsg(steerOp('late steer'), (event: RdChatEvent) =>
+      steerEvents.push(event)
+    )
+    expect(ack).toEqual({ msgId: 'm-2', accepted: true, turnId: STEER_TURN })
+    expect(h.host.steer).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledTimes(2), WAIT)
+    h.releaseOne()
+    await vi.waitFor(() => expect(steerEvents.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/webchat-steering.test.ts
+++ b/packages/daemon/test/webchat-steering.test.ts
@@ -154,6 +154,56 @@ describe('webchat steer-only turns', () => {
     await daemon.stop()
   })
 
+  it('joins a reconnect copy to the steer admission still deciding, so both copies get the one verdict', async () => {
+    let releaseSteer!: () => void
+    const held = new Promise<void>((r) => (releaseSteer = r))
+    const h = steeringHost(async () => {
+      await held
+      return 'injected'
+    })
+    const daemon = await boot(h.host)
+    const events: RdChatEvent[] = []
+    await startTurn(daemon, h.host, events)
+
+    const original = (daemon as any).handleRelayMsg(steerOp('use staging'), () => {})
+    await vi.waitFor(() => expect(h.host.steer).toHaveBeenCalledOnce(), WAIT)
+    // The browser reconnected meanwhile and re-sent the same steer under a fresh relay msgId.
+    const copy = (daemon as any).handleRelayMsg({ ...steerOp('use staging'), msgId: 'm-3' }, () => {})
+    releaseSteer()
+    expect(await original).toEqual({ msgId: 'm-2', accepted: true, turnId: STEER_TURN, steered: true })
+    expect(await copy).toEqual({ msgId: 'm-3', accepted: true, turnId: STEER_TURN, steered: true })
+    expect(h.host.steer).toHaveBeenCalledOnce()
+    h.releaseOne()
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    expect(h.host.prompt).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  it('reports a reconnect copy of a steer that became its own turn as accepted, never `busy`', async () => {
+    const h = steeringHost()
+    const daemon = await boot(h.host)
+    const events: RdChatEvent[] = []
+    await startTurn(daemon, h.host, events)
+    h.releaseOne()
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+
+    expect(await (daemon as any).handleRelayMsg(steerOp('late steer'), () => {})).toEqual({
+      msgId: 'm-2',
+      accepted: true,
+      turnId: STEER_TURN
+    })
+    await vi.waitFor(() => expect(h.host.prompt).toHaveBeenCalledTimes(2), WAIT)
+    // While that turn runs (and after it ends) a re-sent copy is not a second delivery.
+    expect(await (daemon as any).handleRelayMsg({ ...steerOp('late steer'), msgId: 'm-3' }, () => {})).toEqual({
+      msgId: 'm-3',
+      accepted: true,
+      turnId: STEER_TURN
+    })
+    expect(h.host.prompt).toHaveBeenCalledTimes(2)
+    h.releaseOne()
+    await daemon.stop()
+  })
+
   it('admits a steer whose turn had already ended as an ordinary turn, without `steered`', async () => {
     const h = steeringHost()
     const daemon = await boot(h.host)

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -174,7 +174,10 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
     runtime: WebchatRuntimeConfig.optional(),
     // Per-conversation workspace override. The daemon honors it only while
     // creating the logical session; later turns cannot move an existing session.
-    worktree: z.boolean().optional()
+    worktree: z.boolean().optional(),
+    // Steer-or-refuse (#1847): the browser sent this while a turn was running and keeps its
+    // own queue, so the daemon steers it into that turn or refuses `busy` — never parks it.
+    steer: z.boolean().optional()
   }),
   // A conversation post another participant produced (a user turn targeted
   // elsewhere, or a peer agent's reply), fanned out by the relay so THIS frame's
@@ -530,6 +533,8 @@ export const RdAck = z.object({
   reason: z.string().optional(),
   /** Bounded human-readable cause for a refusal the browser should explain (see WebchatAck.detail). */
   detail: z.string().max(240).optional(),
+  /** Webchat `turn` verdicts only: delivered into the running turn (see WebchatAck.steered). */
+  steered: z.boolean().optional(),
   /** `attach` verdicts only: the named stream's current resume generation — the browser
    *  seeds its cursor from it so the follow-up `resume` outruns pre-reload generations. */
   generation: z.number().int().min(0).optional(),

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -66,7 +66,10 @@ export const WebchatAck = z.object({
     .optional(),
   // One bounded, path-free line naming the fault, so the client can state the cause instead of
   // guessing at it. The daemon redacts it; nothing here reveals its filesystem layout.
-  detail: z.string().max(240).optional()
+  detail: z.string().max(240).optional(),
+  // The turn was delivered INTO the running turn over `_session/steering` (#1847); its own
+  // stream ends at once with `stopReason: 'steered_into_turn'` and the live reply continues.
+  steered: z.boolean().optional()
 })
 export type WebchatAck = z.infer<typeof WebchatAck>
 
@@ -316,6 +319,9 @@ export const WebchatStatus = z.object({
   // config option only appears once a fast-capable model is selected). Absent/false ⇒
   // no fast toggle shown.
   fastModeAvailable: z.boolean().optional(),
+  // Whether a message sent while this turn runs can be steered into it over the runtime's
+  // `_session/steering` (#1847): the composer then sends at once instead of queueing locally.
+  steerable: z.boolean().optional(),
   // This conversation's session, by its outward id (session-concept.md §1.1), so the console can
   // deep-link to the session detail page. Absent until the session is created.
   sessionId: z.string().optional()

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -86,6 +86,18 @@ function build(
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
 
 describe('parseBrowserFrame', () => {
+  it('carries the steer-or-refuse flag (#547) only when the browser set it to true', () => {
+    expect(parseBrowserFrame({ text: 'hi', steer: true }, USER)).toEqual({
+      op: { op: 'turn', text: 'hi', user: USER, steer: true }
+    })
+    expect(parseBrowserFrame({ text: 'hi', steer: 'yes' }, USER)).toEqual({
+      op: { op: 'turn', text: 'hi', user: USER }
+    })
+    expect(parseBrowserFrame({ text: 'hi', steer: false }, USER)).toEqual({
+      op: { op: 'turn', text: 'hi', user: USER }
+    })
+  })
+
   it('maps a bare {text} and {type:"message",text} to a turn op carrying the user', () => {
     expect(parseBrowserFrame({ text: 'hi' }, USER)).toEqual({ op: { op: 'turn', text: 'hi', user: USER } })
     expect(parseBrowserFrame({ type: 'message', text: 'hi', turnId: AGENT }, USER)).toEqual({
@@ -389,6 +401,18 @@ describe('RelayBrowserConnection', () => {
     transport.feed({ text: 'hi' })
     await tick()
     expect(transport.last('ack')).toEqual({ type: 'ack', ack: { accepted: false, agentId: AGENT, reason: 'paused' } })
+  })
+
+  it('surfaces a steered turn verdict to the browser (#547)', async () => {
+    const turnId = '22222222-2222-4222-8222-222222222222'
+    const { transport, sent } = build({ ack: { msgId: 'turn-1', accepted: true, turnId, steered: true } })
+    transport.feed({ text: 'use staging', turnId, steer: true })
+    await tick()
+    expect(sent[0]).toMatchObject({ payload: { op: 'turn', text: 'use staging', turnId, steer: true } })
+    expect(transport.last('ack')).toEqual({
+      type: 'ack',
+      ack: { accepted: true, turnId, agentId: AGENT, steered: true }
+    })
   })
 
   it('forwards a resume cursor and surfaces its replay verdict', async () => {

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -148,7 +148,8 @@ export function parseBrowserFrame(
       ...(mentions ? { mentions } : {}),
       ...(m.attachments !== undefined ? { attachments: m.attachments } : {}),
       ...(m.runtime !== undefined ? { runtime: m.runtime } : {}),
-      ...(m.worktree !== undefined ? { worktree: m.worktree } : {})
+      ...(m.worktree !== undefined ? { worktree: m.worktree } : {}),
+      ...(m.steer === true ? { steer: true } : {})
     })
     if (!parsed.success || parsed.data.op !== 'turn') return null
     const targets = m.targets !== undefined ? uuidArray(m.targets, 16) : undefined
@@ -463,7 +464,8 @@ export class RelayBrowserConnection implements ChatSink {
         agentId,
         ...(ack.reason ? { reason: ack.reason } : {}),
         ...(ack.detail ? { detail: ack.detail } : {}),
-        ...(ack.generation !== undefined ? { generation: ack.generation } : {})
+        ...(ack.generation !== undefined ? { generation: ack.generation } : {}),
+        ...(ack.steered ? { steered: true } : {})
       }
       // A refusal is the whole story of a stream that "never came back" — name it, and who
       // refused. Attach misses are the normal idle answer, not worth a line.

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -345,6 +345,8 @@ type PendingSteer = {
   frame: string
   /** The socket this frame last went out on — a reconnect re-sends it once per new socket. */
   sentOn?: WebSocket
+  /** Went out more than once: a verdict may describe a delivery an earlier socket already made. */
+  resent?: boolean
 }
 
 export function PlaygroundProvider({ children }: { children: ReactNode }) {
@@ -915,24 +917,26 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [mutateSteps]
   )
 
-  /** Every steer of a session still awaiting its verdict goes back to the queue, in send order. */
-  const requeueUnackedSteers = useCallback(
-    (id: string): void => {
-      const pending = [...(steerTurns.current.get(id)?.entries() ?? [])].sort(([, a], [, b]) => a.seq - b.seq)
-      for (const [turnId, steer] of pending) requeueSteer(id, turnId, steer)
-    },
-    [requeueSteer]
-  )
+  /** Steers of a session still awaiting the daemon's verdict — they keep their turnId until it comes. */
+  const hasUnackedSteers = (id: string): boolean => (steerTurns.current.get(id)?.size ?? 0) > 0
 
   const failStream = useCallback(
     (id: string, message: string): void => {
       dropLanes(id)
       reconnectAttempts.current.delete(id)
-      requeueUnackedSteers(id)
+      // An unacked steer may already have reached the runtime, so it is NOT turned into a fresh
+      // turn here — that could run the instruction twice. It keeps its turnId and is re-sent on
+      // the next socket, where the daemon reconciles it; until then the delivery reads as uncertain.
+      if (hasUnackedSteers(id)) {
+        pushStep(id, {
+          kind: 'done',
+          text: '⚠️ Could not confirm that your last message reached the agent — it is re-sent once the connection returns.'
+        })
+      }
       pushStep(id, { kind: 'done', text: `⚠️ ${message}` })
       setBusy(id, false)
     },
-    [pushStep, requeueUnackedSteers, setBusy]
+    [pushStep, setBusy]
   )
 
   /** Retire a cold-attached turn's replayed steps by stamping the reply's canonical
@@ -1156,10 +1160,16 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         // One resume per live lane — a multi-agent turn streams from several
         // participants, each with its own daemon-side replay window.
         for (const key of lanesOf(id)) sendLaneResume(ws, key)
-        // Steers nobody acked ride the new socket too (same turnId): the daemon answers a copy it
-        // already steered idempotently, and one it never saw is steered or refused as usual.
+      }
+
+      /** Steers nobody acked ride every new socket (same turnId): the daemon joins a copy to an
+       *  admission still pending, confirms one it already steered, reports one that became its own
+       *  turn as accepted, and only a steer it never saw is steered or refused afresh. */
+      const resendUnackedSteers = (ws: WebSocket): void => {
+        if (ws.readyState !== WebSocket.OPEN) return
         for (const steer of steerTurns.current.get(id)?.values() ?? []) {
           if (steer.sentOn === ws) continue
+          if (steer.sentOn) steer.resent = true
           steer.sentOn = ws
           ws.send(steer.frame)
         }
@@ -1185,7 +1195,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
 
       const scheduleReconnect = (): void => {
         const reconnectId = conn.conversationId ?? resumeId ?? conversationIds.current.get(id)
-        if (closingAll.current || conn.closing || !busyRef.current[id] || !reconnectId) {
+        // An unacked steer keeps reconnecting too: its verdict is the only way to learn whether the
+        // runtime took it, and its identity must survive until then.
+        if (closingAll.current || conn.closing || (!busyRef.current[id] && !hasUnackedSteers(id)) || !reconnectId) {
           setBusy(id, false)
           return
         }
@@ -1198,7 +1210,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         const delay = Math.min(WEBCHAT_RECONNECT_MAX_MS, WEBCHAT_RECONNECT_BASE_MS * 2 ** attempt)
         conn.reconnectTimer = window.setTimeout(() => {
           conn.reconnectTimer = undefined
-          if (!busyRef.current[id] || conns.current.has(id)) return
+          if ((!busyRef.current[id] && !hasUnackedSteers(id)) || conns.current.has(id)) return
           void connect(id, agentId, reconnectId, true).ready.catch(() => {})
         }, delay)
       }
@@ -1222,13 +1234,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               if (conn.reconnectTimer) window.clearTimeout(conn.reconnectTimer)
               conn.reconnectTimer = undefined
               dropSelf()
-              if (busyRef.current[id]) scheduleReconnect()
-              else {
-                // No reconnect follows an idle close, so a steer still awaiting its verdict would be
-                // lost with the socket: it goes back to the queue and out as an ordinary turn.
-                requeueUnackedSteers(id)
-                setBusy(id, false)
-              }
+              if (busyRef.current[id] || hasUnackedSteers(id)) scheduleReconnect()
+              else setBusy(id, false)
             }
             /** A per-participant rejection: fail only that lane — the other targets of a multi-agent turn keep streaming. */
             const rejectLane = (
@@ -1321,6 +1328,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                     }
                   })
                 }
+                resendUnackedSteers(ws)
                 if (resumeStream && busyRef.current[id]) {
                   sendResume(ws)
                 } else if (probeOnReady && !busyRef.current[id] && lanesOf(id).length === 0) {
@@ -1373,7 +1381,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                         ]
                   )
               } else if (m.type === 'ack' && m.ack?.turnId && steerTurns.current.get(id)?.has(m.ack.turnId)) {
-                settleSteerAck(id, m.ack.turnId, m.ack)
+                settleSteerAck(id, m.ack.turnId, m.ack, (key) => sendLaneResume(ws, key))
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
                 let key = cursorKeyFor(id, m.ack?.agentId)
                 // The relay may target participants the client did not lane (a
@@ -1763,11 +1771,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     (
       id: string,
       turnId: string,
-      ack: { accepted?: boolean; reason?: string; detail?: string; agentId?: string; steered?: boolean }
+      ack: { accepted?: boolean; reason?: string; detail?: string; agentId?: string; steered?: boolean },
+      resumeLane: (key: string) => void
     ): void => {
       const steer = steerTurns.current.get(id)?.get(turnId)
       if (!steer) return
       if (ack.accepted === false) {
+        // `busy` is the daemon's DEFINITE refusal of a steer (a copy of one it holds or already
+        // ran is answered differently), so only here does the text become a fresh queued turn.
         if (ack.reason === 'busy') {
           requeueSteer(id, turnId, steer)
           return
@@ -1794,16 +1805,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // Not steered while that lane is still live: an older relay dropped the flag and the daemon
       // decided alone — whatever it did surfaces through this turn's own frames (pendingTurnIdFor).
       if (lanesOf(id).length > 0) return
-      // The turn had already ended: this message runs as its own turn, so open its lane.
+      // The turn had already ended: this message runs as its own turn, so open its lane. A copy
+      // re-sent after a reconnect may find that turn already streaming or finished — the resume
+      // pulls its replay from the daemon instead of waiting on frames that went out before.
       steerTurns.current.get(id)?.delete(turnId)
       mutateSteps(id, (steps) => steps.map((s) => (s.turnId === turnId && s.steer ? { ...s, steer: undefined } : s)))
       pendingTurnIds.current.set(id, turnId)
       finishedTurnLanes.current.delete(id)
       const cursor = createWebchatCursor<WebchatOutput, WebchatDone>(turnId)
       bindWebchatTurn(cursor, turnId)
-      streamCursors.current.set(laneKey(id, ack.agentId ?? steer.agentId), cursor)
+      const key = laneKey(id, ack.agentId ?? steer.agentId)
+      streamCursors.current.set(key, cursor)
       syncBusyLanes(id)
       setBusy(id, true)
+      if (steer.sentOn && steer.resent) resumeLane(key)
     },
     [mutateSteps, participantName, pushStep, requeueSteer, setBusy, syncBusyLanes]
   )

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -347,6 +347,10 @@ type PendingSteer = {
   sentOn?: WebSocket
   /** Went out more than once: a verdict may describe a delivery an earlier socket already made. */
   resent?: boolean
+  /** The daemon admitted it as its own turn while an older lane was still open here: that lane's
+   *  retirement opens this turn's lane and resumes it (see openAcceptedSteerLane). */
+  acceptedAsTurn?: boolean
+  acceptedAgentId?: string
 }
 
 export function PlaygroundProvider({ children }: { children: ReactNode }) {
@@ -960,6 +964,58 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [mutateSteps]
   )
 
+  /** Ask the daemon to replay one lane from where its cursor stands (also used inside connect()). */
+  const sendLaneResumeOn = (ws: WebSocket, key: string): void => {
+    const cursor = streamCursors.current.get(key)
+    const turnId = cursor?.turnId ?? cursor?.requestedTurnId
+    if (!cursor || !turnId || ws.readyState !== WebSocket.OPEN) return
+    cursor.resumeGeneration += 1
+    const agentId = laneAgentId(key)
+    ws.send(
+      JSON.stringify({
+        type: 'resume',
+        turnId,
+        ...(agentId ? { agentId } : {}),
+        generation: cursor.resumeGeneration,
+        afterIndex: cursor.nextIndex - 1
+      })
+    )
+  }
+
+  /** Open the lane of a steer the daemon admitted as its own turn (#547): the step becomes an
+   *  ordinary user turn, the lane binds to that turnId and — for a copy re-sent after a reconnect,
+   *  or one deferred behind an older lane — a resume pulls the reply already streamed elsewhere. */
+  const openSteerTurnLane = useCallback(
+    (id: string, turnId: string, steer: PendingSteer, agentId: string | undefined, resume: boolean): void => {
+      steerTurns.current.get(id)?.delete(turnId)
+      mutateSteps(id, (steps) => steps.map((s) => (s.turnId === turnId && s.steer ? { ...s, steer: undefined } : s)))
+      pendingTurnIds.current.set(id, turnId)
+      finishedTurnLanes.current.delete(id)
+      const cursor = createWebchatCursor<WebchatOutput, WebchatDone>(turnId)
+      bindWebchatTurn(cursor, turnId)
+      const key = laneKey(id, agentId ?? steer.agentId)
+      streamCursors.current.set(key, cursor)
+      syncBusyLanes(id)
+      setBusy(id, true)
+      const ws = conns.current.get(id)?.ws
+      if (resume && ws) sendLaneResumeOn(ws, key)
+    },
+    [mutateSteps, setBusy, syncBusyLanes]
+  )
+
+  /** When the last lane retires, a steer accepted as its own turn meanwhile takes over (true), so
+   *  the ack that arrived ahead of the older turn's replayed `done` is not lost with it. */
+  const openAcceptedSteerLane = useCallback(
+    (id: string): boolean => {
+      const entry = [...(steerTurns.current.get(id)?.entries() ?? [])].find(([, s]) => s.acceptedAsTurn)
+      if (!entry) return false
+      const [turnId, steer] = entry
+      openSteerTurnLane(id, turnId, steer, steer.acceptedAgentId, true)
+      return true
+    },
+    [openSteerTurnLane]
+  )
+
   const applyStreamResult = useCallback(
     (id: string, cursorKey: string, result: OrderedWebchatResult<WebchatOutput, WebchatDone>): void => {
       const agentId = laneAgentId(cursorKey)
@@ -1020,12 +1076,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         // every chunk back — so a clean end is the last chance to retire the wait it announced.
         retireWaitNotice(id, agentId, result.done.turnId)
       }
-      // The turn stays busy until every targeted participant's lane finished.
-      if (lanesOf(id).length === 0) setBusy(id, false)
+      // The turn stays busy until every targeted participant's lane finished — unless a steer the
+      // daemon already admitted as its own turn was waiting for exactly this lane to retire.
+      if (lanesOf(id).length === 0 && !openAcceptedSteerLane(id)) setBusy(id, false)
     },
     [
       anchorColdTurn,
       applyEvent,
+      openAcceptedSteerLane,
       applyStatus,
       applyTitle,
       deltaBuffer,
@@ -1119,22 +1177,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         if (conns.current.get(id) === conn) conns.current.delete(id)
       }
 
-      const sendLaneResume = (ws: WebSocket, key: string): void => {
-        const cursor = streamCursors.current.get(key)
-        const turnId = cursor?.turnId ?? cursor?.requestedTurnId
-        if (!cursor || !turnId || ws.readyState !== WebSocket.OPEN) return
-        cursor.resumeGeneration += 1
-        const agentId = laneAgentId(key)
-        ws.send(
-          JSON.stringify({
-            type: 'resume',
-            turnId,
-            ...(agentId ? { agentId } : {}),
-            generation: cursor.resumeGeneration,
-            afterIndex: cursor.nextIndex - 1
-          })
-        )
-      }
+      const sendLaneResume = (ws: WebSocket, key: string): void => sendLaneResumeOn(ws, key)
 
       /** The turn nobody acked yet, if this reconnect should put it back on the wire (once per socket). */
       const unackedTurn = (
@@ -1271,7 +1314,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               })
               if (lanesOf(id).length === 0) {
                 reconnectAttempts.current.delete(id)
-                setBusy(id, false)
+                if (!openAcceptedSteerLane(id)) setBusy(id, false)
               }
             }
             ws.onmessage = (e) => {
@@ -1381,7 +1424,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                         ]
                   )
               } else if (m.type === 'ack' && m.ack?.turnId && steerTurns.current.get(id)?.has(m.ack.turnId)) {
-                settleSteerAck(id, m.ack.turnId, m.ack, (key) => sendLaneResume(ws, key))
+                settleSteerAck(id, m.ack.turnId, m.ack)
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
                 let key = cursorKeyFor(id, m.ack?.agentId)
                 // The relay may target participants the client did not lane (a
@@ -1771,8 +1814,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     (
       id: string,
       turnId: string,
-      ack: { accepted?: boolean; reason?: string; detail?: string; agentId?: string; steered?: boolean },
-      resumeLane: (key: string) => void
+      ack: { accepted?: boolean; reason?: string; detail?: string; agentId?: string; steered?: boolean }
     ): void => {
       const steer = steerTurns.current.get(id)?.get(turnId)
       if (!steer) return
@@ -1802,25 +1844,21 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         steerTurns.current.get(id)?.delete(turnId)
         return
       }
-      // Not steered while that lane is still live: an older relay dropped the flag and the daemon
-      // decided alone — whatever it did surfaces through this turn's own frames (pendingTurnIdFor).
-      if (lanesOf(id).length > 0) return
+      // Not steered while an older lane is still open: the daemon ran this message as its own turn
+      // (or, behind an older relay, decided alone). Its lane opens once that lane retires — an ack
+      // that outran the older turn's replayed `done` must not be forgotten with it — and until
+      // then this turn's own frames still admit a lane lazily (pendingTurnIdFor).
+      if (lanesOf(id).length > 0) {
+        steer.acceptedAsTurn = true
+        steer.acceptedAgentId = ack.agentId
+        return
+      }
       // The turn had already ended: this message runs as its own turn, so open its lane. A copy
       // re-sent after a reconnect may find that turn already streaming or finished — the resume
       // pulls its replay from the daemon instead of waiting on frames that went out before.
-      steerTurns.current.get(id)?.delete(turnId)
-      mutateSteps(id, (steps) => steps.map((s) => (s.turnId === turnId && s.steer ? { ...s, steer: undefined } : s)))
-      pendingTurnIds.current.set(id, turnId)
-      finishedTurnLanes.current.delete(id)
-      const cursor = createWebchatCursor<WebchatOutput, WebchatDone>(turnId)
-      bindWebchatTurn(cursor, turnId)
-      const key = laneKey(id, ack.agentId ?? steer.agentId)
-      streamCursors.current.set(key, cursor)
-      syncBusyLanes(id)
-      setBusy(id, true)
-      if (steer.sentOn && steer.resent) resumeLane(key)
+      openSteerTurnLane(id, turnId, steer, ack.agentId, steer.resent === true)
     },
-    [mutateSteps, participantName, pushStep, requeueSteer, setBusy, syncBusyLanes]
+    [mutateSteps, openSteerTurnLane, participantName, pushStep, requeueSteer]
   )
 
   const pgSend = useCallback(

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -293,6 +293,7 @@ type WebchatStatus = {
   efforts?: string[]
   permissionModes?: string[]
   fastModeAvailable?: boolean
+  steerable?: boolean
   sessionId?: string
 }
 
@@ -310,6 +311,7 @@ type WebchatDone = {
   turnId: string
   agentId?: string
   lastIndex?: number
+  stopReason?: string
   error?: string
 }
 
@@ -370,6 +372,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // where the relay applied the all-participants default) create its stream
   // lane lazily instead of dropping the reply.
   const pendingTurnIds = useRef<Map<string, string>>(new Map())
+  // Messages sent INTO a running turn (#1847), per session id → turnId. Their ack and terminal
+  // `done` settle here instead of opening a lane: the running turn's own lane carries the reply.
+  const steerTurns = useRef<Map<string, Map<string, { agentId: string; text: string; conversationId?: string }>>>(
+    new Map()
+  )
+  // Whether the session's live turn accepts steering — from the daemon's status frame.
+  const steerableRef = useRef<Record<string, boolean>>({})
   // The in-flight turn's wire frame per session id: a socket that drops between `send` and the ack leaves it in limbo (it may never have reached a daemon), so the reconnect re-sends it once — same turnId, an already-admitted copy is refused `busy` and we attach to its stream — instead of only resuming a stream that may not exist.
   const pendingTurnFrames = useRef<
     Map<string, { turnId: string; frame: string; resentOn?: WebSocket; attaching?: Set<string> }>
@@ -423,6 +432,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const setBusy = useCallback((id: string, v: boolean): void => {
     if (v) busyRef.current[id] = true
     else delete busyRef.current[id]
+    // Steerability belongs to the live turn: the next turn's status frame declares it afresh.
+    if (!v) delete steerableRef.current[id]
     setPgBusyBy((cur) => (!!cur[id] === v ? cur : { ...cur, [id]: v }))
   }, [])
   const setPgInput = useCallback((id: string, v: string): void => {
@@ -766,6 +777,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  model or the last token total. Playground sessions only (adopted webchat rows carry
    *  their own persisted headline). */
   const applyStatus = useCallback((id: string, st: WebchatStatus, agentId?: string): void => {
+    // Steerability is read even for an adopted session with no pgSessions row: pgSend's
+    // queue-or-steer decision needs it, and only the daemon knows the live runtime.
+    if (st.steerable !== undefined) {
+      if (st.steerable) steerableRef.current[id] = true
+      else delete steerableRef.current[id]
+    }
     // Record every participant's session id BEFORE the primary fence below —
     // member lanes never reach the session-row merge, but their tool steps need
     // the owning session for the live tool-body read (keyed '' for the sole/
@@ -803,6 +820,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           ...(st.permissionModes !== undefined ? { availablePermissionModes: st.permissionModes } : {}),
           ...(st.fastMode !== undefined ? { fastMode: st.fastMode } : {}),
           ...(st.fastModeAvailable !== undefined ? { fastModeAvailable: st.fastModeAvailable } : {}),
+          ...(st.steerable !== undefined ? { steerable: st.steerable } : {}),
           ...(st.sessionId !== undefined ? { realSessionId: st.sessionId } : {}),
           ...(st.totalTokens !== undefined ? { tokens: fmtCountCompact(st.totalTokens) } : {}),
           ...(st.costAmount !== undefined ? { cost: fmtCost(st.costAmount, st.costCurrency) } : {})
@@ -823,6 +841,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   }
   const cursorKeyFor = (id: string, agentId?: string): string | undefined =>
     cursorKeyForLanes(streamCursors.current, id, agentId)
+  // A steer the daemon could not steer runs as its own turn later: its frames admit a lane
+  // exactly like the in-flight send's would, so the reply is not dropped.
+  const pendingTurnIdFor = (id: string, turnId: string | undefined): string | undefined =>
+    turnId !== undefined && steerTurns.current.get(id)?.has(turnId) ? turnId : pendingTurnIds.current.get(id)
   // REACTIVE lane membership (review fix): the cursor map is a ref, and a
   // lane's removal (a peer's non-final done) may arrive with no other state
   // change — reading the ref at render time would keep showing a finished
@@ -972,7 +994,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // frame while it waits for this one (webchat-multi-agents.md §5.3).
       if (
         !key &&
-        admitsLane(output.agentId, output.turnId, pendingTurnIds.current.get(id), finishedFor(id, output.turnId))
+        admitsLane(output.agentId, output.turnId, pendingTurnIdFor(id, output.turnId), finishedFor(id, output.turnId))
       ) {
         key = laneKey(id, output.agentId)
         streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(output.turnId))
@@ -988,10 +1010,21 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
 
   const receiveDone = useCallback(
     (id: string, done: WebchatDone): void => {
+      // A steered message's own stream ends at once: the running turn's lane carries the reply,
+      // so this terminal frame settles the steer and must not touch busy state or lanes.
+      const steered = steerTurns.current.get(id)?.has(done.turnId) === true
+      if (steered && (done.stopReason === 'steered_into_turn' || done.stopReason === 'coalesced_into_turn')) {
+        steerTurns.current.get(id)?.delete(done.turnId)
+        return
+      }
+      if (steered) steerTurns.current.get(id)?.delete(done.turnId)
       let key = cursorKeyFor(id, done.agentId)
       // Same early-frame admission as receiveOutput: a participant's terminal
       // frame (e.g. a coalesced turn's immediate done) may also beat its ack.
-      if (!key && admitsLane(done.agentId, done.turnId, pendingTurnIds.current.get(id), finishedFor(id, done.turnId))) {
+      if (
+        !key &&
+        admitsLane(done.agentId, done.turnId, pendingTurnIdFor(id, done.turnId), finishedFor(id, done.turnId))
+      ) {
         key = laneKey(id, done.agentId)
         streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(done.turnId))
         syncBusyLanes(id)
@@ -1186,6 +1219,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                   turnId?: string
                   agentId?: string
                   generation?: number
+                  steered?: boolean
                 }
                 post?: WebchatPost
                 initiator?: string
@@ -1276,6 +1310,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                           })
                         ]
                   )
+              } else if (m.type === 'ack' && m.ack?.turnId && steerTurns.current.get(id)?.has(m.ack.turnId)) {
+                settleSteerAck(id, m.ack.turnId, m.ack)
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
                 let key = cursorKeyFor(id, m.ack?.agentId)
                 // The relay may target participants the client did not lane (a
@@ -1627,6 +1663,89 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [pgSessions, connect, pushStep, setBusy, refreshSessions]
   )
 
+  /** Put a steer the daemon refused (or a socket failure dropped) back at the head of the
+   *  composer's queue: the user still sees it, can cancel it, and it goes out when the turn ends. */
+  const requeueSteer = useCallback(
+    (id: string, turnId: string, steer: { agentId: string; text: string; conversationId?: string }): void => {
+      steerTurns.current.get(id)?.delete(turnId)
+      mutateSteps(id, (steps) => steps.filter((s) => s.turnId !== turnId))
+      const queued: QueuedTurn = {
+        queueId: randomUuid(),
+        text: steer.text,
+        agentId: steer.agentId,
+        ...(steer.conversationId ? { conversationId: steer.conversationId } : {})
+      }
+      pgQueueRef.current[id] = [queued, ...(pgQueueRef.current[id] ?? NO_QUEUE)]
+      setPgQueueBy((cur) => ({ ...cur, [id]: [queued, ...(cur[id] ?? NO_QUEUE)] }))
+    },
+    [mutateSteps]
+  )
+
+  /** Send a message INTO the running turn (#1847). The step lands at once as a steer; no lane
+   *  is opened — the ack says whether the daemon steered it, ran it as its own turn because the
+   *  turn had ended, or refused it (then it goes back to the queue). */
+  const sendSteer = useCallback(
+    (id: string, agentForId: string, text: string, conversationId?: string): void => {
+      const turnId = randomUuid()
+      const steer = { agentId: agentForId, text, ...(conversationId ? { conversationId } : {}) }
+      const bucket = steerTurns.current.get(id) ?? new Map()
+      bucket.set(turnId, steer)
+      steerTurns.current.set(id, bucket)
+      pushStep(id, { kind: 'msg', who: '@you', turnId, text, steer: true })
+      if (conversationId) conversationIds.current.set(id, conversationId)
+      const conn = connect(id, agentForId, conversationId)
+      conn.ready
+        .then((ws) => ws.send(JSON.stringify({ text, turnId, steer: true })))
+        .catch(() => requeueSteer(id, turnId, steer))
+    },
+    [connect, pushStep, requeueSteer]
+  )
+
+  /** The daemon's verdict on a steer (see sendSteer). */
+  const settleSteerAck = useCallback(
+    (
+      id: string,
+      turnId: string,
+      ack: { accepted?: boolean; reason?: string; detail?: string; agentId?: string; steered?: boolean }
+    ): void => {
+      const steer = steerTurns.current.get(id)?.get(turnId)
+      if (!steer) return
+      if (ack.accepted === false) {
+        if (ack.reason === 'busy') {
+          requeueSteer(id, turnId, steer)
+          return
+        }
+        steerTurns.current.get(id)?.delete(turnId)
+        mutateSteps(id, (steps) => steps.filter((s) => s.turnId !== turnId))
+        const name = participantName(id, ack.agentId)
+        pushStep(id, {
+          kind: 'done',
+          turnId,
+          text:
+            ack.reason === 'paused'
+              ? `⚠️ ${name ?? 'Agent'} is paused — it is not processing messages.`
+              : `⚠️ ${name ?? 'Agent'} could not take the message${ack.detail ? ` — ${ack.detail}` : '.'}`
+        })
+        return
+      }
+      // Steered: the step keeps its mark and the running lane keeps streaming. Not steered while
+      // that lane is still live: an older relay dropped the flag and the daemon decided alone —
+      // whatever it did surfaces through this turn's own frames (pendingTurnIdFor admits them).
+      if (ack.steered || lanesOf(id).length > 0) return
+      // The turn had already ended: this message runs as its own turn, so open its lane.
+      steerTurns.current.get(id)?.delete(turnId)
+      mutateSteps(id, (steps) => steps.map((s) => (s.turnId === turnId && s.steer ? { ...s, steer: undefined } : s)))
+      pendingTurnIds.current.set(id, turnId)
+      finishedTurnLanes.current.delete(id)
+      const cursor = createWebchatCursor<WebchatOutput, WebchatDone>(turnId)
+      bindWebchatTurn(cursor, turnId)
+      streamCursors.current.set(laneKey(id, ack.agentId ?? steer.agentId), cursor)
+      syncBusyLanes(id)
+      setBusy(id, true)
+    },
+    [mutateSteps, participantName, pushStep, requeueSteer, setBusy, syncBusyLanes]
+  )
+
   const pgSend = useCallback(
     (
       id: string,
@@ -1646,6 +1765,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // queued messages are still waiting for the dispatcher, so a send landing
       // between a turn's end and the dispatch of the queue head stays FIFO.
       if (busyRef.current[id] || (pgQueueRef.current[id]?.length ?? 0) > 0) {
+        // Steer instead of queue (#1847): the live turn's runtime takes the text at once. Only
+        // with nothing already waiting (FIFO), text only (the steer carries no image bytes), and
+        // for a single-agent conversation — a roster would need one verdict per participant.
+        const roster = knownParticipants?.length ?? rosterAgentIds.current.get(id)?.length ?? 1
+        if (
+          steerableRef.current[id] &&
+          (pgQueueRef.current[id]?.length ?? 0) === 0 &&
+          !image &&
+          roster <= 1 &&
+          !commandPick
+        ) {
+          sendSteer(id, agentForId, text, conversationId)
+          return true
+        }
         const queued: QueuedTurn = {
           queueId: randomUuid(),
           text,
@@ -1662,7 +1795,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       sendTurn(id, agentForId, text, image, conversationId, knownParticipants, commandPick)
       return true
     },
-    [pgImageBy, sendTurn, setPgImage, setPgInput]
+    [pgImageBy, sendSteer, sendTurn, setPgImage, setPgInput]
   )
 
   // Dispatch the oldest queued message the moment its session's turn ends. The

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -177,6 +177,8 @@ export interface QueuedTurn {
   participants?: Array<{ agentId: string; name: string; primary?: boolean }>
   /** A `/` pick's owner, revalidated at dispatch — see sendTurn. */
   commandPick?: { agentId: string; name: string }
+  /** Composer send order (per provider), so a steer put back in the queue keeps its place. */
+  seq?: number
 }
 
 // Synthetic playground session ids start with `pg_`; real CP session ids do not.
@@ -334,6 +336,17 @@ type WebchatRuntimeConfig = {
   fastMode?: boolean
 }
 
+/** A steer on the wire (see sendSteer): its send args for a requeue, its frame for a reconnect re-send. */
+type PendingSteer = {
+  agentId: string
+  text: string
+  conversationId?: string
+  seq: number
+  frame: string
+  /** The socket this frame last went out on — a reconnect re-sends it once per new socket. */
+  sentOn?: WebSocket
+}
+
 export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const { refreshSessions } = useConsoleData()
   const [pgSessions, setPgSessions] = useState<Record<string, Session>>({})
@@ -374,9 +387,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const pendingTurnIds = useRef<Map<string, string>>(new Map())
   // Messages sent INTO a running turn (#1847), per session id → turnId. Their ack and terminal
   // `done` settle here instead of opening a lane: the running turn's own lane carries the reply.
-  const steerTurns = useRef<Map<string, Map<string, { agentId: string; text: string; conversationId?: string }>>>(
-    new Map()
-  )
+  const steerTurns = useRef<Map<string, Map<string, PendingSteer>>>(new Map())
+  // Composer send order across steers and queued messages — a refused steer is restored where it was sent.
+  const sendSeq = useRef(0)
   // Whether the session's live turn accepts steering — from the daemon's status frame.
   const steerableRef = useRef<Record<string, boolean>>({})
   // The in-flight turn's wire frame per session id: a socket that drops between `send` and the ack leaves it in limbo (it may never have reached a daemon), so the reconnect re-sends it once — same turnId, an already-admitted copy is refused `busy` and we attach to its stream — instead of only resuming a stream that may not exist.
@@ -602,7 +615,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           const collapsed = [...steps]
           for (let i = collapsed.length - 1; i >= 0; i--) {
             const step = collapsed[i]!
-            if (step.kind === 'msg' && step.agentId === undefined) break
+            // A steer is part of THIS turn (#1847): the discarded candidate spans it.
+            if (step.kind === 'msg' && step.agentId === undefined && !step.steer) break
             if ((step.agentId ?? undefined) !== agentId) continue
             if (step.turnId !== turnId) break
             if (step.boundary) break
@@ -631,7 +645,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           // snapshot keyed to the turn, so it crosses.
           for (let i = steps.length - 1; i >= 0; i--) {
             const step = steps[i]!
-            if (step.kind === 'msg' && step.agentId === undefined) break
+            // A steer only fences TEXT grouping; the turn's one plan row is still upserted across it.
+            if (step.kind === 'msg' && step.agentId === undefined && !step.steer) break
             if ((step.agentId ?? undefined) !== agentId) continue
             if (step.turnId !== turnId) break
             if (step.kind === 'planblock') return replaceAt(i, { ...step, plan: ev.entries, observedAtMs })
@@ -733,10 +748,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           // Address the update to ITS call, not the lane tail: ACP allows parallel
           // tool calls, so the most recent tool step may belong to a different call.
           // Same fences as the lane scan above — never cross a user message, a
-          // foreign turn, or the supersession boundary.
+          // foreign turn, or the supersession boundary. A steer (#1847) is not a fence here: a
+          // call that started before it still completes in this turn and must find its row.
           for (let i = steps.length - 1; i >= 0; i--) {
             const step = steps[i]!
-            if (step.kind === 'msg' && step.agentId === undefined) break
+            if (step.kind === 'msg' && step.agentId === undefined && !step.steer) break
             if ((step.agentId ?? undefined) !== agentId) continue
             if (step.turnId !== turnId) break
             if (step.boundary) break
@@ -875,14 +891,48 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     syncBusyLanes(id)
   }
 
+  /** Put a steer the daemon refused (or a lost socket dropped) back into the composer's queue
+   *  at its send position: the user still sees it, can cancel it, and it goes out in order once
+   *  the turn ends. Two refusals arriving A then B therefore restore [A, B], never [B, A]. */
+  const requeueSteer = useCallback(
+    (id: string, turnId: string, steer: PendingSteer): void => {
+      steerTurns.current.get(id)?.delete(turnId)
+      mutateSteps(id, (steps) => steps.filter((s) => s.turnId !== turnId))
+      const queued: QueuedTurn = {
+        queueId: randomUuid(),
+        text: steer.text,
+        agentId: steer.agentId,
+        seq: steer.seq,
+        ...(steer.conversationId ? { conversationId: steer.conversationId } : {})
+      }
+      const insert = (queue: QueuedTurn[]): QueuedTurn[] => {
+        const at = queue.findIndex((q) => (q.seq ?? Number.POSITIVE_INFINITY) > steer.seq)
+        return at < 0 ? [...queue, queued] : [...queue.slice(0, at), queued, ...queue.slice(at)]
+      }
+      pgQueueRef.current[id] = insert(pgQueueRef.current[id] ?? NO_QUEUE)
+      setPgQueueBy((cur) => ({ ...cur, [id]: insert(cur[id] ?? NO_QUEUE) }))
+    },
+    [mutateSteps]
+  )
+
+  /** Every steer of a session still awaiting its verdict goes back to the queue, in send order. */
+  const requeueUnackedSteers = useCallback(
+    (id: string): void => {
+      const pending = [...(steerTurns.current.get(id)?.entries() ?? [])].sort(([, a], [, b]) => a.seq - b.seq)
+      for (const [turnId, steer] of pending) requeueSteer(id, turnId, steer)
+    },
+    [requeueSteer]
+  )
+
   const failStream = useCallback(
     (id: string, message: string): void => {
       dropLanes(id)
       reconnectAttempts.current.delete(id)
+      requeueUnackedSteers(id)
       pushStep(id, { kind: 'done', text: `⚠️ ${message}` })
       setBusy(id, false)
     },
-    [pushStep, setBusy]
+    [pushStep, requeueUnackedSteers, setBusy]
   )
 
   /** Retire a cold-attached turn's replayed steps by stamping the reply's canonical
@@ -1106,6 +1156,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         // One resume per live lane — a multi-agent turn streams from several
         // participants, each with its own daemon-side replay window.
         for (const key of lanesOf(id)) sendLaneResume(ws, key)
+        // Steers nobody acked ride the new socket too (same turnId): the daemon answers a copy it
+        // already steered idempotently, and one it never saw is steered or refused as usual.
+        for (const steer of steerTurns.current.get(id)?.values() ?? []) {
+          if (steer.sentOn === ws) continue
+          steer.sentOn = ws
+          ws.send(steer.frame)
+        }
       }
 
       /** A reconnect can beat the original turn across different relay links.
@@ -1166,7 +1223,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               conn.reconnectTimer = undefined
               dropSelf()
               if (busyRef.current[id]) scheduleReconnect()
-              else setBusy(id, false)
+              else {
+                // No reconnect follows an idle close, so a steer still awaiting its verdict would be
+                // lost with the socket: it goes back to the queue and out as an ordinary turn.
+                requeueUnackedSteers(id)
+                setBusy(id, false)
+              }
             }
             /** A per-participant rejection: fail only that lane — the other targets of a multi-agent turn keep streaming. */
             const rejectLane = (
@@ -1663,40 +1725,35 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [pgSessions, connect, pushStep, setBusy, refreshSessions]
   )
 
-  /** Put a steer the daemon refused (or a socket failure dropped) back at the head of the
-   *  composer's queue: the user still sees it, can cancel it, and it goes out when the turn ends. */
-  const requeueSteer = useCallback(
-    (id: string, turnId: string, steer: { agentId: string; text: string; conversationId?: string }): void => {
-      steerTurns.current.get(id)?.delete(turnId)
-      mutateSteps(id, (steps) => steps.filter((s) => s.turnId !== turnId))
-      const queued: QueuedTurn = {
-        queueId: randomUuid(),
-        text: steer.text,
-        agentId: steer.agentId,
-        ...(steer.conversationId ? { conversationId: steer.conversationId } : {})
-      }
-      pgQueueRef.current[id] = [queued, ...(pgQueueRef.current[id] ?? NO_QUEUE)]
-      setPgQueueBy((cur) => ({ ...cur, [id]: [queued, ...(cur[id] ?? NO_QUEUE)] }))
-    },
-    [mutateSteps]
-  )
-
   /** Send a message INTO the running turn (#1847). The step lands at once as a steer; no lane
    *  is opened — the ack says whether the daemon steered it, ran it as its own turn because the
    *  turn had ended, or refused it (then it goes back to the queue). */
   const sendSteer = useCallback(
-    (id: string, agentForId: string, text: string, conversationId?: string): void => {
+    (id: string, agentForId: string, text: string, seq: number, conversationId?: string): void => {
       const turnId = randomUuid()
-      const steer = { agentId: agentForId, text, ...(conversationId ? { conversationId } : {}) }
-      const bucket = steerTurns.current.get(id) ?? new Map()
+      const steer: PendingSteer = {
+        agentId: agentForId,
+        text,
+        seq,
+        frame: JSON.stringify({ text, turnId, steer: true }),
+        ...(conversationId ? { conversationId } : {})
+      }
+      const bucket = steerTurns.current.get(id) ?? new Map<string, PendingSteer>()
       bucket.set(turnId, steer)
       steerTurns.current.set(id, bucket)
       pushStep(id, { kind: 'msg', who: '@you', turnId, text, steer: true })
       if (conversationId) conversationIds.current.set(id, conversationId)
       const conn = connect(id, agentForId, conversationId)
       conn.ready
-        .then((ws) => ws.send(JSON.stringify({ text, turnId, steer: true })))
-        .catch(() => requeueSteer(id, turnId, steer))
+        .then((ws) => {
+          // A verdict or a socket close may already have settled it while the socket was opening.
+          if (steerTurns.current.get(id)?.get(turnId) !== steer || steer.sentOn) return
+          steer.sentOn = ws
+          ws.send(steer.frame)
+        })
+        .catch(() => {
+          if (steerTurns.current.get(id)?.get(turnId) === steer) requeueSteer(id, turnId, steer)
+        })
     },
     [connect, pushStep, requeueSteer]
   )
@@ -1728,10 +1785,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         })
         return
       }
-      // Steered: the step keeps its mark and the running lane keeps streaming. Not steered while
-      // that lane is still live: an older relay dropped the flag and the daemon decided alone —
-      // whatever it did surfaces through this turn's own frames (pendingTurnIdFor admits them).
-      if (ack.steered || lanesOf(id).length > 0) return
+      // Steered: the step keeps its mark and the running lane keeps streaming; its own `done`
+      // may have landed already (the daemon emits it inside admission) or is harmless later.
+      if (ack.steered) {
+        steerTurns.current.get(id)?.delete(turnId)
+        return
+      }
+      // Not steered while that lane is still live: an older relay dropped the flag and the daemon
+      // decided alone — whatever it did surfaces through this turn's own frames (pendingTurnIdFor).
+      if (lanesOf(id).length > 0) return
       // The turn had already ended: this message runs as its own turn, so open its lane.
       steerTurns.current.get(id)?.delete(turnId)
       mutateSteps(id, (steps) => steps.map((s) => (s.turnId === turnId && s.steer ? { ...s, steer: undefined } : s)))
@@ -1776,11 +1838,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           roster <= 1 &&
           !commandPick
         ) {
-          sendSteer(id, agentForId, text, conversationId)
+          sendSteer(id, agentForId, text, ++sendSeq.current, conversationId)
           return true
         }
         const queued: QueuedTurn = {
           queueId: randomUuid(),
+          seq: ++sendSeq.current,
           text,
           ...(image ? { image } : {}),
           agentId: agentForId,

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -41,6 +41,8 @@ const { PlaygroundProvider, usePlayground } = await import('./PlaygroundProvider
 // the synchronous return value instead of the streaming machinery.
 class StubSocket {
   static CONNECTING = 0
+  // The provider reuses a socket only while `readyState` reads as OPEN against the class constant.
+  static OPEN = 1
   readyState = 0
   send = vi.fn()
   close = vi.fn()
@@ -1075,5 +1077,128 @@ describe('in-band elicitation cards', () => {
     // The daemon owns the outcome: nothing settles locally on the send alone.
     expect(getLiveSteps('s1').find((s) => s.kind === 'elicit')?.elicit?.outcome).toBeUndefined()
     expect(ElicitSocket.instances).toHaveLength(1) // one socket, card in and answer out
+  })
+})
+
+// #547: once the daemon's status frame says the running turn is steerable, a send while it
+// streams goes straight to the wire as a steer instead of into the composer's queue.
+describe('mid-turn steering', () => {
+  class SteerSocket extends StubSocket {
+    static instances: SteerSocket[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onerror?: (e: unknown) => void
+    onclose?: () => void
+    constructor() {
+      super()
+      SteerSocket.instances.push(this)
+    }
+  }
+
+  async function openSteerableStream() {
+    SteerSocket.instances = []
+    Reflect.set(globalThis, 'WebSocket', SteerSocket)
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockResolvedValue('wss://relay.test/ws')
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello', 'c1')
+    })
+    const socket = SteerSocket.instances[0]!
+    await act(async () => {
+      socket.readyState = 1
+      socket.onopen?.()
+    })
+    const turn = JSON.parse(String(socket.send.mock.calls.at(-1)?.[0])) as { turnId: string }
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId: turn.turnId, agentId: 'agent-1', index: 0, status: { steerable: true } }
+        })
+      })
+    })
+    return { socket, turnId: turn.turnId }
+  }
+  const frames = (socket: SteerSocket) =>
+    socket.send.mock.calls.map((call) => JSON.parse(String(call[0])) as Record<string, unknown>)
+
+  it('steers a follow-up into the running turn instead of queueing it', async () => {
+    const { socket, turnId } = await openSteerableStream()
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'use staging instead', 'c1')).toBe(true)
+    })
+    expect(getPgQueue('s1')).toEqual([])
+    const steer = frames(socket).find((f) => f.steer === true)
+    expect(steer).toMatchObject({ text: 'use staging instead', steer: true })
+    expect(steer!.turnId).not.toBe(turnId)
+    const step = getLiveSteps('s1').find((s) => s.text === 'use staging instead')
+    expect(step).toMatchObject({ kind: 'msg', who: '@you', steer: true })
+
+    // The daemon steered it: its own stream ends at once and the first turn keeps streaming —
+    // a further send is still a steer, not a fresh turn.
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'ack',
+          ack: { accepted: true, turnId: steer!.turnId, agentId: 'agent-1', steered: true }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'done',
+          done: { turnId: steer!.turnId, agentId: 'agent-1', stopReason: 'steered_into_turn' }
+        })
+      })
+    })
+    expect(getLiveSteps('s1').find((s) => s.text === 'use staging instead')).toMatchObject({ steer: true })
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'and skip the migration', 'c1')).toBe(true)
+    })
+    expect(frames(socket).filter((f) => f.steer === true)).toHaveLength(2)
+    expect(getPgQueue('s1')).toEqual([])
+  })
+
+  it('puts a steer the daemon refused back at the head of the queue', async () => {
+    const { socket } = await openSteerableStream()
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'declined steer', 'c1')).toBe(true)
+    })
+    const steer = frames(socket).find((f) => f.steer === true)!
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'ack',
+          ack: { accepted: false, turnId: steer.turnId, agentId: 'agent-1', reason: 'busy' }
+        })
+      })
+    })
+    expect(getPgQueue('s1').map((q) => q.text)).toEqual(['declined steer'])
+    expect(getLiveSteps('s1').some((s) => s.text === 'declined steer')).toBe(false)
+    // With something already queued, the next send waits behind it — FIFO beats steering.
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'after it', 'c1')).toBe(true)
+    })
+    expect(getPgQueue('s1').map((q) => q.text)).toEqual(['declined steer', 'after it'])
+    expect(frames(socket).filter((f) => f.steer === true)).toHaveLength(1)
+  })
+
+  it('keeps queueing while the daemon has not declared the turn steerable', async () => {
+    SteerSocket.instances = []
+    Reflect.set(globalThis, 'WebSocket', SteerSocket)
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockResolvedValue('wss://relay.test/ws')
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello', 'c1')
+    })
+    const socket = SteerSocket.instances[0]!
+    await act(async () => {
+      socket.readyState = 1
+      socket.onopen?.()
+    })
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'queued as before', 'c1')).toBe(true)
+    })
+    expect(getPgQueue('s1').map((q) => q.text)).toEqual(['queued as before'])
+    expect(frames(socket).some((f) => f.steer === true)).toBe(false)
   })
 })

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -1111,6 +1111,9 @@ describe('mid-turn steering', () => {
     const turn = JSON.parse(String(socket.send.mock.calls.at(-1)?.[0])) as { turnId: string }
     act(() => {
       socket.onmessage?.({
+        data: JSON.stringify({ type: 'ack', ack: { accepted: true, turnId: turn.turnId, agentId: 'agent-1' } })
+      })
+      socket.onmessage?.({
         data: JSON.stringify({
           type: 'output',
           output: { turnId: turn.turnId, agentId: 'agent-1', index: 0, status: { steerable: true } }
@@ -1121,6 +1124,109 @@ describe('mid-turn steering', () => {
   }
   const frames = (socket: SteerSocket) =>
     socket.send.mock.calls.map((call) => JSON.parse(String(call[0])) as Record<string, unknown>)
+  const feed = (socket: SteerSocket, message: unknown) => socket.onmessage?.({ data: JSON.stringify(message) })
+
+  it('restores two refused steers in their send order, ahead of a later queued message', async () => {
+    const { socket } = await openSteerableStream()
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'first steer', 'c1')).toBe(true)
+      expect(pgSend('s1', 'agent-1', 'second steer', 'c1')).toBe(true)
+    })
+    const [a, b] = frames(socket).filter((f) => f.steer === true)
+    expect([a!.text, b!.text]).toEqual(['first steer', 'second steer'])
+    act(() => {
+      feed(socket, { type: 'ack', ack: { accepted: false, turnId: a!.turnId, agentId: 'agent-1', reason: 'busy' } })
+    })
+    // A later send lands behind the first refusal while the second is still on the wire …
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'typed after', 'c1')).toBe(true)
+    })
+    act(() => {
+      feed(socket, { type: 'ack', ack: { accepted: false, turnId: b!.turnId, agentId: 'agent-1', reason: 'busy' } })
+    })
+    // … and the second refusal slots back into ITS place, so the instructions run in the order typed.
+    expect(getPgQueue('s1').map((q) => q.text)).toEqual(['first steer', 'second steer', 'typed after'])
+  })
+
+  it('lets a tool call that started before a steer complete in the live view', async () => {
+    const { socket, turnId } = await openSteerableStream()
+    act(() => {
+      feed(socket, {
+        type: 'output',
+        output: {
+          turnId,
+          agentId: 'agent-1',
+          index: 1,
+          event: { kind: 'tool_call', toolCallId: 'tc-1', title: 'Run tests', status: 'in_progress' }
+        }
+      })
+    })
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'also lint', 'c1')).toBe(true)
+    })
+    act(() => {
+      feed(socket, {
+        type: 'output',
+        output: {
+          turnId,
+          agentId: 'agent-1',
+          index: 2,
+          event: { kind: 'tool_update', toolCallId: 'tc-1', status: 'completed' }
+        }
+      })
+    })
+    const tool = getLiveSteps('s1').find((s) => s.kind === 'tool' && s.toolCallId === 'tc-1')
+    expect(tool).toMatchObject({ toolStatus: 'completed' })
+    // The steer still sits between the call and whatever the agent says next.
+    const kinds = getLiveSteps('s1').map((s) => (s.steer ? 'steer' : s.kind))
+    expect(kinds.indexOf('tool')).toBeLessThan(kinds.indexOf('steer'))
+  })
+
+  it('re-sends a steer nobody acked when the socket drops and reconnects', async () => {
+    vi.useFakeTimers()
+    try {
+      const { socket } = await openSteerableStream()
+      await act(async () => {
+        expect(pgSend('s1', 'agent-1', 'lost on the wire', 'c1')).toBe(true)
+      })
+      const steer = frames(socket).find((f) => f.steer === true)!
+      // The socket dies before the daemon's verdict arrives; the turn is still busy, so the
+      // provider reconnects and must put the steer back on the wire under the SAME turnId.
+      act(() => socket.onclose?.())
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000)
+      })
+      const reconnected = SteerSocket.instances[1]!
+      expect(reconnected).toBeDefined()
+      await act(async () => {
+        reconnected.readyState = 1
+        reconnected.onopen?.()
+      })
+      act(() => feed(reconnected, { type: 'ready', conversationId: 'c1' }))
+      const resent = frames(reconnected).find((f) => f.steer === true)
+      expect(resent).toEqual(steer)
+      expect(getLiveSteps('s1').find((s) => s.text === 'lost on the wire')).toMatchObject({ steer: true })
+      expect(getPgQueue('s1')).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns an unacked steer to the queue when the socket closes on an idle turn', async () => {
+    const { socket, turnId } = await openSteerableStream()
+    await act(async () => {
+      expect(pgSend('s1', 'agent-1', 'still unanswered', 'c1')).toBe(true)
+    })
+    // The running turn ends (busy clears) and then the socket closes with the steer unacked:
+    // nothing will reconnect, so the message must not vanish behind its steer label.
+    act(() => feed(socket, { type: 'done', done: { turnId, agentId: 'agent-1', stopReason: 'end_turn' } }))
+    act(() => socket.onclose?.())
+    // Back in the queue, and — the turn being idle — straight out again as an ordinary turn.
+    const resent = getLiveSteps('s1').filter((s) => s.kind === 'msg' && s.text === 'still unanswered')
+    expect(resent).toHaveLength(1)
+    expect(resent[0]!.steer).toBeFalsy()
+    expect(getPgQueue('s1')).toEqual([])
+  })
 
   it('steers a follow-up into the running turn instead of queueing it', async () => {
     const { socket, turnId } = await openSteerableStream()

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -1212,20 +1212,65 @@ describe('mid-turn steering', () => {
     }
   })
 
-  it('returns an unacked steer to the queue when the socket closes on an idle turn', async () => {
-    const { socket, turnId } = await openSteerableStream()
-    await act(async () => {
-      expect(pgSend('s1', 'agent-1', 'still unanswered', 'c1')).toBe(true)
-    })
-    // The running turn ends (busy clears) and then the socket closes with the steer unacked:
-    // nothing will reconnect, so the message must not vanish behind its steer label.
-    act(() => feed(socket, { type: 'done', done: { turnId, agentId: 'agent-1', stopReason: 'end_turn' } }))
-    act(() => socket.onclose?.())
-    // Back in the queue, and — the turn being idle — straight out again as an ordinary turn.
-    const resent = getLiveSteps('s1').filter((s) => s.kind === 'msg' && s.text === 'still unanswered')
-    expect(resent).toHaveLength(1)
-    expect(resent[0]!.steer).toBeFalsy()
-    expect(getPgQueue('s1')).toEqual([])
+  it('keeps an unacked steer under its own turnId when the socket closes on an idle turn', async () => {
+    vi.useFakeTimers()
+    try {
+      const { socket, turnId } = await openSteerableStream()
+      await act(async () => {
+        expect(pgSend('s1', 'agent-1', 'still unanswered', 'c1')).toBe(true)
+      })
+      const steer = frames(socket).find((f) => f.steer === true)!
+      // The running turn ends (busy clears) and then the socket closes with the steer unacked. The
+      // runtime may already have it, so it must NOT become a fresh turn: the provider reconnects for
+      // the steer alone and re-sends the same frame, which the daemon reconciles.
+      act(() => feed(socket, { type: 'done', done: { turnId, agentId: 'agent-1', stopReason: 'end_turn' } }))
+      act(() => socket.onclose?.())
+      expect(getPgQueue('s1')).toEqual([])
+      expect(getLiveSteps('s1').filter((s) => s.text === 'still unanswered')).toMatchObject([{ steer: true }])
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000)
+      })
+      const reconnected = SteerSocket.instances[1]!
+      expect(reconnected).toBeDefined()
+      await act(async () => {
+        reconnected.readyState = 1
+        reconnected.onopen?.()
+      })
+      act(() => feed(reconnected, { type: 'ready', conversationId: 'c1' }))
+      expect(frames(reconnected).find((f) => f.steer === true)).toEqual(steer)
+      // The daemon had run it as its own turn (the turn was over): the copy is reported accepted, the
+      // step becomes an ordinary user turn and the browser opens its lane and pulls the replay.
+      act(() => feed(reconnected, { type: 'ack', ack: { accepted: true, turnId: steer.turnId, agentId: 'agent-1' } }))
+      expect(getLiveSteps('s1').filter((s) => s.text === 'still unanswered')).toMatchObject([{ steer: undefined }])
+      expect(frames(reconnected).find((f) => f.type === 'resume')).toMatchObject({ turnId: steer.turnId })
+      expect(getPgQueue('s1')).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not requeue an unacked steer when reconnecting gives up — the delivery is marked uncertain', async () => {
+    vi.useFakeTimers()
+    try {
+      const { socket } = await openSteerableStream()
+      await act(async () => {
+        expect(pgSend('s1', 'agent-1', 'maybe delivered', 'c1')).toBe(true)
+      })
+      act(() => socket.onclose?.())
+      // Every reconnect attempt dies at once until the budget is spent.
+      for (let attempt = 0; attempt < 8; attempt++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5_000)
+        })
+        const latest = SteerSocket.instances.at(-1)!
+        if (latest !== socket && latest.readyState === 0) act(() => latest.onclose?.())
+      }
+      expect(getPgQueue('s1')).toEqual([])
+      expect(getLiveSteps('s1').filter((s) => s.text === 'maybe delivered')).toMatchObject([{ steer: true }])
+      expect(getLiveSteps('s1').some((s) => s.kind === 'done' && s.text.includes('Could not confirm'))).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('steers a follow-up into the running turn instead of queueing it', async () => {

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -1249,6 +1249,44 @@ describe('mid-turn steering', () => {
     }
   })
 
+  it('opens and resumes a late steer whose accepted ack outran the older turn’s replayed done', async () => {
+    vi.useFakeTimers()
+    try {
+      const { socket, turnId } = await openSteerableStream()
+      await act(async () => {
+        expect(pgSend('s1', 'agent-1', 'late steer', 'c1')).toBe(true)
+      })
+      const steer = frames(socket).find((f) => f.steer === true)!
+      // The socket drops while the first turn still streams here; daemon-side that turn ends and
+      // the steer is admitted as its own turn before the browser reconnects.
+      act(() => socket.onclose?.())
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000)
+      })
+      const reconnected = SteerSocket.instances[1]!
+      await act(async () => {
+        reconnected.readyState = 1
+        reconnected.onopen?.()
+      })
+      act(() => feed(reconnected, { type: 'ready', conversationId: 'c1' }))
+      expect(frames(reconnected).find((f) => f.steer === true)).toEqual(steer)
+      // The copy's plain accepted ack arrives BEFORE the older turn's replayed done.
+      act(() => feed(reconnected, { type: 'ack', ack: { accepted: true, turnId: steer.turnId, agentId: 'agent-1' } }))
+      expect(frames(reconnected).filter((f) => f.type === 'resume' && f.turnId === steer.turnId)).toEqual([])
+      act(() => feed(reconnected, { type: 'done', done: { turnId, agentId: 'agent-1', stopReason: 'end_turn' } }))
+      // Retiring the older lane hands over to the late turn: its lane opens and is resumed, and the
+      // message reads as an ordinary turn — the reply will stream into this connection.
+      expect(frames(reconnected).find((f) => f.type === 'resume' && f.turnId === steer.turnId)).toMatchObject({
+        turnId: steer.turnId,
+        agentId: 'agent-1'
+      })
+      expect(getLiveSteps('s1').filter((s) => s.text === 'late steer')).toMatchObject([{ steer: undefined }])
+      expect(getPgQueue('s1')).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not requeue an unacked steer when reconnecting gives up — the delivery is marked uncertain', async () => {
     vi.useFakeTimers()
     try {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1921,6 +1921,8 @@ type Turn =
       image?: SessionImage
       isCron: boolean
       cronId: string | null
+      /** Sent into the agent's running turn (#1847) rather than as a turn of its own. */
+      steer?: boolean
       /** The platform this message was authored on — see `FmtStep.platform`. */
       platform?: string
       /** The facts behind a delivery turn (transcript-full-tool-body.md §9) — the bubble's "more". */
@@ -3959,8 +3961,14 @@ export default function SessionDetailView() {
     }
   } else {
     let firstMsg = true
+    // Steers fence the running turn's block: the reply that continues after one starts a
+    // fresh block below it instead of merging back into the block above (#1847).
+    let steerSegment = 0
+    const segmentedKey = (turnKey: string | undefined): string | undefined =>
+      turnKey && steerSegment > 0 ? `${turnKey}:s${steerSegment}` : turnKey
     session.steps.forEach((stp) => {
       if (stp.kind === 'msg') {
+        if (stp.steer) steerSegment += 1
         const who = stp.who ?? session.user
         if (isBgTaskWake(stp.who)) {
           pushOwnerWakeTurn(
@@ -4001,6 +4009,7 @@ export default function SessionDetailView() {
           image: stp.image,
           isCron: !!cron,
           cronId: cron?.id ?? null,
+          ...(stp.steer ? { steer: true } : {}),
           platform: session.platform
         })
         firstMsg = false
@@ -4015,7 +4024,7 @@ export default function SessionDetailView() {
         if (stp.agentId && stp.agentId !== session.agentId) {
           rememberAgentParticipant(stp.agentId, stepAgentName, stepAgent ?? null)
         }
-        const turnKey = liveBotTurnKey(stp.turnId, stp.agentId)
+        const turnKey = segmentedKey(liveBotTurnKey(stp.turnId, stp.agentId))
         let last = turnKey ? botTurnByKey.get(turnKey) : turns[turns.length - 1]
         last = bindWakeBlock(last, { agentId: stp.agentId, agentName: stepAgentName }, turnKey)
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
@@ -4046,8 +4055,12 @@ export default function SessionDetailView() {
   // turns you send THIS visit below its fetched history, like a synthetic
   // playground session.
   if (isWebchat || isContinuable) {
+    let steerSegment = 0
+    const segmentedKey = (turnKey: string | undefined): string | undefined =>
+      turnKey && steerSegment > 0 ? `${turnKey}:s${steerSegment}` : turnKey
     for (const stp of liveSteps) {
       if (stp.kind === 'msg') {
+        if (stp.steer) steerSegment += 1
         const who = stp.who ?? session.user
         if (isBgTaskWake(stp.who)) {
           pushOwnerWakeTurn(
@@ -4083,6 +4096,7 @@ export default function SessionDetailView() {
           image: stp.image,
           isCron: false,
           cronId: null,
+          ...(stp.steer ? { steer: true } : {}),
           platform: session.platform
         })
       } else {
@@ -4091,7 +4105,7 @@ export default function SessionDetailView() {
         if (stp.agentId && stp.agentId !== session.agentId) {
           rememberAgentParticipant(stp.agentId, stepAgentName, stepAgent ?? null)
         }
-        const turnKey = liveBotTurnKey(stp.turnId, stp.agentId)
+        const turnKey = segmentedKey(liveBotTurnKey(stp.turnId, stp.agentId))
         let last = turnKey ? botTurnByKey.get(turnKey) : turns[turns.length - 1]
         last = bindWakeBlock(last, { agentId: stp.agentId, agentName: stepAgentName }, turnKey)
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
@@ -4882,6 +4896,11 @@ export default function SessionDetailView() {
                                   ) : (
                                     <span>{turn.sp.name}</span>
                                   )}
+                                </span>
+                              )}
+                              {turn.steer && (
+                                <span className="pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
+                                  Steered into the running reply
                                 </span>
                               )}
                               <div className={SELF_BUBBLE}>

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1151,6 +1151,9 @@ export interface SessionStep {
    *  history view gets, via the existing `fetchToolBody` read. */
   toolCallId?: string
   toolStatus?: string
+  /** A `msg` step sent INTO a running turn (#1847): rendered as a steer, and a grouping fence
+   *  so the reply that continues after it starts a fresh block below it. */
+  steer?: boolean
   /** The daemon session that recorded this tool call — set on live multi-agent
    *  steps where the owning participant's session differs from the row's
    *  primary `realSessionId`; the on-demand tool-body read targets it. */
@@ -1269,6 +1272,9 @@ export interface Session {
    *  status frame). `fastModeAvailable` false/absent ⇒ no fast toggle shown. */
   fastMode?: boolean
   fastModeAvailable?: boolean
+  /** A message sent while the turn streams is steered into it (webchat status frame, #1847)
+   *  instead of waiting in the composer's queue. */
+  steerable?: boolean
   /** Daemon-side output verbosity the session ran with (low/medium/high) — the
    *  CP-stored execution-config snapshot; absent on legacy rows. */
   outputMode?: string


### PR DESCRIPTION
Closes #1847. Delivers the daemon-side wiring #547 asked for and the console composer slice on top of it.

## What changed

**Daemon: steer instead of queue (#1847)**

- `AcpHost` reads `_meta.steering.supported` at `initialize` (`steeringSupported()`) and exposes `steer(sessionId, blocks, { idleBehavior })` over the `_session/steering` extension method. The daemon always sends `idleBehavior: promptRequired`, so a steer that races the turn end is declined by the runtime instead of becoming a turn nobody admitted. The wire helpers live in `acp/steering.ts`; when upstream `session/inject` lands, that module and `AcpHost.steer()` are the only places that change.
- The queued admission branch offers an eligible arrival to the live prompt before placing it on `serialQueue` (`steerIntoLiveTurn`). Eligible means an ordinary human chat message: `!queue`, code-host hooks, scheduler wakes, agent-to-agent calls and barrier-holding entries stay serialised (`daemon/steering-admission.ts`). `Pending` gained `promptInFlight` and `steerCount`, so only a turn whose `session/prompt` is awaiting the runtime is a target, bounded by `MAX_STEERS_PER_TURN`.
- `injected` settles the entry exactly like a coalesced one (`steered_into_turn`): transcript row upgraded to a delivery, durable inbox row released, dispatch promise resolved with the live session id, `turn_queue_steered_total` metric. The row is marked absorbed and claimed at steer time, so neither the start fence nor the final refresh regenerates for it and a late admission cannot coalesce it twice.
- `failed`, an RPC error, a spent per-turn budget, a runtime without the capability, or `features.sessionSteering: false` fall back to today's queue path.
- The Linear ack says the message was added to the running task instead of queued (`onAdmission` reports `steered`). The runtime probe records and logs the capability.

**Webchat composer (#547)**

- The webchat status frame carries `steerable` while the live turn's host advertised steering. The browser turn frame may carry `steer: true`; the relay passes it through and copies the daemon's `steered` verdict back on the ack.
- A `steer: true` turn is steer-or-refuse: `dispatchWebchatTurn` awaits the admission verdict and acks `steered`, plain accepted when the turn had already ended (it runs as its own turn), or `busy` when the runtime declined. A refused steer leaves no queue entry, stream or transcript row behind, so the browser can re-send the same text later without it being answered twice.
- The console provider steers when the daemon declared the turn steerable, nothing is already queued, the message is text-only and the conversation has one agent; otherwise it queues as before. A steer opens no stream lane: its `done` settles it, a `busy` refusal puts it back at the head of the composer queue (still cancellable), and a late ack without `steered` on an idle lane opens the lane for the turn it became. An older relay that drops the flag still works: that turn's own frames admit a lane lazily.
- The session view labels a steered message as steered into the running reply, and the reply that continues after it starts a fresh block below it instead of merging into the block above.

**Docs**: `docs/product-conventions.md` gains a section on mid-turn steering; `turn-final-context-refresh.md` §5.4 notes that steering precedes queueing.

## Decisions a reviewer should check

- **Default on.** `features.sessionSteering` defaults to `true`, matching where `turnFinalContextRefresh` ended up; the capability gate makes it a no-op for runtimes that cannot steer.
- **Past the per-turn cap the message queues rather than being rejected `busy`.** The issue text says reject; queueing keeps the existing depth cap as the backstop and does not drop a user's message. One-line change if you prefer the issue's wording.
- **`startedNewTurn`** (should not happen under `promptRequired`) is treated as admitted, with a warning.
- **Steering capability is not persisted in the CP `RuntimeProfile`.** It reaches the probe result, the probe log and the webchat status frame; the Prisma column, DTO and web surfacing are a separate change.
- Multi-agent conversations and image sends keep the composer queue.

## Tests

- New: `acp-steering.test.ts` (wire helpers + admission policy), `daemon-session-steering.test.ts` (steer, fallback ladder, `!queue`/cron/feature switch, budget, steer while parked on `session/request_permission`), `webchat-steering.test.ts` (steered / busy refusal / turn already ended), AcpHost steering cases against the fake ACP agent (fixture gained `AC_STEERING` / `AC_STEER_HOLD_PROMPT`), relay parse and ack passthrough, provider steering cases in `PlaygroundSend.test.tsx`.
- Passing: protocol and relay full suites; daemon suites touched by the change (serial gate, turn-output workflow, webchat refresh, Linear ingress, runtime prober, cluster probe); web typecheck; eslint and prettier on all changed files.
- Not done: browser end-to-end verification (needs daemon + relay + a real runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
