### PR TITLE
fix(control-plane): a pin to a managed pool member is refused, not a 500

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -234,6 +234,11 @@ export const DaemonViewDto = z.object({
    *  owns its agents outright. A member serves only what it holds a duty lease for, so this is
    *  what says whether an agent may be pinned here or must be placed on the set. */
   memberSetId: z.string().nullable(),
+  /** Whether an agent may be given a `daemon` placement naming THIS daemon (daemon-groups.md §3).
+   *  False for a member of the install-wide managed pool: the reconciler retires those Pods without
+   *  notice, so a pin outlives what it names — such an agent belongs on the pool itself. An org's
+   *  own machines stay pinnable whether or not they have joined a group. */
+  pinnable: z.boolean(),
   // ── visibility / sharing (docs/designs/resource-visibility.md) ──
   visibility: ResourceVisibilityEnum,
   sharedWith: z.array(z.string()), // complete app_user.id audience when restricted

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -240,7 +240,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: 'listDaemons',
     description:
-      'List the daemons (edge execution units) in the organization that are visible to you, with status and load. This is the liveness view — what each daemon can RUN is listDaemonCapabilities, and one runtime’s model catalog is getDaemon.',
+      'List the daemons (edge execution units) in the organization that are visible to you, with status and load. `pinnable: false` marks a member of the install-wide managed pool: it is a replaceable Pod, so never pass its id as createAgent’s daemonId — place the agent on the pool instead. This is the liveness view — what each daemon can RUN is listDaemonCapabilities, and one runtime’s model catalog is getDaemon.',
     schema: NoArgs,
     call: (ctx) => ctx.get(org(ctx, '/daemons'))
   },
@@ -379,7 +379,20 @@ export const MCP_TOOLS: McpToolDef[] = [
         outputMode: OutputMode.optional(),
         fastMode: z.boolean().optional(),
         permissionMode: z.string().min(1).optional(),
-        daemonId: z.string().min(1).optional().describe('Pin to a daemon (from listDaemons); omit to leave unplaced'),
+        placementKind: z
+          .enum(['daemon', 'pool', 'set'])
+          .optional()
+          .describe(
+            'Where the agent runs: "pool" for the install-wide managed pool (needs no daemonId — use this on a Cloud install), "set" with setId, or "daemon" (the default) with daemonId. Omit all three to leave the agent unplaced.'
+          ),
+        setId: z.string().uuid().optional().describe('The member set to place on, for placementKind "set"'),
+        daemonId: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            'Pin to ONE daemon from listDaemons, for placementKind "daemon". Only a daemon whose `pinnable` is true may be named: a managed pool member is replaceable and is refused. Omit to leave unplaced.'
+          ),
         pause: z.boolean().optional()
       })
       .strict(),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -115,6 +115,8 @@ import { reconcileAgentLinkedDms } from '../../orchestrator/linkedDmReconcile.js
 import { ProtocolError } from '../../domain/errors.js'
 import {
   AGENT_WORKSPACE_INTEGRATION_CONFLICT_MESSAGE,
+  AgentSetPlacementDenied,
+  DaemonPlacementInSet,
   MemoryConnectionBusy,
   MemoryConnectionMissing
 } from '../../persistence/errors.js'
@@ -424,6 +426,18 @@ async function placedOnInstallPool(
   if (target.setId) return target.setId === pool
   if (target.daemonId) return (await deps.repos.memberSet.setIdOf(DaemonId(target.daemonId))) === pool
   return false
+}
+
+/** The write-time placement invariants (daemon-groups.md §2, §3) are asserted inside the
+ *  transaction that writes the placement, so they surface as a throw from any route that
+ *  writes one. Both are caller refusals, not faults — a route that lets one escape answers
+ *  a bare 500. Returns the client-facing message, or null when the error is something else. */
+function placementRefusalMessage(e: unknown): string | null {
+  if (e instanceof DaemonPlacementInSet) {
+    return 'that daemon is a managed pool member, and a pool member is a replaceable identity that an agent may not be pinned to — place the agent on the pool itself instead (placementKind: "pool")'
+  }
+  if (e instanceof AgentSetPlacementDenied) return 'the agent may not be placed on that member set'
+  return null
 }
 
 /** The members of a set that could serve an agent right now. One read; reuse it for a page.
@@ -1821,6 +1835,8 @@ export function agentRoutes(deps: HttpDeps) {
           if (e instanceof OrganizationEnvironmentAdmissionError) {
             return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: e.message })
           }
+          const refused = placementRefusalMessage(e)
+          if (refused) return conflict(refused)
           throw e
         }
       }
@@ -2803,6 +2819,8 @@ export function agentRoutes(deps: HttpDeps) {
                 app.log.warn({ err, agentId: existing.id }, 'agent move repair failed')
                 return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: err.message })
               }
+              const refusedRepair = placementRefusalMessage(err)
+              if (refusedRepair) return conflict(refusedRepair)
               throw err
             }
           }
@@ -2849,6 +2867,8 @@ export function agentRoutes(deps: HttpDeps) {
             app.log.warn({ err, agentId: existing.id }, 'agent move failed')
             return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: err.message })
           }
+          const refusedMove = placementRefusalMessage(err)
+          if (refusedMove) return conflict(refusedMove)
           throw err
         } finally {
           // Re-read usage instead of trusting a local "committed" flag: a move

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -121,7 +121,9 @@ function toDto(
   graceMs: number,
   nowMs: number,
   release: { channel: string; latestVersion: string | null; availableVersions: string[] },
-  latestOp: DaemonLifecycleOpRecord | null
+  latestOp: DaemonLifecycleOpRecord | null,
+  // The install-wide pool's set id, or null where this read does not project `pinnable`.
+  poolSetId: string | null
 ): DaemonViewDtoT {
   // Read-time expiry projection: a still-`pending` op past its deadline is reported as
   // `failed` (timed out) even before the sweep/next-command persists that — so the
@@ -171,6 +173,10 @@ function toDto(
     // failing the whole response's schema serialization.
     sessionRetention: SESSION_RETENTION_RE.test(view.sessionRetention) ? view.sessionRetention : '7d',
     memberSetId: view.memberSetId,
+    // Membership is the read, not "org-less daemon" — the same predicate `assertDaemonNotInSet`
+    // enforces inside the placement transaction, so what the fleet advertises is what a create
+    // or a move will actually accept.
+    pinnable: !(view.memberSetId !== null && poolSetId !== null && view.memberSetId === poolSetId),
     visibility: view.visibility,
     sharedWith: view.sharedWith,
     canEdit: orgOwned && canEdit(view, ctx),
@@ -225,10 +231,19 @@ export function daemonRoutes(deps: HttpDeps) {
   // single mutation response fetches its own daemon's latest op; the list route batches
   // (see below) to avoid an N+1. `latestForDaemon` (any status, not just pending) so a
   // terminal op stays observable — the console reads terminal state, not just in-flight.
-  const dtoWith = (view: DaemonView, ctx: ViewCtx, latestOp: DaemonLifecycleOpRecord | null): DaemonViewDtoT =>
-    toDto(view, deps.liveness, ctx, graceMs, Date.now(), release(), latestOp)
-  const dto = async (view: DaemonView, ctx: ViewCtx): Promise<DaemonViewDtoT> =>
-    dtoWith(view, ctx, await deps.repos.daemonLifecycleOp.latestForDaemon(DaemonId(view.daemonId)))
+  const dtoWith = (
+    view: DaemonView,
+    ctx: ViewCtx,
+    latestOp: DaemonLifecycleOpRecord | null,
+    poolSetId: string | null
+  ): DaemonViewDtoT => toDto(view, deps.liveness, ctx, graceMs, Date.now(), release(), latestOp, poolSetId)
+  const dto = async (view: DaemonView, ctx: ViewCtx): Promise<DaemonViewDtoT> => {
+    const [latestOp, poolSetId] = await Promise.all([
+      deps.repos.daemonLifecycleOp.latestForDaemon(DaemonId(view.daemonId)),
+      deps.repos.memberSet.crossOrgSetId()
+    ])
+    return dtoWith(view, ctx, latestOp, poolSetId)
+  }
 
   return async function daemonRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
@@ -249,9 +264,12 @@ export function daemonRoutes(deps: HttpDeps) {
         const ctx = ctxOf(req)
         const rows = await deps.registry.listAvailable(orgOf(req), ctx)
         // One batched latest-op query for the whole fleet (no N+1), grouped by daemon.
-        const ops = await deps.repos.daemonLifecycleOp.latestForDaemons(rows.map((d) => DaemonId(d.daemonId)))
+        const [ops, poolSetId] = await Promise.all([
+          deps.repos.daemonLifecycleOp.latestForDaemons(rows.map((d) => DaemonId(d.daemonId))),
+          deps.repos.memberSet.crossOrgSetId()
+        ])
         const byDaemon = new Map(ops.map((o) => [o.daemonId as string, o]))
-        return rows.map((d) => fleetOf(dtoWith(d, ctx, byDaemon.get(d.daemonId) ?? null)))
+        return rows.map((d) => fleetOf(dtoWith(d, ctx, byDaemon.get(d.daemonId) ?? null, poolSetId)))
       }
     )
 
@@ -272,7 +290,8 @@ export function daemonRoutes(deps: HttpDeps) {
         const ctx = ctxOf(req)
         const rows = await deps.registry.listAvailable(orgOf(req), ctx)
         // Capability needs no lifecycle op, so this read skips that query entirely.
-        return rows.map((d) => capabilityOf(toDto(d, deps.liveness, ctx, graceMs, Date.now(), release(), null)))
+        // `pinnable` is not part of the capability half, so this read skips the pool lookup too.
+        return rows.map((d) => capabilityOf(toDto(d, deps.liveness, ctx, graceMs, Date.now(), release(), null, null)))
       }
     )
 

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -959,3 +959,36 @@ describe('PUT /agents/:id/daemon — a two-hop move back onto the pool (#1093)',
     expect(control.activateCalls.slice(hop1Activates).filter((a) => a.daemonId === TARGET)).toEqual([])
   })
 })
+
+describe('a `daemon` placement naming a managed pool member', () => {
+  it('POST /agents refuses the pin as a 409 instead of letting the invariant escape as a 500', async () => {
+    // A pool member is a replaceable Pod, so `assertDaemonNotInSet` throws inside the create
+    // transaction. A route that does not map that throw answers a bare 500 — and the delegated
+    // admin MCP, whose only placement field is `daemonId`, walks straight into it.
+    await seedMoveDaemons()
+    await seedPoolMember()
+    running = buildHttpApp(prisma, undefined, poolLive, new MoveControlSpy() as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'pinned-to-member', runtime: 'Claude Code', daemonId: MEMBER }
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toMatch(/managed pool member/)
+    expect(await prisma.agent.findFirst({ where: { name: 'pinned-to-member' } })).toBeNull()
+  })
+
+  it('GET /daemons marks the pool member unpinnable and an org-owned machine pinnable', async () => {
+    await seedMoveDaemons()
+    await seedPoolMember()
+    running = buildHttpApp(prisma, undefined, poolLive, new MoveControlSpy() as unknown as ControlSender)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    expect(res.statusCode).toBe(200)
+    const byId = new Map((res.json() as { daemonId: string; pinnable: boolean }[]).map((d) => [d.daemonId, d]))
+    expect(byId.get(MEMBER)?.pinnable).toBe(false)
+    expect(byId.get(SOURCE)?.pinnable).toBe(true)
+  })
+})


### PR DESCRIPTION
## What happened

A user asked the built-in `agentconnect` preset to create a code-reviewer agent from a
private webchat conversation. The delegated `createAgent` reached the operation ledger,
the user approved it in the browser, and the CP answered:

```
{"statusCode":500,"body":"{\"error\":\"Internal Server Error\",\"statusCode\":500,\"message\":\"internal server error\"}"}
```

`assertDaemonNotInSet` (daemon-groups.md §3) refuses a `daemon` placement naming a member
of the install-wide managed pool — the reconciler retires those Pods without notice, so a
pin is a pointer that outlives what it names. It throws inside the transaction that writes
the placement, and **no route caught it**: the create route's outer catch handles
`MemoryConnectionBusy` / `MemoryConnectionMissing` / `OrganizationEnvironmentAdmissionError`
and rethrows everything else. `AgentSetPlacementDenied`, thrown by `assertAgentMayUseSet`
on the same seam, escaped identically. Both were reachable from `POST /agents` and from
both `PUT /agents/:id/daemon` paths.

The delegated admin MCP walks straight into it. Its `createAgent` exposed only `daemonId`
("Pin to a daemon (from listDaemons); omit to leave unplaced"), and `listDaemons` returns
the pool's Pods with nothing marking them unpinnable. On a Cloud install the tool's only
two expressible outcomes were a 500 or an agent left unplaced — a pool placement, the
correct answer, had no field at all.

Reproduced deterministically against a live control plane:

| body | before |
| --- | --- |
| `{name, runtime}` | 201 |
| `+ daemonId` = pool member | **500** |
| `+ daemonId` = unknown uuid | 404 |
| `+ daemonId` = pool member, `memory.home: "daemon"` | 409 |
| `{name, runtime, placementKind: "pool"}` | 201 |

## Fix

- **`routes/agents.ts`** — one `placementRefusalMessage` mapper for both placement
  invariants, wired into the create catch and both move catches. A pin to a pool member
  now answers 409 naming `placementKind: "pool"` as the way out. Both routes already
  declared 409.
- **`mcp/tools.ts`** — `createAgent` gains `placementKind` (`daemon` | `pool` | `set`) and
  `setId`; `daemonId` now says only a daemon whose `pinnable` is true may be named. The
  REST `CreateAgentBody` already accepted both fields, so this exposes existing capability.
- **`dto/index.ts` + `routes/daemons.ts`** — the daemon DTO projects `pinnable`, computed
  with the *same membership predicate* the placement transaction enforces (not `cloud` or a
  bare `memberSetId`, which also match an org's own group), so the fleet advertises what a
  create or move will actually accept. `listDaemons`' tool description names it. The
  capability half does not carry it and skips the extra lookup.

## Verification

- Two regression tests in `agents.move.route.test.ts`, where the live pool fixtures already
  are: the pin answers 409 and persists nothing; `GET /daemons` marks the pool member
  `pinnable: false` and an org-owned machine `true`.
- `typecheck` clean for control-plane and web (`pinnable` is additive).
- control-plane unit: 2283 passed. Integration: `agents.move`, `agents`, `daemons`,
  `member-sets`, `mcp` — 148 passed, including the two new cases.

## Not in this PR

The same session first failed with `401 remote MCP grant denied` during a pool rollout: a
delegated grant is rotated when a new Pod picks up the agent's duty, but the bearer is
baked into the runtime's MCP descriptor at turn start and only refreshed at the *next*
prompt via `forgetSession`. An in-flight turn keeps a revoked credential and the generic
401 leaves the model to guess (it reported "read-only access"). That needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
