### PR TITLE
style(daemon): format no-response sentinel expression

### DIFF
--- a/packages/daemon/src/session/no-response.ts
+++ b/packages/daemon/src/session/no-response.ts
@@ -81,8 +81,5 @@ export function isNoResponseBody(trimmedBody: string): boolean {
   const terminalLine = trimmedBody.split(/\r?\n/).at(-1)?.trim()
   if (terminalLine === NO_RESPONSE_SENTINEL) return true
   // Only-sentinel bodies (repeated or whitespace-separated) are unambiguous.
-  return (
-    trimmedBody.length > 0 &&
-    trimmedBody.split(NO_RESPONSE_SENTINEL).every((part) => part.trim() === '')
-  )
+  return trimmedBody.length > 0 && trimmedBody.split(NO_RESPONSE_SENTINEL).every((part) => part.trim() === '')
 }


### PR DESCRIPTION
The Check job in #1938 failed because Prettier requires the repeated-sentinel return expression on one line. Apply that formatting to restore the check after #1938 merged; runtime behavior is unchanged.

Validation: repository-wide Prettier check, ESLint for the changed file, and the existing no-response test suite.

Created by Codex . GPT-6 Astra
