### PR TITLE
chore: add Dependabot and update contributor image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ conventions, the monorepo layout, and the deeper design documentation.
 Thanks to everyone who has already contributed:
 
 <a href="https://github.com/agentconnect-md/agentconnect/graphs/contributors">
-  <img src="https://stg.contrib.rocks/image?repo=agentconnect-md/agentconnect" height="40" alt="AgentConnect contributors" />
+  <img src="https://contrib.rocks/image?repo=agentconnect-md/agentconnect" height="40" alt="AgentConnect contributors" />
 </a>
 
 ## Architecture


### PR DESCRIPTION
Add weekly Dependabot updates for the root pnpm workspace and GitHub Actions. Group minor and patch updates within each ecosystem, keep major upgrades separate, and use Conventional Commit titles compatible with the existing release process.

Point the README contributor image at https://contrib.rocks/image?repo=agentconnect-md/agentconnect.

Validation: frozen-lockfile install, Dependabot JSON Schema validation, duplicate-key check, Prettier checks, and pre-push lint passed. The first hosted Dependabot update run will occur after this configuration reaches the default branch.

Created by Codex . GPT-6
