### PR TITLE
feat(daemon): a Telegram form is filled in over one keyboard

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -2014,12 +2014,16 @@ export class PermissionCoordinator {
       const form = this.cardForm(rec)
       if (!form) continue
       const claimed = rec.facet.claimReply(rec, { requestId, params: rec.params, form }, reply)
-      if (!claimed || claimed.kind !== 'submit') continue
-      await this.submitElicitForm({
-        requestId,
-        fields: claimed.fields,
-        ...(reply.actor ? { actor: reply.actor } : {})
-      })
+      if (!claimed) continue
+      // `pending` is still a CLAIM: the words answered this card, they just filled one field of a
+      // form the reader has yet to Confirm. Treating it as unclaimed would send that field's own
+      // answer on to the agent as a fresh prompt.
+      if (claimed.kind === 'submit')
+        await this.submitElicitForm({
+          requestId,
+          fields: claimed.fields,
+          ...(reply.actor ? { actor: reply.actor } : {})
+        })
       return true
     }
     return false

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -28,6 +28,7 @@
  * 2026-09-08 against the Bot API: an edit omitting `reply_markup`, and one sending an empty
  * `inline_keyboard`, both return a message with no markup).
  */
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
 import { elicitFormBlockId } from '@agentconnect.md/protocol'
 import type {
   ElicitCardAsk,
@@ -47,9 +48,10 @@ import { TELEGRAM_MESSAGE_LIMIT } from '../../telegram/render.js'
 import type { TelegramTurnState } from './turn-output.js'
 import {
   clampTo,
-  elicitCardShape,
   elicitFieldExpectation,
   elicitFormFieldHint,
+  elicitFormFieldLabel,
+  elicitOptionLiteral,
   elicitOptionToken,
   type ElicitKind,
   type ElicitSurface,
@@ -85,13 +87,42 @@ const TELEGRAM_ELICIT_DISMISS = 'x'
  *  for the same reason Dismiss is not: it names no option, it names the set of them. */
 const TELEGRAM_ELICIT_CONFIRM = 'ok'
 
+/** The token that returns a field's own keyboard to the card's overview. Names no field: there
+ *  is one overview, and going back to it is the same act whichever field was open. */
+const TELEGRAM_ELICIT_BACK = 'bk'
+
+/** A form field's own token: `f<i>` opens field i, `f<i>o<n>` picks or ticks its option n. A field
+ *  index and an option position both fit what a 64-byte `callback_data` has left after the request
+ *  id (21 characters), and both are bounded — ten fields, twenty-four options. Pure. */
+export function telegramElicitFieldToken(field: number, option?: number): string {
+  return option === undefined ? `f${field}` : `f${field}o${option}`
+}
+
+/** The field, and the option within it, one form token names — null for anything else. Pure. */
+export function parseTelegramElicitField(token: string): { field: number; option?: number } | null {
+  const m = /^f(\d{1,2})(?:o(\d{1,3}))?$/.exec(token)
+  if (!m) return null
+  const field = Number(m[1])
+  return m[2] === undefined ? { field } : { field, option: Number(m[2]) }
+}
+
 /** The token the button that OPENS A PROMPT carries — the one control a keyboard has for a field
  *  that must be typed. It names no option either: it asks for the box, it does not answer. */
 const TELEGRAM_ELICIT_PROMPT = 'ed'
 
-/** How an assembled card draws one option's checkbox. Literal emoji, as the marks are. */
+/** How an assembled card draws one option's checkbox, and — for a field that takes ONE of them —
+ *  its radio. Two vocabularies because they promise different things: a tick accumulates, a dot
+ *  replaces. Literal emoji, as the marks are. */
 const TELEGRAM_ELICIT_CHECKED = '\u2611\ufe0f'
 const TELEGRAM_ELICIT_UNCHECKED = '\u2b1c\ufe0f'
+const TELEGRAM_ELICIT_PICKED = '\ud83d\udd35'
+const TELEGRAM_ELICIT_UNPICKED = '\u26aa'
+
+/** How long one button's label may be. Telegram publishes no per-button cap — an over-large
+ *  `reply_markup` is refused as a whole (see {@link TELEGRAM_ELICIT_MAX_BUTTONS}) — so this is the
+ *  75 characters a reduced option label already clamps to, applied to the composed labels a form
+ *  card builds so the measured headroom keeps holding. */
+const TELEGRAM_BUTTON_LABEL_CAP = 75
 
 /**
  * How much of the ANSWER a settled card echoes back. The decision core supplies is not bounded —
@@ -210,13 +241,110 @@ export function telegramElicitFormText(message: string, target: ElicitTarget): s
   return `${telegramElicitText(clampTo(message, Math.max(0, TELEGRAM_ELICIT_MESSAGE_CAP - hint.length - 1)))}\n${hint}`
 }
 
-/** The one field an assembled Telegram card renders, or null when this form is not one — a LONE
- *  multi-select, which the keyboard ticks, or a lone typed field, which a prompt collects. Several
- *  questions are not one of these: they would need a prompt per field. Pure. */
+/** The one field an assembled SINGLE-FIELD Telegram card renders, or null when this form is not
+ *  one — a LONE multi-select, which the keyboard ticks, or a lone typed field, which a prompt
+ *  collects. Several questions take the form card instead. Pure. */
 export function telegramAssembledField(form: readonly ElicitTarget[]): ElicitTarget | null {
   const only = form.length === 1 ? form[0]! : null
   if (!only) return null
   return only.kind === 'multi-enum' || only.kind === 'text' || only.kind === 'number' ? only : null
+}
+
+/**
+ * Which of Telegram's four elicitation cards a reduction takes, or null for none.
+ *
+ * One keyboard, four uses, decided ONCE here rather than re-derived by `build` and again by `tap`
+ * — the two disagreeing is how a card gets a control its own fold does not understand.
+ *
+ * - `buttons` — a lone single-select or boolean: one tap is the whole answer.
+ * - `checkboxes` — a lone multi-select: a flat tick list with one Confirm.
+ * - `prompt` — a lone typed field: a button that opens a `force_reply` box.
+ * - `form` — several questions: one row per field over the same keyboard, each opening the field's
+ *   own controls, with ONE Confirm for the whole card. This is also the shape a question that
+ *   brought a free-text companion takes ("pick one, or type your own"), which is two TARGETS.
+ */
+export type TelegramCardShape = 'buttons' | 'checkboxes' | 'prompt' | 'form'
+
+export function telegramCardShape(form: readonly ElicitTarget[]): TelegramCardShape | null {
+  if (!form.length) return null
+  if (form.length > 1) return 'form'
+  const only = form[0]!
+  if (only.kind === 'enum' || only.kind === 'boolean') return only.options.length ? 'buttons' : null
+  if (only.kind === 'multi-enum') return only.options.length ? 'checkboxes' : null
+  return 'prompt'
+}
+
+/** What a form card's row says a field currently holds — the chosen labels, in the card's own
+ *  words, or an em dash for a field nobody has filled in yet.
+ *
+ *  A form card holds its answers as the wire holds them: an option field's value is that option's
+ *  POSITION (`ac_o<n>`), because that is what the Confirm submits and what core re-derives against
+ *  the card's own form (#1815). So the label is looked up THROUGH the position, never from the
+ *  stored string. A typed field has no options and holds its own words. Pure. */
+export function telegramFieldValueLabel(target: ElicitTarget, value: string | string[] | undefined): string {
+  if (value === undefined) return '—'
+  if (!target.options.length) return Array.isArray(value) ? value.join(', ') : value
+  const label = (carried: string) => {
+    const literal = elicitOptionLiteral(target, carried)
+    return target.options.find((o) => o.value === literal)?.label ?? carried
+  }
+  if (Array.isArray(value)) return value.length ? value.map(label).join(', ') : 'none'
+  return label(value)
+}
+
+/** A form card's OVERVIEW keyboard: one row per field, saying what it holds and opening its own
+ *  controls, then the single Confirm the whole card submits on and Dismiss. Pure. */
+export function telegramElicitFormButtons(
+  requestId: string,
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[],
+  values: readonly (string | string[] | undefined)[]
+): InlineButton[][] {
+  const rows = form.map((target, i) => [
+    {
+      text: clampTo(
+        `${elicitFormFieldLabel(params, target)}: ${telegramFieldValueLabel(target, values[i])}`,
+        TELEGRAM_BUTTON_LABEL_CAP
+      ),
+      callbackData: telegramElicitData(requestId, telegramElicitFieldToken(i))
+    }
+  ])
+  rows.push([
+    { text: 'Confirm', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_CONFIRM) },
+    { text: 'Dismiss', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_DISMISS) }
+  ])
+  return rows
+}
+
+/** ONE field's own keyboard, opened from the overview: its options, each marked with what it
+ *  currently is, and the way back. A single-select's pick returns to the overview by itself (the
+ *  pick IS the whole of that field), so its way back is only for a reader who changed their mind;
+ *  a multi-select's ticks accumulate, so `Done` is how it closes. Pure. */
+export function telegramElicitFieldButtons(
+  requestId: string,
+  field: number,
+  target: ElicitTarget,
+  value: string | string[] | undefined
+): InlineButton[][] {
+  const multi = target.kind === 'multi-enum'
+  // Held as POSITIONS, which is what the buttons carry and what the Confirm submits.
+  const chosen = new Set(Array.isArray(value) ? value : value === undefined ? [] : [value])
+  const mark = (n: number) =>
+    multi
+      ? chosen.has(elicitOptionToken(n))
+        ? TELEGRAM_ELICIT_CHECKED
+        : TELEGRAM_ELICIT_UNCHECKED
+      : chosen.has(elicitOptionToken(n))
+        ? TELEGRAM_ELICIT_PICKED
+        : TELEGRAM_ELICIT_UNPICKED
+  const rows = target.options.map((o, n) => [
+    {
+      text: clampTo(`${mark(n)} ${o.label}`, TELEGRAM_BUTTON_LABEL_CAP),
+      callbackData: telegramElicitData(requestId, telegramElicitFieldToken(field, n))
+    }
+  ])
+  rows.push([{ text: multi ? 'Done' : 'Back', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_BACK) }])
+  return rows
 }
 
 /** The keyboard under a card whose answer must be TYPED: the button that opens the box, and
@@ -229,6 +357,17 @@ export function telegramElicitPromptButtons(requestId: string): InlineButton[][]
       { text: 'Dismiss', callbackData: telegramElicitData(requestId, TELEGRAM_ELICIT_DISMISS) }
     ]
   ]
+}
+
+/** What a form card says while ONE of its fields is open: the question it belongs to, then that
+ *  field's own label and whatever the field has to say for itself. Pure. */
+export function telegramElicitFieldText(
+  message: string,
+  target: ElicitTarget,
+  params: CreateElicitationRequest
+): string {
+  const hint = elicitFormFieldHint(target)
+  return `${telegramElicitText(message)}\n${elicitFormFieldLabel(params, target)}${hint ? ` — ${hint}` : ''}`
 }
 
 /** What the prompt message says above the reader's own compose box: the question again, because a
@@ -249,19 +388,89 @@ interface TelegramElicitDraft {
  *  record, so a card that ends without a Confirm leaves nothing behind. */
 interface TelegramElicitCardState {
   chosen: Set<number>
-  /** EVERY `force_reply` prompt this card has posted, by message id — which is what a reply to one
-   *  names. All of them stay answerable until the card settles: each tap of Answer posts its own
-   *  box, so two readers can be typing at once (or one reader can tap twice), and a box still on
-   *  screen must not have stopped working because a later one appeared. */
-  prompts: Set<string>
+  /** EVERY `force_reply` prompt this card has posted: its message id — which is what a reply to
+   *  one names — against the FIELD it was opened for. All of them stay answerable until the card
+   *  settles: each tap posts its own box, so two readers can be typing at once (or one reader can
+   *  tap twice), and a box still on screen must not have stopped working because a later one
+   *  appeared. The field is what lets one form hold an open box per question at the same time. */
+  prompts: Map<string, number>
+  /** A form card's answers so far, by field position — the state a Slack message keeps for itself
+   *  in `state.values`. */
+  values: (string | string[] | undefined)[]
+  /** Which field's own keyboard is currently showing, if the overview is not. */
+  open?: number
 }
 
 function cardStateOf(handle: ElicitCardHandle): TelegramElicitCardState {
   const existing = handle.cardState as TelegramElicitCardState | undefined
   if (existing) return existing
-  const fresh: TelegramElicitCardState = { chosen: new Set<number>(), prompts: new Set<string>() }
+  const fresh: TelegramElicitCardState = { chosen: new Set<number>(), prompts: new Map<string, number>(), values: [] }
   handle.cardState = fresh
   return fresh
+}
+
+/**
+ * Fold one tap on a FORM card, whose keyboard has two levels: the overview, one row per field,
+ * and one field's own controls opened from it.
+ *
+ * Nothing here decides whether an answer is GOOD. The Confirm hands core the fields it has, keyed
+ * as a Slack Confirm's are, and core's one re-derivation says whether a required field is missing,
+ * a selection breaks its bounds, or a typed value breaks its `pattern` — with the card left live
+ * and the field named. Moving any of that here would be a second opinion on the same question.
+ */
+function telegramFoldForm(
+  state: TelegramElicitCardState,
+  card: ElicitCardTapTarget,
+  token: string,
+  message: string,
+  redraw: (text: string, buttons: InlineButton[][]) => { kind: 'pending' },
+  openBox: (field: number, target: ElicitTarget) => { kind: 'pending' }
+): ElicitCardTap | null {
+  const overview = () => {
+    state.open = undefined
+    return redraw(
+      telegramElicitText(message),
+      telegramElicitFormButtons(card.requestId, card.params, card.form, state.values)
+    )
+  }
+  if (token === TELEGRAM_ELICIT_BACK) return overview()
+  if (token === TELEGRAM_ELICIT_CONFIRM) {
+    const fields: Record<string, string | string[]> = {}
+    for (const [i, value] of state.values.entries()) {
+      // A field nobody filled in is an OMISSION, not an empty answer — core lets an optional one
+      // be absent and refuses a required one by name, which is the same verdict on every surface.
+      if (value !== undefined) fields[elicitFormBlockId(i)] = value
+    }
+    return { kind: 'submit', fields }
+  }
+  const named = parseTelegramElicitField(token)
+  const target = named ? card.form[named.field] : undefined
+  if (!named || !target) return null
+  // Opening a field: a typed one has no keyboard control at all and goes straight to its box.
+  if (named.option === undefined) {
+    if (target.kind === 'text' || target.kind === 'number') return openBox(named.field, target)
+    state.open = named.field
+    return redraw(
+      telegramElicitFieldText(message, target, card.params),
+      telegramElicitFieldButtons(card.requestId, named.field, target, state.values[named.field])
+    )
+  }
+  if (!target.options[named.option]) return null
+  const carried = elicitOptionToken(named.option)
+  if (target.kind === 'multi-enum') {
+    const held = new Set(Array.isArray(state.values[named.field]) ? (state.values[named.field] as string[]) : [])
+    if (held.has(carried)) held.delete(carried)
+    else held.add(carried)
+    // Kept in the field's OWN option order, so what the agent receives reads as the card did.
+    state.values[named.field] = target.options.map((_o, n) => elicitOptionToken(n)).filter((t) => held.has(t))
+    return redraw(
+      telegramElicitFieldText(message, target, card.params),
+      telegramElicitFieldButtons(card.requestId, named.field, target, state.values[named.field])
+    )
+  }
+  // One of them: the pick IS the whole of this field, so it closes the field and shows the card.
+  state.values[named.field] = carried
+  return overview()
 }
 
 export const telegramElicitCards: ElicitCardFacet = {
@@ -269,31 +478,39 @@ export const telegramElicitCards: ElicitCardFacet = {
   reduction: TELEGRAM_ELICIT_SURFACE,
 
   build(_host: ElicitCardHost, _turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null {
-    // No consent control, and no control for a typed box or a form carrying one.
+    // No consent control: an inline `url` button fires no callback_query, so consent could never
+    // be observed, and consent is the whole of what that seam decides.
     if (ask.url || !ask.form?.length) return null
-    const oneTap = elicitCardShape(ask.form) === 'buttons'
-    const assembled = oneTap ? null : telegramAssembledField(ask.form)
-    if (!oneTap && !assembled) return null
-    const target = assembled ?? ask.form[0]!
-    // A typed field offers no options at all; every other card's widest button must fit 64 bytes.
-    const typed = target.kind === 'text' || target.kind === 'number'
-    if (!typed && (!target.options.length || !telegramElicitDataFits(ask.requestId, target.options.length))) return null
-    if (typed && !telegramElicitDataFits(ask.requestId, 1)) return null
-    const draft: TelegramElicitDraft = typed
-      ? {
-          text: telegramElicitFormText(ask.message, target),
-          buttons: telegramElicitPromptButtons(ask.requestId)
-        }
-      : assembled
-        ? {
-            text: telegramElicitFormText(ask.message, assembled),
-            buttons: telegramElicitCheckboxes(ask.requestId, assembled.options, new Set())
-          }
-        : {
-            text: telegramElicitText(ask.message),
-            buttons: telegramElicitButtons(ask.requestId, target.options)
-          }
-    return draft
+    const shape = telegramCardShape(ask.form)
+    if (!shape) return null
+    // Every card's WIDEST `callback_data` must fit 64 bytes, or the API refuses the whole message.
+    // A form's widest is its last field's last option; a flat card's is its last option; a prompt
+    // card mints one token and no positions at all.
+    const widest =
+      shape === 'form' ? Math.max(...ask.form.map((t) => t.options.length), 1) : ask.form[0]!.options.length || 1
+    if (!telegramElicitDataFits(ask.requestId, widest)) return null
+    if (shape === 'form') {
+      const values = ask.form.map(() => undefined)
+      return {
+        text: telegramElicitText(ask.message),
+        buttons: telegramElicitFormButtons(ask.requestId, ask.params, ask.form, values)
+      } satisfies TelegramElicitDraft
+    }
+    const target = ask.form[0]!
+    if (shape === 'prompt')
+      return {
+        text: telegramElicitFormText(ask.message, target),
+        buttons: telegramElicitPromptButtons(ask.requestId)
+      } satisfies TelegramElicitDraft
+    if (shape === 'checkboxes')
+      return {
+        text: telegramElicitFormText(ask.message, target),
+        buttons: telegramElicitCheckboxes(ask.requestId, target.options, new Set())
+      } satisfies TelegramElicitDraft
+    return {
+      text: telegramElicitText(ask.message),
+      buttons: telegramElicitButtons(ask.requestId, target.options)
+    } satisfies TelegramElicitDraft
   },
 
   async send(
@@ -328,53 +545,54 @@ export const telegramElicitCards: ElicitCardFacet = {
    * a Slack Confirm's is. Toggling is free; the Confirm is where a card is judged.
    */
   tap(handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null {
-    const target = telegramAssembledField(card.form)
-    if (!target) return null
-    const state = cardStateOf(handle)
+    const shape = telegramCardShape(card.form)
+    // A card with no addressable message can show nothing, and nothing this fold does is worth
+    // remembering unshown: what the keyboard shows and what a Confirm would submit are ONE fact
+    // here, unlike Slack, where the message itself holds the reader's half-filled state.
     const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
-    // A typed field is answered in a box, never on the keyboard: the one button it has asks for
-    // that box. Opening it is not an answer, so the card stays exactly as open as it was.
-    if (target.kind === 'text' || target.kind === 'number') {
-      if (token !== TELEGRAM_ELICIT_PROMPT || !Number.isInteger(messageId)) return null
-      const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
-      // The prompt REPLIES to the card, which is also what keeps it inside a forum topic: Telegram
-      // places a reply where the message it answers is, so no thread coordinate is re-derived here.
+    if (!shape || !Number.isInteger(messageId)) return null
+    const state = cardStateOf(handle)
+    const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+    const redraw = (text: string, buttons: InlineButton[][]) => {
+      // Best effort, like every other card rewrite: a redraw that fails leaves the reader looking
+      // at the previous state, and the Confirm still submits what THIS daemon recorded.
+      void (handle.conn as TelegramConnection).editCard(handle.channel, messageId, text, buttons).catch(() => {})
+      return { kind: 'pending' } as const
+    }
+    // The prompt REPLIES to the card, which is also what keeps it inside a forum topic: Telegram
+    // places a reply where the message it answers is, so no thread coordinate is re-derived here.
+    const openBox = (field: number, target: ElicitTarget) => {
       void (handle.conn as TelegramConnection)
         .postPrompt(handle.channel, telegramElicitPromptText(message, target), {
           replyTo: messageId,
           placeholder: elicitFieldExpectation(target)
         })
         .then((ts) => {
-          if (ts !== undefined) state.prompts.add(ts)
+          if (ts !== undefined) state.prompts.set(ts, field)
         })
         .catch(() => {})
-      return { kind: 'pending' }
+      return { kind: 'pending' } as const
     }
+
+    if (shape === 'form') return telegramFoldForm(state, card, token, message, redraw, openBox)
+
+    const target = card.form[0]!
+    // A typed field is answered in a box, never on the keyboard: the one button it has asks for
+    // that box. Opening it is not an answer, so the card stays exactly as open as it was.
+    if (shape === 'prompt') return token === TELEGRAM_ELICIT_PROMPT ? openBox(0, target) : null
+    if (shape !== 'checkboxes') return null
     if (token === TELEGRAM_ELICIT_CONFIRM) {
       const picked = [...state.chosen].sort((a, b) => a - b).map(elicitOptionToken)
       return { kind: 'submit', fields: { [elicitFormBlockId(0)]: picked } }
     }
     const index = target.options.findIndex((_o, i) => elicitOptionToken(i) === token)
     if (index < 0) return null
-    // A tick nobody can be shown is not recorded. What the keyboard shows and what a Confirm would
-    // submit are ONE fact here — unlike Slack, where the message itself holds the reader's half-
-    // filled state — so a card with no addressable message refuses the tap instead of remembering
-    // a selection its own boxes still show unticked.
-    if (!Number.isInteger(messageId)) return null
     if (state.chosen.has(index)) state.chosen.delete(index)
     else state.chosen.add(index)
-    // Best effort, like every other card rewrite: a redraw that fails leaves the reader looking at
-    // the previous ticks, and the Confirm still submits what THIS daemon recorded.
-    const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
-    void (handle.conn as TelegramConnection)
-      .editCard(
-        handle.channel,
-        messageId,
-        telegramElicitFormText(message, target),
-        telegramElicitCheckboxes(card.requestId, target.options, state.chosen)
-      )
-      .catch(() => {})
-    return { kind: 'pending' }
+    return redraw(
+      telegramElicitFormText(message, target),
+      telegramElicitCheckboxes(card.requestId, target.options, state.chosen)
+    )
   },
 
   /**
@@ -388,15 +606,43 @@ export const telegramElicitCards: ElicitCardFacet = {
    * string breaking its own `pattern` are refused with the field's own words.
    */
   claimReply(handle: ElicitCardHandle, card: ElicitCardTapTarget, reply: ElicitCardReply): ElicitCardTap | null {
-    const target = telegramAssembledField(card.form)
-    if (!target || (target.kind !== 'text' && target.kind !== 'number')) return null
     const state = handle.cardState as TelegramElicitCardState | undefined
-    if (reply.replyTo === undefined || !state?.prompts.has(reply.replyTo)) return null
+    if (reply.replyTo === undefined) return null
+    const field = state?.prompts.get(reply.replyTo)
+    if (field === undefined) return null
+    const target = card.form[field]
+    if (!target || (target.kind !== 'text' && target.kind !== 'number')) return null
     const text = reply.text.trim()
     if (!text) return null
     // The prompt is deliberately NOT spent here. An accepted answer settles the card, and a card
     // that is gone claims nothing more; a REFUSED one is still open, and the reader who has just
     // been told what was wrong is typing into the very box that should still take their retry.
+    //
+    // A FORM's box does not submit the card, though: it fills ONE field, and the whole card is
+    // still submitted by its own Confirm. So the words are recorded and the overview redrawn,
+    // exactly as a picked option is — a single typed question has no other field to wait for, and
+    // its box IS the submission.
+    if (telegramCardShape(card.form) === 'form') {
+      state!.values[field] = text
+      const messageId = handle.ts === undefined ? NaN : Number(handle.ts)
+      if (Number.isInteger(messageId)) {
+        const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+        state!.open = undefined
+        void (handle.conn as TelegramConnection)
+          .editCard(
+            handle.channel,
+            messageId,
+            telegramElicitText(message),
+            telegramElicitFormButtons(card.requestId, card.params, card.form, state!.values)
+          )
+          .catch(() => {})
+      }
+      // The answered box is retired now rather than at settlement: the card lives on, and a box
+      // left open would take a second answer to a field the overview already shows filled in.
+      state!.prompts.delete(reply.replyTo)
+      void (handle.conn as TelegramConnection).deleteMessage(handle.channel, reply.replyTo).catch(() => {})
+      return { kind: 'pending' }
+    }
     return { kind: 'submit', fields: { [elicitFormBlockId(0)]: text } }
   },
 
@@ -418,7 +664,7 @@ export const telegramElicitCards: ElicitCardFacet = {
     // is DELETED rather than edited: Telegram edits only a message carrying no markup or an inline
     // keyboard, so an edit aimed at a `force_reply` is refused and the box would simply remain.
     const prompts = (handle.cardState as TelegramElicitCardState | undefined)?.prompts
-    for (const promptTs of prompts ?? [])
+    for (const promptTs of prompts?.keys() ?? [])
       void (handle.conn as TelegramConnection).deleteMessage(handle.channel, promptTs).catch(() => {})
   }
 }

--- a/packages/daemon/src/platforms/telegram/elicit-card.ts
+++ b/packages/daemon/src/platforms/telegram/elicit-card.ts
@@ -360,14 +360,20 @@ export function telegramElicitPromptButtons(requestId: string): InlineButton[][]
 }
 
 /** What a form card says while ONE of its fields is open: the question it belongs to, then that
- *  field's own label and whatever the field has to say for itself. Pure. */
+ *  field's own label and whatever the field has to say for itself.
+ *
+ *  The tail is inside the same budget the question is, and the QUESTION yields — a field's label
+ *  plus its hint runs past 2000 characters where the limit is 4096, so appending them to an
+ *  already-clamped question would make the EDIT too long, and a refused edit leaves the reader
+ *  looking at the overview with no way into the field they just opened. Pure. */
 export function telegramElicitFieldText(
   message: string,
   target: ElicitTarget,
   params: CreateElicitationRequest
 ): string {
   const hint = elicitFormFieldHint(target)
-  return `${telegramElicitText(message)}\n${elicitFormFieldLabel(params, target)}${hint ? ` — ${hint}` : ''}`
+  const tail = `${elicitFormFieldLabel(params, target)}${hint ? ` — ${hint}` : ''}`
+  return `${telegramElicitText(clampTo(message, Math.max(0, TELEGRAM_ELICIT_MESSAGE_CAP - tail.length - 1)))}\n${tail}`
 }
 
 /** What the prompt message says above the reader's own compose box: the question again, because a
@@ -433,7 +439,15 @@ function telegramFoldForm(
       telegramElicitFormButtons(card.requestId, card.params, card.form, state.values)
     )
   }
-  if (token === TELEGRAM_ELICIT_BACK) return overview()
+  if (token === TELEGRAM_ELICIT_BACK) {
+    // Done on a multi-select the reader opened and ticked nothing in is an EXPLICIT empty
+    // selection, which a field with no `minItems` accepts — so it is recorded as one. Without
+    // this the reader is told the field is required and has to discover that ticking an option
+    // and unticking it produces the very same answer. A field never OPENED stays omitted.
+    const open = state.open === undefined ? undefined : card.form[state.open]
+    if (open?.kind === 'multi-enum' && state.values[state.open!] === undefined) state.values[state.open!] = []
+    return overview()
+  }
   if (token === TELEGRAM_ELICIT_CONFIRM) {
     const fields: Record<string, string | string[]> = {}
     for (const [i, value] of state.values.entries()) {

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -17,8 +17,10 @@ import {
   TELEGRAM_ELICIT_SURFACE,
   parseTelegramElicit,
   telegramElicitButtons,
+  telegramCardShape,
   telegramElicitCheckboxes,
   telegramElicitData,
+  telegramElicitFieldToken,
   telegramElicitFormText,
   telegramElicitDataFits,
   telegramElicitCards
@@ -91,7 +93,7 @@ describe('what Telegram declares it can collect, and what it declines', () => {
     expect(elicitForm(form(many(25)), TELEGRAM_ELICIT_SURFACE)).toBeNull()
   })
 
-  it('builds nothing for a URL consent, a multi-field form, or an optionless field', () => {
+  it('builds nothing for a URL consent or an optionless field', () => {
     const host = { postCardSerialized: async () => undefined, sessionTarget: () => undefined, turnState: () => ({}) }
     const turn = { plan: { platform: 'telegram', channel: '-100', statusThread: 'T', agentName: 'a' } }
     const ask = { requestId: REQUEST_ID, params: form(BRANCH), message: 'q', fallback: 'q' }
@@ -100,6 +102,7 @@ describe('what Telegram declares it can collect, and what it declines', () => {
       telegramElicitCards.build(host, turn, { ...ask, url: { elicitationId: 'e1', url: 'https://x.example' } })
     ).toBeNull()
     expect(telegramElicitCards.build(host, turn, ask)).toBeNull()
+    // A form of several questions DOES build now — one row per field over the same keyboard.
     const two = form({ ...BRANCH, also: { type: 'string', enum: ['a', 'b'] } })
     expect(
       telegramElicitCards.build(host, turn, {
@@ -107,7 +110,7 @@ describe('what Telegram declares it can collect, and what it declines', () => {
         params: two,
         form: elicitForm(two, TELEGRAM_ELICIT_SURFACE) ?? undefined
       })
-    ).toBeNull()
+    ).not.toBeNull()
   })
 })
 
@@ -287,9 +290,8 @@ describe('a Telegram turn posts an elicitation card and settles it in place', ()
 
   it('declines an ask Telegram has no card for, and says so in the chat', async () => {
     const h = telegramTurn()
-    // Several questions: one prompt at a time is a state machine across fields, and a reader who
-    // walks away mid-way leaves half a form standing.
-    const req = form({ note: { type: 'string' }, count: { type: 'integer' } }, ['note', 'count'])
+    // An option list past what one keyboard holds: declined whole rather than shown in part.
+    const req = form({ pick: { type: 'string', enum: Array.from({ length: 25 }, (_, i) => `o${i}`) } }, ['pick'])
     await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
     expect(h.cards).toEqual([])
     expect(h.notices()[0]).toContain("this chat can't collect an answer for")
@@ -599,5 +601,123 @@ describe('a Telegram typed answer is written into a force-reply box', () => {
     await tap(h, requestId, 'x')
     await expect(result).resolves.toEqual({ action: 'decline' })
     expect(h.edits[0]!.text).toContain('🚫 Dismissed')
+  })
+})
+
+describe('a Telegram form of several questions is filled in over one keyboard', () => {
+  async function tap(h: Harness, requestId: string, token: string): Promise<void> {
+    await h.daemon.handleTelegramCallback(
+      { id: `cb-${token}`, data: telegramElicitData(requestId, token), channel: '-100', messageId: 4242, userId: '77' },
+      h.conn
+    )
+  }
+  const CONV = '-100\u001ftelegram:bot-a'
+  const rows = (h: Harness) => (h.edits.at(-1) ?? h.cards[0]!).buttons.map((r) => r[0]!.text)
+
+  const TWO = {
+    branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+    checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] }, title: 'Checks' }
+  }
+
+  it('is the shape a reduction of several fields takes, and each single field keeps its own', () => {
+    expect(telegramCardShape(elicitForm(form(TWO), TELEGRAM_ELICIT_SURFACE)!)).toBe('form')
+    expect(telegramCardShape(elicitForm(form(BRANCH), TELEGRAM_ELICIT_SURFACE)!)).toBe('buttons')
+    expect(telegramCardShape(elicitForm(form(CHECKS), TELEGRAM_ELICIT_SURFACE)!)).toBe('checkboxes')
+    expect(telegramCardShape(elicitForm(form({ note: { type: 'string' } }), TELEGRAM_ELICIT_SURFACE)!)).toBe('prompt')
+  })
+
+  it('shows one row per field with what it holds, and ONE Confirm for the whole card', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    expect(rows(h)).toEqual(['Base branch: —', 'Checks: —', 'Confirm'])
+
+    // Opening a single-select shows its options; picking one closes the field and returns.
+    await tap(h, requestId, telegramElicitFieldToken(0))
+    expect(rows(h)).toEqual(['⚪ main', '⚪ develop', 'Back'])
+    await tap(h, requestId, telegramElicitFieldToken(0, 1))
+    expect(rows(h)).toEqual(['Base branch: develop', 'Checks: —', 'Confirm'])
+
+    // A multi-select's ticks accumulate, so its own keyboard closes on Done.
+    await tap(h, requestId, telegramElicitFieldToken(1))
+    await tap(h, requestId, telegramElicitFieldToken(1, 0))
+    expect(rows(h)).toEqual(['☑️ lint', '⬜️ test', 'Done'])
+    await tap(h, requestId, 'bk')
+    expect(rows(h)).toEqual(['Base branch: develop', 'Checks: lint', 'Confirm'])
+
+    // Nothing has been answered until the card's own Confirm.
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    await tap(h, requestId, 'ok')
+    await expect(result).resolves.toEqual({
+      action: 'accept',
+      content: { branch: 'develop', checks: ['lint'] }
+    })
+  })
+
+  it('leaves an untouched optional field out, and refuses a Confirm missing a required one', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    // Required field still empty: refused by name, card left live.
+    await tap(h, requestId, 'ok')
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain('Base branch')
+
+    await tap(h, requestId, telegramElicitFieldToken(0))
+    await tap(h, requestId, telegramElicitFieldToken(0, 0))
+    await tap(h, requestId, 'ok')
+    // The optional multi-select nobody touched is an OMISSION, not an empty answer.
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('gives a question that brought its own free-text box both controls', async () => {
+    // "Pick one, or type your own" — the AskUserQuestion shape, which is two TARGETS. Before this
+    // card existed the companion was dropped by the reduction and the reader could only pick.
+    const h = telegramTurn()
+    const withOther = {
+      sessionId: 's1',
+      mode: 'form',
+      message: 'Which branch should I cut from?',
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+          other: {
+            type: 'string',
+            title: 'Other',
+            _meta: { _askUserQuestionCustomAnswer: { isCustomAnswer: true, questionId: 'branch' } }
+          }
+        },
+        required: []
+      }
+    } as unknown as CreateElicitationRequest
+    const { requestId, result } = await raise(h, withOther)
+    expect(rows(h)).toEqual(['Base branch: —', 'Base branch (Other): —', 'Confirm'])
+
+    // The typed half opens a box straight away — there is no keyboard control for characters.
+    await tap(h, requestId, telegramElicitFieldToken(1))
+    expect(h.prompts).toHaveLength(1)
+    // And it fills ONE field rather than submitting: the card is still submitted by its Confirm.
+    expect(
+      await h.daemon.permissions.claimElicitReply({ conversation: CONV, replyTo: '5150', text: 'release/2.4' })
+    ).toBe(true)
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(rows(h)).toEqual(['Base branch: —', 'Base branch (Other): release/2.4', 'Confirm'])
+    // The answered box is retired now, not at settlement: the card lives on.
+    expect(h.deleted).toEqual(['5150'])
+
+    await tap(h, requestId, 'ok')
+    await expect(result).resolves.toEqual({ action: 'accept', content: { other: 'release/2.4' } })
+  })
+
+  it('refuses a field or an option the card never offered', async () => {
+    const h = telegramTurn()
+    const { requestId } = await raise(h, form(TWO, ['branch']))
+    await tap(h, requestId, telegramElicitFieldToken(9))
+    await tap(h, requestId, telegramElicitFieldToken(0, 9))
+    expect(h.edits).toEqual([])
+    expect(h.notices()).toEqual([
+      "That answer wasn't accepted — the question is still open.",
+      "That answer wasn't accepted — the question is still open."
+    ])
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
   })
 })

--- a/packages/daemon/test/telegram-elicit-card.test.ts
+++ b/packages/daemon/test/telegram-elicit-card.test.ts
@@ -20,6 +20,7 @@ import {
   telegramCardShape,
   telegramElicitCheckboxes,
   telegramElicitData,
+  telegramElicitFieldText,
   telegramElicitFieldToken,
   telegramElicitFormText,
   telegramElicitDataFits,
@@ -706,6 +707,46 @@ describe('a Telegram form of several questions is filled in over one keyboard', 
 
     await tap(h, requestId, 'ok')
     await expect(result).resolves.toEqual({ action: 'accept', content: { other: 'release/2.4' } })
+  })
+
+  it('keeps a long question and its whole field heading inside one Telegram message', () => {
+    // The EDIT is what would be refused, and a refused edit leaves the reader looking at the
+    // overview with no way into the field they just opened.
+    const target = {
+      propName: 'checks',
+      kind: 'multi-enum' as const,
+      options: [{ value: 'lint', label: 'lint' }],
+      description: 'd'.repeat(300),
+      minItems: 1
+    }
+    const text = telegramElicitFieldText('q'.repeat(4000), target, form(CHECKS))
+    expect([...text].length).toBeLessThanOrEqual(4096)
+    // The question yields, never the heading: it is what says which field is open.
+    expect(text).toContain('Select at least 1.')
+  })
+
+  it('records Done on an untouched multi-select as the empty selection it is', async () => {
+    const h = telegramTurn()
+    const optional = { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } }
+    const { requestId, result } = await raise(h, form({ ...BRANCH, ...optional }, ['branch', 'checks']))
+    await tap(h, requestId, telegramElicitFieldToken(0))
+    await tap(h, requestId, telegramElicitFieldToken(0, 0))
+    // Opened, nothing ticked, Done — a field with no `minItems` accepts that, and the reader
+    // should not have to tick an option and untick it to say so.
+    await tap(h, requestId, telegramElicitFieldToken(1))
+    await tap(h, requestId, 'bk')
+    expect(rows(h)).toEqual(['Base branch: main', 'checks: none', 'Confirm'])
+    await tap(h, requestId, 'ok')
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main', checks: [] } })
+  })
+
+  it('leaves a field the reader never OPENED omitted, not emptied', async () => {
+    const h = telegramTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    await tap(h, requestId, telegramElicitFieldToken(0))
+    await tap(h, requestId, telegramElicitFieldToken(0, 0))
+    await tap(h, requestId, 'ok')
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 
   it('refuses a field or an option the card never offered', async () => {


### PR DESCRIPTION
## The last shape Telegram declined

#1901 gave the keyboard a toggle; #1905 gave it a box. Between them that is everything a form
needs — what was missing was somewhere to put more than one field.

## Two levels over one message

```
💬 Which branch, and what should I run?
┌────────────────────────────┐        ┌────────────────────────┐
│ Base branch: —             │  tap → │ ⚪ main                │
│ Checks: —                  │        │ 🔵 develop             │  pick closes the field
│ Confirm       Dismiss      │        │ Back                   │
└────────────────────────────┘        └────────────────────────┘
                ↓
┌────────────────────────────┐        ┌────────────────────────┐
│ Base branch: develop       │  tap → │ ☑️ lint                │
│ Checks: lint               │        │ ⬜️ test                │  ticks accumulate
│ Confirm       Dismiss      │        │ Done                   │
└────────────────────────────┘        └────────────────────────┘
```

- **overview** — one row per field saying what it holds, and **one Confirm for the whole card**,
  never one per question.
- **single-select** — radios; the pick *is* the whole field, so it closes and returns.
- **multi-select** — ticks; they accumulate, so it closes on Done.
- **typed field** — no keyboard control exists for characters, so tapping it goes straight to the
  `force_reply` box from #1905. Its answer fills **that one field** and redraws the overview
  rather than submitting the card, and the answered box is retired immediately (the card lives
  on, and a box left open would take a second answer to a field already shown filled in).

## Select-with-Other

This is also the shape a question that brought its own free-text box takes — "pick one, or type
your own", which is two *targets*. Until now Telegram's reduction dropped the companion and the
reader could only pick a preset. They now get both controls, and the Confirm submits whichever
they used:

```
Base branch: —
Base branch (Other): release/2.4
Confirm      Dismiss
```

## Positions, not values

A form holds its answers exactly as the wire does: an option field's value is that option's
**position**, so the Confirm hands core the same `ac_o<n>` a Slack Confirm carries under the same
block id, and every label on screen is looked up *through* the position. I had this wrong first
time — storing literals made core's re-derivation refuse every Confirm, which the tests caught.

Nothing about whether an answer is *good* lives in the platform module: a missing required field,
a selection breaking its bounds, a typed value breaking its `pattern` are all core's one
re-derivation (#1815), which names the field and leaves the card live.

## One shape decision

Which of Telegram's four cards a reduction takes is now decided once in `telegramCardShape`
(`buttons` / `checkboxes` / `prompt` / `form`) rather than re-derived by `build` and again by
`tap` — those two disagreeing is how a card gets a control its own fold cannot understand.

One core change: a `pending` result from `claimReply` now counts as a **claim**. A form's typed
answer fills a field without submitting, and treating that as unclaimed would have sent the
field's own answer on to the agent as a fresh prompt.

## Verification

- `telegram-elicit-card.test.ts` — 38 tests. All 6 new/changed assertions confirmed **red** on
  `main` first.
- New coverage: the shape function against all four reductions; the overview's rows and both
  field keyboards, with the full pick → tick → Confirm path; an untouched optional field omitted
  and a missing required one refused by name with the card live; the select-with-Other shape
  end-to-end including the box filling one field and being retired; a field index and an option
  position the card never offered both refused aloud.
- `pnpm eval:gates` 192/193 (the known pre-existing `evaluation-runner` baseline). typecheck /
  eslint / prettier clean.

Closes the Telegram half of #1794 — Discord and Feishu remain.

Refs #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
