### PR TITLE
feat(memory): add unified console entry browser and editor

### DIFF
--- a/docs/designs/unified-memory-interface.md
+++ b/docs/designs/unified-memory-interface.md
@@ -432,3 +432,26 @@ Clients must inspect current state before deciding whether to issue a new write;
 HTTP retries are not idempotency keys. Confirmed conditional conflicts retain
 `currentRevision` where known. Legacy file and record routes remain available.
 The console UI and catalog-refresh integration are subsequent slices.
+
+### Unified console entry browser
+
+The Memory panel now defaults to a capability-driven entry browser for providers
+that support list/get. Managed and external views share the same paged list and
+complete-content reader. The existing settings, channel selector, and Dream panel
+remain in place. Unsupported/older peers use the existing view; “More memory
+tools” also retains file/history and provider-specific operations during rollout.
+
+The editor loads every content slice before enabling edits, rejecting missing,
+repeated, changed-revision, or oversized continuation chains. Reads are bounded to
+128 slices and the smaller of the provider item limit or 4 MiB. Scope changes
+remount the browser and invalidate outstanding reads. Conditional writes use the
+ref/revision of the loaded document; inherited entries and read-only callers have
+no edit/delete controls. Create/update respect both item bytes and the advertised
+normalized JSON mutation request budget. Delete requires an explicit confirmation.
+
+Conflicts and unconfirmed writes retain the draft and block another mutation until
+the user reloads saved memory. No write is automatically retried. Refresh rechecks
+capabilities and starts a new list; further pages load explicitly. The initial UI
+shows stored text directly, preserving full Markdown/frontmatter during edits.
+Activation-time catalog refresh and retirement of compatibility tools remain
+separate work.

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -12,7 +12,12 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/components/console/UnifiedMemoryPanel', () => ({
-  UnifiedMemoryPanel: ({ children }: { children: ReactNode }) => children
+  UnifiedMemoryPanel: ({ children, onOpenLegacy }: { children: ReactNode; onOpenLegacy?: () => Promise<void> }) => (
+    <>
+      <button onClick={() => void onOpenLegacy?.()}>Open retained memory tools</button>
+      {children}
+    </>
+  )
 }))
 
 vi.mock('next/dynamic', () => ({ default: () => () => null }))
@@ -1018,4 +1023,28 @@ describe('MemoryPanel memory home', () => {
     expect(vi.mocked(fetchAgentMemoryChannels).mock.calls.length).toBeGreaterThan(before)
     expect(container?.textContent).toContain('general')
   })
+})
+
+it('refreshes retained file listing and preview before opening its tools', async () => {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () =>
+    root?.render(
+      <MemoryPanel
+        agentId="22222222-2222-4222-8222-222222222222"
+        canEdit
+        memoryProvider="managed"
+        autoDistill={false}
+      />
+    )
+  )
+  const before = vi.mocked(fetchAgentMemoryFull).mock.calls.length
+  vi.mocked(listAgentMemory).mockResolvedValue({
+    exists: true,
+    files: [{ name: 'new-entry.md', size: 12, mtime: '2026-09-10T00:00:00Z' }]
+  })
+  await clickButton(container, 'Open retained memory tools')
+  expect(container.textContent).toContain('new-entry.md')
+  expect(vi.mocked(fetchAgentMemoryFull).mock.calls.length).toBeGreaterThan(before)
 })

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -11,6 +11,10 @@ const mocks = vi.hoisted(() => ({
   wake: 'starting' as 'running' | 'starting' | 'unsupported'
 }))
 
+vi.mock('@/components/console/UnifiedMemoryPanel', () => ({
+  UnifiedMemoryPanel: ({ children }: { children: ReactNode }) => children
+}))
+
 vi.mock('next/dynamic', () => ({ default: () => () => null }))
 
 vi.mock('@/lib/data-context', () => ({

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { UnifiedMemoryPanel } from '@/components/console/UnifiedMemoryPanel'
+
 // Agent memory viewer/editor — the memory DIRECTORY at the agent root
 // (<agent-root>/memory/): a MEMORY.md index plus topic files the agent maintains
 // across sessions. Content is proxied through the CP straight from the owning
@@ -1200,11 +1202,17 @@ export function MemoryPanel({
           </div>
         </div>
       ) : persistedProvider === 'external' ? (
-        <RecordMemoryPanel
+        <UnifiedMemoryPanel
           key={`${agentId}:${persistedSettings.external.connectionId}`}
           agentId={agentId}
           canEdit={canEdit}
-        />
+        >
+          <RecordMemoryPanel
+            key={`${agentId}:${persistedSettings.external.connectionId}`}
+            agentId={agentId}
+            canEdit={canEdit}
+          />
+        </UnifiedMemoryPanel>
       ) : persistedProvider === 'none' ? (
         <div className="rounded-(--radius-lg) border border-(--border-subtle) p-5 text-[13px] text-(--text-secondary)">
           Persistent memory is disabled for this agent. Existing memory remains stored but is not loaded.
@@ -1232,67 +1240,74 @@ export function MemoryPanel({
               ) : null}
             </div>
           ) : null}
-          <FileBrowserShell
-            title={
-              <FileBrowserBreadcrumb
-                root="Memory"
-                path={editor?.target ?? selected}
-                creating={editor?.target === ''}
-                draftName={editor?.name ?? ''}
-                onDraftNameChange={(name) =>
-                  setEditor((current) => (current?.target === '' ? { ...current, name, error: null } : current))
-                }
-                onBack={isMobile && editor ? backFromEditor : undefined}
-                disabled={editor?.saving}
-                nested={false}
-                ariaLabel="Memory file path"
-                inputAriaLabel="New memory file name"
-              />
-            }
-            headerEnd={
-              editor ? (
-                <FileBrowserEditorActions
-                  saving={editor.saving}
-                  onCancel={closeEditor}
-                  onSave={() => void save()}
-                  disabled={editor.loading || (!editor.target && !editor.name.trim())}
-                />
-              ) : canEdit ? (
-                <div className="flex flex-none items-center gap-2">
-                  <Button variant="secondary" size="xs" className="flex-none" onClick={startCreate}>
-                    <Icon name="file-plus" size={13} />
-                    Add file
-                  </Button>
-                  {!loading && !error && fileExists !== null ? (
-                    <Button variant="secondary" size="xs" className="flex-none" onClick={startEdit}>
-                      <Icon name="pencil" size={13} />
-                      Edit
-                    </Button>
-                  ) : null}
-                </div>
-              ) : undefined
-            }
+          <UnifiedMemoryPanel
+            key={`${agentId}:${persistedSettings.home}:${selectedChannel}`}
+            agentId={agentId}
+            channelKey={selectedChannel}
+            canEdit={canEdit}
           >
-            <FileBrowserLayout
-              resetKey={`${agentId}:${mobileListSignal}`}
-              previewOpen={editor !== null}
-              tree={renderFileTree}
-              preview={
-                editor
-                  ? () => (
-                      <FileBrowserEditor
-                        draft={editor}
-                        onContentChange={(content) =>
-                          setEditor((current) => (current ? { ...current, content, error: null } : current))
-                        }
-                        onCancel={closeEditor}
-                        onSubmit={() => void save()}
-                      />
-                    )
-                  : renderPreview
+            <FileBrowserShell
+              title={
+                <FileBrowserBreadcrumb
+                  root="Memory"
+                  path={editor?.target ?? selected}
+                  creating={editor?.target === ''}
+                  draftName={editor?.name ?? ''}
+                  onDraftNameChange={(name) =>
+                    setEditor((current) => (current?.target === '' ? { ...current, name, error: null } : current))
+                  }
+                  onBack={isMobile && editor ? backFromEditor : undefined}
+                  disabled={editor?.saving}
+                  nested={false}
+                  ariaLabel="Memory file path"
+                  inputAriaLabel="New memory file name"
+                />
               }
-            />
-          </FileBrowserShell>
+              headerEnd={
+                editor ? (
+                  <FileBrowserEditorActions
+                    saving={editor.saving}
+                    onCancel={closeEditor}
+                    onSave={() => void save()}
+                    disabled={editor.loading || (!editor.target && !editor.name.trim())}
+                  />
+                ) : canEdit ? (
+                  <div className="flex flex-none items-center gap-2">
+                    <Button variant="secondary" size="xs" className="flex-none" onClick={startCreate}>
+                      <Icon name="file-plus" size={13} />
+                      Add file
+                    </Button>
+                    {!loading && !error && fileExists !== null ? (
+                      <Button variant="secondary" size="xs" className="flex-none" onClick={startEdit}>
+                        <Icon name="pencil" size={13} />
+                        Edit
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : undefined
+              }
+            >
+              <FileBrowserLayout
+                resetKey={`${agentId}:${mobileListSignal}`}
+                previewOpen={editor !== null}
+                tree={renderFileTree}
+                preview={
+                  editor
+                    ? () => (
+                        <FileBrowserEditor
+                          draft={editor}
+                          onContentChange={(content) =>
+                            setEditor((current) => (current ? { ...current, content, error: null } : current))
+                          }
+                          onCancel={closeEditor}
+                          onSubmit={() => void save()}
+                        />
+                      )
+                    : renderPreview
+                }
+              />
+            </FileBrowserShell>
+          </UnifiedMemoryPanel>
           {/* Dreaming is managed-only and is secondary to the live memory
               content, so it sits below the browser. Only render it when the
               persisted policy is on; otherwise its trigger would be noise. */}

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -1245,6 +1245,9 @@ export function MemoryPanel({
             agentId={agentId}
             channelKey={selectedChannel}
             canEdit={canEdit}
+            onOpenLegacy={async () => {
+              await Promise.all([loadList(), loadFile(selected)])
+            }}
           >
             <FileBrowserShell
               title={

--- a/packages/web/src/components/console/UnifiedMemoryPanel.test.tsx
+++ b/packages/web/src/components/console/UnifiedMemoryPanel.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import type { MemoryEntryCapabilities } from '@agentconnect.md/protocol'
+vi.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public status: number,
+      public code?: string
+    ) {
+      super(message)
+    }
+  }
+  return {
+    ApiError,
+    describeAgentMemoryEntries: vi.fn(),
+    listAgentMemoryEntries: vi.fn(),
+    getAgentMemoryEntry: vi.fn(),
+    createAgentMemoryEntry: vi.fn(),
+    updateAgentMemoryEntry: vi.fn(),
+    deleteAgentMemoryEntry: vi.fn()
+  }
+})
+import * as api from '@/lib/api'
+import { UnifiedMemoryPanel } from './UnifiedMemoryPanel'
+const entry = {
+  ref: 'opaque-ref',
+  label: 'Topic',
+  revision: 'r1',
+  byteSize: 8,
+  format: 'markdown' as const,
+  origin: 'active' as const,
+  editable: true
+}
+const caps: MemoryEntryCapabilities = {
+  version: 1,
+  operations: ['list', 'get', 'create', 'update', 'delete'],
+  supportedScopes: ['agent', 'channel'],
+  writeConsistency: 'conditional',
+  exactCreate: true,
+  exactEdit: true,
+  enumeration: 'live',
+  graph: false,
+  limits: { maxItemBytes: 256000, maxPageItems: 100, maxMutationRequestBytes: 196608 }
+}
+let root: Root
+let host: HTMLDivElement
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  vi.mocked(api.describeAgentMemoryEntries).mockResolvedValue(caps)
+  vi.mocked(api.listAgentMemoryEntries).mockResolvedValue({ entries: [entry], consistency: 'live', order: 'topic' })
+  vi.mocked(api.getAgentMemoryEntry).mockResolvedValue({ entry, text: 'headtail', complete: true })
+  vi.mocked(api.updateAgentMemoryEntry).mockResolvedValue({ operationId: 'op', state: 'completed' })
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+})
+async function render(channelKey = 'one', canEdit = true) {
+  await act(async () =>
+    root.render(
+      <UnifiedMemoryPanel agentId="agent" channelKey={channelKey} canEdit={canEdit}>
+        <div>Legacy memory tools</div>
+      </UnifiedMemoryPanel>
+    )
+  )
+}
+async function click(text: string) {
+  const button = [...host.querySelectorAll('button')].find((b) => b.textContent?.includes(text))
+  expect(button).toBeTruthy()
+  await act(async () => button!.click())
+}
+it('reads all slices and submits the original revision/ref in a conditional update', async () => {
+  vi.mocked(api.getAgentMemoryEntry)
+    .mockResolvedValueOnce({ entry, text: 'head', complete: false, nextContentCursor: 'next' })
+    .mockResolvedValueOnce({ entry, text: 'tail', complete: true })
+  await render()
+  await click('Topic')
+  await click('Edit memory')
+  expect(host.querySelector('textarea')?.value).toBe('headtail')
+  await click('Save memory')
+  expect(api.updateAgentMemoryEntry).toHaveBeenCalledWith(
+    'agent',
+    { ref: 'opaque-ref', revision: 'r1', text: 'headtail' },
+    'one'
+  )
+})
+it('keeps a draft and blocks replay after an ambiguous response', async () => {
+  vi.mocked(api.updateAgentMemoryEntry).mockRejectedValueOnce(new api.ApiError('lost', 503, 'AMBIGUOUS_WRITE'))
+  await render()
+  await click('Topic')
+  await click('Edit memory')
+  await click('Save memory')
+  expect(host.querySelector('textarea')?.value).toBe('headtail')
+  expect([...host.querySelectorAll('button')].find((b) => b.textContent === 'Save memory')?.disabled).toBe(true)
+  await click('Save memory')
+  expect(api.updateAgentMemoryEntry).toHaveBeenCalledTimes(1)
+  await click('Reload saved version')
+  expect(host.querySelector('textarea')).toBeNull()
+})
+it('never offers editing partial or inherited memory, or writes to a viewer', async () => {
+  vi.mocked(api.getAgentMemoryEntry).mockResolvedValueOnce({ entry, text: 'head', complete: false })
+  await render()
+  await click('Topic')
+  expect(host.textContent).not.toContain('Edit memory')
+  vi.mocked(api.getAgentMemoryEntry).mockResolvedValue({
+    entry: { ...entry, origin: 'inherited', editable: false },
+    text: 'base',
+    complete: true
+  })
+  await click('Topic')
+  expect(host.textContent).not.toContain('Edit memory')
+  await render('two', false)
+  expect(host.textContent).not.toContain('New memory')
+})
+it('drops late content when switching channel scope', async () => {
+  let resolve!: (value: Awaited<ReturnType<typeof api.getAgentMemoryEntry>>) => void
+  vi.mocked(api.getAgentMemoryEntry).mockImplementationOnce(
+    () =>
+      new Promise((r) => {
+        resolve = r
+      })
+  )
+  await render()
+  await click('Topic')
+  await render('two')
+  await act(async () => resolve({ entry, text: 'old private content', complete: true }))
+  expect(host.textContent).not.toContain('old private content')
+})
+it('falls back for an old peer and pages lists explicitly', async () => {
+  vi.mocked(api.listAgentMemoryEntries).mockResolvedValueOnce({
+    entries: [entry],
+    consistency: 'snapshot',
+    order: 'topic',
+    nextCursor: 'next'
+  })
+  await render()
+  await click('Load more')
+  expect(api.listAgentMemoryEntries).toHaveBeenLastCalledWith('agent', 'one', 'next')
+  vi.mocked(api.describeAgentMemoryEntries).mockRejectedValueOnce(new api.ApiError('old', 501, 'UNSUPPORTED'))
+  await render('two')
+  expect(host.textContent).toContain('Legacy memory tools')
+})
+it('requires deletion confirmation and submits the selected revision', async () => {
+  vi.mocked(api.deleteAgentMemoryEntry).mockResolvedValue({ operationId: 'op', state: 'completed' })
+  await render()
+  await click('Topic')
+  await click('Delete memory')
+  expect(api.deleteAgentMemoryEntry).not.toHaveBeenCalled()
+  await click('Confirm deletion')
+  expect(api.deleteAgentMemoryEntry).toHaveBeenCalledWith('agent', { ref: 'opaque-ref', revision: 'r1' }, 'one')
+})
+it('prevents a mutation exceeding the advertised request budget', async () => {
+  vi.mocked(api.describeAgentMemoryEntries).mockResolvedValue({
+    ...caps,
+    limits: { ...caps.limits, maxMutationRequestBytes: 10 }
+  })
+  await render()
+  await click('New memory')
+  expect(host.textContent).toContain('too large')
+  await click('Save memory')
+  expect(api.createAgentMemoryEntry).not.toHaveBeenCalled()
+})

--- a/packages/web/src/components/console/UnifiedMemoryPanel.test.tsx
+++ b/packages/web/src/components/console/UnifiedMemoryPanel.test.tsx
@@ -63,10 +63,10 @@ afterEach(async () => {
   host.remove()
   vi.unstubAllGlobals()
 })
-async function render(channelKey = 'one', canEdit = true) {
+async function render(channelKey = 'one', canEdit = true, onOpenLegacy?: () => Promise<void>) {
   await act(async () =>
     root.render(
-      <UnifiedMemoryPanel agentId="agent" channelKey={channelKey} canEdit={canEdit}>
+      <UnifiedMemoryPanel agentId="agent" channelKey={channelKey} canEdit={canEdit} {...{ onOpenLegacy }}>
         <div>Legacy memory tools</div>
       </UnifiedMemoryPanel>
     )
@@ -167,4 +167,38 @@ it('prevents a mutation exceeding the advertised request budget', async () => {
   expect(host.textContent).toContain('too large')
   await click('Save memory')
   expect(api.createAgentMemoryEntry).not.toHaveBeenCalled()
+})
+
+it('recovers an unconfirmed first create only after an explicit complete empty refresh', async () => {
+  vi.mocked(api.listAgentMemoryEntries).mockResolvedValue({ entries: [], consistency: 'live', order: 'topic' })
+  vi.mocked(api.createAgentMemoryEntry).mockRejectedValueOnce(new api.ApiError('lost', 503, 'AMBIGUOUS_WRITE'))
+  await render()
+  await click('New memory')
+  await click('Save memory')
+  const save = () => [...host.querySelectorAll('button')].find((b) => b.textContent === 'Save memory')!
+  expect(save().disabled).toBe(true)
+  vi.mocked(api.listAgentMemoryEntries).mockResolvedValueOnce({
+    entries: [],
+    consistency: 'live',
+    order: 'topic',
+    nextCursor: 'more'
+  })
+  await click('Refresh')
+  expect(save().disabled).toBe(true)
+  vi.mocked(api.listAgentMemoryEntries).mockRejectedValueOnce(new Error('offline'))
+  await click('Refresh')
+  expect(save().disabled).toBe(true)
+  await click('Refresh')
+  expect(save().disabled).toBe(false)
+  expect(api.createAgentMemoryEntry).toHaveBeenCalledTimes(1)
+})
+it('refreshes retained tools when switching from a successful entry create', async () => {
+  const refresh = vi.fn(async () => {})
+  vi.mocked(api.createAgentMemoryEntry).mockResolvedValue({ state: 'completed', operationId: 'op' })
+  await render('one', true, refresh)
+  await click('New memory')
+  await click('Save memory')
+  await click('More memory tools')
+  expect(refresh).toHaveBeenCalledTimes(1)
+  expect(host.textContent).toContain('Legacy memory tools')
 })

--- a/packages/web/src/components/console/UnifiedMemoryPanel.tsx
+++ b/packages/web/src/components/console/UnifiedMemoryPanel.tsx
@@ -1,0 +1,374 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import type { MemoryEntryCapabilities, MemoryEntryContent, MemoryEntrySummary } from '@agentconnect.md/protocol'
+import {
+  ApiError,
+  describeAgentMemoryEntries,
+  listAgentMemoryEntries,
+  getAgentMemoryEntry,
+  createAgentMemoryEntry,
+  updateAgentMemoryEntry,
+  deleteAgentMemoryEntry
+} from '@/lib/api'
+import { readCompleteMemoryEntry } from '@/lib/memory-entry-content'
+import { Button } from '@/components/ui'
+
+interface Props {
+  agentId: string
+  channelKey?: string
+  canEdit: boolean
+  children: ReactNode
+}
+export function UnifiedMemoryPanel(props: Props) {
+  return <Entries key={`${props.agentId}:${props.channelKey ?? ''}`} {...props} />
+}
+function errorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    if (error.code === 'CONFLICT' || error.code === 'STALE_BINDING')
+      return 'Memory changed. Your draft is kept; reload the saved version before editing again.'
+    if (error.code === 'CURSOR_EXPIRED') return 'This list expired. Refresh memory to start again.'
+    if (error.code === 'TOO_LARGE') return 'This change is too large to save here. Reduce its size and try again.'
+    if (error.code === 'AMBIGUOUS_WRITE')
+      return 'The change could not be confirmed. Check saved memory before making another change.'
+    if (error.status === 403) return 'You no longer have permission to change this memory.'
+    if (error.status === 503) return 'Memory is temporarily unavailable. Try loading it again.'
+  }
+  return error instanceof Error ? error.message : 'Memory is unavailable.'
+}
+function Entries({ agentId, channelKey, canEdit, children }: Props) {
+  const generation = useRef(0)
+  const detailRequest = useRef(0)
+  const [capabilities, setCapabilities] = useState<MemoryEntryCapabilities | null>(null)
+  const [legacy, setLegacy] = useState(false)
+  const [entries, setEntries] = useState<MemoryEntrySummary[]>([])
+  const [cursor, setCursor] = useState<string>()
+  const [busy, setBusy] = useState(true)
+  const [reading, setReading] = useState(false)
+  const [error, setError] = useState<string>()
+  const [document, setDocument] = useState<MemoryEntryContent | null>(null)
+  const [draft, setDraft] = useState('')
+  const [label, setLabel] = useState('')
+  const [mode, setMode] = useState<'create' | 'update' | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [blocked, setBlocked] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [notice, setNotice] = useState<string>()
+  const reload = useCallback(async () => {
+    const id = ++generation.current
+    ++detailRequest.current
+    setReading(false)
+    setBusy(true)
+    setError(undefined)
+    try {
+      const caps = await describeAgentMemoryEntries(agentId, channelKey)
+      if (id !== generation.current) return
+      if (!caps.operations.includes('list') || !caps.operations.includes('get')) {
+        setLegacy(true)
+        return
+      }
+      setCapabilities(caps)
+      const page = await listAgentMemoryEntries(agentId, channelKey)
+      if (id !== generation.current) return
+      setEntries(page.entries)
+      setCursor(page.nextCursor)
+    } catch (err) {
+      if (id !== generation.current) return
+      if (err instanceof ApiError && (err.status === 404 || err.status === 501 || err.code === 'UNSUPPORTED'))
+        setLegacy(true)
+      else setError(errorMessage(err))
+    } finally {
+      if (id === generation.current) setBusy(false)
+    }
+  }, [agentId, channelKey])
+  useEffect(() => {
+    void reload()
+    return () => {
+      generation.current++
+      detailRequest.current++
+    }
+  }, [reload])
+  async function more() {
+    const id = generation.current
+    setBusy(true)
+    setError(undefined)
+    try {
+      const page = await listAgentMemoryEntries(agentId, channelKey, cursor)
+      if (id !== generation.current) return
+      setEntries((old) => [...old, ...page.entries])
+      setCursor(page.nextCursor)
+    } catch (err) {
+      if (id === generation.current) setError(errorMessage(err))
+    } finally {
+      if (id === generation.current) setBusy(false)
+    }
+  }
+  async function open(entry: MemoryEntrySummary) {
+    const id = ++detailRequest.current
+    setReading(true)
+    setDocument(null)
+    setError(undefined)
+    setConfirmDelete(false)
+    try {
+      const result = await readCompleteMemoryEntry(
+        (cursor) => getAgentMemoryEntry(agentId, entry.ref, channelKey, cursor),
+        capabilities!.limits.maxItemBytes
+      )
+      if (id !== detailRequest.current) return
+      setDocument(result)
+      setMode(null)
+      setDraft('')
+      setBlocked(false)
+      if (!result) setError('This memory no longer exists. Refresh the list.')
+    } catch (err) {
+      if (id === detailRequest.current) setError(errorMessage(err))
+    } finally {
+      if (id === detailRequest.current) setReading(false)
+    }
+  }
+  const supports = (operation: 'create' | 'update' | 'delete') =>
+    canEdit && capabilities?.operations.includes(operation)
+  const editable =
+    document?.entry.editable && (capabilities?.writeConsistency !== 'conditional' || !!document.entry.revision)
+  const request =
+    mode === 'create'
+      ? { text: draft, ...(label.trim() ? { label: label.trim() } : {}) }
+      : { ref: document?.entry.ref ?? '', revision: document?.entry.revision, text: draft }
+  const tooLarge =
+    !!capabilities &&
+    (new TextEncoder().encode(draft).byteLength > capabilities.limits.maxItemBytes ||
+      (capabilities.limits.maxMutationRequestBytes !== undefined &&
+        new TextEncoder().encode(
+          JSON.stringify({ agentId, ...(channelKey ? { channelKey } : {}), operation: mode, request })
+        ).byteLength > capabilities.limits.maxMutationRequestBytes))
+  async function mutate(remove = false) {
+    const id = generation.current
+    setSaving(true)
+    setError(undefined)
+    setNotice(undefined)
+    try {
+      if (remove)
+        await deleteAgentMemoryEntry(
+          agentId,
+          { ref: document!.entry.ref, revision: document!.entry.revision },
+          channelKey
+        )
+      else if (mode === 'create') await createAgentMemoryEntry(agentId, request, channelKey)
+      else await updateAgentMemoryEntry(agentId, { ...request, ref: document!.entry.ref }, channelKey)
+      if (id !== generation.current) return
+      setMode(null)
+      setDraft('')
+      setDocument(null)
+      setConfirmDelete(false)
+      setNotice(remove ? 'Memory deleted. Inherited memory may now be visible.' : 'Memory saved.')
+      await reload()
+    } catch (err) {
+      if (id !== generation.current) return
+      const uncertain = !(err instanceof ApiError) || err.status >= 500
+      setBlocked(uncertain || (err instanceof ApiError && (err.code === 'CONFLICT' || err.code === 'STALE_BINDING')))
+      setError(
+        uncertain
+          ? 'The change could not be confirmed. Your draft is kept; check saved memory before making another change.'
+          : errorMessage(err)
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+  if (legacy)
+    return (
+      <>
+        {capabilities && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              setLegacy(false)
+              void reload()
+            }}
+          >
+            Memory entries
+          </Button>
+        )}
+        {children}
+      </>
+    )
+  return (
+    <section
+      className="rounded-lg border border-(--border-subtle) bg-(--surface-card) p-4 font-sans text-[13px] leading-normal"
+      aria-label="Memory entries"
+    >
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="m-0 font-semibold">Memory</h3>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={busy || saving || (!!mode && !blocked)}
+            onClick={() => void reload()}
+          >
+            Refresh
+          </Button>
+          {supports('create') && (
+            <Button
+              size="sm"
+              disabled={busy || reading || saving || !!mode || blocked}
+              onClick={() => {
+                setMode('create')
+                setDocument(null)
+                setDraft('')
+                setLabel('')
+                setError(undefined)
+              }}
+            >
+              New memory
+            </Button>
+          )}
+          <Button variant="secondary" size="sm" disabled={saving || !!mode} onClick={() => setLegacy(true)}>
+            More memory tools
+          </Button>
+        </div>
+      </div>
+      {notice && <p role="status">{notice}</p>}
+      {error && (
+        <p role="alert" className="text-(--text-secondary)">
+          {error}
+        </p>
+      )}
+      <div className="grid gap-4 desktop:grid-cols-[240px_minmax(0,1fr)]">
+        <div className="flex flex-col gap-2">
+          {busy && <p role="status">Loading memory…</p>}
+          {!busy && !error && entries.length === 0 && <p>No memory entries on this page.</p>}
+          {entries.map((entry, index) => (
+            <button
+              key={`${entry.ref}:${index}`}
+              className="rounded-sm border border-(--border-subtle) p-2 text-left text-(--text-primary) hover:bg-(--surface-hover) disabled:opacity-50"
+              disabled={saving || (!!mode && !blocked)}
+              onClick={() => void open(entry)}
+            >
+              <span className="block break-words font-semibold">{entry.label ?? 'Untitled memory'}</span>
+              <span className="text-[11px] text-(--text-secondary)">
+                {entry.origin === 'active' ? '' : 'Inherited · '}
+                {entry.byteSize} bytes
+              </span>
+            </button>
+          ))}
+          {cursor && (
+            <Button variant="secondary" size="sm" disabled={busy || saving} onClick={() => void more()}>
+              Load more
+            </Button>
+          )}
+        </div>
+        <div className="min-w-0">
+          {reading ? (
+            <p role="status">Loading complete memory…</p>
+          ) : mode ? (
+            <>
+              {mode === 'create' && (
+                <label className="mb-2 block">
+                  Name
+                  <input
+                    aria-label="Memory name"
+                    value={label}
+                    maxLength={512}
+                    disabled={saving}
+                    onChange={(e) => setLabel(e.target.value)}
+                    className="mt-1 w-full rounded-sm border border-(--border-subtle) bg-(--surface-card) p-2"
+                  />
+                </label>
+              )}
+              <label className="block">
+                Content
+                <textarea
+                  aria-label="Memory content"
+                  value={draft}
+                  disabled={saving}
+                  onChange={(e) => setDraft(e.target.value)}
+                  className="mt-1 min-h-64 w-full rounded-sm border border-(--border-subtle) bg-(--surface-card) p-2 font-mono text-[12px] leading-[1.5]"
+                />
+              </label>
+              {tooLarge && <p role="alert">This change is too large to save here. Reduce its size.</p>}
+              <div className="mt-2 flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  disabled={saving || blocked || tooLarge || !supports(mode === 'create' ? 'create' : 'update')}
+                  onClick={() => void mutate()}
+                >
+                  {saving ? 'Saving…' : 'Save memory'}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={saving}
+                  onClick={() => {
+                    setMode(null)
+                    setDraft('')
+                  }}
+                >
+                  Cancel edit
+                </Button>
+                {blocked && document && (
+                  <Button variant="secondary" size="sm" disabled={saving} onClick={() => void open(document.entry)}>
+                    Reload saved version
+                  </Button>
+                )}
+              </div>
+            </>
+          ) : document ? (
+            <>
+              <h4 className="mt-0 break-words">{document.entry.label ?? 'Memory'}</h4>
+              <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-sm bg-(--surface-sunken) p-3 font-mono text-[12px] leading-[1.5]">
+                {document.text}
+              </pre>
+              <div className="flex flex-wrap gap-2">
+                {supports('update') && editable && (
+                  <Button
+                    size="sm"
+                    disabled={saving || blocked}
+                    onClick={() => {
+                      setDraft(document.text)
+                      setMode('update')
+                      setError(undefined)
+                    }}
+                  >
+                    Edit memory
+                  </Button>
+                )}
+                {supports('delete') && editable && (
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={saving || blocked}
+                    onClick={() => setConfirmDelete(true)}
+                  >
+                    Delete memory
+                  </Button>
+                )}
+              </div>
+              {confirmDelete && (
+                <div className="mt-3 rounded-sm border border-(--border-subtle) p-3">
+                  <p>
+                    Delete “{document.entry.label ?? 'this memory'}”? Deleting an override can reveal inherited memory.
+                  </p>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={saving || blocked || !supports('delete')}
+                    onClick={() => void mutate(true)}
+                  >
+                    Confirm deletion
+                  </Button>
+                  <Button variant="secondary" size="sm" disabled={saving} onClick={() => setConfirmDelete(false)}>
+                    Keep memory
+                  </Button>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-(--text-secondary)">Select a memory to read its complete content.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/web/src/components/console/UnifiedMemoryPanel.tsx
+++ b/packages/web/src/components/console/UnifiedMemoryPanel.tsx
@@ -19,6 +19,7 @@ interface Props {
   channelKey?: string
   canEdit: boolean
   children: ReactNode
+  onOpenLegacy?: () => Promise<void>
 }
 export function UnifiedMemoryPanel(props: Props) {
   return <Entries key={`${props.agentId}:${props.channelKey ?? ''}`} {...props} />
@@ -36,7 +37,7 @@ function errorMessage(error: unknown) {
   }
   return error instanceof Error ? error.message : 'Memory is unavailable.'
 }
-function Entries({ agentId, channelKey, canEdit, children }: Props) {
+function Entries({ agentId, channelKey, canEdit, children, onOpenLegacy }: Props) {
   const generation = useRef(0)
   const detailRequest = useRef(0)
   const [capabilities, setCapabilities] = useState<MemoryEntryCapabilities | null>(null)
@@ -54,33 +55,42 @@ function Entries({ agentId, channelKey, canEdit, children }: Props) {
   const [blocked, setBlocked] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [notice, setNotice] = useState<string>()
-  const reload = useCallback(async () => {
-    const id = ++generation.current
-    ++detailRequest.current
-    setReading(false)
-    setBusy(true)
-    setError(undefined)
-    try {
-      const caps = await describeAgentMemoryEntries(agentId, channelKey)
-      if (id !== generation.current) return
-      if (!caps.operations.includes('list') || !caps.operations.includes('get')) {
-        setLegacy(true)
-        return
+  const reload = useCallback(
+    async (reconcileEmpty = false) => {
+      const id = ++generation.current
+      ++detailRequest.current
+      setReading(false)
+      setBusy(true)
+      setError(undefined)
+      try {
+        const caps = await describeAgentMemoryEntries(agentId, channelKey)
+        if (id !== generation.current) return
+        if (!caps.operations.includes('list') || !caps.operations.includes('get')) {
+          setLegacy(true)
+          return
+        }
+        setCapabilities(caps)
+        const page = await listAgentMemoryEntries(agentId, channelKey)
+        if (id !== generation.current) return
+        setEntries(page.entries)
+        setCursor(page.nextCursor)
+        if (reconcileEmpty && page.entries.length === 0 && !page.nextCursor) {
+          setBlocked(false)
+          setNotice(
+            'No saved memory found. An earlier request may still complete; review your draft before saving again.'
+          )
+        }
+      } catch (err) {
+        if (id !== generation.current) return
+        if (err instanceof ApiError && (err.status === 404 || err.status === 501 || err.code === 'UNSUPPORTED'))
+          setLegacy(true)
+        else setError(errorMessage(err))
+      } finally {
+        if (id === generation.current) setBusy(false)
       }
-      setCapabilities(caps)
-      const page = await listAgentMemoryEntries(agentId, channelKey)
-      if (id !== generation.current) return
-      setEntries(page.entries)
-      setCursor(page.nextCursor)
-    } catch (err) {
-      if (id !== generation.current) return
-      if (err instanceof ApiError && (err.status === 404 || err.status === 501 || err.code === 'UNSUPPORTED'))
-        setLegacy(true)
-      else setError(errorMessage(err))
-    } finally {
-      if (id === generation.current) setBusy(false)
-    }
-  }, [agentId, channelKey])
+    },
+    [agentId, channelKey]
+  )
   useEffect(() => {
     void reload()
     return () => {
@@ -175,6 +185,18 @@ function Entries({ agentId, channelKey, canEdit, children }: Props) {
       setSaving(false)
     }
   }
+  async function openLegacy() {
+    const id = generation.current
+    setBusy(true)
+    try {
+      await onOpenLegacy?.()
+      if (id === generation.current) setLegacy(true)
+    } catch (err) {
+      if (id === generation.current) setError(errorMessage(err))
+    } finally {
+      if (id === generation.current) setBusy(false)
+    }
+  }
   if (legacy)
     return (
       <>
@@ -205,7 +227,7 @@ function Entries({ agentId, channelKey, canEdit, children }: Props) {
             variant="secondary"
             size="sm"
             disabled={busy || saving || (!!mode && !blocked)}
-            onClick={() => void reload()}
+            onClick={() => void reload(blocked)}
           >
             Refresh
           </Button>
@@ -224,7 +246,7 @@ function Entries({ agentId, channelKey, canEdit, children }: Props) {
               New memory
             </Button>
           )}
-          <Button variant="secondary" size="sm" disabled={saving || !!mode} onClick={() => setLegacy(true)}>
+          <Button variant="secondary" size="sm" disabled={busy || saving || !!mode} onClick={() => void openLegacy()}>
             More memory tools
           </Button>
         </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -6053,3 +6053,56 @@ export function reviewOrganizationSuggestion(
     ...(decision === 'accept' ? { snapshotToken: detail } : detail?.trim() ? { reason: detail.trim() } : {})
   })
 }
+
+function memoryEntryUrl(agentId: string, suffix: string, channelKey?: string, query: Record<string, string> = {}) {
+  const params = new URLSearchParams({ ...query, ...(channelKey ? { channelKey } : {}) })
+  return `${orgBase()}/agents/${encodeURIComponent(agentId)}/memory/${suffix}${params.size ? `?${params}` : ''}`
+}
+export function describeAgentMemoryEntries(agentId: string, channelKey?: string) {
+  return apiGet<import('@agentconnect.md/protocol').MemoryEntryCapabilities>(
+    memoryEntryUrl(agentId, 'capabilities', channelKey)
+  )
+}
+export function listAgentMemoryEntries(agentId: string, channelKey?: string, cursor?: string) {
+  return apiGet<import('@agentconnect.md/protocol').MemoryEntryListResult>(
+    memoryEntryUrl(agentId, 'entries', channelKey, { limit: '20', ...(cursor ? { cursor } : {}) })
+  )
+}
+export function getAgentMemoryEntry(agentId: string, ref: string, channelKey?: string, cursor?: string) {
+  return apiGet<import('@agentconnect.md/protocol').MemoryEntryContent | null>(
+    memoryEntryUrl(agentId, `entries/${encodeURIComponent(ref)}`, channelKey, {
+      maxBytes: '32768',
+      ...(cursor ? { cursor } : {})
+    })
+  )
+}
+export function createAgentMemoryEntry(
+  agentId: string,
+  request: import('@agentconnect.md/protocol').MemoryEntryCreateRequest,
+  channelKey?: string
+) {
+  return apiPost<import('@agentconnect.md/protocol').MemoryEntryMutationReceipt>(
+    memoryEntryUrl(agentId, 'entries', channelKey),
+    request
+  )
+}
+export function updateAgentMemoryEntry(
+  agentId: string,
+  request: import('@agentconnect.md/protocol').MemoryEntryUpdateRequest,
+  channelKey?: string
+) {
+  return apiPatch<import('@agentconnect.md/protocol').MemoryEntryMutationReceipt>(
+    memoryEntryUrl(agentId, 'entries', channelKey),
+    request
+  )
+}
+export function deleteAgentMemoryEntry(
+  agentId: string,
+  request: import('@agentconnect.md/protocol').MemoryEntryDeleteRequest,
+  channelKey?: string
+) {
+  return apiDelete<import('@agentconnect.md/protocol').MemoryEntryMutationReceipt>(
+    memoryEntryUrl(agentId, 'entries', channelKey),
+    request
+  )
+}

--- a/packages/web/src/lib/memory-entry-content.test.ts
+++ b/packages/web/src/lib/memory-entry-content.test.ts
@@ -1,0 +1,34 @@
+import { expect, it, vi } from 'vitest'
+import { readCompleteMemoryEntry } from './memory-entry-content'
+const entry = {
+  ref: 'opaque-ref',
+  label: 'Topic',
+  revision: 'r1',
+  byteSize: 6,
+  format: 'markdown' as const,
+  origin: 'active' as const,
+  editable: true
+}
+it('loads every slice before returning an editable document', async () => {
+  const read = vi
+    .fn()
+    .mockResolvedValueOnce({ entry, text: 'head', complete: false, nextContentCursor: 'next' })
+    .mockResolvedValueOnce({ entry, text: 'tail', complete: true })
+  expect(await readCompleteMemoryEntry(read, 100)).toMatchObject({ text: 'headtail', complete: true })
+  expect(read.mock.calls).toEqual([[undefined], ['next']])
+})
+it.each(['missing', 'loop', 'changed', 'too large'] as const)(
+  'refuses %s content instead of exposing a partial editor',
+  async (reason) => {
+    const read = vi.fn().mockResolvedValue({ entry, text: 'head', complete: false, nextContentCursor: 'next' })
+    if (reason === 'missing') read.mockResolvedValueOnce({ entry, text: 'head', complete: false })
+    if (reason === 'changed')
+      read.mockResolvedValueOnce({
+        entry: { ...entry, revision: 'old' },
+        text: 'head',
+        complete: false,
+        nextContentCursor: 'next'
+      })
+    await expect(readCompleteMemoryEntry(read, reason === 'too large' ? 1 : 100)).rejects.toThrow()
+  }
+)

--- a/packages/web/src/lib/memory-entry-content.ts
+++ b/packages/web/src/lib/memory-entry-content.ts
@@ -1,0 +1,32 @@
+import type { MemoryEntryContent } from '@agentconnect.md/protocol'
+
+// Never make a partial document editable, including malformed or expired continuation chains.
+export async function readCompleteMemoryEntry(
+  read: (cursor?: string) => Promise<MemoryEntryContent | null>,
+  maxBytes: number
+): Promise<MemoryEntryContent | null> {
+  let cursor: string | undefined
+  let first: MemoryEntryContent | undefined
+  let text = ''
+  let bytes = 0
+  const seen = new Set<string>()
+  for (let page = 0; page < 128; page++) {
+    const part = await read(cursor)
+    if (!part) {
+      if (first) throw new Error('Memory changed while loading. Reload it before editing.')
+      return null
+    }
+    if (first && part.entry.revision !== first.entry.revision)
+      throw new Error('Memory changed while loading. Reload it before editing.')
+    first ??= part
+    bytes += new TextEncoder().encode(part.text).byteLength
+    if (bytes > Math.min(maxBytes, 4 * 1024 * 1024)) throw new Error('This memory is too large to open in the editor.')
+    text += part.text
+    if (part.complete) return { ...first, text, complete: true, nextContentCursor: undefined }
+    if (!part.nextContentCursor || seen.has(part.nextContentCursor))
+      throw new Error('Memory could not be loaded completely. Reload it before editing.')
+    cursor = part.nextContentCursor
+    seen.add(cursor)
+  }
+  throw new Error('Memory could not be loaded completely. Reload it before editing.')
+}


### PR DESCRIPTION
## Change
The Memory panel now opens a shared capability-driven entry browser for managed and external providers. Users can page entries, read complete content, and perform authorized conditional create/update/delete operations. The existing settings/channel selector/Dream panel stay in place; older or unsupported peers fall back, and “More memory tools” keeps legacy file/history/provider features available.

Editing waits for all content slices and retains the loaded opaque ref/revision. Inherited/read-only entries cannot be edited. Request and item byte limits are checked before saving, deletion requires confirmation, and conflicts or uncertain outcomes retain the draft and block replay until saved memory is reloaded. Scope changes invalidate outstanding reads. After an unconfirmed first create, an explicit successful refresh of a complete empty list permits a manual new save and explains that the earlier request may still complete; failed/partial refreshes never unlock it. Opening retained file tools reloads the file list and preview.

## Validation
46 tests passed covering complete/invalid content pagination, conditional payloads, ambiguous-write blocking, inherited/viewer restrictions, late responses after channel changes, fallback/list pagination, delete confirmation, request limits, and existing Memory settings/file interactions. Web typecheck and targeted ESLint passed. Inspected an isolated browser render with production CSS at desktop/light and mobile/dark widths; no horizontal overflow.

Stored text is displayed directly in this initial view. Activation catalog refresh and retirement of compatibility tools remain follow-up work.
