### PR TITLE
fix(daemon): show a provider's refusal without the runtime's wrapper (Codex, Claude Code, DeepSeek Harness)

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -170,17 +170,36 @@ export type ConfigSelectionPlan = { configId: string; value: string } | { skip: 
  * try again at 7:01 PM.") under `error.data.message` — so prefer that detail
  * over a bare title, and append it when a specific message carries extra data.
  * Non-RequestError failures fall back to the plain Error message.
+ *
+ * Both texts are first stripped of the decoration Codex puts around a provider's own error
+ * (`undecorateRuntimeError`): what reaches the person is the sentence the provider wrote.
  */
 export function turnFailureReason(err: unknown): string {
   const e = err as { message?: unknown; data?: { message?: unknown } } | null | undefined
-  const msg = typeof e?.message === 'string' && e.message.trim() ? e.message.trim() : String(err)
-  const detail = typeof e?.data?.message === 'string' ? e.data.message.trim() : ''
+  const raw = typeof e?.message === 'string' && e.message.trim() ? e.message.trim() : String(err)
+  const msg = undecorateRuntimeError(raw)
+  const detail = typeof e?.data?.message === 'string' ? undecorateRuntimeError(e.data.message.trim()) : ''
   if (!detail || msg.includes(detail)) return msg
   // The SDK's generic titles (RequestError statics) add nothing over the
   // runtime's own text; any more specific message keeps both.
   const generic =
     /^(parse error|invalid request|invalid params|internal error|request cancelled|authentication required|resource not found)$/i
   return generic.test(msg) ? detail : `${msg}: ${detail}`
+}
+
+/**
+ * Codex reports a non-2xx model response as `unexpected status <code> <reason>: <provider message>`,
+ * newer versions with `, url: <request url>` appended. Neither wrapper is for the person reading the
+ * turn: the status is implied by the provider's sentence, and the URL is the gateway or proxy the
+ * runtime was pointed at — an internal address that means nothing to them and should not be shown.
+ * Only that exact shape is unwrapped; the provider's own text passes through untouched, and any other
+ * message is returned as is. A message that is nothing but the wrapper keeps its status line.
+ */
+export function undecorateRuntimeError(text: string): string {
+  const m = /^unexpected status (\d{3})(?: [A-Za-z][A-Za-z '-]*)?: ([\s\S]*?)(?:, url: \S+)?$/.exec(text.trim())
+  if (!m) return text
+  const inner = m[2]!.trim()
+  return inner || `unexpected status ${m[1]}`
 }
 
 /** Machine-stable classification for a failed ACP turn. Keep the default conservative:

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -188,18 +188,39 @@ export function turnFailureReason(err: unknown): string {
 }
 
 /**
- * Codex reports a non-2xx model response as `unexpected status <code> <reason>: <provider message>`,
- * newer versions with `, url: <request url>` appended. Neither wrapper is for the person reading the
- * turn: the status is implied by the provider's sentence, and the URL is the gateway or proxy the
- * runtime was pointed at — an internal address that means nothing to them and should not be shown.
- * Only that exact shape is unwrapped; the provider's own text passes through untouched, and any other
- * message is returned as is. A message that is nothing but the wrapper keeps its status line.
+ * The wrappers runtimes put around a provider's own error sentence, unwrapped so what reaches the person
+ * is the sentence the provider wrote — nothing else in it is for them:
+ *
+ * - **Codex**: `unexpected status <code> <reason>: <sentence>`, newer versions with `, url: <request
+ *   url>` appended. The status is implied by the sentence; the url is the gateway or proxy the runtime
+ *   was pointed at, an internal address.
+ * - **Claude Code** (through claude-agent-acp, which rejects the prompt with the CLI's result text): a
+ *   401/403 renders as `Failed to authenticate. API Error: <code> <sentence>` in non-interactive mode
+ *   (`Please run /login · API Error: …` interactively); other statuses as `API Error: <code> <sentence>`
+ *   or `API Error: <sentence>`. "Failed to authenticate" is the CLI's guess at what a 401 means, wrong
+ *   for a gateway that refuses a stopped org with its own sentence.
+ * - **DeepSeek Harness** (deepseek-harness-acp): `turn failed: <reason>`.
+ *
+ * Only those exact shapes are unwrapped; the sentence inside passes through untouched, and any other
+ * message is returned as is. A wrapper around nothing keeps a status line rather than answering with an
+ * empty string.
  */
 export function undecorateRuntimeError(text: string): string {
-  const m = /^unexpected status (\d{3})(?: [A-Za-z][A-Za-z '-]*)?: ([\s\S]*?)(?:, url: \S+)?$/.exec(text.trim())
-  if (!m) return text
-  const inner = m[2]!.trim()
-  return inner || `unexpected status ${m[1]}`
+  const t = text.trim()
+  const codex = /^unexpected status (\d{3})(?: [A-Za-z][A-Za-z '-]*)?: ([\s\S]*?)(?:, url: \S+)?$/.exec(t)
+  if (codex) {
+    const inner = codex[2]!.trim()
+    return inner || `unexpected status ${codex[1]}`
+  }
+  const claude =
+    /^(?:Failed to authenticate\. |Please run \/login (?:·|\u00b7) )?API Error: (?:(\d{3})(?: |$))?([\s\S]*)$/.exec(t)
+  if (claude) {
+    const inner = claude[2]!.trim()
+    return inner || (claude[1] ? `API error ${claude[1]}` : text)
+  }
+  const harness = /^turn failed: ([\s\S]+)$/.exec(t)
+  if (harness) return undecorateRuntimeError(harness[1]!)
+  return text
 }
 
 /** Machine-stable classification for a failed ACP turn. Keep the default conservative:

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -26,7 +26,7 @@ import {
   type TranscriptRow,
   type StoredUsage
 } from './store/local-store.js'
-import { AcpHost, turnFailureCode, turnFailureReason } from './acp/acp-host.js'
+import { AcpHost, turnFailureCode, turnFailureReason, undecorateRuntimeError } from './acp/acp-host.js'
 import {
   probeSandboxHost,
   removeHostSandboxState,
@@ -12304,7 +12304,14 @@ export class Daemon {
       } else {
         let covered = false
         for (const action of p.conv.flushTerminal()) {
-          covered ||= action.kind === 'post' && action.text.includes(reason)
+          if (action.kind === 'post') {
+            // A runtime that narrated its terminal error narrated it WRAPPED — Claude Code's "Failed
+            // to authenticate. API Error: 401 …" — while `reason` is the unwrapped sentence. When the
+            // narration is exactly that wrapper, post the sentence instead: it is the same message,
+            // minus the runtime's guess at what it means.
+            if (undecorateRuntimeError(action.text) === reason) action.text = reason
+            covered ||= action.text.includes(reason)
+          }
           this.enqueueApply(p, action)
         }
         if (!covered)

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -585,6 +585,30 @@ describe('turnFailureReason (actionable message from a failed ACP request)', () 
     expect(turnFailureReason(new Error('status 401: nope, url: http://x'))).toBe('status 401: nope, url: http://x')
   })
 
+  it('strips Claude Code’s "API Error" wrapper as claude-agent-acp relays it, including the authenticate guess on a 401', () => {
+    // claude-agent-acp rejects the prompt with the CLI's own result text (RequestError.internalError with
+    // the text as data.message). For a gateway 401 that text is the CLI's non-interactive rendering.
+    const err = Object.assign(new Error('Internal error'), {
+      code: -32603,
+      data: { message: `Failed to authenticate. API Error: 401 ${GATEWAY_STOP}` }
+    })
+    expect(turnFailureReason(err)).toBe(GATEWAY_STOP)
+    // Interactive rendering, a plain status, and no status at all.
+    expect(turnFailureReason(new Error(`Please run /login · API Error: 403 ${GATEWAY_STOP}`))).toBe(GATEWAY_STOP)
+    expect(turnFailureReason(new Error('API Error: 402 Payment is required.'))).toBe('Payment is required.')
+    expect(turnFailureReason(new Error('API Error: Request was aborted.'))).toBe('Request was aborted.')
+    // A wrapper around nothing keeps a status line; a bare label is not a wrapper.
+    expect(turnFailureReason(new Error('API Error: 500 '))).toBe('API error 500')
+    expect(turnFailureReason(new Error('API Error'))).toBe('API Error')
+  })
+
+  it('strips the DeepSeek Harness adapter’s "turn failed:" prefix, then whatever the harness wrapped', () => {
+    expect(turnFailureReason(new Error(`turn failed: ${GATEWAY_STOP}`))).toBe(GATEWAY_STOP)
+    expect(turnFailureReason(new Error(`turn failed: unexpected status 401 Unauthorized: ${GATEWAY_STOP}`))).toBe(
+      GATEWAY_STOP
+    )
+  })
+
   it('prefers data.message over a generic JSON-RPC title (codex-acp quota exhaustion)', () => {
     // Exactly what codex-acp rejects session/prompt with when Codex is out of usage.
     const err = Object.assign(new Error('Internal error'), {

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -562,6 +562,28 @@ describe('AcpHost — auto-inject CLAUDE_CODE_EXECUTABLE for a Claude runtime', 
 describe('turnFailureReason (actionable message from a failed ACP request)', () => {
   const LIMIT =
     "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 7:01 PM."
+  const GATEWAY_STOP =
+    'Out of AgentConnect credits — this message was not processed. Add credits (https://console.example.test/example-org/billing) or run this agent on a self-hosted Daemon (https://docs.example.test/install). Then resend.'
+
+  it('strips Codex’s status prefix and request-url suffix from a gateway refusal, keeping the provider’s sentence', () => {
+    // Exactly what Codex surfaces when the AI gateway refuses a stopped org's credential: its own
+    // wrapper around the gateway's sentence, plus the internal URL it was dialling.
+    const err = Object.assign(new Error('Internal error'), {
+      code: -32603,
+      data: {
+        message: `unexpected status 401 Unauthorized: ${GATEWAY_STOP}, url: http://example-aigw-drain.example.svc.cluster.local:8082/v1/responses`
+      }
+    })
+    expect(turnFailureReason(err)).toBe(GATEWAY_STOP)
+    // The older shape, with no url, and a reason phrase with spaces.
+    expect(turnFailureReason(new Error(`unexpected status 402 Payment Required: ${GATEWAY_STOP}`))).toBe(GATEWAY_STOP)
+    // A wrapper around nothing keeps a status line rather than answering with an empty string.
+    expect(turnFailureReason(new Error('unexpected status 502 Bad Gateway: , url: http://x/y'))).toBe(
+      'unexpected status 502'
+    )
+    // Anything not in that exact shape passes through untouched.
+    expect(turnFailureReason(new Error('status 401: nope, url: http://x'))).toBe('status 401: nope, url: http://x')
+  })
 
   it('prefers data.message over a generic JSON-RPC title (codex-acp quota exhaustion)', () => {
     // Exactly what codex-acp rejects session/prompt with when Codex is out of usage.


### PR DESCRIPTION
## What

`turnFailureReason` strips the decoration runtimes put around a provider's error before the text reaches the person, keeping the provider's own sentence verbatim. Three shapes, each read from the source the daemon runs against:

| runtime | what the daemon receives | shown as |
| --- | --- | --- |
| Codex (codex-acp) | `unexpected status 401 Unauthorized: <sentence>, url: http://<internal gateway host>/v1/responses` | `<sentence>` |
| Claude Code (claude-agent-acp relays the CLI's result text) | `Failed to authenticate. API Error: 401 <sentence>` (non-interactive), `API Error: <code> <sentence>` for other statuses | `<sentence>` |
| DeepSeek Harness (deepseek-harness-acp) | `turn failed: <reason>` | `<reason>`, itself unwrapped if it carries one of the shapes above |

## Why

A failed turn in the session read `unexpected status 401 Unauthorized: <the provider's sentence>, url: http://<internal gateway host>/v1/responses`. The status adds nothing the sentence does not already say, and the url is the gateway or proxy the runtime was configured with — an internal name a user cannot act on. Claude Code's wrapper is worse: "Failed to authenticate" is the CLI's guess at what a 401 means, and for a gateway that refuses a stopped org with its own sentence the guess is wrong.

## How

- `undecorateRuntimeError` matches exactly those wrapper shapes and returns the body. Applied to both the JSON-RPC title and `data.message` before the existing title-vs-detail choice, so every surface that goes through `turnFailureReason` (platform notice, webchat sink, transcript) benefits. Any other message passes through unchanged; a wrapper around an empty body keeps a status line.
- Claude Code also narrates the wrapped text into the reply stream before the adapter rejects. The terminal flush in `daemon.ts` now posts the unwrapped sentence when the narration is exactly that wrapper, so the agent's "reply" is the sentence rather than the wrapper. Narrations that are not exactly a wrapper are untouched.

## Verified against

- Codex: observed on a test session.
- Claude Code 2.1.226's error mapper (`Failed to authenticate. ${LE}: ${Z_r(e)}` on 401/403 in non-interactive mode, with the JSON body's `error.message` extracted) and claude-agent-acp 0.23.1 (`RequestError.internalError(undefined, message.result)` on `is_error`). Not yet observed on a live session — worth one run with a Claude agent against a stopped org.
- deepseek-harness-acp 0.4.30 (`internalError(\`turn failed: ${reason.error.message}\`)`). The harness core's own wording of an HTTP error is not in the package, so the inner text is unverified; the prefix strip is.

Runtimes the gateway does not serve (Gemini, Qwen, Qoder, OpenClaw with its own gateway) never see this refusal.

## Tests

`acp-host.test.ts`: Codex with and without the url suffix, the empty-body case, a near-miss that must pass through; Claude Code's interactive and non-interactive renderings, plain and status-less forms, the status-only case, and the bare label; the DeepSeek prefix alone and around a Codex wrapper. daemon typecheck clean.

## Not in this PR

The gateway's out-of-credits sentence is not classified as `provider_quota_exhausted` by `turnFailureCode` (the existing patterns expect "out of credits" with nothing in between). Worth a separate look if that classification should drive reporting for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
