### PR TITLE
feat: expand full sandbox image runtime catalog

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -107,6 +107,40 @@ RUN set -eu; \
   test -x /out/chrome; \
   chmod -R a-w /out
 
+# Standalone runtimes for the full image; their downloads never enter the pool image.
+FROM node:24-bookworm-slim AS full-native-runtimes
+ARG OMP_VERSION=17.0.5
+ARG OMP_SHA256_AMD64=319d08ab8e5fb80c73f734907d5f47aa8bbd4ea31f7a19bacf8611c5aba26c31
+ARG ANTIGRAVITY_VERSION=1.1.1
+ARG ANTIGRAVITY_SHA256_AMD64=38f62d01b32deb0907b3d39a71ec301fd36369f6ffd1cf262d4af385177f79df
+ARG DEVIN_VERSION=3000.6.14
+ARG DEVIN_SHA256_AMD64=28cf64c1df9f58ccd063fb7e6fd6e9391073c585b733449371485e1ef8a3e6db
+ARG TARGETARCH
+RUN test "${TARGETARCH:-amd64}" = amd64 \
+  && apt-get update \
+  && apt-get install --no-install-recommends -y ca-certificates curl unzip \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /out/bin /out/antigravity
+RUN curl --retry 5 -fsSL -o /tmp/omp \
+  "https://github.com/can1357/oh-my-pi/releases/download/v${OMP_VERSION}/omp-linux-x64" \
+  && printf '%s  /tmp/omp\n' "$OMP_SHA256_AMD64" | sha256sum -c - \
+  && install -m 0555 /tmp/omp /out/bin/omp \
+  && rm /tmp/omp
+RUN curl --retry 5 -fsSL -o /tmp/antigravity.zip \
+  "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_${ANTIGRAVITY_VERSION}-linux-x86_64.zip" \
+  && printf '%s  /tmp/antigravity.zip\n' "$ANTIGRAVITY_SHA256_AMD64" | sha256sum -c - \
+  && unzip -q /tmp/antigravity.zip -d /out/antigravity \
+  && test -x /out/antigravity/agy_acp_server.par \
+  && test -x /out/antigravity/localharness_external \
+  && chmod -R a-w /out/antigravity \
+  && rm /tmp/antigravity.zip
+RUN curl --retry 5 -fsSL -o /tmp/devin.tar.gz \
+  "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-x86_64-unknown-linux.tar.gz" \
+  && printf '%s  /tmp/devin.tar.gz\n' "$DEVIN_SHA256_AMD64" | sha256sum -c - \
+  && tar -xzf /tmp/devin.tar.gz -C /tmp bin/devin \
+  && install -m 0555 /tmp/bin/devin /out/bin/devin \
+  && rm -rf /tmp/devin.tar.gz /tmp/bin
+
 # ─────────────────────────────── runtime ────────────────────────────────────
 FROM node:24-bookworm-slim AS runtime-base
 
@@ -271,6 +305,7 @@ RUN mkdir -p /run/agentconnect \
 # it by PROBING a sandbox for it (the shim's probe channel), and compiling it in would tie
 # the image pin to the daemon version, which is the coupling this seam exists to avoid.
 COPY docker/runtime-sandbox/generate-runtime-table.mjs /opt/agentconnect/bin/generate-runtime-table.mjs
+COPY docker/runtime-sandbox/installed-runtimes.json /opt/agentconnect/runtime/installed-runtimes.json
 # Probed AS THE RUNTIME USER, in a throwaway HOME and cwd that are deleted afterwards. Two reasons,
 # both learned from getting it wrong: a table probed as root describes an identity production never
 # uses, and the probe leaves state behind — a root-run probe left root-owned .claude/.codex in
@@ -308,16 +343,43 @@ USER 10001:10001
 # the runtime only after the channel is bound.
 ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/agentconnect/shim/index.js"]
 
-# Self-hosted daemon VMs extend the shared runtime layer with native shields and Docker.
+# Self-hosted daemon VMs add the broader runtime catalog, native shields and Docker.
 FROM runtime-base AS runtime-sandbox-full
 USER root
+ARG CLINE_VERSION=3.0.61
+ARG PI_ACP_VERSION=0.0.33
+ARG PI_VERSION=0.80.6
+ARG OPENCODE_VERSION=1.17.18
+ARG QWEN_CODE_VERSION=0.23.1
+ARG COPILOT_VERSION=1.0.83
+ARG GROK_VERSION=1.0.24
+ARG QODER_VERSION=1.1.14
+ARG QODER_CN_VERSION=1.1.2
 ARG DOCKER_VERSION=5:29.8.0-1~debian.12~bookworm
 ARG CONTAINERD_VERSION=2.3.5-1~debian.12~bookworm
 ARG DOCKER_BUILDX_VERSION=0.37.0-1~debian.12~bookworm
 ARG DOCKER_COMPOSE_VERSION=5.5.1-1~debian.12~bookworm
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y bubblewrap socat \
+  && apt-get install --no-install-recommends -y bubblewrap socat ripgrep \
   && rm -rf /var/lib/apt/lists/*
+
+# pi-acp delegates to the separately installed pi CLI; all launches use local executables.
+RUN export HOME=/root \
+  && npm install --global --no-fund --no-audit \
+    "cline@${CLINE_VERSION}" \
+    "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    "opencode-ai@${OPENCODE_VERSION}" \
+    "@qwen-code/qwen-code@${QWEN_CODE_VERSION}" \
+    "@github/copilot@${COPILOT_VERSION}" \
+    "@xai-official/grok@${GROK_VERSION}" \
+    "@qoder-ai/qodercli@${QODER_VERSION}" "@qodercn-ai/qoderclicn@${QODER_CN_VERSION}" \
+  && npm cache clean --force
+COPY --from=full-native-runtimes --chown=0:0 /out/bin/ /usr/local/bin/
+# Antigravity resolves its local harness relative to the ACP executable.
+COPY --from=full-native-runtimes --chown=0:0 /out/antigravity/ /opt/agentconnect/runtimes/antigravity/
+RUN printf '%s\n' '#!/bin/sh' \
+  'exec /opt/agentconnect/runtimes/antigravity/agy_acp_server.par "$@"' > /usr/local/bin/antigravity-acp \
+  && chmod 0555 /usr/local/bin/antigravity-acp
 
 # Docker's signed Debian repository supplies exact versions; the image never starts dockerd automatically.
 RUN install -m 0755 -d /etc/apt/keyrings \
@@ -338,6 +400,18 @@ RUN usermod --append --groups docker agent \
   && printf 'agent ALL=(root) NOPASSWD: /usr/bin/dockerd\n' > /etc/sudoers.d/agent-dockerd \
   && chmod 0440 /etc/sudoers.d/agent-dockerd \
   && visudo --check --file /etc/sudoers.d/agent-dockerd
+
+# Rebuild the declared table from the full image's explicitly installed runtime catalog.
+COPY docker/runtime-sandbox/installed-runtimes-full.json /opt/agentconnect/runtime/installed-runtimes.json
+USER 10001:10001
+RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
+  && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
+    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/k8s-runtimes.json
+USER root
+RUN mv /tmp/ac-probe/k8s-runtimes.json /opt/agentconnect/runtime/k8s-runtimes.json \
+  && rm -rf /tmp/ac-probe \
+  && chown -R root:root /opt/agentconnect/runtime \
+  && chmod -R a-w /opt/agentconnect/runtime
 USER 10001:10001
 
 # Keep the pool image as the default build target.

--- a/docker/runtime-sandbox/generate-runtime-table.d.mts
+++ b/docker/runtime-sandbox/generate-runtime-table.d.mts
@@ -1,3 +1,7 @@
-/** Types for the two probe-classification exports the daemon's test suite imports. */
+import type { K8sRuntimeTable } from '../../packages/daemon/src/runtimes/k8s-runtimes.js'
+
 export declare const ACP_AUTH_REQUIRED_CODE: number
 export declare function isAuthRequired(error: unknown): boolean
+export declare function buildTable(
+  provided?: readonly { id: string; command: string; args?: readonly string[] }[]
+): Promise<K8sRuntimeTable>

--- a/docker/runtime-sandbox/generate-runtime-table.mjs
+++ b/docker/runtime-sandbox/generate-runtime-table.mjs
@@ -12,18 +12,11 @@
 //
 // Run twice: at build time to produce the artifact, and in CI against the built image to compare.
 import { spawn } from 'node:child_process'
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-/** Runtime ids this image provides and the executable (plus args) each is launched as. */
-const PROVIDED = [
-  { id: 'claude-acp', bin: 'claude-agent-acp' },
-  { id: 'codex-acp', bin: 'codex-acp' },
-  // The curated catalog launches this one through npx; here it is the image's own executable,
-  // which is what makes it admissible at all under --k8s (runtimes/k8s-runtimes.ts).
-  { id: 'dsh-acp', bin: 'dsh-acp' }
-]
+const INSTALLED_RUNTIMES_PATH = '/opt/agentconnect/runtime/installed-runtimes.json'
 
 const PROBE_TIMEOUT_MS = 60_000
 
@@ -46,6 +39,16 @@ async function probe(bin, args = []) {
   // root-owned .claude/.codex state in /agent that the runtime user could not then write.
   const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'ignore'], env: process.env, cwd: PROBE_CWD })
   const replies = new Map()
+  let failure
+  child.on('error', (error) => {
+    failure = error
+  })
+  child.stdin.on('error', (error) => {
+    failure ??= error
+  })
+  child.on('close', (code, signal) => {
+    failure ??= new Error(`${bin} exited before answering ACP (code ${code}, signal ${signal})`)
+  })
   let buffered = ''
   child.stdout.on('data', (chunk) => {
     buffered += chunk.toString('utf8')
@@ -74,6 +77,7 @@ async function probe(bin, args = []) {
         throw failure
       }
       if (reply) return reply.result
+      if (failure) throw failure
       if (Date.now() > deadline) throw new Error(`${bin} did not answer ${method} within ${PROBE_TIMEOUT_MS}ms`)
       await new Promise((resolve) => setTimeout(resolve, 100))
     }
@@ -118,29 +122,51 @@ function stable(value) {
   return value
 }
 
-export async function buildTable() {
+export async function buildTable(provided = JSON.parse(readFileSync(INSTALLED_RUNTIMES_PATH, 'utf8'))) {
+  if (!Array.isArray(provided) || provided.length === 0) throw new Error('the image declares no installed runtimes')
+  const ids = new Set()
+  for (const entry of provided) {
+    if (
+      !entry ||
+      typeof entry.id !== 'string' ||
+      !entry.id ||
+      typeof entry.command !== 'string' ||
+      !entry.command ||
+      !Array.isArray(entry.args ?? []) ||
+      !(entry.args ?? []).every((arg) => typeof arg === 'string')
+    ) {
+      throw new Error('invalid installed runtime entry')
+    }
+    if (ids.has(entry.id)) throw new Error(`duplicate installed runtime id: ${entry.id}`)
+    ids.add(entry.id)
+  }
   const runtimes = []
-  for (const entry of PROVIDED) {
-    const { initialized, session, sessionProbe } = await probe(entry.bin, entry.args ?? [])
+  for (const entry of provided) {
+    const { initialized, session, sessionProbe } = await probe(entry.command, entry.args ?? [])
     const version = initialized?.agentInfo?.version
-    if (typeof version !== 'string' || version.length === 0) {
-      throw new Error(`${entry.bin} reported no agentInfo.version at initialize`)
+    const protocolVersion = initialized?.protocolVersion
+    if (!Number.isInteger(protocolVersion) || protocolVersion < 0) {
+      throw new Error(`${entry.command} reported no valid ACP protocol version at initialize`)
+    }
+    const capabilities = initialized.agentCapabilities
+    if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+      throw new Error(`${entry.command} reported no ACP capabilities object at initialize`)
     }
     runtimes.push({
       id: entry.id,
-      version,
+      ...(typeof version === 'string' && version.length > 0 ? { version } : {}),
       // The executable, published rather than merely used: the daemon cannot see this filesystem,
       // and without it operators had to restate the mapping in daemon config — a claim about an
       // image made somewhere the image is not.
-      command: entry.bin,
+      command: entry.command,
       args: [...(entry.args ?? [])],
       // The ACP snapshot: what the daemon can state about this runtime without probing it, and
       // what CI compares a fresh probe against.
       acp: stable({
-        protocolVersion: initialized.protocolVersion ?? null,
-        agentName: initialized.agentInfo?.name ?? null,
+        protocolVersion,
+        ...(typeof initialized.agentInfo?.name === 'string' ? { agentName: initialized.agentInfo.name } : {}),
         authMethods: (initialized.authMethods ?? []).map((method) => method?.id ?? method?.name ?? String(method)),
-        capabilities: initialized.agentCapabilities ?? {},
+        capabilities,
         modes: (session?.modes?.availableModes ?? []).map((mode) => mode.id).sort(),
         // The model/permission/effort surface the console renders. Ids, categories and option
         // values only — the prose descriptions would make the table churn on every wording change.

--- a/docker/runtime-sandbox/installed-runtimes-full.json
+++ b/docker/runtime-sandbox/installed-runtimes-full.json
@@ -1,0 +1,17 @@
+[
+  { "id": "antigravity-acp", "command": "antigravity-acp", "args": ["--uid="] },
+  { "id": "claude-acp", "command": "claude-agent-acp", "args": [] },
+  { "id": "cline", "command": "cline", "args": ["--acp"] },
+  { "id": "codex-acp", "command": "codex-acp", "args": [] },
+  { "id": "devin", "command": "devin", "args": ["acp"] },
+  { "id": "dsh-acp", "command": "dsh-acp", "args": [] },
+  { "id": "github-copilot-cli", "command": "copilot", "args": ["--acp"] },
+  { "id": "grok-build", "command": "grok", "args": ["agent", "stdio"] },
+  { "id": "omp", "command": "omp", "args": ["acp"] },
+  { "id": "opencode", "command": "opencode", "args": ["acp"] },
+  { "id": "pi-acp", "command": "pi-acp", "args": [] },
+  { "id": "qoder", "command": "qodercli", "args": ["--acp"] },
+  { "id": "qoder-cli", "command": "qodercli", "args": ["--acp"] },
+  { "id": "qoder-cli-cn", "command": "qoderclicn", "args": ["--acp"] },
+  { "id": "qwen-code", "command": "qwen", "args": ["--acp", "--experimental-skills"] }
+]

--- a/docker/runtime-sandbox/installed-runtimes.json
+++ b/docker/runtime-sandbox/installed-runtimes.json
@@ -1,0 +1,5 @@
+[
+  { "id": "claude-acp", "command": "claude-agent-acp", "args": [] },
+  { "id": "codex-acp", "command": "codex-acp", "args": [] },
+  { "id": "dsh-acp", "command": "dsh-acp", "args": [] }
+]

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -322,15 +322,27 @@ reference. It names the current release's `runtime-sandbox-full:v<version>` alia
 The image workflow creates this alias even when it reuses an older component
 image. The pool continues to use the separate `runtime-sandbox` image. Both targets
 share a base stage with the toolchain, browser, ACP runtimes, and shim. Additional
-self-hosted runtimes and development toolchains belong in the full target, which
-already adds the daemon-specific tools.
+self-hosted runtimes belong in the full target. The pool provides Claude Code,
+Codex, and DeepSeek Harness. The full image additionally installs Antigravity,
+Cline, Devin, GitHub Copilot, Grok Build, Oh My Pi, OpenCode, pi, Qwen Code,
+Qoder CLI, and Qoder CN CLI. The legacy `qoder` catalog ID uses the same Qoder
+CLI executable as `qoder-cli`. pi includes both its ACP adapter and the underlying
+CLI. Packages are version-pinned; standalone downloads also pin their SHA-256.
+
+Each image bakes an explicit runtime roster and generates its own runtime table
+by probing the installed executables as the ordinary runtime user, without
+provider credentials. Missing executables fail the build instead of silently
+reducing the roster. Installing a runtime does not establish a host login or
+make it a discovery candidate; credential discovery still governs that list.
+General development toolchain expansion can follow independently.
 The daemon package is published before image finalization; the matching
 image workflow must complete before this default can be pulled. A missing image
 fails preflight rather than selecting another version.
 Runtime-image input changes also trigger daemon package publication so its
 bundled default follows the updated image.
 The release images are currently Linux amd64; an arm64 daemon must configure
-a compatible image explicitly.
+a compatible image explicitly. The full image's Antigravity binary requires
+AVX in the guest CPU; amd64 emulation without AVX cannot run that runtime.
 
 An explicit daemon image overrides this metadata. Development builds remove
 release metadata and require an explicit image; they do not derive a default

--- a/packages/daemon/test/runtime-table-generator.test.ts
+++ b/packages/daemon/test/runtime-table-generator.test.ts
@@ -1,5 +1,12 @@
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { ACP_AUTH_REQUIRED_CODE, isAuthRequired } from '../../../docker/runtime-sandbox/generate-runtime-table.mjs'
+import {
+  ACP_AUTH_REQUIRED_CODE,
+  buildTable,
+  isAuthRequired
+} from '../../../docker/runtime-sandbox/generate-runtime-table.mjs'
 
 // The runtime image's table generator tolerates exactly one session/new failure: a runtime that is
 // unauthenticated. Everything else must fail the build, because the smoke test exercises only
@@ -22,5 +29,50 @@ describe('runtime table probe classification', () => {
     // And an error carrying no code at all — a spawn failure or a timeout — is never auth.
     expect(isAuthRequired(new Error('codex-acp did not answer session/new within 60000ms'))).toBe(false)
     expect(isAuthRequired(undefined)).toBe(false)
+  })
+
+  it.each([
+    {
+      label: 'reported version',
+      agentInfo: { name: 'fixture', version: '1.2.3' },
+      metadata: { version: '1.2.3' },
+      identity: { agentName: 'fixture' }
+    },
+    { label: 'no version', agentInfo: { name: 'fixture' }, metadata: {}, identity: { agentName: 'fixture' } },
+    { label: 'no agentInfo', agentInfo: undefined, metadata: {}, identity: {} }
+  ])('records real initialize metadata with $label and an unauthenticated session', async (fixture) => {
+    const initialized = { protocolVersion: 1, agentInfo: fixture.agentInfo, agentCapabilities: {} }
+    const script = `
+      require('node:readline').createInterface({ input: process.stdin }).on('line', (line) => {
+        const { id, method } = JSON.parse(line)
+        const response = method === 'initialize'
+          ? { result: ${JSON.stringify(initialized)} }
+          : { error: { code: -32000, message: 'Authentication required' } }
+        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, ...response }) + '\\n')
+      })
+    `
+    const entry = { id: 'fixture', command: process.execPath, args: ['--eval', script] }
+    const table = await buildTable([entry])
+    expect(table.runtimes).toEqual([
+      {
+        ...entry,
+        ...fixture.metadata,
+        acp: {
+          protocolVersion: 1,
+          ...fixture.identity,
+          authMethods: [],
+          capabilities: {},
+          modes: [],
+          configOptions: [],
+          sessionProbe: 'auth-required'
+        }
+      }
+    ])
+  })
+
+  it('reports a missing executable without waiting for the ACP timeout', async () => {
+    await expect(
+      buildTable([{ id: 'missing', command: join(tmpdir(), `missing-runtime-${randomUUID()}`) }])
+    ).rejects.toThrow(/ENOENT/)
   })
 })

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -14,6 +14,7 @@
  * its own manifests, but wrong about what runs, still fails.
  */
 import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { builtinModules } from 'node:module'
 
 import { diffRuntimeTables } from './runtime-table-diff.mjs'
@@ -263,12 +264,37 @@ check('the published runtime table matches a fresh ACP probe of this image', () 
   if (!Array.isArray(table.runtimes) || table.runtimes.length === 0) {
     throw new Error('the table declares no runtimes, so the daemon would advertise none')
   }
+  const expected = JSON.parse(
+    readFileSync(
+      new URL(
+        `../docker/runtime-sandbox/installed-runtimes${variant === 'runtime-sandbox-full' ? '-full' : ''}.json`,
+        import.meta.url
+      ),
+      'utf8'
+    )
+  )
+  const declaredIds = table.runtimes.map((entry) => entry.id).sort()
+  const expectedIds = expected.map((entry) => entry.id).sort()
+  if (JSON.stringify(declaredIds) !== JSON.stringify(expectedIds)) {
+    throw new Error(`${variant} runtime ids: expected ${expectedIds.join(', ')}, got ${declaredIds.join(', ')}`)
+  }
   for (const entry of table.runtimes) {
+    const installed = expected.find((runtime) => runtime.id === entry.id)
+    if (
+      entry.command !== installed.command ||
+      JSON.stringify(entry.args ?? []) !== JSON.stringify(installed.args ?? [])
+    ) {
+      throw new Error(`${entry.id} does not use the executable and arguments declared for ${variant}`)
+    }
     if (typeof entry.acp?.protocolVersion !== 'number') {
       throw new Error(`${entry.id} has no ACP protocol version, so the snapshot is not from initialize`)
     }
-    if (!entry.acp.capabilities || Object.keys(entry.acp.capabilities).length === 0) {
-      throw new Error(`${entry.id} publishes no ACP capabilities`)
+    if (
+      !entry.acp.capabilities ||
+      typeof entry.acp.capabilities !== 'object' ||
+      Array.isArray(entry.acp.capabilities)
+    ) {
+      throw new Error(`${entry.id} publishes no ACP capabilities object`)
     }
   }
   const { failures: drift, warnings: rosters } = diffRuntimeTables(table, JSON.parse(fresh))
@@ -278,7 +304,9 @@ check('the published runtime table matches a fresh ACP probe of this image', () 
     // Field by field, because the previous id@version list printed two identical strings for the drift it caught.
     throw new Error(`the shipped table differs from a fresh probe — ${drift.join('; ')}`)
   }
-  return table.runtimes.map((entry) => `${entry.id}@${entry.version} acp/${entry.acp.protocolVersion}`).join(' ')
+  return table.runtimes
+    .map((entry) => `${entry.id}${entry.version ? `@${entry.version}` : ''} acp/${entry.acp.protocolVersion}`)
+    .join(' ')
 })
 
 // Asserted against the BUILT image because the preset is generated from whatever adapter the build


### PR DESCRIPTION
The full daemon sandbox image now includes 14 runtime families: the existing Claude Code, Codex and DeepSeek Harness, plus Antigravity, Cline, Devin, GitHub Copilot, Grok Build, Oh My Pi, OpenCode, pi, Qwen Code, Qoder CLI and Qoder CN CLI. The pool image keeps its three runtimes. The legacy `qoder` ID shares the current Qoder CLI executable.

Pin package versions and standalone download checksums, install pi's underlying CLI alongside its ACP adapter, and preserve Antigravity's sibling harness binary. Both images declare explicit local commands and generate their runtime table through real ACP probes. Missing optional agent information stays omitted, and empty capability objects remain valid. Antigravity requires AVX on amd64 hosts or guests.

Root-run package installers use root's HOME, leaving the runtime user's HOME writable.

Validation: 21 focused daemon tests, runtime-table-diff tests, daemon typecheck, lint and formatting passed. Native Linux amd64 builds of both variants passed image verification and real shim-to-ACP session creation. The full image passed all 25 checks, freshly probed all 15 runtime IDs and passed the daemon's runtime-table schema. The pool image retained three runtimes. No provider login was needed for these build checks.

Created by Codex . GPT-6
