### PR TITLE
docs(memory): align tool guidance and supported entry workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ the picture it draws.
 
 - [memory-system-plan.md](designs/memory-system-plan.md) — The managed memory system.
 - [memory-evolution.md](designs/memory-evolution.md) — `MemoryProvider` and external memory plugins.
-- [unified-memory-interface.md](designs/unified-memory-interface.md) — Proposed shared entry operations, context freshness, and managed/external compatibility.
+- [unified-memory-interface.md](designs/unified-memory-interface.md) — Implemented common entry operations and console, supported activation catalogs, and remaining live-refresh/compatibility work.
 - [memory-dreaming.md](designs/memory-dreaming.md) — Offline memory consolidation ("dreaming").
 - [organization-knowledge.md](designs/organization-knowledge.md) — Organization knowledge bundles and dream suggestions.
 - [shared-skills.md](designs/shared-skills.md) — One isolated `skills` CLI for git and local skill sources.

--- a/docs/designs/memory-evolution.md
+++ b/docs/designs/memory-evolution.md
@@ -7,7 +7,7 @@
 
 ---
 
-The proposed [unified memory interface](unified-memory-interface.md) extends this lifecycle with common entry operations, a bounded context catalog, and shared mutation semantics. It preserves the plugin ABI and storage choices; the current file/record surfaces remain compatibility contracts until that proposal is implemented.
+The [unified memory interface](unified-memory-interface.md) implements common reads, conditional managed mutations, model/admin projections, and a capability-driven console on this lifecycle. New/native-resumed sessions have bounded catalog delivery; continuously live refresh is still pending. The plugin ABI and storage choices are unchanged. File/record tools remain compatibility contracts pending old-client drainage and preservation of legacy index workflows.
 
 ## 1. Background and Current State
 

--- a/docs/designs/memory-system-plan.md
+++ b/docs/designs/memory-system-plan.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented.
 
-For the proposed common managed/external entry interface and context workflow, see [Unified Memory Operations and Context](unified-memory-interface.md). That proposal does not change the implemented storage behavior described here.
+The [unified memory interface](unified-memory-interface.md) now supplies common reads, conditional managed mutations, model/admin projections, and a capability-driven console. Supported new/native-resumed sessions receive a bounded catalog; continuously live refresh remains pending. The lifecycle and compatibility paths below remain relevant.
 
 Agent memory is isolated per agent, lives outside the workspace, and is
 selected through a provider-neutral lifecycle. The implementation authority is
@@ -17,8 +17,9 @@ provider lifecycle.
 - Memory belongs to an agent, not to a workspace checkout.
 - Workspace reset, replacement, or repository operations must not modify agent
   memory.
-- The Control Plane proxies memory administration but does not persist memory
-  bodies.
+- The Control Plane proxies memory administration. Managed memory with
+  `home: control-plane` is the curated-content exception: its home authority
+  persists memory bodies, history, and atomic mutation receipts.
 - Runtime-native memory must be isolated per agent or explicitly disabled so
   two memory systems do not run concurrently.
 - Agent-facing tools expose a stable AgentConnect contract rather than
@@ -32,7 +33,7 @@ Each agent selects one provider:
 
 | Provider       | Behavior                                                                                          |
 | -------------- | ------------------------------------------------------------------------------------------------- |
-| **`managed`**  | AgentConnect owns Markdown memory, injects the index, and exposes file-oriented memory tools.     |
+| **`managed`**  | AgentConnect owns Markdown memory, exposes common entries, and retains file compatibility tools.  |
 | **`native`**   | The runtime owns memory; the daemon redirects its memory/configuration directory into agent root. |
 | **`external`** | A registered memory plugin supplies per-turn recall and capture through the canonical plugin ABI. |
 | **`none`**     | Persistent memory is disabled, including verified runtime-native memory mechanisms.               |
@@ -43,7 +44,8 @@ mixing memory from different providers.
 
 ## 3. Managed Memory Layout
 
-Daemon root (`--root`, default `~/.agentconnect`):
+Daemon-local home layout (`--root`, default `~/.agentconnect`); a Control Plane
+home stores the same logical topics at its authority instead:
 
 ```text
 ~/.agentconnect/
@@ -73,7 +75,10 @@ File operations accept only safe relative Markdown paths within the memory
 directory. They reject traversal, subdirectories, symlink escapes, unsupported
 extensions, and writes that exceed the configured limits. Writes replace the
 whole named file and use modification-time checks where the caller supplies an
-expected version.
+expected version. These are legacy file semantics. Common entry mutations on
+capable Control Plane homes require create-if-absent or a current revision, and
+commit topic/index/history together. Native-writable and older homes do not
+advertise those strong guarantees.
 
 ## 4. Runtime Integration
 
@@ -87,8 +92,11 @@ The provider supplies spawn-time environment overrides:
   host-global memory directory.
 
 Managed memory is runtime-neutral. It supplies standing context through prompt
-injection and exposes `readMemory` and `writeMemory` through the daemon-owned
-MCP server. The daemon resolves the agent identity and path; the model cannot
+injection and exposes common entry tools through the daemon-owned MCP server,
+with `readMemory`/`writeMemory` retained for compatibility and bound extraction
+workflows. Common mutations are preferred when capability discovery supports
+them; a conflict or unknown outcome must not fall back to an unconditional write.
+The daemon resolves the agent identity and path; the model cannot
 select an arbitrary filesystem location.
 
 External memory uses record-oriented recall and capture rather than pretending
@@ -108,22 +116,30 @@ File-oriented providers use the daemon-control protocol:
 The Control Plane exposes agent-scoped memory routes and forwards requests to
 the owning daemon. Authorization uses the same organization and agent
 visibility rules as the rest of the agent API. An offline or unplaced daemon is
-reported as unavailable; content is never copied into Control Plane storage.
+reported as unavailable. Proxying does not change content ownership; a managed
+Control Plane home is the explicit persistence exception.
 
-The console selects the admin surface from the provider:
+The console first uses common capability discovery and list/get, exposing only
+actual supported mutations. The common `memory/entries/read/v1` and
+`memory/entries/write/v1` transport projects the same service with console
+authority. Conditional writes are not automatically replayed after an unknown
+outcome. Unsupported peers and the explicit additional-tools view retain these
+provider-specific compatibility surfaces:
 
 - `files`: index/topic list with read and edit operations; managed files also
   expose lazy, newest-first change history with expandable before/after snapshots;
 - `records`: search, inspect, create, update, delete, and history operations;
 - `none`: no memory administration surface.
 
-The web and protocol layers discriminate on these representation shapes and do
-not expose a concrete external backend name.
+Representation-specific tools preserve index editing, links/history, external
+record operations, and native administration. They cannot be removed until old
+sessions/clients are drained or a documented compatibility window ends, and
+legacy hand-authored indexes have an explicit preservation path.
 
 ## 6. Security and Privacy Boundaries
 
-- Memory bodies remain daemon-local for managed/native providers or in the
-  selected external backend.
+- Memory bodies belong to the configured managed home (daemon-local or Control
+  Plane), the isolated native runtime store, or the selected external backend.
 - Provider configuration contains references and non-secret settings only.
   Credentials use the platform secret store and are never returned in read
   DTOs.
@@ -140,8 +156,10 @@ not expose a concrete external backend name.
 ## 7. Extension Boundary
 
 `MemoryProvider` owns product policy: runtime environment, standing context,
-per-turn recall, post-turn capture, model tools, and the console
-representation. External plugins translate the canonical memory profile to a
+per-turn recall and post-turn capture. The common entry service owns entry
+authorization/contracts; core projections own model descriptors and the common
+console. Provider-specific representations remain compatibility capabilities.
+External plugins translate the canonical memory profile to a
 backend protocol; they do not control scope, prompt trust, retry policy, or
 agent-visible tool definitions.
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -840,6 +840,21 @@ contract test compares that declaration with the production policy. Adding or ch
 a policy requires a focused env assertion and a source comment naming the verified
 runtime lever.
 
+## Common memory operations and compatibility
+
+The common memory browser and model tools expose actual provider capabilities.
+Managed conditional mutations require a capable authoritative home; external and
+older homes must not inherit guarantees their provider cannot enforce. Show only
+supported actions and retain explicit provider tools for index/history and other
+compatibility workflows. Conflicts and unknown write outcomes require inspection;
+never silently retry through an unconditional legacy write.
+
+Memory catalogs are reference context delivered through supported session system
+context. New/native-resumed delivery does not imply automatic updates inside an
+already-live runtime. Do not turn a catalog refresh into a user message or title.
+See [unified memory operations](designs/unified-memory-interface.md) for the
+implemented boundaries and remaining compatibility-retirement conditions.
+
 ## Managed-memory prompt provenance
 
 The session-start `MEMORY.md` index must be enclosed in an explicit, labeled start/end

--- a/packages/daemon/src/memory/tools.ts
+++ b/packages/daemon/src/memory/tools.ts
@@ -17,6 +17,7 @@ export const MEMORY_TOOLS: ToolDescriptor[] = [
   {
     name: 'readMemory',
     description:
+      'Compatibility file reader for the index, linked files, and legacy sessions. Prefer listMemoryEntries/getMemoryEntry for topic entries when available. ' +
       'Read one of your memory files. Omit `path` (or pass "MEMORY.md") to read the index; pass a topic file name ' +
       '(e.g. "deploys.md") to read that topic. The index is already shown to you at the start of each session (you ' +
       'do NOT need to read it first) — use this to pull the detail behind an index entry, or the current contents of ' +
@@ -33,6 +34,7 @@ export const MEMORY_TOOLS: ToolDescriptor[] = [
   {
     name: 'writeMemory',
     description:
+      'Compatibility file writer. For ordinary topic changes, first check describeMemoryEntries and prefer its supported createMemoryEntry/updateMemoryEntry/deleteMemoryEntry operations with current refs and revisions. Never use this tool to bypass a denied, conflicting, or ambiguous unified mutation. Keep this path for legacy file/index operations, unsupported homes, and explicitly bound extraction/Dream workflows. ' +
       'Save durable facts across sessions (conventions, decisions, who to ask, things you had to re-learn). Omit ' +
       '`path` to target the MEMORY.md index; pass a topic file name (e.g. "deploys.md") for a topic. Keep the INDEX ' +
       'short — a scannable list linking to topic files (e.g. "- [deploys](deploys.md) — how we ship"); put the detail ' +


### PR DESCRIPTION
Common managed mutations are available, but legacy tool descriptions still steer models toward unconditional file writes and the memory overview still describes common entries as a proposal. Prefer supported common operations for ordinary topic changes, and explicitly prohibit legacy fallback after a denied, conflicting, or ambiguous mutation. Preserve legacy index/file behavior and bound extraction/Dream workflows.

Update the memory overview, evolution entry point, documentation index, and product conventions to reflect the common console and the Control Plane memory-home exception. State the remaining live-refresh and old-client/index preservation boundaries. No tool names, argument schemas, handlers, or storage behavior change.

Validation: 35 existing tool/mutation tests passed; Prettier, diff whitespace, and repository pre-push lint. This does not retire compatibility tools or implement a live runtime context-update mechanism.
