### PR TITLE
fix(console): separate host and sandbox runtime status

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -1215,6 +1215,15 @@ and its child processes.
 
 ## Sandbox availability and feature support
 
+The daemon's **Runtimes** section defaults to **Host** and offers a **Host / Sandbox**
+view switch when sandboxing is optional. A daemon that requires sandboxing, including
+a managed pool member, shows only the sandbox view. The switch changes only the
+displayed runtime facts; it does not change an agent's execution setting. Image-only
+installation warnings belong to the sandbox view, while the host view retains the
+host's runtime version and login result. A missing image binary must not mark the
+host runtime unavailable. Self-hosted models and capabilities continue to use the
+existing host probe; this switch does not add another probe sweep.
+
 Every feature is supported in environments both **with and without** an OS sandbox,
 and a trusted agent may deliberately run unsandboxed. A sandbox is a best-effort
 isolation layer, never a precondition: no feature may fail closed just because the

--- a/packages/control-plane/prisma/migrations/20260929000000_runtime_host_version/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260929000000_runtime_host_version/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runtime_profile" ADD COLUMN "hostVersion" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -640,6 +640,7 @@ model RuntimeProfile {
   daemonId           String     @db.Uuid
   runtime            String // "claude" / "codex"
   version            String
+  hostVersion        String?
   models             String[]   @default([])
   contextWindow      Int?
   acpSupport         AcpSupport @default(none)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -139,6 +139,7 @@ export const RuntimeModelCatalogDto = z.object({
 export const RuntimeProfileDto = z.object({
   runtime: z.string(),
   version: z.string(),
+  hostVersion: z.string().nullable().optional(),
   models: z.array(z.string()),
   contextWindow: z.number().int().nullable(),
   acpSupport: z.string(),

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4954,6 +4954,7 @@ export interface RuntimeProfileRecord {
    *  (-32000): installed but needing a login on the daemon host. */
   authRequired: boolean
   unavailableReason?: 'image-binary-missing' | null
+  hostVersion?: string | null
   /** When the daemon last reported this profile. */
   observedAt: Date
 }

--- a/packages/control-plane/src/persistence/repositories/runtime-profile.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/runtime-profile.repo.ts
@@ -17,6 +17,7 @@ function toRecord(p: RuntimeProfile): RuntimeProfileRecord {
     daemonId: DaemonId(p.daemonId),
     runtime: p.runtime,
     version: p.version,
+    hostVersion: p.hostVersion,
     models: p.models,
     contextWindow: p.contextWindow,
     acpSupport: p.acpSupport as AcpSupport,
@@ -50,6 +51,7 @@ export class PgRuntimeProfileRepo implements RuntimeProfileRepo {
         daemonId,
         runtime: f.runtime,
         version: f.version,
+        hostVersion: f.hostVersion ?? null,
         models: f.models,
         contextWindow: f.contextWindow,
         acpSupport: f.acpSupport,
@@ -64,6 +66,7 @@ export class PgRuntimeProfileRepo implements RuntimeProfileRepo {
       },
       update: {
         version: f.version,
+        hostVersion: f.hostVersion ?? null,
         models: f.models,
         contextWindow: f.contextWindow,
         acpSupport: f.acpSupport,

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -215,6 +215,7 @@ export interface DaemonRuntimeProfile {
    *  Drives the console's per-runtime login warning. */
   authRequired: boolean
   unavailableReason?: 'image-binary-missing' | null
+  hostVersion?: string | null
   /** When the daemon last reported this profile. */
   observedAt: Date
 }

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -51,6 +51,7 @@ function toProfileView(p: RuntimeProfileRecord): DaemonRuntimeProfile {
   return {
     runtime: p.runtime,
     version: p.version,
+    hostVersion: p.hostVersion ?? null,
     models: p.models,
     contextWindow: p.contextWindow,
     acpSupport: p.acpSupport,

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -270,6 +270,7 @@ describe('GET /daemons — live-status overlay', () => {
       {
         runtime: 'claude',
         version: '1.4.0',
+        hostVersion: '2.0.0',
         models: [],
         acpSupport: 'full',
         toolCalling: true,
@@ -281,6 +282,7 @@ describe('GET /daemons — live-status overlay', () => {
     running = buildHttpApp(prisma)
     expect((await listCapabilities()).find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]).toMatchObject({
       runtime: 'claude',
+      hostVersion: '2.0.0',
       authRequired: true,
       unavailableReason: 'image-binary-missing'
     })
@@ -288,6 +290,7 @@ describe('GET /daemons — live-status overlay', () => {
     expect(response.statusCode).toBe(200)
     expect((response.json() as DaemonDto).runtimeProfiles[0]).toMatchObject({
       runtime: 'claude',
+      hostVersion: '2.0.0',
       authRequired: true,
       unavailableReason: 'image-binary-missing'
     })

--- a/packages/control-plane/test/protocol/daemon-runtimes.handler.test.ts
+++ b/packages/control-plane/test/protocol/daemon-runtimes.handler.test.ts
@@ -180,11 +180,19 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     // The probe was rejected with ACP auth-required: the runtime stays listed
     // (installed) but carries the login warning.
     stub.inject('facts/daemon-runtimes', {
-      runtimes: [{ ...profile('claude-acp'), authRequired: true, unavailableReason: 'image-binary-missing' }]
+      runtimes: [
+        {
+          ...profile('claude-acp'),
+          hostVersion: '2.0.0',
+          authRequired: true,
+          unavailableReason: 'image-binary-missing'
+        }
+      ]
     })
     await vi.waitFor(async () => {
       expect((await repo.forDaemon(DaemonId(DAEMON)))[0]).toMatchObject({
         authRequired: true,
+        hostVersion: '2.0.0',
         unavailableReason: 'image-binary-missing'
       })
     })
@@ -195,6 +203,7 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     await vi.waitFor(async () => {
       expect((await repo.forDaemon(DaemonId(DAEMON)))[0]).toMatchObject({
         authRequired: false,
+        hostVersion: null,
         unavailableReason: null
       })
     })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2361,7 +2361,6 @@ export class Daemon {
     } else this.runtimeCatalog = localCatalog
     this.refreshAdmittedRuntimes()
     this.runtimeFacts.setInstalled(installedEntries)
-    if (this.microsandboxCatalog) this.runtimeFacts.noteImageCatalog(this.microsandboxCatalog.entries)
     this.log.info(`runtimes ready: ${Object.keys(this.runtimes).join(', ') || '(none)'}`)
     const pendingCurated = Object.keys(installed).filter((id) => installedEntries[id]?.source === 'curated')
     if (pendingCurated.length) this.log.info(`runtimes pending ACP admission: ${pendingCurated.join(', ')}`)

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -156,14 +156,13 @@ export class RuntimeFactsRegistry {
     return this.catalogs.get(runtimeId)
   }
 
-  /** Build the current profile entry for a runtime (one element of the
-   *  `facts/daemon-runtimes` snapshot), folding in any models learned by the
-   *  probe sweep. */
+  /** Report the current runtime profile, preserving both host and image versions. */
   profileFor(id: string): FactsRuntimeProfile {
+    const hostVersion = this.probedVersions.get(id) || this.versions[id] || ''
     return {
       runtime: id,
-      // VM versions come from the image; a host probe supplies models and capabilities only.
-      version: this.host.imageVersion(id) || this.probedVersions.get(id) || this.versions[id] || '',
+      version: this.host.imageVersion(id) || hostVersion,
+      ...(!this.host.launch().k8s ? { hostVersion } : {}),
       models: this.models.get(id) ?? [],
       acpSupport: 'full',
       acpProtocolVersion: this.acpVersions.get(id),

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -309,6 +309,7 @@ describe('microsandbox runtime facts', () => {
         expect(d.microsandboxCatalog.entries.opencode).toBeUndefined()
         await d.hydrateRuntimeCaches()
         expect(d.runtimeFacts.profileFor('codex-acp').models).toEqual([])
+        expect(d.runtimeFacts.profileFor('codex-acp').hostVersion).toBe('')
         const onCatalogUpdated = d.modelCatalogSvc.deps.onUpdated
         const noteProbe = stubCatalogSvc(daemon)
         const emitted = captureEmits(daemon)
@@ -323,12 +324,14 @@ describe('microsandbox runtime facts', () => {
         expect(d.runtimeFacts.profileFor('codex-acp')).toMatchObject({
           runtime: 'codex-acp',
           version: 'image-version',
+          hostVersion: 'host-version',
           models: ['host-model'],
           modelsSource: 'probed',
           acpProtocolVersion: 1
         })
         expect(d.runtimeFacts.profileFor('codex-acp').unavailableReason).toBeUndefined()
         expect(d.runtimeFacts.profileFor('grok-build')).toMatchObject({
+          hostVersion: 'host-version',
           models: ['host-model'],
           unavailableReason: 'image-binary-missing'
         })

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -306,6 +306,8 @@ export type RuntimeModelCatalog = z.infer<typeof RuntimeModelCatalog>
 export const FactsRuntimeProfile = z.object({
   runtime: z.string(), // "claude" / "codex" / ...
   version: z.string(),
+  // The host probe's version, kept separate from a sandbox image's runtime version.
+  hostVersion: z.string().optional(),
   models: z.array(z.string()),
   contextWindow: z.number().int().optional(),
   acpSupport: z.enum(['full', 'partial', 'none']), // gates the dual-mode decision (#1)

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -387,6 +387,7 @@ export function FleetRuntimesCard({
   agents,
   empty,
   note,
+  headerActions,
   daemonName
 }: {
   title: string
@@ -396,6 +397,7 @@ export function FleetRuntimesCard({
   empty: string
   /** What the header says the list means — a group's is narrower than a pool's. */
   note?: string
+  headerActions?: ReactNode
   /** The one machine these runtimes are on, when the card is a single daemon's — a login command
    *  belongs on a named host, and a set of them has no single one to name. */
   daemonName?: string
@@ -416,6 +418,7 @@ export function FleetRuntimesCard({
     <div className="card mb-[18px]">
       <div className="cardhead">
         <span className="cardtitle">{title}</span>
+        {headerActions && <div className="ml-auto">{headerActions}</div>}
         {note && (
           <span className="ml-auto font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
             {note}

--- a/packages/web/src/components/console/views/DaemonDetailView.runtimes.test.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.runtimes.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DaemonRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({ mobile: false, daemon: null as DaemonRow | null }))
+vi.mock('next/navigation', () => ({ useParams: () => ({ id: 'd1' }), useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/example${path}` }) }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => mocks.mobile }))
+vi.mock('@/lib/feature-flags', () => ({ featureFlagEnabled: () => false }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({ daemons: [mocks.daemon], agents: [], memberSets: [], members: [] })
+}))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+vi.mock('@/components/console/FleetDetail', async (original) => ({
+  ...(await original<typeof import('@/components/console/FleetDetail')>()),
+  FleetUsageCard: () => null
+}))
+
+import DaemonDetailView from './DaemonDetailView'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  mocks.daemon = {
+    daemonId: 'd1',
+    name: 'Example daemon',
+    version: '1.0.0',
+    status: 'online',
+    pool: false,
+    caps: { platforms: [], runtimes: ['claude', 'codex'], acp: true, features: ['sandbox'] },
+    runtimeModels: [
+      { runtime: 'claude', version: '9.0.0', hostVersion: '2.0.0', models: ['example-model'] },
+      {
+        runtime: 'codex',
+        version: '3.0.0',
+        hostVersion: '3.0.0',
+        models: [],
+        authRequired: true,
+        unavailableReason: 'image-binary-missing'
+      }
+    ],
+    cpu: 0,
+    mem: 0,
+    loadAgents: 0,
+    conns: '4',
+    activeSessions: '0',
+    uptime: '1m',
+    availableVersions: [],
+    createdBy: '',
+    lastModifiedBy: '',
+    visibility: 'org',
+    sharedWith: []
+  } as unknown as DaemonRow
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+})
+
+const render = () => act(async () => root.render(<DaemonDetailView />))
+const control = () => host.querySelector('[aria-label="Runtime environment"]')
+const choose = async (label: string) => {
+  const button = Array.from(control()!.querySelectorAll('button')).find((b) => b.textContent === label)!
+  await act(async () => button.click())
+}
+
+describe.each([false, true])('runtime environment view (mobile: %s)', (mobile) => {
+  beforeEach(() => {
+    mocks.mobile = mobile
+  })
+
+  it('defaults to host and switches versions and warnings without changing the reported facts', async () => {
+    await render()
+    expect(control()?.querySelector('[aria-pressed="true"]')?.textContent).toBe('Host')
+    expect(host.textContent).toContain('v2.0.0')
+    expect(host.textContent).not.toContain('v9.0.0')
+    expect(host.textContent).toContain('Login required')
+    expect(host.textContent).not.toContain('Binary not installed in image')
+
+    await choose('Sandbox')
+    expect(host.textContent).toContain('v9.0.0')
+    expect(host.textContent).not.toContain('v2.0.0')
+    expect(host.textContent).not.toContain('v3.0.0')
+    expect(host.textContent).toContain('Binary not installed in image')
+    expect(host.textContent).not.toContain('Login required')
+
+    await choose('Host')
+    expect(host.textContent).toContain('v3.0.0')
+    expect(host.textContent).toContain('Login required')
+    expect(host.textContent).not.toContain('Binary not installed in image')
+    expect(mocks.daemon!.runtimeModels[1]!.unavailableReason).toBe('image-binary-missing')
+  })
+
+  it.each(['required', 'pool'])('shows only sandbox when policy is %s', async (policy) => {
+    if (policy === 'pool') mocks.daemon!.pool = true
+    else mocks.daemon!.caps.features.push('sandbox-required')
+    await render()
+    expect(control()).toBeNull()
+    expect(host.textContent).toContain('Sandbox')
+    expect(host.textContent).toContain('v9.0.0')
+    expect(host.textContent).not.toContain('v2.0.0')
+    expect(host.textContent).toContain('Binary not installed in image')
+  })
+
+  it('explains an unavailable sandbox while keeping host runtimes visible', async () => {
+    mocks.daemon!.caps.features = []
+    await render()
+    expect(host.textContent).toContain('v2.0.0')
+    await choose('Sandbox')
+    expect(host.textContent).toContain('Sandbox is unavailable on this daemon.')
+    expect(host.textContent).not.toContain('v9.0.0')
+    await choose('Host')
+    expect(host.textContent).toContain('v2.0.0')
+  })
+})

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -66,6 +66,7 @@ export default function DaemonDetailView() {
   // Mobile: tap a runtime row to expand its model list (design: `rtOpen` map —
   // independent toggles, so more than one can be open at once).
   const [expandedRuntimes, setExpandedRuntimes] = useState<Set<string>>(new Set())
+  const [runtimeMode, setRuntimeMode] = useState<'host' | 'sandbox'>('host')
   const toggleRuntime = (rid: string) =>
     setExpandedRuntimes((prev) => {
       const next = new Set(prev)
@@ -120,7 +121,41 @@ export default function DaemonDetailView() {
   const canUpgrade = canRestart && daemon.availableVersions.some((v) => v !== daemon.version)
 
   const hosted = agents.filter((a) => a.daemon === daemon.daemonId)
-  const runtimes: FleetRuntime[] = unionRuntimes([daemon])
+  const sandboxRequired = daemon.pool || daemon.caps.features.includes('sandbox-required')
+  const sandboxSupported = daemon.pool || daemon.caps.features.includes('sandbox')
+  const runtimeEnvironment = sandboxRequired ? 'sandbox' : runtimeMode
+  const runtimeAgents = hosted.filter(
+    (a) => (sandboxRequired || (sandboxSupported && a.runInSandbox)) === (runtimeEnvironment === 'sandbox')
+  )
+  const runtimeModels = daemon.runtimeModels.map((rt) =>
+    runtimeEnvironment === 'host'
+      ? { ...rt, version: rt.hostVersion ?? rt.version, unavailableReason: null }
+      : { ...rt, version: rt.unavailableReason === 'image-binary-missing' ? '' : rt.version }
+  )
+  const sandboxUnavailable = runtimeEnvironment === 'sandbox' && !sandboxSupported
+  const runtimes: FleetRuntime[] = sandboxUnavailable ? [] : unionRuntimes([{ ...daemon, runtimeModels }])
+  const runtimeEmpty = sandboxUnavailable
+    ? 'Sandbox is unavailable on this daemon.'
+    : 'No runtimes reported by this daemon.'
+  const runtimeModeControl = sandboxRequired ? (
+    <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">Sandbox</span>
+  ) : (
+    <div className="pillbar" role="group" aria-label="Runtime environment">
+      {(['host', 'sandbox'] as const).map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          className={
+            runtimeEnvironment === mode ? 'pill on px-[10px] py-1 text-[12px]' : 'pill px-[10px] py-1 text-[12px]'
+          }
+          aria-pressed={runtimeEnvironment === mode}
+          onClick={() => setRuntimeMode(mode)}
+        >
+          {mode === 'host' ? 'Host' : 'Sandbox'}
+        </button>
+      ))}
+    </div>
+  )
   const seen = daemon.uptime === '—' ? 'never connected' : `last seen ${daemon.uptime} ago`
   // `conns` is the daemon's agent ceiling; <= 0 is its UNBOUNDED sentinel, not a ceiling of zero.
   // Its numerator is the daemon's OWN heartbeat count, never `hosted`: a group duty this member
@@ -264,13 +299,14 @@ export default function DaemonDetailView() {
 
         {/* runtimes — full-width stacked rows */}
         <div className="mx-4 mt-1 overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs)">
-          <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal">
-            Runtimes
+          <div className="flex items-center justify-between gap-3 border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal">
+            <span>Runtimes</span>
+            {runtimeModeControl}
           </div>
           {runtimes.length > 0 ? (
             runtimes.map((rt, i) => {
               const meta = acpRuntime(acpRegistry, rt.runtime)
-              const users = hosted.filter(
+              const users = runtimeAgents.filter(
                 (a) => a.runtime === rt.runtime || runtimeLabel(a.runtime) === runtimeLabel(rt.runtime, meta?.name)
               )
               const usage = users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'
@@ -385,7 +421,7 @@ export default function DaemonDetailView() {
             })
           ) : (
             <div className="px-4 py-7 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-              No runtimes reported by this daemon.
+              {runtimeEmpty}
             </div>
           )}
         </div>
@@ -730,8 +766,9 @@ export default function DaemonDetailView() {
       <FleetRuntimesCard
         title="Runtimes"
         runtimes={runtimes}
-        agents={hosted}
-        empty="No runtimes reported by this daemon."
+        agents={runtimeAgents}
+        empty={runtimeEmpty}
+        headerActions={runtimeModeControl}
         daemonName={daemon.name}
       />
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1065,6 +1065,7 @@ export interface RuntimeProfileDto {
   // CP) ⇒ no warning.
   authRequired?: boolean
   unavailableReason?: 'image-binary-missing' | null
+  hostVersion?: string | null
 }
 
 // One daemon-configured MCP server (name + transport), reported in the
@@ -2174,6 +2175,7 @@ export function withDaemonCapability(row: DaemonRow, cap: DaemonCapabilityDto | 
     runtimeModels: cap.runtimeProfiles.map((p) => ({
       runtime: p.runtime,
       version: p.version,
+      hostVersion: p.hostVersion ?? null,
       models: p.models,
       acpProtocolVersion: p.acpProtocolVersion,
       mcpCapabilities: p.mcpCapabilities ?? null,
@@ -2222,6 +2224,7 @@ export function daemonFromDto(
     runtimeModels: (d.runtimeProfiles ?? []).map((p) => ({
       runtime: p.runtime,
       version: p.version,
+      hostVersion: p.hostVersion ?? null,
       models: p.models,
       acpProtocolVersion: p.acpProtocolVersion,
       mcpCapabilities: p.mcpCapabilities ?? null,

--- a/packages/web/src/lib/daemon-read-split.test.ts
+++ b/packages/web/src/lib/daemon-read-split.test.ts
@@ -44,6 +44,7 @@ const capability: DaemonCapabilityDto = {
     {
       runtime: 'claude-acp',
       version: '0.70.0',
+      hostVersion: '0.75.0',
       models: ['opus', 'sonnet'],
       contextWindow: null,
       acpSupport: 'full',
@@ -88,6 +89,7 @@ describe('daemon read split', () => {
     // The login warning is fleet-wide information, so it survives the split.
     expect(row.runtimeModels[0]!.authRequired).toBe(true)
     expect(row.runtimeModels[0]!.unavailableReason).toBe('image-binary-missing')
+    expect(row.runtimeModels[0]!.hostVersion).toBe('0.75.0')
     // The runtime-level answers survive, so the read-only model/permission labels resolve
     // for every agent; the per-model matrix is empty until `useDaemonDetail` reads one daemon.
     expect(row.runtimeModels[0]!.modelCatalog!.defaultModel).toBe('sonnet')
@@ -107,6 +109,7 @@ describe('mergeDaemonCatalogs — the detail read owns catalogs, the fleet row o
       runtime: 'claude-acp',
       version: '0.70.0',
       models: ['opus'],
+      hostVersion: '0.75.0',
       authRequired: true,
       unavailableReason: 'image-binary-missing',
       modelCatalog: null
@@ -130,6 +133,7 @@ describe('mergeDaemonCatalogs — the detail read owns catalogs, the fleet row o
     expect(merged!.models).toEqual(['opus'])
     expect(merged!.authRequired).toBe(true)
     expect(merged!.unavailableReason).toBe('image-binary-missing')
+    expect(merged!.hostVersion).toBe('0.75.0')
   })
 
   it('never adds a runtime the fleet row no longer reports', () => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -2248,6 +2248,7 @@ export interface DaemonRow {
      *  on the daemon detail page). Absent ⇒ no warning. */
     authRequired?: boolean
     unavailableReason?: 'image-binary-missing' | null
+    hostVersion?: string | null
   }[]
   /** Daemon-configured MCP servers (name + transport, facts/daemon-runtimes). */
   mcpServers: McpServerInfo[]


### PR DESCRIPTION
Daemon runtime cards currently show sandbox-image installation warnings even when agents can run on the host. Add a Host / Sandbox view switch, defaulting to Host when sandboxing is optional; required-sandbox daemons and pool members show only Sandbox. Both desktop and mobile views select the matching versions, warnings, and agent counts without changing execution settings or starting additional probes.

Preserve the host probe version separately from the image version through runtime facts, a nullable database column, and the existing API. Older snapshots clear the optional field; the console retains the legacy version fallback.

Validation: 101 focused tests passed, including desktop/mobile switching, runtime discovery, real PostgreSQL migration and round-trip reads. Protocol, daemon, control-plane, and web typechecks passed; targeted lint and formatting passed.

Created by Codex . GPT-6
