### PR TITLE
fix(daemon): grok-build logs in through its own device flow

### DIFF
--- a/packages/daemon/src/cli/auth.ts
+++ b/packages/daemon/src/cli/auth.ts
@@ -10,6 +10,7 @@ import { AcpHost } from '../acp/acp-host.js'
 import { loadConfig } from '../config/load-config.js'
 import { resolveRoot } from '../paths.js'
 import { ArchiveStore, parseArchiveLaunch, storedArchiveRuntimeDef } from '../runtimes/archive-store.js'
+import { cliLoginLaunch } from '../runtimes/cli-login.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { probeAllRuntimes, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
 import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
@@ -453,10 +454,14 @@ export async function runAuth(opts: RunAuthOpts): Promise<void> {
     }
     out.write(`Using ${method.id} — ${method.name}\n`)
 
-    if (isTerminalMethod(method)) {
+    // A runtime that cannot finish this login over ACP is driven through its own CLI instead —
+    // same handover as a `terminal` method, on a launch that names the login subcommand.
+    const cli = cliLoginLaunch(runtimeId, method.id, runtime)
+    if (isTerminalMethod(method) || cli) {
       // The client owns this one: hand the operator's terminal to the agent program itself.
+      if (cli) out.write(`${cli.reason}\n`)
       await host.stop(5000, EOF_GRACE_MS)
-      const code = await (opts.runTerminalAuth ?? spawnTerminalAuth)(runtime, method)
+      const code = await (opts.runTerminalAuth ?? spawnTerminalAuth)(cli?.runtime ?? runtime, method)
       if (code !== 0) throw new Error(`interactive login exited with code ${code}`)
     } else {
       const login = host.authenticate(method.id)

--- a/packages/daemon/src/runtimes/cli-login.ts
+++ b/packages/daemon/src/runtimes/cli-login.ts
@@ -1,0 +1,46 @@
+// Runtimes whose ACP `authenticate` cannot be finished from a headless client, and the login
+// subcommand of their own CLI that can. An entry here is not a preference: it is a runtime that
+// answers `authenticate` with silence, leaving the operator with nothing to act on.
+
+import type { RuntimeDef } from '../config/config-schema.js'
+
+interface CliLoginSpec {
+  /** Only these method ids are redirected; anything else the runtime offers still goes over ACP. */
+  methods: string[]
+  /** The ACP-mode argv tail the launch ends with. Login is a different subcommand, so it replaces
+   *  this rather than appending — and a launch that does not end in it is left to ACP untouched. */
+  acpTail: string[]
+  /** What takes the tail's place. */
+  loginArgs: string[]
+  /** One line telling the operator why their terminal is being handed to the runtime's own CLI. */
+  reason: string
+}
+
+const CLI_LOGIN: Record<string, CliLoginSpec> = {
+  // grok-build's inline flow silently tries to open a browser ON THE DAEMON HOST and then waits
+  // forever: no elicitation, nothing on stderr, and no loopback listener for the redirect-paste
+  // fallback to reach. `grok login --device-auth` prints a URL and a code, and writes the same
+  // ~/.grok/auth.json that sessions are seeded from.
+  'grok-build': {
+    methods: ['grok.com'],
+    acpTail: ['agent', 'stdio'],
+    loginArgs: ['login', '--device-auth'],
+    reason: 'grok-build cannot run this login over ACP — handing your terminal to `grok login --device-auth`.'
+  }
+}
+
+export interface CliLoginLaunch {
+  /** The interactive launch, spawned exactly like a `terminal` method's. */
+  runtime: RuntimeDef
+  reason: string
+}
+
+/** The CLI login that logs `runtimeId` in, or undefined when ACP `authenticate` is the way. */
+export function cliLoginLaunch(runtimeId: string, methodId: string, runtime: RuntimeDef): CliLoginLaunch | undefined {
+  const spec = CLI_LOGIN[runtimeId]
+  if (!spec?.methods.includes(methodId)) return undefined
+  const head = runtime.args.slice(0, runtime.args.length - spec.acpTail.length)
+  const tail = runtime.args.slice(head.length)
+  if (tail.length !== spec.acpTail.length || tail.some((arg, i) => arg !== spec.acpTail[i])) return undefined
+  return { runtime: { ...runtime, args: [...head, ...spec.loginArgs] }, reason: spec.reason }
+}

--- a/packages/daemon/test/auth-cli.test.ts
+++ b/packages/daemon/test/auth-cli.test.ts
@@ -378,6 +378,89 @@ describe('runAuth: method selection', () => {
     expect(out.text()).toContain('✓ claude-acp is logged in on this host.')
   })
 
+  /** grok-build as the registry launches it: the ACP mode is a subcommand, not a flag. */
+  function grokCatalog(args: string[]): ResolvedRuntimeCatalog {
+    const runtime: RuntimeDef = { command: 'npx', args, env: [] }
+    return {
+      entries: {
+        'grok-build': { runtime, source: 'registry', name: 'Grok Build', version: '', skillsAgentId: null }
+      },
+      runtimes: { 'grok-build': runtime }
+    }
+  }
+
+  it('logs grok-build in through its own device flow, and never through authenticate', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    const calls: string[] = []
+    const ran: RuntimeDef[] = []
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'grok-build',
+      resolveCatalog: async () => grokCatalog(['-y', '@xai-official/grok@1.0.24', 'agent', 'stdio']),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([{ id: 'grok.com', name: 'Grok' }], calls),
+      runTerminalAuth: async (runtime) => {
+        ran.push(runtime)
+        return 0
+      }
+    })
+    // `authenticate` answers this one with silence — no elicitation, no stderr, no loopback listener.
+    expect(calls).toEqual([])
+    expect(ran).toEqual([
+      { command: 'npx', args: ['-y', '@xai-official/grok@1.0.24', 'login', '--device-auth'], env: [] }
+    ])
+    expect(out.text()).toContain('grok login --device-auth')
+    expect(out.text()).toContain('✓ grok-build is logged in on this host.')
+  })
+
+  it('leaves a grok-build launch it does not recognise to ACP', async () => {
+    const { root, configPath } = scaffold()
+    const calls: string[] = []
+    let ran = 0
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      runtimeId: 'grok-build',
+      resolveCatalog: async () => grokCatalog(['--acp']),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([{ id: 'grok.com', name: 'Grok' }], calls),
+      runTerminalAuth: async () => {
+        ran += 1
+        return 0
+      },
+      pasteAfterMs: 5_000
+    })
+    expect(ran).toBe(0)
+    expect(calls).toEqual(['grok.com'])
+  })
+
+  it('leaves another grok-build method to ACP', async () => {
+    const { root, configPath } = scaffold()
+    const calls: string[] = []
+    let ran = 0
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      runtimeId: 'grok-build',
+      methodId: 'api-key',
+      resolveCatalog: async () => grokCatalog(['-y', '@xai-official/grok@1.0.24', 'agent', 'stdio']),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([{ id: 'api-key', name: 'Use XAI_API_KEY' }], calls),
+      runTerminalAuth: async () => {
+        ran += 1
+        return 0
+      },
+      pasteAfterMs: 5_000
+    })
+    expect(ran).toBe(0)
+    expect(calls).toEqual(['api-key'])
+  })
+
   it('fails when the interactive login exits non-zero', async () => {
     const { root, configPath } = scaffold()
     await expect(


### PR DESCRIPTION
## Why

`agentconnect-daemon auth --runtime grok-build` hung with nothing to act on. Driving the
runtime's ACP `authenticate` directly shows why — it answers with silence:

- no `session/request_permission` or elicitation, so the CLI's URL branch never fires;
- not a byte on stderr;
- no loopback listener bound, so the redirect-paste fallback has nowhere to deliver to.

Its own log stops at `auth: inline auth flow {"headless":false}` → `auth: method resolved
{"use_oidc":true}` and never logs again: it decided a browser was reachable, tried to open one
on the daemon host, and waited forever. `GROK_LOGIN_DEVICE_FLOW=1` does not change that path.

`grok login --device-auth` is xAI's documented flow for headless/remote hosts, prints a URL plus
a confirmation code, and writes the same `auth.json` that runtime state seeding reads.

## What changed

- New `packages/daemon/src/runtimes/cli-login.ts`: a table of runtimes whose login cannot finish
  over ACP and the login subcommand of their own CLI that can, plus `cliLoginLaunch()`. The ACP
  argv tail (`agent stdio`) is **replaced**, not appended — appending would launch a nonsense
  command line. A launch that does not end in the expected tail (an operator override), or a
  method the entry does not name, is left to ACP untouched.
- `packages/daemon/src/cli/auth.ts`: reuse the existing `terminal`-method handover for such a
  runtime — stop the ACP host, hand the operator's terminal to the login subcommand, zero exit
  means success. One line tells the operator why.

Only `grok-build` is in the table. Nothing else changes behaviour.

## Verification

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/auth-cli.test.ts` — 27 passed,
  including three new cases: the device flow is used and `authenticate` is never called (asserting
  the rewritten argv), an unrecognised launch tail falls back to ACP, and another method on the
  same runtime still goes over ACP.
- `typecheck`, `eslint`, `prettier --check` clean.
- Ran for real on a headless host: `auth --runtime grok-build` now prints the sign-in URL and the
  confirmation code and waits for authorization, instead of hanging silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
