### PR TITLE
fix(memory): identify entry targets before write approval

### DIFF
--- a/docs/designs/unified-memory-interface.md
+++ b/docs/designs/unified-memory-interface.md
@@ -478,3 +478,49 @@ continuously live host without a supported update mechanism still uses explicit
 entry tools for fresh reads. Its automatic refresh requires a separately verified
 runtime capability; silently inserting a leading user-message catalog is not an
 acceptable fallback.
+
+### Live refresh capability audit (2026-09-10)
+
+A repeated `session/load` in an already-live Claude ACP process is not a
+system-context refresh. This was checked against the installed published
+`@agentclientprotocol/claude-agent-acp` packages **0.59.0 and 0.70.0**, not inferred
+from the daemon's `loadSession` method signature:
+
+- `ClaudeAcpAgent.getOrCreateSession` compares a fingerprint containing only
+  `cwd` and sorted `mcpServers`. An unchanged fingerprint returns the existing
+  query; `_meta.systemPrompt` does not participate in that comparison.
+- `createSession` consumes `_meta.systemPrompt` when constructing the SDK query.
+  `prompt` instead converts ACP content to a user message and pushes it into the
+  existing query. Neither path implements a live system-context replacement.
+- A no-model probe called the actual exported agent class with an existing
+  session and instrumented creation/teardown methods. Changing only the system
+  append produced zero creations and zero teardowns in both versions. Changing
+  `cwd` as a positive control produced one of each. This verifies adapter
+  dispatch behavior; it is not a model-level end-to-end refresh test.
+
+Consequently the supported native-resume delivery above means loading a session
+that is **not already live in that adapter process**. The daemon's warm-session
+fast path remains unchanged. Do not force a different cwd or MCP configuration
+just to invalidate the adapter fingerprint: those are session execution and
+permission inputs, not cache-busting fields. Do not silently restart unrelated
+sessions in a shared host process.
+
+Before enabling automatic live delivery, provide and verify an explicit adapter
+capability (or a separately tested, session-scoped close/resume lifecycle) with:
+
+1. A turn-boundary update receipt identifying the accepted catalog revision;
+   failed or unsupported updates must not mark that revision delivered.
+2. Preservation of conversation identity/history, cwd, MCP authorization,
+   protected settings, model configuration, and capture provenance. Loading must
+   not replay history into ordinary live delivery or duplicate a user turn.
+3. Coalesced invalidation after committed writes/adoption, including both base
+   and overlay revisions; unchanged catalogs should not recreate the query.
+4. A runtime integration test showing that a subsequent real turn receives the
+   changed reference context without adding a user message or changing its title.
+   Cover interrupted updates and retry without duplicating content.
+
+These package observations do not establish support for other versions or
+runtimes. Until a supported mechanism passes those checks, new/native-resumed
+sessions receive the bounded observation and live sessions retrieve current
+entries through the common tools. Compatibility retirement is also still pending;
+this audit does not close the overall unified-memory implementation task.

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,4 +1,5 @@
 import {
+  memoryEntryWriteAsk,
   describeMemoryEntries,
   listMemoryEntries,
   getMemoryEntry,
@@ -35,7 +36,6 @@ import {
   getMemory,
   GET_MEMORY_ARGS,
   MEMORY_TOOL_ACCESS_MODES,
-  memoryWriteAsk,
   readMemory,
   READ_MEMORY_ARGS,
   saveMemory,
@@ -355,7 +355,9 @@ export async function executeTool(
     if (decision === 'deny') throw new Error(MEMORY_WRITE_NO_APPROVER)
     if (decision === 'ask') {
       // The approval covers THIS call's payload and nothing else: it is awaited inline, never cached.
-      const verdict = (await deps.requestMemoryWriteApproval?.(ctx, memoryWriteAsk(name, args))) ?? 'no_approver'
+      const verdict =
+        (await deps.requestMemoryWriteApproval?.(ctx, await memoryEntryWriteAsk(ctx, name, args, deps))) ??
+        'no_approver'
       if (verdict === 'no_approver') throw new Error(MEMORY_WRITE_NO_APPROVER)
       if (verdict !== 'allowed') throw new Error(MEMORY_WRITE_NOT_APPROVED)
       // This call's approval survives service rechecks; a subsequent deny still wins.

--- a/packages/daemon/src/mcp/ops/memory-entries.ts
+++ b/packages/daemon/src/mcp/ops/memory-entries.ts
@@ -1,9 +1,13 @@
 import { createMemoryEntryService } from '../../memory/entries/factory.js'
 import { MemoryEntriesError } from '../../memory/entries/contract.js'
 import type { MemoryEntries } from '../../memory/entries/service.js'
-import { DESCRIBE_MEMORY_ENTRIES_ARGS } from '../../memory/entries/tools.js'
+import {
+  DESCRIBE_MEMORY_ENTRIES_ARGS,
+  UPDATE_MEMORY_ENTRY_ARGS,
+  DELETE_MEMORY_ENTRY_ARGS
+} from '../../memory/entries/tools.js'
 import type { MemoryOpsDeps } from './memory.js'
-import { memoryScopeFor } from './memory.js'
+import { memoryScopeFor, memoryWriteAsk } from './memory.js'
 import type { SessionContext } from './context.js'
 
 async function entries(ctx: SessionContext, deps: MemoryOpsDeps) {
@@ -25,7 +29,7 @@ async function entries(ctx: SessionContext, deps: MemoryOpsDeps) {
     canRead: async () => !deps.memoryAccessDecision || (await deps.memoryAccessDecision(ctx, 'read')) === 'allow'
   })
 }
-async function call(ctx: SessionContext, deps: MemoryOpsDeps, action: (service: MemoryEntries) => Promise<unknown>) {
+async function call<T>(ctx: SessionContext, deps: MemoryOpsDeps, action: (service: MemoryEntries) => Promise<T>) {
   try {
     return await action(await entries(ctx, deps))
   } catch (error) {
@@ -53,4 +57,27 @@ export async function updateMemoryEntry(ctx: SessionContext, args: Record<string
 }
 export async function deleteMemoryEntry(ctx: SessionContext, args: Record<string, unknown>, deps: MemoryOpsDeps) {
   return call(ctx, deps, (service) => service.delete(args))
+}
+
+/** Resolve opaque mutation targets under the same trusted read scope before asking a human. */
+export async function memoryEntryWriteAsk(
+  ctx: SessionContext,
+  tool: string,
+  args: Record<string, unknown>,
+  deps: MemoryOpsDeps
+) {
+  const ask = memoryWriteAsk(tool, args)
+  if (tool !== 'updateMemoryEntry' && tool !== 'deleteMemoryEntry') return ask
+  const request = (tool === 'updateMemoryEntry' ? UPDATE_MEMORY_ENTRY_ARGS : DELETE_MEMORY_ENTRY_ARGS).parse(args)
+  return call(ctx, deps, async (service) => {
+    const current = await service.get({ ref: request.ref, maxBytes: 32768 })
+    if (!current) throw new MemoryEntriesError('NOT_FOUND', 'memory entry no longer exists')
+    if (current.entry.revision !== request.revision)
+      throw new MemoryEntriesError(
+        'CONFLICT',
+        'memory entry changed; read it again before requesting approval',
+        current.entry.revision
+      )
+    return { ...ask, target: current.entry.label.replace(/\s+/g, ' ').trim().slice(0, 200) }
+  })
 }

--- a/packages/daemon/test/managed-memory-crud.test.ts
+++ b/packages/daemon/test/managed-memory-crud.test.ts
@@ -271,12 +271,14 @@ it('executes conditional MCP writes with trusted scope, approvals and synthetic-
   let decision: 'allow' | 'ask' | 'deny' = 'allow'
   let approve = true
   let approvals = 0
+  const targets: string[] = []
   const deps = {
     memory: f.provider,
     memoryEntryStore: f.db,
     memoryScope: () => ({ agentId: 'agent', sourceTurnId: f.sourceTurnId }),
     memoryAccessDecision: (_ctx: unknown, mode: string) => (mode === 'write' ? decision : 'allow'),
-    requestMemoryWriteApproval: () => {
+    requestMemoryWriteApproval: (_ctx: unknown, ask: { target: string }) => {
+      targets.push(ask.target)
       approvals++
       return approve ? 'allowed' : 'denied'
     }
@@ -292,11 +294,28 @@ it('executes conditional MCP writes with trusted scope, approvals and synthetic-
   expect(f.commits[0]).toMatchObject({ source: 'tool', sourceTurnId: f.sourceTurnId })
   await expect(invoke('createMemoryEntry', { label: 'forged', text: 'x', source: 'distill' })).rejects.toThrow()
   decision = 'ask'
+  await expect(
+    executeTool(
+      ctx,
+      'deleteMemoryEntry',
+      { ref: created.entry!.ref, revision: created.entry!.revision },
+      {
+        ...deps,
+        memoryAccessDecision: (_ctx, mode) => (mode === 'read' ? 'deny' : 'ask')
+      }
+    )
+  ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  expect(approvals).toBe(0)
   const updated = (await invoke('updateMemoryEntry', {
     ref: created.entry!.ref,
     revision: created.entry!.revision,
     edit: { oldText: 'before', newText: '$& after' }
   })) as import('@agentconnect.md/protocol').MemoryEntryMutationReceipt
+  expect(approvals).toBe(1)
+  expect(targets).toEqual(['model'])
+  await expect(
+    invoke('deleteMemoryEntry', { ref: created.entry!.ref, revision: created.entry!.revision })
+  ).rejects.toMatchObject({ code: 'CONFLICT' })
   expect(approvals).toBe(1)
   expect(await invoke('getMemoryEntry', { ref: updated.entry!.ref })).toMatchObject({
     text: expect.stringContaining('$& after')
@@ -305,6 +324,7 @@ it('executes conditional MCP writes with trusted scope, approvals and synthetic-
   await expect(
     invoke('deleteMemoryEntry', { ref: updated.entry!.ref, revision: updated.entry!.revision })
   ).rejects.toThrow('did not approve')
+  expect(targets).toEqual(['model', 'model'])
   expect(f.commits).toHaveLength(2)
   decision = 'deny'
   await expect(


### PR DESCRIPTION
## Problem and result

Common memory update/delete approval cards previously showed only “memory entry”, hiding the target behind an opaque ref. Resolve the ref through the authorized common read service before requesting approval and display the stored label, bounded to one line. A missing entry, denied read, or stale revision fails before the card is shown. Execution still enforces its existing conditional write and authorization checks after approval.

Includes the already-reviewed live-refresh capability audit from #1935. That documentation-only PR cannot satisfy required CI because the workflow excludes docs; this code PR carries the unchanged audit through normal checks and supersedes #1935. It documents the verified adapter limitation, without claiming live refresh is implemented.

## Validation

- 49 focused tests passed: managed mutations, common entries, and write approval.
- Added assertions for update/delete target labels, denied read without prompting, and stale revision without prompting; existing approval-time policy-change checks remain.
- Daemon typecheck passed; repository pre-push lint.
- Audit evidence: actual exported Claude ACP 0.59.0/0.70.0 dispatch probe (metadata-only load reuses query, changed-cwd positive control recreates). No model-level live refresh test or runtime behavior change.
