### PR TITLE
feat(memory): add authorized admin entry mutations

### DIFF
--- a/docs/designs/unified-memory-interface.md
+++ b/docs/designs/unified-memory-interface.md
@@ -404,3 +404,31 @@ staged-root provenance, and adoption checks cannot be bypassed.
 Admin HTTP mutation transport and UI remain separate follow-up work. This MCP
 projection does not send large mutation bodies in the bounded daemon/CP read frame;
 the controlled writer continues using staged chunks and atomic home publication.
+
+### Admin conditional mutation projection
+
+The authorized BFF exposes `POST`, `PATCH`, and `DELETE` on
+`/agents/:id/memory/entries`, with the canonical create/update/delete body and an
+optional `channelKey` query. Update/delete carry the opaque `ref` in the body.
+Agent visibility and edit authorization run before dispatch; read-only callers
+also receive capabilities and entry summaries with write operations/editability
+removed. The daemon independently rechecks agent ownership and duty before
+resolving the active home. Console provenance is trusted server input, never a
+field the HTTP caller can choose.
+
+`memory-entries-write-v1` negotiates the new `memory/entries/write/v1` request and
+result. The first transport supports JSON requests up to 192 KiB, measured after
+normalizing the `{ agentId, channelKey?, operation, request }` payload and including
+JSON escaping. `limits.maxMutationRequestBytes` advertises that separate transport
+budget; `maxItemBytes` remains the provider's stored-content budget. CP refuses
+oversized mutations with `TOO_LARGE`/HTTP 413 before sending, leaving envelope
+headroom under the 256 KiB connection cap. The daemon repeats this check. This
+initial transport does not support all maximum-size stored documents; a future
+chunked admin upload may lift this limit. Home publication itself remains staged
+and atomic.
+
+An uncertain reply after dispatch returns `AMBIGUOUS_WRITE`/503 without replay.
+Clients must inspect current state before deciding whether to issue a new write;
+HTTP retries are not idempotency keys. Confirmed conditional conflicts retain
+`currentRevision` where known. Legacy file and record routes remain available.
+The console UI and catalog-refresh integration are subsequent slices.

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1,4 +1,9 @@
 import {
+  MemoryEntryCreateRequest,
+  MemoryEntryUpdateRequest,
+  MemoryEntryDeleteRequest,
+  MemoryEntryMutationReceipt,
+  type MemoryEntriesWriteReq,
   MemoryEntryCapabilities,
   MemoryEntryListRequest,
   MemoryEntryListResult,
@@ -931,8 +936,8 @@ export function agentRoutes(deps: HttpDeps) {
       return { ...agent, daemonId }
     }
 
-    type MemoryEntryReadOperation = MemoryEntriesReadReq extends infer R
-      ? R extends MemoryEntriesReadReq
+    type MemoryEntryOperation = MemoryEntriesReadReq | MemoryEntriesWriteReq extends infer R
+      ? R extends MemoryEntriesReadReq | MemoryEntriesWriteReq
         ? Omit<R, 'agentId'>
         : never
       : never
@@ -940,16 +945,19 @@ export function agentRoutes(deps: HttpDeps) {
       error: z.string(),
       statusCode: z.number(),
       message: z.string(),
-      code: MemoryEntryErrorCode.optional()
+      code: MemoryEntryErrorCode.optional(),
+      currentRevision: z.string().max(512).optional()
     })
-    const entryRead = async (
-      req: FastifyRequest,
-      reply: FastifyReply,
-      id: string,
-      operation: MemoryEntryReadOperation
-    ) => {
+    const entryCall = async (req: FastifyRequest, reply: FastifyReply, id: string, operation: MemoryEntryOperation) => {
       const agent = await getServingAgent(req, id)
       if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+      const mutation =
+        operation.operation === 'create' || operation.operation === 'update' || operation.operation === 'delete'
+      const editable = canEdit(agent, ctxOf(req))
+      if (mutation && !editable)
+        return reply
+          .code(403)
+          .send({ error: 'Forbidden', statusCode: 403, message: 'memory edit access is required', code: 'FORBIDDEN' })
       if (!agent.daemonId)
         return reply.code(503).send({
           error: 'Service Unavailable',
@@ -958,10 +966,10 @@ export function agentRoutes(deps: HttpDeps) {
           code: 'UNAVAILABLE'
         })
       try {
-        const answer = await deps.control.memoryEntriesRead(agent.daemonId, {
-          ...operation,
-          agentId: agent.id
-        } as MemoryEntriesReadReq)
+        const payload = { ...operation, agentId: agent.id }
+        const answer = mutation
+          ? await deps.control.memoryEntriesWrite(agent.daemonId, payload as MemoryEntriesWriteReq)
+          : await deps.control.memoryEntriesRead(agent.daemonId, payload as MemoryEntriesReadReq)
         if (answer.operation === 'error') {
           const statuses = {
             UNSUPPORTED: 501,
@@ -976,11 +984,34 @@ export function agentRoutes(deps: HttpDeps) {
             AMBIGUOUS_WRITE: 503
           } as const
           const status = statuses[answer.code]
-          return reply
-            .code(status)
-            .send({ error: answer.code, statusCode: status, message: answer.message, code: answer.code })
+          return reply.code(status).send({
+            error: answer.code,
+            statusCode: status,
+            message: answer.message,
+            code: answer.code,
+            ...('currentRevision' in answer ? { currentRevision: answer.currentRevision } : {})
+          })
         }
-        if (answer.operation !== operation.operation) throw new Error('unexpected memory entry reply')
+        if (answer.operation !== (mutation ? 'completed' : operation.operation))
+          throw new Error('unexpected memory entry reply')
+        if (!editable) {
+          if (answer.operation === 'describe')
+            return reply.send({
+              ...answer.result,
+              operations: answer.result.operations.filter(
+                (op) => op !== 'create' && op !== 'update' && op !== 'delete'
+              ),
+              exactCreate: false,
+              exactEdit: false
+            })
+          if (answer.operation === 'list')
+            return reply.send({
+              ...answer.result,
+              entries: answer.result.entries.map((entry) => ({ ...entry, editable: false }))
+            })
+          if (answer.operation === 'get' && answer.result)
+            return reply.send({ ...answer.result, entry: { ...answer.result.entry, editable: false } })
+        }
         return reply.send(answer.result)
       } catch (err) {
         const failure = memoryAdminFailure(err)
@@ -1008,7 +1039,7 @@ export function agentRoutes(deps: HttpDeps) {
           response: { 200: MemoryEntryCapabilities, ...entryErrors }
         }
       },
-      (req, reply) => entryRead(req, reply, req.params.id, { operation: 'describe', ...req.query })
+      (req, reply) => entryCall(req, reply, req.params.id, { operation: 'describe', ...req.query })
     )
     r.get(
       '/agents/:id/memory/entries',
@@ -1028,7 +1059,7 @@ export function agentRoutes(deps: HttpDeps) {
       },
       (req, reply) => {
         const { channelKey, ...request } = req.query
-        return entryRead(req, reply, req.params.id, {
+        return entryCall(req, reply, req.params.id, {
           operation: 'list',
           ...(channelKey ? { channelKey } : {}),
           request
@@ -1054,12 +1085,66 @@ export function agentRoutes(deps: HttpDeps) {
       },
       (req, reply) => {
         const { channelKey, ...request } = req.query
-        return entryRead(req, reply, req.params.id, {
+        return entryCall(req, reply, req.params.id, {
           operation: 'get',
           ...(channelKey ? { channelKey } : {}),
           request: { ...request, ref: req.params.ref }
         })
       }
+    )
+
+    r.post(
+      '/agents/:id/memory/entries',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'Create a unified memory entry',
+          description:
+            'Applies a scoped conditional mutation through the serving daemon. JSON requests are bounded by capabilities.limits.maxMutationRequestBytes; oversized requests return 413. An ambiguous outcome must be reconciled by reading before retrying.',
+          operationId: 'createAgentMemoryEntry',
+          params: IdParam,
+          querystring: entryScopeQuery,
+          body: MemoryEntryCreateRequest,
+          response: { 200: MemoryEntryMutationReceipt, ...entryErrors }
+        }
+      },
+      (req, reply) => entryCall(req, reply, req.params.id, { operation: 'create', ...req.query, request: req.body })
+    )
+
+    r.patch(
+      '/agents/:id/memory/entries',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'Update a unified memory entry',
+          description:
+            'Applies a scoped conditional mutation through the serving daemon. JSON requests are bounded by capabilities.limits.maxMutationRequestBytes; oversized requests return 413. An ambiguous outcome must be reconciled by reading before retrying.',
+          operationId: 'updateAgentMemoryEntry',
+          params: IdParam,
+          querystring: entryScopeQuery,
+          body: MemoryEntryUpdateRequest,
+          response: { 200: MemoryEntryMutationReceipt, ...entryErrors }
+        }
+      },
+      (req, reply) => entryCall(req, reply, req.params.id, { operation: 'update', ...req.query, request: req.body })
+    )
+
+    r.delete(
+      '/agents/:id/memory/entries',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'Delete a unified memory entry',
+          description:
+            'Applies a scoped conditional mutation through the serving daemon. JSON requests are bounded by capabilities.limits.maxMutationRequestBytes; oversized requests return 413. An ambiguous outcome must be reconciled by reading before retrying.',
+          operationId: 'deleteAgentMemoryEntry',
+          params: IdParam,
+          querystring: entryScopeQuery,
+          body: MemoryEntryDeleteRequest,
+          response: { 200: MemoryEntryMutationReceipt, ...entryErrors }
+        }
+      },
+      (req, reply) => entryCall(req, reply, req.params.id, { operation: 'delete', ...req.query, request: req.body })
     )
 
     // A session worktree is part of that session's protected body surface. The

--- a/packages/control-plane/src/orchestrator/outbound.memory-entries.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.memory-entries.test.ts
@@ -1,4 +1,11 @@
-import { MEMORY_ENTRIES_V1_FEATURE, MEMORY_ENTRIES_WRITE_V1_FEATURE } from '@agentconnect.md/protocol'
+import { ReqRep } from '../ws/correlator.js'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import {
+  buildEnvelope,
+  type MemoryEntriesWriteReq,
+  MEMORY_ENTRIES_V1_FEATURE,
+  MEMORY_ENTRIES_WRITE_V1_FEATURE
+} from '@agentconnect.md/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import type { LaunchRepo } from '../persistence/ports.js'
 import { ConnectionRegistry, type ConnChannel, type DaemonConnState } from '../ws/registry.js'
@@ -8,7 +15,10 @@ const DAEMON = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const OFFLINE = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 /** A sender over one READY connection at epoch 7, recording every issued REQ. */
-function senderWith(features: string[] = []): {
+function senderWith(
+  features: string[] = [],
+  requestOverride?: ConnChannel['request']
+): {
   sender: ControlSender
   sent: Array<{ type: string; payload: unknown; ext: unknown; budget: unknown }>
   fail: () => void
@@ -20,7 +30,12 @@ function senderWith(features: string[] = []): {
     if (fail) throw new Error('connection closed')
     return {}
   })
-  const conn = { daemonId: DAEMON, request, send: vi.fn(), close: vi.fn() } as unknown as ConnChannel
+  const conn = {
+    daemonId: DAEMON,
+    request: requestOverride ?? request,
+    send: vi.fn(),
+    close: vi.fn()
+  } as unknown as ConnChannel
   const registry = new ConnectionRegistry()
   const state: DaemonConnState = {
     daemonId: DAEMON,
@@ -80,3 +95,32 @@ it('gates mutations, bounds escaped JSON before sending, and never replays uncer
   expect(await live.sender.memoryEntriesWrite(DAEMON, req)).toMatchObject({ code: 'AMBIGUOUS_WRITE' })
   expect(live.sent).toHaveLength(2)
 })
+
+it.each(['create', 'update', 'delete'] as const)(
+  'never retransmits a %s mutation through the real correlator',
+  async (operation) => {
+    const clock = new FakeClock()
+    const correlator = new ReqRep(clock, 10)
+    const frames: string[] = []
+    const { sender } = senderWith([MEMORY_ENTRIES_WRITE_V1_FEATURE], async (type, payload, ext, budget) => {
+      expect(type).toBe('memory/entries/write/v1')
+      await correlator.request(
+        buildEnvelope('memory/entries/write/v1', payload as MemoryEntriesWriteReq, { ext }),
+        (encoded) => frames.push(encoded),
+        budget
+      )
+      throw new Error('test expected no reply')
+    })
+    const request: MemoryEntriesWriteReq =
+      operation === 'create'
+        ? { agentId: DAEMON, operation, request: { text: 'hello' } }
+        : operation === 'update'
+          ? { agentId: DAEMON, operation, request: { ref: 'opaque-ref', revision: 'old', text: 'changed' } }
+          : { agentId: DAEMON, operation, request: { ref: 'opaque-ref', revision: 'old' } }
+    const pending = sender.memoryEntriesWrite(DAEMON, request)
+    clock.advance(100000)
+    expect(await pending).toMatchObject({ code: 'AMBIGUOUS_WRITE' })
+    expect(frames).toHaveLength(1)
+    expect(correlator.inflight()).toBe(0)
+  }
+)

--- a/packages/control-plane/src/orchestrator/outbound.memory-entries.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.memory-entries.test.ts
@@ -1,4 +1,4 @@
-import { MEMORY_ENTRIES_V1_FEATURE } from '@agentconnect.md/protocol'
+import { MEMORY_ENTRIES_V1_FEATURE, MEMORY_ENTRIES_WRITE_V1_FEATURE } from '@agentconnect.md/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import type { LaunchRepo } from '../persistence/ports.js'
 import { ConnectionRegistry, type ConnChannel, type DaemonConnState } from '../ws/registry.js'
@@ -11,10 +11,13 @@ const OFFLINE = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 function senderWith(features: string[] = []): {
   sender: ControlSender
   sent: Array<{ type: string; payload: unknown; ext: unknown; budget: unknown }>
+  fail: () => void
 } {
   const sent: Array<{ type: string; payload: unknown; ext: unknown; budget: unknown }> = []
+  let fail = false
   const request = vi.fn(async (type: string, payload: unknown, ext?: unknown, budget?: unknown) => {
     sent.push({ type, payload, ext, budget })
+    if (fail) throw new Error('connection closed')
     return {}
   })
   const conn = { daemonId: DAEMON, request, send: vi.fn(), close: vi.fn() } as unknown as ConnChannel
@@ -34,7 +37,13 @@ function senderWith(features: string[] = []): {
     launches: new Map()
   }
   registry.add(state)
-  return { sender: new ControlSender(registry, {} as LaunchRepo), sent }
+  return {
+    sender: new ControlSender(registry, {} as LaunchRepo),
+    sent,
+    fail: () => {
+      fail = true
+    }
+  }
 }
 
 describe('ControlSender.memoryEntriesRead', () => {
@@ -53,4 +62,21 @@ describe('ControlSender.memoryEntriesRead', () => {
     expect(sent).toEqual([{ type: 'memory/entries/read/v1', payload: req, ext: { epoch: 7 }, budget: undefined }])
     await expect(sender.memoryEntriesRead(OFFLINE, req)).rejects.toBeInstanceOf(NoConnection)
   })
+})
+
+it('gates mutations, bounds escaped JSON before sending, and never replays uncertain writes', async () => {
+  const req = { agentId: DAEMON, operation: 'create' as const, request: { text: 'hello' } }
+  const old = senderWith([MEMORY_ENTRIES_V1_FEATURE])
+  expect(await old.sender.memoryEntriesWrite(DAEMON, req)).toMatchObject({ code: 'UNSUPPORTED' })
+  expect(old.sent).toHaveLength(0)
+  const live = senderWith([MEMORY_ENTRIES_WRITE_V1_FEATURE])
+  expect(
+    await live.sender.memoryEntriesWrite(DAEMON, { ...req, request: { text: '\u0000'.repeat(40000) } })
+  ).toMatchObject({ code: 'TOO_LARGE' })
+  expect(live.sent).toHaveLength(0)
+  await live.sender.memoryEntriesWrite(DAEMON, req)
+  expect(live.sent[0]).toMatchObject({ type: 'memory/entries/write/v1', payload: req, ext: { epoch: 7 } })
+  live.fail()
+  expect(await live.sender.memoryEntriesWrite(DAEMON, req)).toMatchObject({ code: 'AMBIGUOUS_WRITE' })
+  expect(live.sent).toHaveLength(2)
 })

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -1,5 +1,9 @@
 import {
   MEMORY_ENTRIES_V1_FEATURE,
+  MEMORY_ENTRIES_WRITE_V1_FEATURE,
+  memoryEntryMutationFits,
+  type MemoryEntriesWriteReq,
+  type MemoryEntriesWriteResult,
   type MemoryEntriesReadReq,
   type MemoryEntriesReadResult,
   Ack,
@@ -705,6 +709,23 @@ export class ControlSender {
   async memoryRecordSearch(daemonId: string, req: MemoryRecordSearchReq): Promise<MemoryRecordSearchPage> {
     const c = this.must(daemonId)
     return c.conn.request<MemoryRecordSearchPage>('memory/record/search', req, { epoch: c.sessionEpoch })
+  }
+
+  async memoryEntriesWrite(daemonId: string, req: MemoryEntriesWriteReq): Promise<MemoryEntriesWriteResult> {
+    const c = this.must(daemonId)
+    if (!c.capabilities?.features?.includes(MEMORY_ENTRIES_WRITE_V1_FEATURE))
+      return { operation: 'error', code: 'UNSUPPORTED', message: 'this daemon does not support unified memory writes' }
+    if (!memoryEntryMutationFits(req))
+      return { operation: 'error', code: 'TOO_LARGE', message: 'memory mutation exceeds the JSON request byte limit' }
+    try {
+      return await c.conn.request<MemoryEntriesWriteResult>('memory/entries/write/v1', req, { epoch: c.sessionEpoch })
+    } catch {
+      return {
+        operation: 'error',
+        code: 'AMBIGUOUS_WRITE',
+        message: 'memory mutation outcome is unconfirmed; read current state before retrying'
+      }
+    }
   }
 
   async memoryEntriesRead(daemonId: string, req: MemoryEntriesReadReq): Promise<MemoryEntriesReadResult> {

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -718,7 +718,13 @@ export class ControlSender {
     if (!memoryEntryMutationFits(req))
       return { operation: 'error', code: 'TOO_LARGE', message: 'memory mutation exceeds the JSON request byte limit' }
     try {
-      return await c.conn.request<MemoryEntriesWriteResult>('memory/entries/write/v1', req, { epoch: c.sessionEpoch })
+      // Each delivery allocates a fresh mutation operation; retransmission is not idempotent.
+      return await c.conn.request<MemoryEntriesWriteResult>(
+        'memory/entries/write/v1',
+        req,
+        { epoch: c.sessionEpoch },
+        { maxTries: 1 }
+      )
     } catch {
       return {
         operation: 'error',

--- a/packages/control-plane/test/integration/agents.memory.route.test.ts
+++ b/packages/control-plane/test/integration/agents.memory.route.test.ts
@@ -707,3 +707,115 @@ it('reads refs returned by listing through the full HTTP router up to the contra
   }
   expect(seen).toEqual(entries.map((entry) => entry.ref))
 })
+
+it('proxies canonical admin mutations and preserves conflict/ambiguous/size refusals', async () => {
+  await seedDaemon(prisma, DAEMON)
+  await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+  const calls: import('@agentconnect.md/protocol').MemoryEntriesWriteReq[] = []
+  let error: import('@agentconnect.md/protocol').MemoryEntryErrorCode | undefined
+  const control = {
+    async memoryEntriesWrite(
+      _daemon: string,
+      req: import('@agentconnect.md/protocol').MemoryEntriesWriteReq
+    ): Promise<import('@agentconnect.md/protocol').MemoryEntriesWriteResult> {
+      calls.push(req)
+      if (error) return { operation: 'error', code: error, message: 'refused', currentRevision: 'current' }
+      return { operation: 'completed', result: { operationId: randomUUID(), state: 'completed' } }
+    }
+  }
+  running = buildHttpApp(prisma, undefined, LIVE, control as unknown as ControlSender)
+  const url = `${ORG}/agents/${AGENT}/memory/entries?channelKey=channel-a`
+  for (const [method, operation, payload] of [
+    ['POST', 'create', { label: 'topic', text: 'hello' }],
+    ['PATCH', 'update', { ref: 'opaque-ref', revision: 'old', edit: { oldText: 'hello', newText: '' } }],
+    ['DELETE', 'delete', { ref: 'opaque-ref', revision: 'old' }]
+  ] as const) {
+    const response = await running.app.inject({ method, url, payload })
+    expect(response.statusCode).toBe(200)
+    expect(calls.at(-1)).toEqual({ agentId: AGENT, channelKey: 'channel-a', operation, request: payload })
+  }
+  for (const [code, status] of [
+    ['CONFLICT', 409],
+    ['AMBIGUOUS_WRITE', 503],
+    ['TOO_LARGE', 413],
+    ['UNSUPPORTED', 501]
+  ] as const) {
+    error = code
+    const response = await running.app.inject({
+      method: 'DELETE',
+      url,
+      payload: { ref: 'opaque-ref', revision: 'old' }
+    })
+    expect(response.statusCode).toBe(status)
+    expect(response.json()).toMatchObject({ code, currentRevision: 'current' })
+  }
+  const before = calls.length
+  expect((await running.app.inject({ method: 'POST', url, payload: { text: 'x', source: 'tool' } })).statusCode).toBe(
+    400
+  )
+  expect(
+    (
+      await running.app.inject({
+        method: 'PATCH',
+        url,
+        payload: { ref: 'opaque-ref', text: 'x', edit: { oldText: 'x', newText: 'y' } }
+      })
+    ).statusCode
+  ).toBe(400)
+  expect(
+    (
+      await running.app.inject({
+        method: 'POST',
+        url: `${ORG}/agents/${randomUUID()}/memory/entries`,
+        payload: { text: 'x' }
+      })
+    ).statusCode
+  ).toBe(404)
+  expect(calls).toHaveLength(before)
+})
+
+it('refuses viewer mutations before daemon I/O', async () => {
+  const { PgUserRepo } = await import('../../src/persistence/repositories/user.repo.js')
+  const users = new PgUserRepo(prisma)
+  const email = `memory-viewer-${randomUUID()}@acme.dev`
+  const { userId } = await users.provisionOidcUser({ oidcSubject: email, email, emailVerified: true })
+  await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'viewer')
+  await seedDaemon(prisma, DAEMON)
+  await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+  let calls = 0
+  const control = {
+    async memoryEntriesWrite() {
+      calls++
+      throw new Error('must not write')
+    },
+    async memoryEntriesRead(): Promise<import('@agentconnect.md/protocol').MemoryEntriesReadResult> {
+      return {
+        operation: 'describe',
+        result: {
+          version: 1,
+          operations: ['list', 'get', 'create', 'update', 'delete'],
+          supportedScopes: ['agent'],
+          writeConsistency: 'conditional',
+          exactCreate: true,
+          exactEdit: true,
+          enumeration: 'live',
+          graph: false,
+          limits: { maxItemBytes: 256000, maxPageItems: 100, maxMutationRequestBytes: 196608 }
+        }
+      }
+    }
+  }
+  running = buildHttpApp(prisma, { DEFAULT_OWNER_ID: userId }, LIVE, control as unknown as ControlSender)
+  for (const [method, payload] of [
+    ['POST', { text: 'x' }],
+    ['PATCH', { ref: 'opaque-ref', text: 'x' }],
+    ['DELETE', { ref: 'opaque-ref' }]
+  ] as const)
+    expect(
+      (await running.app.inject({ method, url: `${ORG}/agents/${AGENT}/memory/entries`, payload })).statusCode
+    ).toBe(403)
+  expect(calls).toBe(0)
+  const capabilities = await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/memory/capabilities` })
+  expect(capabilities.statusCode).toBe(200)
+  expect(capabilities.json()).toMatchObject({ operations: ['list', 'get'], exactCreate: false, exactEdit: false })
+})

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -317,6 +317,7 @@ export class CpClient {
       agentWake: deps.agentWake,
       memoryReader: deps.memoryReader,
       memoryEntriesRead: deps.memoryEntriesRead,
+      memoryEntriesWrite: deps.memoryEntriesWrite,
       dreamReader: deps.dreamReader,
       localSkillsReader: deps.localSkillsReader,
       runtimeCommandsReader: deps.runtimeCommandsReader,

--- a/packages/daemon/src/cp/control/memory.ts
+++ b/packages/daemon/src/cp/control/memory.ts
@@ -1,4 +1,6 @@
 import type {
+  MemoryEntriesWriteReq,
+  MemoryEntriesWriteResult,
   MemoryEntriesReadReq,
   MemoryEntriesReadResult,
   AnyFrame,
@@ -29,6 +31,7 @@ import type { ControlHandler, ControlWire } from './context.js'
 
 export interface MemoryControlDeps {
   /** Read/write seam over the agents' memory dirs (`<agent-root>/memory/`, §1/§12). */
+  memoryEntriesWrite?: (req: MemoryEntriesWriteReq) => Promise<MemoryEntriesWriteResult>
   memoryEntriesRead?: (req: MemoryEntriesReadReq) => Promise<MemoryEntriesReadResult>
   memoryReader: MemoryReader
 }
@@ -160,4 +163,11 @@ export const memoryEntriesRead: ControlHandler<MemoryControlDeps> = async (frame
     ? await deps.memoryEntriesRead(frame.payload as MemoryEntriesReadReq)
     : { operation: 'error', code: 'UNSUPPORTED', message: 'memory entry reads are unavailable' }
   wire.reply(frame, 'memory/entries/read/v1/result', result)
+}
+
+export const memoryEntriesWrite: ControlHandler<MemoryControlDeps> = async (frame, deps, wire) => {
+  const result = deps.memoryEntriesWrite
+    ? await deps.memoryEntriesWrite(frame.payload as MemoryEntriesWriteReq)
+    : { operation: 'error', code: 'UNSUPPORTED', message: 'unified memory writes are unavailable' }
+  wire.reply(frame, 'memory/entries/write/v1/result', result)
 }

--- a/packages/daemon/src/cp/control/registry.ts
+++ b/packages/daemon/src/cp/control/registry.ts
@@ -1,4 +1,4 @@
-import { memoryEntriesRead } from './memory.js'
+import { memoryEntriesWrite, memoryEntriesRead } from './memory.js'
 import {
   agentActivate,
   agentDetach,
@@ -165,6 +165,7 @@ export const CONTROL_HANDLERS: Map<string, ControlHandler<ControlDeps>> = new Ma
   ['sandbox/keepalive', sandboxKeepAlive],
   ['agent/wake', agentWake],
   ['memory/channels', memoryChannels],
+  ['memory/entries/write/v1', memoryEntriesWrite],
   ['memory/entries/read/v1', memoryEntriesRead],
   ['memory/list', memoryList],
   ['memory/read', memoryRead],

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -1,4 +1,4 @@
-import { createMemoryEntriesReader } from './memory-entries.js'
+import { createMemoryEntriesWriter, createMemoryEntriesReader } from './memory-entries.js'
 import type { MemoryProvider } from '../memory/provider.js'
 // The `CpClientDeps` literal the daemon hands `CpClient`, hoisted out of `Daemon.startCpClient`.
 // Construction order is load-bearing (the workspace resolvers feed the file, git and skills seams),
@@ -408,6 +408,11 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
         host.dutyCoordinator().dutyEnforced() && (await host.dutyCoordinator().claimDutyForTrigger(id)).granted,
       log: host.log()
     }),
+    memoryEntriesWrite: createMemoryEntriesWriter(
+      host.memory(),
+      host.store(),
+      (id) => host.agents().has(id) && (!host.dutyCoordinator().dutyEnforced() || host.duties().holdsAgent(id))
+    ),
     memoryEntriesRead: createMemoryEntriesReader(
       host.memory(),
       host.store(),

--- a/packages/daemon/src/cp/memory-entries.ts
+++ b/packages/daemon/src/cp/memory-entries.ts
@@ -1,4 +1,11 @@
-import type { MemoryEntriesReadReq, MemoryEntriesReadResult } from '@agentconnect.md/protocol'
+import {
+  memoryEntryMutationFits,
+  MEMORY_ENTRY_MUTATION_REQUEST_BYTES,
+  type MemoryEntriesWriteReq,
+  type MemoryEntriesWriteResult,
+  type MemoryEntriesReadReq,
+  type MemoryEntriesReadResult
+} from '@agentconnect.md/protocol'
 import type { MemoryProvider } from '../memory/provider.js'
 import type { LocalStore } from '../store/local-store.js'
 import { createMemoryEntryService } from '../memory/entries/factory.js'
@@ -15,11 +22,20 @@ export function createMemoryEntriesReader(
         provider,
         store,
         scope: { agentId: req.agentId, ...(req.channelKey ? { channelKey: req.channelKey } : {}) },
+        write: { source: 'console', canWrite: () => canRead(req.agentId) },
         canRead: () => canRead(req.agentId)
       })
       switch (req.operation) {
-        case 'describe':
-          return { operation: 'describe', result: await entries.describe() }
+        case 'describe': {
+          const result = await entries.describe()
+          return {
+            operation: 'describe',
+            result: {
+              ...result,
+              limits: { ...result.limits, maxMutationRequestBytes: MEMORY_ENTRY_MUTATION_REQUEST_BYTES }
+            }
+          }
+        }
         case 'list':
           return { operation: 'list', result: await entries.list(req.request) }
         case 'get':
@@ -29,6 +45,41 @@ export function createMemoryEntriesReader(
       if (error instanceof MemoryEntriesError)
         return { operation: 'error', code: error.code, message: error.message.slice(0, 512) }
       return { operation: 'error', code: 'UNAVAILABLE', message: 'memory entry service is unavailable' }
+    }
+  }
+}
+
+export function createMemoryEntriesWriter(
+  provider: MemoryProvider,
+  store: LocalStore,
+  canWrite: (agentId: string) => boolean
+) {
+  return async (req: MemoryEntriesWriteReq): Promise<MemoryEntriesWriteResult> => {
+    try {
+      if (!memoryEntryMutationFits(req))
+        return { operation: 'error', code: 'TOO_LARGE', message: 'memory mutation exceeds the JSON request byte limit' }
+      const entries = await createMemoryEntryService({
+        provider,
+        store,
+        scope: { agentId: req.agentId, ...(req.channelKey ? { channelKey: req.channelKey } : {}) },
+        canRead: () => canWrite(req.agentId),
+        write: { source: 'console', canWrite: () => canWrite(req.agentId) }
+      })
+      const result = await entries[req.operation](req.request)
+      return { operation: 'completed', result }
+    } catch (error) {
+      if (error instanceof MemoryEntriesError)
+        return {
+          operation: 'error',
+          code: error.code,
+          message: error.message.slice(0, 512),
+          ...(error.currentRevision ? { currentRevision: error.currentRevision } : {})
+        }
+      return {
+        operation: 'error',
+        code: 'AMBIGUOUS_WRITE',
+        message: 'memory mutation outcome is unconfirmed; read current state before retrying'
+      }
     }
   }
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,6 +1,7 @@
 import { memorySourceTurnId } from './memory/source-turn.js'
 import {
   MEMORY_ENTRIES_V1_FEATURE,
+  MEMORY_ENTRIES_WRITE_V1_FEATURE,
   AgentActivate as AgentActivateSchema,
   AgentSkillEntry as AgentSkillEntrySchema,
   WEBCHAT_MULTI_AGENT_FEATURE,
@@ -4903,6 +4904,7 @@ export class Daemon {
       ...(this.cfg.security.requireSandbox ? ['sandbox-required'] : []),
       'memory-dreaming-v1',
       MEMORY_ENTRIES_V1_FEATURE,
+      MEMORY_ENTRIES_WRITE_V1_FEATURE,
       ORGANIZATION_KNOWLEDGE_FEATURE,
       ...(this.dreamOperationsAllowed() ? [ORGANIZATION_SUGGESTION_REVIEW_FEATURE] : []),
       SESSION_VISIBILITY_FEATURE,

--- a/packages/daemon/test/managed-memory-crud.test.ts
+++ b/packages/daemon/test/managed-memory-crud.test.ts
@@ -343,3 +343,38 @@ it('executes conditional MCP writes with trusted scope, approvals and synthetic-
   ).toMatchObject({ state: 'completed' })
   expect(f.commits).toHaveLength(3)
 })
+
+it('admin mutations use console origin, reject lost ownership and expose conditional entries', async () => {
+  const f = await fixture()
+  const { createMemoryEntriesReader, createMemoryEntriesWriter } = await import('../src/cp/memory-entries.js')
+  let owned = true
+  const access = (id: string) => owned && id === 'agent'
+  const write = createMemoryEntriesWriter(f.provider, f.db, access)
+  const read = createMemoryEntriesReader(f.provider, f.db, access)
+  const created = await write({ agentId: 'agent', operation: 'create', request: { label: 'admin', text: 'hello' } })
+  expect(created.operation).toBe('completed')
+  if (created.operation !== 'completed') throw new Error('create failed')
+  expect(f.commits[0]).toMatchObject({ source: 'console' })
+  expect(f.commits[0]!.sourceTurnId).toBeUndefined()
+  expect(await read({ agentId: 'agent', operation: 'describe' })).toMatchObject({
+    result: { operations: ['list', 'get', 'create', 'update', 'delete'], limits: { maxMutationRequestBytes: 196608 } }
+  })
+  const ref = created.result.entry!.ref
+  const revision = created.result.entry!.revision
+  expect(
+    await write({ agentId: 'agent', operation: 'update', request: { ref, revision, text: 'changed' } })
+  ).toMatchObject({ operation: 'completed' })
+  expect(await write({ agentId: 'agent', operation: 'delete', request: { ref, revision } })).toMatchObject({
+    code: 'CONFLICT',
+    currentRevision: expect.any(String)
+  })
+  owned = false
+  expect(await write({ agentId: 'agent', operation: 'create', request: { text: 'denied' } })).toMatchObject({
+    code: 'FORBIDDEN'
+  })
+  owned = true
+  expect(
+    await write({ agentId: 'agent', operation: 'create', request: { text: '\u0000'.repeat(40000) } })
+  ).toMatchObject({ code: 'TOO_LARGE' })
+  expect(f.commits).toHaveLength(2)
+})

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -1,5 +1,10 @@
 import { MemoryTransactionReq, MemoryTransactionResult } from './frames/memory-transaction.js'
-import { MemoryEntriesReadReq, MemoryEntriesReadResult } from './frames/memory-entries.js'
+import {
+  MemoryEntriesWriteReq,
+  MemoryEntriesWriteResult,
+  MemoryEntriesReadReq,
+  MemoryEntriesReadResult
+} from './frames/memory-entries.js'
 import { z } from 'zod'
 
 import { AuthReq, AuthOk } from './frames/auth.js'
@@ -423,6 +428,8 @@ export const FRAME_SCHEMAS = {
   'memory/surface/info': MemorySurfaceInfo,
   'memory/record/search': MemoryRecordSearchReq,
   'memory/record/search/page': MemoryRecordSearchPage,
+  'memory/entries/write/v1': MemoryEntriesWriteReq,
+  'memory/entries/write/v1/result': MemoryEntriesWriteResult,
   'memory/entries/read/v1': MemoryEntriesReadReq,
   'memory/entries/read/v1/result': MemoryEntriesReadResult,
   'memory/record/list': MemoryRecordListReq,
@@ -697,6 +704,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('memory/surface/info', FRAME_SCHEMAS['memory/surface/info']),
   frame('memory/record/search', FRAME_SCHEMAS['memory/record/search']),
   frame('memory/record/search/page', FRAME_SCHEMAS['memory/record/search/page']),
+  frame('memory/entries/write/v1', FRAME_SCHEMAS['memory/entries/write/v1']),
+  frame('memory/entries/write/v1/result', FRAME_SCHEMAS['memory/entries/write/v1/result']),
   frame('memory/entries/read/v1', FRAME_SCHEMAS['memory/entries/read/v1']),
   frame('memory/entries/read/v1/result', FRAME_SCHEMAS['memory/entries/read/v1/result']),
   frame('memory/record/list', FRAME_SCHEMAS['memory/record/list']),

--- a/packages/protocol/src/frames/memory-entries.test.ts
+++ b/packages/protocol/src/frames/memory-entries.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { MemoryEntriesReadReq, MemoryEntriesReadResult } from './memory-entries.js'
+import {
+  MemoryEntriesReadReq,
+  MemoryEntriesReadResult,
+  MemoryEntriesWriteReq,
+  memoryEntryMutationFits
+} from './memory-entries.js'
 import { buildEnvelope, decodeEnvelope, encode } from '../index.js'
 
 const agentId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -20,4 +25,14 @@ describe('versioned unified entry read frames', () => {
       MemoryEntriesReadResult.safeParse({ operation: 'error', code: 'CURSOR_EXPIRED', message: 'Expired' }).success
     ).toBe(true)
   })
+})
+
+it('roundtrips scoped mutations and measures JSON escaping instead of text length', () => {
+  const request = MemoryEntriesWriteReq.parse({ agentId, operation: 'create', request: { text: 'hello' } })
+  expect(decodeEnvelope(encode(buildEnvelope('memory/entries/write/v1', request))).ok).toBe(true)
+  expect(memoryEntryMutationFits(request)).toBe(true)
+  expect(memoryEntryMutationFits({ ...request, operation: 'create', request: { text: '\u0000'.repeat(40000) } })).toBe(
+    false
+  )
+  expect(MemoryEntriesWriteReq.safeParse({ ...request, source: 'tool' }).success).toBe(false)
 })

--- a/packages/protocol/src/frames/memory-entries.ts
+++ b/packages/protocol/src/frames/memory-entries.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
 import {
+  MemoryEntryCreateRequest,
+  MemoryEntryUpdateRequest,
+  MemoryEntryDeleteRequest,
+  MemoryEntryMutationReceipt,
   MemoryEntryCapabilities,
   MemoryEntryContent,
   MemoryEntryErrorCode,
@@ -23,3 +27,28 @@ export const MemoryEntriesReadResult = z.discriminatedUnion('operation', [
   z.object({ operation: z.literal('error'), code: MemoryEntryErrorCode, message: z.string().max(512) }).strict()
 ])
 export type MemoryEntriesReadResult = z.infer<typeof MemoryEntriesReadResult>
+
+export const MEMORY_ENTRIES_WRITE_V1_FEATURE = 'memory-entries-write-v1'
+// JSON bytes including scope/operation; leave envelope headroom below the 256 KiB wire cap.
+export const MEMORY_ENTRY_MUTATION_REQUEST_BYTES = 192 * 1024
+export const MemoryEntriesWriteReq = z.discriminatedUnion('operation', [
+  scope.extend({ operation: z.literal('create'), request: MemoryEntryCreateRequest }).strict(),
+  scope.extend({ operation: z.literal('update'), request: MemoryEntryUpdateRequest }).strict(),
+  scope.extend({ operation: z.literal('delete'), request: MemoryEntryDeleteRequest }).strict()
+])
+export type MemoryEntriesWriteReq = z.infer<typeof MemoryEntriesWriteReq>
+export function memoryEntryMutationFits(request: MemoryEntriesWriteReq): boolean {
+  return new TextEncoder().encode(JSON.stringify(request)).byteLength <= MEMORY_ENTRY_MUTATION_REQUEST_BYTES
+}
+export const MemoryEntriesWriteResult = z.discriminatedUnion('operation', [
+  z.object({ operation: z.literal('completed'), result: MemoryEntryMutationReceipt }).strict(),
+  z
+    .object({
+      operation: z.literal('error'),
+      code: MemoryEntryErrorCode,
+      message: z.string().max(512),
+      currentRevision: z.string().max(512).optional()
+    })
+    .strict()
+])
+export type MemoryEntriesWriteResult = z.infer<typeof MemoryEntriesWriteResult>

--- a/packages/protocol/src/memory-entries.ts
+++ b/packages/protocol/src/memory-entries.ts
@@ -17,7 +17,11 @@ export const MemoryEntryCapabilities = z
     exactCreate: z.boolean(),
     enumeration: z.enum(['snapshot', 'live', 'unavailable']),
     graph: z.boolean(),
-    limits: z.object({ maxItemBytes: z.number().int().positive(), maxPageItems: z.number().int().min(1).max(100) })
+    limits: z.object({
+      maxMutationRequestBytes: z.number().int().positive().optional(),
+      maxItemBytes: z.number().int().positive(),
+      maxPageItems: z.number().int().min(1).max(100)
+    })
   })
   .strict()
 export type MemoryEntryCapabilities = z.infer<typeof MemoryEntryCapabilities>


### PR DESCRIPTION
## Change
The admin BFF can create, conditionally update, and delete unified memory entries through POST/PATCH/DELETE `/agents/:id/memory/entries`. Bodies use canonical mutation DTOs with opaque refs/revisions and optional channel scope. Agent edit permission is checked before dispatch; read-only callers receive capabilities/entries with writes disabled. The daemon rechecks ownership/duty and binds console provenance internally.

A negotiated `memory-entries-write-v1` frame carries bounded requests. Both sides enforce a 192 KiB limit on normalized JSON bytes, including escaping, and capabilities expose `maxMutationRequestBytes` separately from the stored item limit. Oversized requests return 413 before sending; uncertain replies return `AMBIGUOUS_WRITE` without replay. Known conflicts preserve `currentRevision`. Atomic home storage and legacy routes are unchanged.

## Validation
- 135 daemon tests: entry CRUD/read services plus CP dispatch/organization/epoch/duty coverage.
- 23 PostgreSQL HTTP integration tests, including canonical mutation forwarding, viewer denial/read capabilities, malformed provenance, conflicts, ambiguity, and size-error mapping.
- 3 protocol codec/budget tests and 6 CP outbound feature/epoch/budget tests plus 3 correlator tests. Real-correlator regression covers create/update/delete: each emits exactly one frame through timeout (`maxTries: 1`), then returns `AMBIGUOUS_WRITE`.
- Protocol, daemon, and control-plane typechecks.

The initial transport deliberately supports a smaller JSON request than the maximum stored document; large admin uploads and the unified UI remain follow-up work.
