### PR TITLE
perf(daemon): share microsandbox layers with a Docker data disk

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -69,7 +69,7 @@ settings.
 | `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                          |
 | Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                     |
 | `sandbox.microsandbox.image`   | Implemented: optional, non-empty OCI override. Release builds default to their bundled shared-image reference; development builds require an explicit image. No Kubernetes image lookup is used.                                                                                     |
-| `cpus`, `memoryMiB`, `diskGiB` | Implemented: per-VM CPU allocation, memory limit, and disk capacity; defaults are `2`, `2048`, and `10`. Host capacity planning remains the operator's responsibility.                                                                                                               |
+| `cpus`, `memoryMiB`, `diskGiB` | Per-VM CPU allocation, memory limit, and capacity of each writable disk; defaults are `2`, `2048`, and `10`. New VMs have a root upper disk and a Docker data disk, each capped by `diskGiB`. Both are sparse; host capacity planning remains the operator's responsibility.         |
 | `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths; microsandbox accepts absolute guest targets. Workspace, HOME, and runtime state remain automatically provisioned. |
 
 ### Shared mounts and manual conversion
@@ -268,7 +268,7 @@ separate VMs do not make a deliberately shared host mount private. Linked-worktr
 Git metadata, secondary repositories, and file attachments keep consistent guest
 paths. This change does not redesign Git storage.
 
-### Current image contract and flat disks
+### Current image contract and VM storage
 
 The resolved OCI image must contain Node at
 `/usr/local/bin/node`, `/usr/bin/git`, Python 3.11+ for filesystem operations and socket bridges, the declared runtime tools,
@@ -295,23 +295,33 @@ terminal event before closing: the pinned relay can otherwise reuse the client
 ID while old output is still arriving. Losing transport before that terminal
 event fences and stops the VM before another execution can reuse it.
 
-The first implementation uses private flat ext4 root disks and explicit
-host-bound workspace/cache mounts. The clone strategy is `auto`: preparation can
-reuse a base image, while each private disk clone can fall back from reflink to
-sparse copying on the host filesystem. Measure both image preparation and cloning.
-Flat disks do not provide native snapshots or rootfs patches; generated launch
-files are written after boot through the guest file API.
+New VMs share the image's read-only layers and keep root filesystem changes in a
+private writable upper disk. Each VM also owns an ext4 disk mounted at
+`/var/lib/docker`, so Docker's OverlayFS snapshots do not nest on the root
+OverlayFS mount. Both sparse disks use `diskGiB` as their individual capacity.
+Workspace, HOME, and cache mounts retain their existing ownership and isolation.
+Creating a VM does not copy the full base image, including on hosts without
+reflink support. Generated launch files are written after boot through the guest
+file API.
+
+Existing flat-root VMs keep their saved layout and data when resumed. A new
+binding records ownership of its Docker disk; older bindings do not acquire or
+delete separate disks. Suspend retains both writable disks. Discard deletes the
+VM and then its owned Docker disk, retaining the binding if disk cleanup fails
+so the operation can be retried. SDK connections are explicitly detached after
+the VM stops. Resume and disk deletion retry the pinned SDK's transient disk-lock
+contention for up to one second after shutdown.
 
 Each VM mounts `/run` as tmpfs so process IDs and service sockets cannot survive
-a stop/start while application data remains on the persistent disk. Operator
-mounts cannot replace `/run`. The Python bridge creates its private socket
+a stop/start while application data remains on the persistent disks. Operator
+mounts cannot replace `/run` or `/var/lib/docker`. The Python bridge creates its private socket
 directory at `/tmp/agentconnect` as the image's ordinary user; the pool keeps its
 existing `/run/agentconnect` paths.
 
 In pinned version `0.6.17`, starting a retained flat-disk VM still validates the
 OCI image's VMDK cache. The manager therefore runs the official
 `msb pull <image> --materialize all --quiet` before its VM probe, preparing both
-image forms, and tests stop/start. The VM continues to use its flat disk. This
+image forms, and tests stop/start. Retained flat VMs continue to use their original disk. This
 uses the upstream CLI and package without an upstream source patch; cold image
 preparation includes the extra materialization cost.
 
@@ -375,9 +385,14 @@ stop an otherwise healthy agent VM. The host Docker socket is not mounted by the
 backend; ambient host Docker contexts and connection paths are removed from guest
 launches. Managed-pool pod privileges are unchanged by the image's installed tools.
 
-Docker image layers, named volumes, and build caches live on the retained flat
-disk. Stopping retains them; after a VM restart the agent starts dockerd again
-when needed. VM retirement deletes them. Docker-published ports belong to the
+Docker image layers, named volumes, and build caches live on the VM's retained
+ext4 Docker disk. The image's manual `dockerd` command starts its own containerd,
+whose data root is `/var/lib/docker/containerd/daemon`, on the same disk. A custom
+image that starts a separate system containerd must also place that service's
+data root on ext4; Docker's `data-root` setting does not relocate a separate
+containerd's storage. Stopping retains the data; after a VM restart the agent
+starts dockerd again when needed. VM retirement deletes the owned disk.
+Docker-published ports belong to the
 VM's network namespace, so two sessions can use the same internal port. This does not publish the port on the
 daemon host or provide a remote browser preview.
 

--- a/packages/daemon/scripts/smoke-microsandbox-docker.mts
+++ b/packages/daemon/scripts/smoke-microsandbox-docker.mts
@@ -40,14 +40,15 @@ for (const path of Object.values(sockets)) {
   })
   servers.push(server)
 }
-const manager = new MicrosandboxManager({
+const managerOptions = {
   root,
   sdk,
   sockets,
   msbCommand: { command: resolve(msbBinary), args: [] },
   config: { image, cpus: 2, memoryMiB: 2048, diskGiB: 8 },
   log: { info: console.log, warn: console.warn, error: console.error, debug: () => {}, trace: () => {} }
-})
+}
+let manager = new MicrosandboxManager(managerOptions)
 const environments: MicrosandboxEnvironment[] = []
 const env = {
   HOME: '/agent',
@@ -107,8 +108,11 @@ try {
   await manager.prepare()
   const beforeFirst = await freeBytes()
   const first = await session('first')
+  const started = performance.now()
   assert.equal(await run(first, '/usr/bin/id', ['-u']), '10001')
-  step('runtime-user', { identity: await run(first, '/usr/bin/id', []) })
+  step('runtime-user', { createMs: performance.now() - started, identity: await run(first, '/usr/bin/id', []) })
+  assert.equal(await run(first, '/usr/bin/findmnt', ['-n', '-o', 'FSTYPE', '-T', '/']), 'overlay')
+  assert.equal(await run(first, '/usr/bin/findmnt', ['-n', '-o', 'FSTYPE', '-T', '/var/lib/docker']), 'ext4')
   const version = await startDocker(first)
   step('docker-manually-started-as-runtime-user', { version })
   await writeFile(
@@ -162,6 +166,8 @@ volumes:
   assert.equal((await readFile(join(first.workspaceRoot, 'container-marker'), 'utf8')).trim(), 'BIND_OK')
   step('compose-build-service-dns-and-workspace-bind-passed')
   await manager.suspend(first.id)
+  await manager.stopAll()
+  manager = new MicrosandboxManager(managerOptions)
   const remaining = await freeBytes()
   const firstAllocation = Math.max(0, beforeFirst - remaining)
   assert.ok(remaining - firstAllocation >= 2 * 1024 ** 3, 'second VM would leave less than 2 GiB free')
@@ -185,6 +191,13 @@ volumes:
   ])
   await startDocker(first)
   assert.equal(await run(first, '/usr/bin/docker', ['image', 'inspect', imageName, '--format', '{{.Id}}']), built)
+  const rebuild = await manager.exec(first, '/usr/bin/docker', ['compose', '--progress', 'plain', 'build'], {
+    cwd: first.workspaceRoot,
+    env,
+    timeoutMs: 180_000
+  })
+  assert.equal(rebuild.exitCode, 0, rebuild.stderr)
+  assert.match(rebuild.stdout + rebuild.stderr, /CACHED/, 'build cache was lost across resume')
   assert.equal(
     await run(first, '/usr/bin/docker', [
       'run',
@@ -293,8 +306,9 @@ try {
   step('testcontainers-random-port-and-cleanup-passed')
   for (const environment of environments) await manager.discard(environment.id)
   assert.deepEqual(await manager.environmentIds(), [])
+  assert.deepEqual(await sdk.Volume.list(), [])
   passed = true
-  step('discarded-all-session-vms')
+  step('discarded-all-session-vms-and-disks')
 } finally {
   for (const environment of environments) await manager.discard(environment.id).catch((error) => console.error(error))
   await manager.stopAll()

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -49,7 +49,10 @@ export interface MicrosandboxExecResult {
 export interface MicrosandboxManagerOptions {
   root: string
   config: { image: string; cpus: number; memoryMiB: number; diskGiB: number }
-  sdk: Pick<typeof import('microsandbox'), 'Sandbox' | 'SandboxNotFoundError' | 'AgentClient'>
+  sdk: Pick<
+    typeof import('microsandbox'),
+    'Sandbox' | 'SandboxNotFoundError' | 'AgentClient' | 'Volume' | 'VolumeNotFoundError' | 'InvalidConfigError'
+  >
   msbCommand: { command: string; args: string[] }
   log?: Logger
   sockets: { mcp: string; gitcred: string }
@@ -73,6 +76,7 @@ interface Binding {
   sandboxId: string
   configHash: string
   environmentId: string
+  dockerVolume?: string
 }
 
 /** Owns VM lifecycle while exposing the existing ACP process-stream contract. */
@@ -214,18 +218,16 @@ export class MicrosandboxManager {
   private builder(name: string, mounts: SandboxMount[]) {
     const builder = this.options.sdk.Sandbox.builder(name)
       .image(this.options.config.image)
-      .rootDisk((disk) =>
-        disk
-          .flat()
-          .size(this.options.config.diskGiB * 1024)
-          .cloneStrategy('auto')
-      )
+      .rootDisk((disk) => disk.size(this.options.config.diskGiB * 1024))
       .cpus(this.options.config.cpus)
       .memory(this.options.config.memoryMiB)
       .deploymentProfile('single-tenant')
       .detached(true)
       .ephemeral(false)
       .volume('/run', (volume) => volume.tmpfs())
+      .volume('/var/lib/docker', (volume) =>
+        volume.namedWith(`${name}-docker`, 'create', 'disk', this.options.config.diskGiB * 1024)
+      )
       .quietLogs()
     for (const mount of mounts) {
       builder.volume(mount.target, (volume) => {
@@ -255,7 +257,8 @@ export class MicrosandboxManager {
       timeout: 5 * 60_000,
       maxBuffer: 1024 * 1024
     })
-    const sandbox = await this.builder(`${this.name('probe')}-${randomUUID().slice(0, 8)}`, []).create()
+    const name = `${this.name('probe')}-${randomUUID().slice(0, 8)}`
+    let sandbox = await this.builder(name, []).create()
     try {
       const output = await sandbox.exec(MICROSANDBOX_NODE, [
         '-e',
@@ -267,12 +270,15 @@ export class MicrosandboxManager {
         throw new Error(`microsandbox image preflight failed (exit ${output.code}): ${output.stderr().trim()}`)
       const table = K8sRuntimeTableSchema.parse(JSON.parse(output.stdout()))
       await sandbox.stopWithTimeout(STOP_TIMEOUT_MS)
-      const resumed = await (await this.options.sdk.Sandbox.get(sandbox.name)).startDetached()
-      await resumed.ping()
+      await sandbox.detach()
+      sandbox = await this.retryDiskOperation(async () => (await this.options.sdk.Sandbox.get(name)).startDetached())
+      await sandbox.ping()
       this.options.log?.info('microsandbox: image, Node, Python/vsock, runtime table and disk resume verified')
       return table
     } finally {
-      await sandbox.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+      await (await this.options.sdk.Sandbox.get(name)).destroy({ timeoutMs: STOP_TIMEOUT_MS })
+      await sandbox.detach()
+      await this.removeDockerVolume(`${name}-docker`)
     }
   }
 
@@ -307,6 +313,34 @@ export class MicrosandboxManager {
     }
   }
 
+  private async removeDockerVolume(name: string): Promise<void> {
+    try {
+      await this.retryDiskOperation(() => this.options.sdk.Volume.remove(name))
+    } catch (error) {
+      if (!(error instanceof this.options.sdk.VolumeNotFoundError)) throw error
+    }
+  }
+
+  private async retryDiskOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const deadline = Date.now() + 1_000
+    for (;;) {
+      try {
+        return await operation()
+      } catch (error) {
+        if (
+          !(error instanceof this.options.sdk.InvalidConfigError) ||
+          !/volume ".+" is (?:currently attached by a running sandbox|already attached with an incompatible disk mode)$/.test(
+            error.message
+          ) ||
+          Date.now() >= deadline
+        )
+          throw error
+        // The pinned SDK can observe stopped state before disk locks are released.
+        await new Promise((resolve) => setTimeout(resolve, 25))
+      }
+    }
+  }
+
   private async readBinding(id: string): Promise<Binding | undefined> {
     try {
       const value: unknown = JSON.parse(await readFile(this.bindingPath(id), 'utf8'))
@@ -317,7 +351,8 @@ export class MicrosandboxManager {
         binding.environmentId !== id ||
         typeof binding.spec !== 'string' ||
         typeof binding.sandboxId !== 'string' ||
-        typeof binding.configHash !== 'string'
+        typeof binding.configHash !== 'string' ||
+        (binding.dockerVolume !== undefined && binding.dockerVolume !== `${this.name(id)}-docker`)
       ) {
         throw new Error('invalid binding')
       }
@@ -366,12 +401,13 @@ export class MicrosandboxManager {
       if (existing.status === 'running' || existing.status === 'starting' || existing.status === 'draining') {
         await existing.stopWithTimeout(STOP_TIMEOUT_MS)
       }
-      const sandbox = await existing.connectOrStart({ detached: true })
+      const sandbox = await this.retryDiskOperation(() => existing.connectOrStart({ detached: true }))
       try {
         await this.startBridge(environment.id, sandbox)
         return sandbox
       } catch (error) {
         await sandbox.stopWithTimeout(STOP_TIMEOUT_MS)
+        await sandbox.detach()
         throw error
       }
     }
@@ -386,7 +422,8 @@ export class MicrosandboxManager {
         environmentId: environment.id,
         spec,
         sandboxId: persisted.id,
-        configHash: hash(stableJson(persisted.config()))
+        configHash: hash(stableJson(persisted.config())),
+        dockerVolume: `${name}-docker`
       }
       const path = this.bindingPath(environment.id)
       await mkdir(dirname(path), { recursive: true, mode: 0o700 })
@@ -401,6 +438,8 @@ export class MicrosandboxManager {
       return sandbox
     } catch (error) {
       await sandbox.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+      await sandbox.detach()
+      await this.removeDockerVolume(`${name}-docker`)
       await rm(this.bindingPath(environment.id), { force: true })
       throw error
     }
@@ -623,8 +662,10 @@ export class MicrosandboxManager {
           if (remove) await handle.destroy({ timeoutMs: STOP_TIMEOUT_MS })
           else await handle.stopWithTimeout(STOP_TIMEOUT_MS)
         }
-        if (remove) await rm(this.bindingPath(id), { force: true })
+        if (state) await (await state.sandbox).detach()
         this.environments.delete(id)
+        if (remove && binding?.dockerVolume) await this.removeDockerVolume(binding.dockerVolume)
+        if (remove) await rm(this.bindingPath(id), { force: true })
       } finally {
         if (state) state.closing = undefined
       }

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -130,6 +130,7 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   const ownedTargets = [
     '/run',
     '/var/run',
+    '/var/lib/docker',
     ...automatic.map((mount) => mount.target),
     ...MICROSANDBOX_SOCKET_BRIDGES.map((bridge) => bridge.path)
   ]

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runInNewContext } from 'node:vm'
@@ -46,6 +46,15 @@ class FakeExec {
 
 function fakeSdk() {
   class SandboxNotFoundError extends Error {}
+  class VolumeNotFoundError extends Error {}
+  class InvalidConfigError extends Error {}
+  const volumes = new Map<string, { attached: boolean }>()
+  const removeVolume = vi.fn(async (name: string) => {
+    const volume = volumes.get(name)
+    if (!volume) throw new VolumeNotFoundError()
+    if (volume.attached) throw new Error('disk is still attached')
+    volumes.delete(name)
+  })
   const sandboxes = new Map<string, FakeSandbox>()
   const created: FakeSandbox[] = []
   const processes: FakeExec[] = []
@@ -68,12 +77,23 @@ function fakeSdk() {
       await this.stopWithTimeout()
       sandboxes.delete(this.name)
     })
+    readonly detach = vi.fn(async () => {
+      if (this.dockerVolume && volumes.has(this.dockerVolume)) volumes.get(this.dockerVolume)!.attached = false
+    })
 
-    constructor(readonly name: string) {}
+    constructor(
+      readonly name: string,
+      readonly dockerVolume?: string
+    ) {}
     config() {
       return this.spec
     }
     async startDetached() {
+      if (this.dockerVolume) {
+        const volume = volumes.get(this.dockerVolume)!
+        if (volume.attached) throw new Error('disk is still attached')
+        volume.attached = true
+      }
       this.status = 'running'
       return this
     }
@@ -115,6 +135,9 @@ function fakeSdk() {
 
   const sdk = {
     SandboxNotFoundError,
+    VolumeNotFoundError,
+    InvalidConfigError,
+    Volume: { remove: removeVolume },
     AgentClient: {
       async connectSandbox(name: string) {
         const sandbox = sandboxes.get(name)!
@@ -164,6 +187,7 @@ function fakeSdk() {
         return sandbox
       },
       builder(name: string) {
+        let dockerVolume: string | undefined
         const builder = {
           image() {
             return builder
@@ -189,14 +213,25 @@ function fakeSdk() {
           quietLogs() {
             return builder
           },
-          volume() {
+          volume(target: string, configure: (volume: { namedWith: (name: string) => unknown }) => unknown) {
+            if (target === '/var/lib/docker')
+              configure({
+                namedWith(name) {
+                  dockerVolume = name
+                  return this
+                }
+              })
             return builder
           },
           vsock() {
             return builder
           },
           async create() {
-            const sandbox = new FakeSandbox(name)
+            if (dockerVolume) {
+              if (volumes.has(dockerVolume)) throw new Error('volume already exists')
+              volumes.set(dockerVolume, { attached: true })
+            }
+            const sandbox = new FakeSandbox(name, dockerVolume)
             created.push(sandbox)
             sandboxes.set(name, sandbox)
             return sandbox
@@ -210,6 +245,8 @@ function fakeSdk() {
     sdk,
     created,
     processes,
+    volumes,
+    removeVolume,
     runWith: (callback: (process: FakeExec) => void | Promise<void>) => {
       onRun = callback
     }
@@ -239,6 +276,53 @@ async function fixture() {
 }
 
 describe('microsandbox process and VM ownership', () => {
+  it('retains Docker data across manager restarts and retries failed volume cleanup without losing ownership', async () => {
+    const { manager, options, environment, request, created, volumes, removeVolume } = await fixture()
+    const runtime = await manager.driverFor(environment).launch(request)
+    const volume = created[0]!.dockerVolume!
+    await runtime.stop(0)
+    await manager.stopAll()
+    expect(volumes.has(volume)).toBe(true)
+    expect(removeVolume).not.toHaveBeenCalled()
+
+    const resumed = new MicrosandboxManager(options)
+    vi.spyOn(created[0]!, 'connectOrStart').mockRejectedValueOnce(
+      new options.sdk.InvalidConfigError(`volume "${volume}" is already attached with an incompatible disk mode`)
+    )
+    const restored = await resumed.driverFor(environment).launch(request)
+    expect(created).toHaveLength(1)
+    await restored.stop(0)
+    removeVolume.mockRejectedValueOnce(new Error('temporary volume removal failure'))
+    await expect(resumed.discard(environment.id)).rejects.toThrow('temporary volume removal failure')
+    expect(await resumed.environmentIds()).toEqual([environment.id])
+    expect(volumes.has(volume)).toBe(true)
+    removeVolume.mockRejectedValueOnce(
+      new options.sdk.InvalidConfigError(`volume "${volume}" is currently attached by a running sandbox`)
+    )
+    await resumed.discard(environment.id)
+    expect(volumes.size).toBe(0)
+    expect(await resumed.environmentIds()).toEqual([])
+  })
+
+  it('resumes bindings from before Docker volumes without claiming or removing a separate disk', async () => {
+    const { manager, options, environment, request, created, removeVolume } = await fixture()
+    const runtime = await manager.driverFor(environment).launch(request)
+    await runtime.stop(0)
+    await manager.stopAll()
+    const directory = join(options.root, 'microsandbox', 'bindings')
+    const path = join(directory, (await readdir(directory))[0]!)
+    const binding = JSON.parse(await readFile(path, 'utf8')) as { dockerVolume?: string }
+    delete binding.dockerVolume
+    await writeFile(path, JSON.stringify(binding))
+
+    const resumed = new MicrosandboxManager(options)
+    const restored = await resumed.driverFor(environment).launch(request)
+    expect(created).toHaveLength(1)
+    await restored.stop(0)
+    await resumed.discard(environment.id)
+    expect(removeVolume).not.toHaveBeenCalled()
+  })
+
   it('shares a VM, preserves binary ACP data, and refuses suspend while another execution is active', async () => {
     const { manager, environment, request, created, processes } = await fixture()
     const [first, second] = await Promise.all([

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -240,6 +240,8 @@ describe('prepareMicrosandboxLaunch', () => {
       '/run',
       '/var/run',
       '/run/docker',
+      '/var/lib/docker',
+      '/var/lib/docker/containerd',
       '/tmp/agentconnect',
       '/tmp'
     ]) {


### PR DESCRIPTION
New microsandbox VMs share read-only image layers and use a private ext4 disk at `/var/lib/docker`, avoiding a full root image copy on hosts without reflink support. Docker's managed containerd uses the same disk. Existing flat VMs retain their saved layout and data; `diskGiB` caps each writable disk independently.

Track the data disk in the VM binding, retain it across suspend and manager restart, and remove it after VM retirement. Explicitly release SDK connections and retry its transient disk-lock contention for up to one second. Failed cleanup keeps the binding for retry.

Validation:
- Daemon typecheck, lint, build, and 35 focused tests pass.
- Real Linux/KVM smoke covers Compose builds and DNS, workspace binds, retained build cache, isolated Docker state and published ports, Testcontainers, and VM/disk cleanup.
- Original flat VM data survives opening with the new manager. Six consecutive new-VM create/resume/discard cycles pass; cached-image startup to the first command takes 1.25–1.48 seconds, with resume around 1.2 seconds. These timings exclude image download and model initialization.

Created by Codex . GPT-6
