### PR TITLE
fix(session): treat repeated AC_NO_RESPONSE bodies as silent

### DIFF
--- a/packages/daemon/src/session/no-response.ts
+++ b/packages/daemon/src/session/no-response.ts
@@ -75,8 +75,14 @@ export function isNoResponsePrefix(trimmedBody: string): boolean {
 /** True when the turn is the bare sentinel, or when a non-compliant model explains itself
  *  and then emits the sentinel as the final standalone line. The terminal-line fallback is
  *  deliberately narrow: inline mentions, punctuation, fenced examples, and any content
- *  after the sentinel remain ordinary replies. */
+ *  after the sentinel remain ordinary replies. A body that is nothing but repeated
+ *  sentinel occurrences and whitespace is unambiguously a silent turn (#1920). */
 export function isNoResponseBody(trimmedBody: string): boolean {
   const terminalLine = trimmedBody.split(/\r?\n/).at(-1)?.trim()
-  return terminalLine === NO_RESPONSE_SENTINEL
+  if (terminalLine === NO_RESPONSE_SENTINEL) return true
+  // Only-sentinel bodies (repeated or whitespace-separated) are unambiguous.
+  return (
+    trimmedBody.length > 0 &&
+    trimmedBody.split(NO_RESPONSE_SENTINEL).every((part) => part.trim() === '')
+  )
 }

--- a/packages/daemon/test/no-response.test.ts
+++ b/packages/daemon/test/no-response.test.ts
@@ -28,6 +28,15 @@ describe('no-response sentinel', () => {
     expect(isNoResponseBody('')).toBe(false)
   })
 
+  it('isNoResponseBody treats a body of only repeated sentinels as silent (#1920)', () => {
+    expect(isNoResponseBody('AC_NO_RESPONSEAC_NO_RESPONSE')).toBe(true)
+    expect(isNoResponseBody('AC_NO_RESPONSE AC_NO_RESPONSE')).toBe(true)
+    expect(isNoResponseBody('AC_NO_RESPONSE\nAC_NO_RESPONSE')).toBe(true)
+    // Any real residue stays an ordinary reply
+    expect(isNoResponseBody('AC_NO_RESPONSE\nAC_NO_RESPONSE.')).toBe(false)
+    expect(isNoResponseBody('No. AC_NO_RESPONSE AC_NO_RESPONSE')).toBe(false)
+  })
+
   it('isNoResponsePrefix holds only genuine (case-sensitive) prefixes of the sentinel', () => {
     // empty + every proper prefix of the sentinel is held while it may still complete
     expect(isNoResponsePrefix('')).toBe(true)


### PR DESCRIPTION
### Problem
When the model emits the control marker twice concatenated (`AC_NO_RESPONSEAC_NO_RESPONSE`), both suppression gates in `packages/daemon/src/session/no-response.ts` miss it:

- `isNoResponsePrefix` releases once the buffer is no longer a prefix of the sentinel
- `isNoResponseBody` requires the last line to equal the sentinel **exactly**

The garbage is posted to the shared channel (observed on Slack). Issue: #1920.

### Solution
Keep the narrow terminal-line rule. Additionally treat a body that is **nothing but** sentinel occurrences and whitespace as a silent turn — the same suggested fix in #1920. Inline mentions, fenced examples, and any prose residue still stay ordinary replies.

### Testing
Offline assertions (full `pnpm` install blocked by ENOSPC on the runner; logic is pure):

```
ok "AC_NO_RESPONSEAC_NO_RESPONSE"     → true
ok "AC_NO_RESPONSE AC_NO_RESPONSE"    → true
ok "AC_NO_RESPONSE\nAC_NO_RESPONSE"    → true
ok "AC_NO_RESPONSE"                   → true
ok "AC_NO_RESPONSE."                  → false
ok "No. AC_NO_RESPONSE AC_NO_RESPONSE" → false
ok "AC_NO_RESPONSE\nAC_NO_RESPONSE."   → false
ok "The reserved token is AC_NO_RESPONSE" → false
```

Also added cases to `packages/daemon/test/no-response.test.ts` for CI.

### Issue alignment
- #1920 has **0 comments** at submission time — no maintainer design note yet
- Implements the issue's suggested `isNoResponseBody` patch verbatim
- Leaves `isNoResponsePrefix` streaming-hold improvement as follow-up (called out in the issue)

### Agent dimension
multi-agent / delivery-boundary (control-marker suppression)

### Core value
Prevents internal silent-turn markers from leaking into shared Slack/Telegram channels when a model double-emits the token.

Fixes #1920
