### PR TITLE
fix(runtimes): unify Qoder compatibility identity

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -509,6 +509,7 @@ Uses an observed runtime-profile pattern. The daemon reports the **observed capa
 
 ```ts
 const FactsRuntimeProfile = z.object({
+  aliasOf: z.string().optional(), // compatibility id sharing another runtime's observed state
   runtime: z.string(), // "claude" / "codex" / ...
   version: z.string(),
   models: z.array(z.string()),

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -345,15 +345,18 @@ share a base stage with the toolchain, browser, ACP runtimes, and shim. Addition
 self-hosted runtimes belong in the full target. The pool provides Claude Code,
 Codex, and DeepSeek Harness. The full image additionally installs Antigravity,
 Cline, Devin, GitHub Copilot, Grok Build, Oh My Pi, OpenCode, pi, Qwen Code,
-Qoder CLI, and Qoder CN CLI. The legacy `qoder` catalog ID uses the same Qoder
-CLI executable as `qoder-cli`. pi includes both its ACP adapter and the underlying
+Qoder CLI, and Qoder CN CLI. The `qoder` compatibility ID resolves to `qoder-cli`
+before host discovery and image projection. Both IDs share one native launch
+definition and one probe state; reported `aliasOf` metadata lets the Console show
+one entry while existing agent configurations retain either ID. Explicit runtime
+overrides remain independent. pi includes both its ACP adapter and the underlying
 CLI. Packages are version-pinned; standalone downloads also pin their SHA-256.
 
 Each image bakes an explicit runtime roster and generates its own runtime table
 by probing the installed executables as the ordinary runtime user, without
 provider credentials. Missing executables fail the build instead of silently
-reducing the roster. Installing a runtime does not establish a host login or
-make it a discovery candidate; credential discovery still governs that list.
+reducing the roster. Installed runtimes remain discoverable without a saved login;
+saved logins also keep runtimes visible when their executable is missing.
 General development toolchain expansion can follow independently.
 The daemon package is published before image finalization; the matching
 image workflow must complete before this default can be pulled. A missing image

--- a/packages/control-plane/prisma/migrations/20260910060000_runtime_profile_alias/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260910060000_runtime_profile_alias/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runtime_profile" ADD COLUMN "aliasOf" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -640,6 +640,7 @@ model RuntimeProfile {
   id                    String     @id @default(cuid())
   daemonId              String     @db.Uuid
   runtime               String // "claude" / "codex"
+  aliasOf               String?
   version               String
   hostVersion           String?
   hostAvailable         Boolean?

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -138,6 +138,7 @@ export const RuntimeModelCatalogDto = z.object({
 /** Observed runtime capability (from `facts/runtime-profile`); `models` drives the console picker. */
 export const RuntimeProfileDto = z.object({
   runtime: z.string(),
+  aliasOf: z.string().nullable().optional(),
   version: z.string(),
   hostVersion: z.string().nullable().optional(),
   hostAvailable: z.boolean().nullable().optional(),

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4936,6 +4936,7 @@ export interface RuntimeProfileRecord {
   id: string
   daemonId: DaemonId
   runtime: string
+  aliasOf?: string | null
   version: string
   models: string[]
   contextWindow: number | null

--- a/packages/control-plane/src/persistence/repositories/runtime-profile.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/runtime-profile.repo.ts
@@ -16,6 +16,7 @@ function toRecord(p: RuntimeProfile): RuntimeProfileRecord {
     id: p.id,
     daemonId: DaemonId(p.daemonId),
     runtime: p.runtime,
+    aliasOf: p.aliasOf,
     version: p.version,
     hostVersion: p.hostVersion,
     hostAvailable: p.hostAvailable,
@@ -52,6 +53,7 @@ export class PgRuntimeProfileRepo implements RuntimeProfileRepo {
       create: {
         daemonId,
         runtime: f.runtime,
+        aliasOf: f.aliasOf ?? null,
         version: f.version,
         hostVersion: f.hostVersion ?? null,
         hostAvailable: f.hostAvailable ?? null,
@@ -69,6 +71,7 @@ export class PgRuntimeProfileRepo implements RuntimeProfileRepo {
         observedAt: at
       },
       update: {
+        aliasOf: f.aliasOf ?? null,
         version: f.version,
         hostVersion: f.hostVersion ?? null,
         hostAvailable: f.hostAvailable ?? null,

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -195,6 +195,7 @@ export interface DaemonLoad {
  */
 export interface DaemonRuntimeProfile {
   runtime: string
+  aliasOf?: string | null
   version: string
   models: string[]
   contextWindow: number | null

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -50,6 +50,7 @@ function normMcpServers(raw: unknown): FactsMcpServer[] {
 function toProfileView(p: RuntimeProfileRecord): DaemonRuntimeProfile {
   return {
     runtime: p.runtime,
+    aliasOf: p.aliasOf ?? null,
     version: p.version,
     hostVersion: p.hostVersion ?? null,
     hostAvailable: p.hostAvailable ?? null,

--- a/packages/control-plane/test/protocol/daemon-runtimes.handler.test.ts
+++ b/packages/control-plane/test/protocol/daemon-runtimes.handler.test.ts
@@ -172,7 +172,7 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     expect(stub.lastSent('error')).toBeUndefined()
   })
 
-  it('keeps auth and missing-image warnings independent and clears omitted status', async () => {
+  it('keeps alias and availability facts independent and clears omitted status', async () => {
     const h = buildWsHarness(prisma)
     const { stub } = await connectReady(h)
     const repo = new PgRuntimeProfileRepo(prisma)
@@ -183,6 +183,7 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
       runtimes: [
         {
           ...profile('claude-acp'),
+          aliasOf: 'native-claude',
           hostVersion: '2.0.0',
           hostAvailable: true,
           credentialsConfigured: false,
@@ -193,6 +194,7 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     })
     await vi.waitFor(async () => {
       expect((await repo.forDaemon(DaemonId(DAEMON)))[0]).toMatchObject({
+        aliasOf: 'native-claude',
         authRequired: true,
         hostVersion: '2.0.0',
         hostAvailable: true,
@@ -206,6 +208,7 @@ describe('facts/daemon-runtimes handler — reconciles the runtime list to the s
     stub.inject('facts/daemon-runtimes', { runtimes: [profile('claude-acp')] })
     await vi.waitFor(async () => {
       expect((await repo.forDaemon(DaemonId(DAEMON)))[0]).toMatchObject({
+        aliasOf: null,
         authRequired: false,
         hostVersion: null,
         hostAvailable: null,

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -77,6 +77,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     : await resolveRuntimeCatalog(cfg, root, { neededRuntimes: [agent.runtime], mode: 'cache-first' })
   const runtimes = opts.installed ? opts.installed(catalog.runtimes) : installedRuntimeCatalog(catalog).runtimes
   const entry = catalog.entries[agent.runtime]
+  const runtimeId = entry?.aliasOf ?? agent.runtime
   const selected = runtimes[agent.runtime]
   if (!selected) {
     if (entry?.source === 'curated') {
@@ -110,7 +111,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     const admission = new CuratedRuntimeAdmission()
     const probe = opts.probeRuntimes ?? probeAllRuntimes
     const results = await probe(
-      { [agent.runtime]: runtime },
+      { [runtimeId]: runtime },
       {
         curated: true,
         hostFactory: defaultProbeHostFactory({ isolateAccountApps: cfg.security.isolateAccountApps }),
@@ -123,14 +124,14 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
       }
     )
     admission.record(
-      results.find((result) => result.runtime === agent.runtime) ?? {
-        runtime: agent.runtime,
+      results.find((result) => result.runtime === runtimeId) ?? {
+        runtime: runtimeId,
         ok: false,
         models: [],
         error: 'ACP probe returned no result'
       }
     )
-    admission.assertLaunch(agent.runtime, entry.source)
+    admission.assertLaunch(runtimeId, entry.source)
   }
 
   const agentEnv = agentChildEnv(agent)
@@ -151,7 +152,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     skillsAgentId: entry?.skillsAgentId ?? null
   })
   const assembled = assembleRuntimeLaunch({
-    runtimeId: agent.runtime,
+    runtimeId,
     runtime,
     provider: memoryKindOf(agent),
     hostKey: agentHostKey(agent.id),
@@ -177,7 +178,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   for (const notice of assembled.configFiles?.notices ?? []) out.write(`⚠️ ${notice}\n`)
   const hostOptions: ConstructorParameters<typeof AcpHost>[1] = {
     onUpdate: renderUpdate(out),
-    runtimeId: agent.runtime,
+    runtimeId,
     isolateAccountApps: cfg.security.isolateAccountApps,
     env: assembled.launch.env,
     inheritProcessEnv: assembled.launch.inheritProcessEnv,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3754,7 +3754,8 @@ export class Daemon {
   } {
     if (!this.microsandbox)
       throw new Error(`microsandbox unavailable: ${this.microsandboxFailure ?? 'not initialized'}`)
-    const runtime = this.microsandboxCatalog?.runtimes[agent.runtime]
+    const runtimeEntry = this.microsandboxCatalog?.entries[agent.runtime]
+    const runtime = runtimeEntry?.runtime
     if (!runtime) throw new Error(`runtime "${agent.runtime}" is not provided by the microsandbox image`)
     const placement = this.microsandboxPlacement(agent, cwd, key)
     const github = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
@@ -3773,7 +3774,7 @@ export class Daemon {
           )
         : undefined
     const launch = prepareMicrosandboxLaunch({
-      runtimeId: agent.runtime,
+      runtimeId: runtimeEntry?.aliasOf ?? agent.runtime,
       runtime,
       scopeDir: agent.dir,
       cwd: placement.trustedSessionDir ?? (key && hostKeySessionKey(key) ? cwd : agent.workspace.path),
@@ -4532,7 +4533,7 @@ export class Daemon {
     const catalog = micro ? this.microsandboxCatalog : (this.localRuntimeCatalog ?? this.runtimeCatalog)
     const runtimeEntry = catalog?.entries[agent.runtime]
     if (runtimeEntry?.source === 'curated') {
-      this.curatedRuntimeAdmission.assertLaunch(agent.runtime, runtimeEntry.source)
+      this.curatedRuntimeAdmission.assertLaunch(runtimeEntry.aliasOf ?? agent.runtime, runtimeEntry.source)
     }
     // The hostFactory seam must obey the same static external-memory admission
     // gate as a real ACP child; otherwise tests/custom embedders could start an
@@ -4698,7 +4699,7 @@ export class Daemon {
               }
             }
           : {}),
-        runtimeId: agent.runtime,
+        runtimeId: runtimeEntry?.aliasOf ?? agent.runtime,
         runtime,
         provider: memoryKindOf(agent),
         scopeDir: agent.dir,
@@ -4815,7 +4816,7 @@ export class Daemon {
           }
         : {}),
       inheritProcessEnv: launch.inheritProcessEnv,
-      runtimeId: agent.runtime,
+      runtimeId: runtimeEntry?.aliasOf ?? agent.runtime,
       isolateAccountApps: cfg.security.isolateAccountApps,
       sandbox: launch.sandbox,
       toolSandbox: launch.toolSandbox,
@@ -18625,7 +18626,9 @@ export class Daemon {
     const plane = this.k8sPlane
     if (!plane) return []
     this.refreshAdmittedRuntimes()
-    const runtimes = this.runtimes
+    const runtimes = Object.fromEntries(
+      Object.entries(this.runtimes).filter(([id]) => !this.runtimeCatalog.entries[id]?.aliasOf)
+    )
     if (Object.keys(runtimes).length === 0) return []
     this.log.info(`probe: reading models from the sandbox for ${Object.keys(runtimes).join(', ')}`)
     const results = await probeClusterRuntimes({

--- a/packages/daemon/src/runtimes/curated-admission.ts
+++ b/packages/daemon/src/runtimes/curated-admission.ts
@@ -53,7 +53,7 @@ export class CuratedRuntimeAdmission {
   probeCandidates(catalog: ResolvedRuntimeCatalog): Record<string, RuntimeDef> {
     const candidates: Record<string, RuntimeDef> = {}
     for (const [id, entry] of Object.entries(catalog.entries)) {
-      if (entry.source === 'curated' && this.status(id, entry.source) === 'pending') {
+      if (!entry.aliasOf && entry.source === 'curated' && this.status(id, entry.source) === 'pending') {
         candidates[id] = entry.runtime
       }
     }
@@ -68,13 +68,17 @@ export class CuratedRuntimeAdmission {
    * warning — the runtime goes back to `pending` and is re-probed instead. */
   authRequiredIds(catalog: ResolvedRuntimeCatalog): string[] {
     return Object.entries(catalog.entries)
-      .filter(([id, entry]) => entry.source === 'curated' && this.fresh(id)?.result.authRequired === true)
+      .filter(
+        ([id, entry]) => entry.source === 'curated' && this.fresh(entry.aliasOf ?? id)?.result.authRequired === true
+      )
       .map(([id]) => id)
   }
 
   filterCatalog(catalog: ResolvedRuntimeCatalog): ResolvedRuntimeCatalog {
     const entries = Object.fromEntries(
-      Object.entries(catalog.entries).filter(([id, entry]) => this.status(id, entry.source) === 'verified')
+      Object.entries(catalog.entries).filter(
+        ([id, entry]) => this.status(entry.aliasOf ?? id, entry.source) === 'verified'
+      )
     )
     return {
       entries,

--- a/packages/daemon/src/runtimes/curated.ts
+++ b/packages/daemon/src/runtimes/curated.ts
@@ -38,9 +38,7 @@ export const CURATED_RUNTIME_CATALOG: Readonly<Record<string, CuratedRuntimeEntr
     name: 'Oh My Pi',
     runtime: { command: 'omp', args: ['acp'], env: [] }
   },
-  // Qoder CLI launches its ACP server via a `--acp` flag (not an `acp`
-  // subcommand). Distributed as @qoder-ai/qodercli; the `qodercli` binary is on
-  // PATH once installed globally.
+  // Qoder CLI launches its ACP server through the native `qodercli --acp` command.
   'qoder-cli': {
     name: 'Qoder CLI',
     runtime: { command: 'qodercli', args: ['--acp'], env: [], skillsAgentId: 'qoder' }

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -141,25 +141,31 @@ export class RuntimeFactsRegistry {
     return this.names
   }
 
+  private canonicalId(id: string): string {
+    return this.host.catalog().entries[id]?.aliasOf ?? id
+  }
+
   offeredModels(runtimeId: string): string[] | undefined {
-    return this.models.get(runtimeId)
+    return this.models.get(this.canonicalId(runtimeId))
   }
 
   /** Whether the offered list for a runtime is live probe knowledge (cache-hydrated is not). */
   offeredModelsAreLive(runtimeId: string): boolean {
-    return this.modelsSource.get(runtimeId) !== 'cached'
+    return this.modelsSource.get(this.canonicalId(runtimeId)) !== 'cached'
   }
 
   mcpCapabilities(runtimeId: string): McpTransportCapabilities | undefined {
-    return this.mcpCaps.get(runtimeId)
+    return this.mcpCaps.get(this.canonicalId(runtimeId))
   }
 
   modelCatalog(runtimeId: string): RuntimeModelCatalog | undefined {
-    return this.catalogs.get(runtimeId)
+    return this.catalogs.get(this.canonicalId(runtimeId))
   }
 
   /** Report the current runtime profile, preserving both host and image versions. */
   profileFor(id: string): FactsRuntimeProfile {
+    const canonicalId = this.canonicalId(id)
+    if (canonicalId !== id) return { ...this.profileFor(canonicalId), runtime: id, aliasOf: canonicalId }
     const hostAvailable = this.host.hostAvailable(id)
     const credentialsConfigured = this.host.credentialsConfigured(id)
     const hostVersion = hostAvailable === false ? '' : this.probedVersions.get(id) || this.versions[id] || ''
@@ -201,6 +207,7 @@ export class RuntimeFactsRegistry {
    *  the telemetry emit is best-effort like emitStoredUsageReport — it must
    *  never affect message delivery. */
   noteAuthFromTurn(runtimeId: string, authRequired: boolean): void {
+    runtimeId = this.canonicalId(runtimeId)
     let changed: boolean
     if (authRequired) {
       changed = !this.authRequiredLive.has(runtimeId) && !this.authRequired.has(runtimeId)
@@ -241,6 +248,7 @@ export class RuntimeFactsRegistry {
    *  reports, which the declared table never does. */
   noteImageCatalog(entries: ResolvedRuntimeCatalog['entries']): void {
     for (const [id, entry] of Object.entries(entries)) {
+      if (entry.aliasOf) continue
       this.names[id] = entry.name
       if (entry.version) this.versions[id] = entry.version
       this.probedVersions.set(id, entry.version || (this.probedVersions.get(id) ?? ''))
@@ -258,7 +266,8 @@ export class RuntimeFactsRegistry {
   async hydrateFromCache(): Promise<void> {
     try {
       for (const meta of await this.host.store().listRuntimeCatalogMetas()) {
-        if (!this.host.catalog().entries[meta.runtimeId]) continue
+        const entry = this.host.catalog().entries[meta.runtimeId]
+        if (!entry || entry.aliasOf) continue
         await this.rebuildCatalog(meta.runtimeId)
         const cachedModels = (await this.host.store().listRuntimeModelCaps(meta.runtimeId)).map((r) => r.modelId)
         if (cachedModels.length > 0 && (this.models.get(meta.runtimeId) ?? []).length === 0) {
@@ -275,6 +284,7 @@ export class RuntimeFactsRegistry {
    *  plus daemon-side synthetic effort levels (Claude max/ultracode) so the
    *  console vocabulary always matches the live-session pickers. */
   async rebuildCatalog(id: string): Promise<void> {
+    id = this.canonicalId(id)
     const meta = await this.host.store().getRuntimeCatalogMeta(id)
     if (!meta) {
       this.catalogs.delete(id)
@@ -374,7 +384,7 @@ export class RuntimeFactsRegistry {
         ? {}
         : Object.fromEntries(
             Object.entries(catalog.entries)
-              .filter(([, entry]) => entry.source !== 'curated')
+              .filter(([, entry]) => !entry.aliasOf && entry.source !== 'curated')
               .map(([id, entry]) => [id, entry.runtime])
           )
     const probeCount = Object.keys(ordinaryRuntimes).length + Object.keys(curatedCandidates).length
@@ -539,6 +549,7 @@ export class RuntimeFactsRegistry {
   /** Fold one probe result into admission, advertised models/caps and the model
    *  catalog. Called per result so a slow runtime delays only itself. */
   private async applyProbeResult(r: RuntimeProbeResult): Promise<void> {
+    r = { ...r, runtime: this.canonicalId(r.runtime) }
     if (this.host.localProbeCatalog().entries[r.runtime]?.source === 'curated') this.host.curatedAdmission().record(r)
     this.host.refreshAdmitted()
     // Successful probes (including empty selectors) and auth failures are

--- a/packages/daemon/src/runtimes/k8s-runtimes.ts
+++ b/packages/daemon/src/runtimes/k8s-runtimes.ts
@@ -140,11 +140,13 @@ export function declaredRuntimeCatalog(catalog: ResolvedRuntimeCatalog, table: K
   const acp: Record<string, K8sRuntimeAcpSnapshot> = {}
 
   for (const declared of table.runtimes) {
-    const entry = catalog.entries[declared.id]
+    const id = catalog.entries[declared.id]?.aliasOf ?? declared.id
+    const entry = catalog.entries[id]
     if (!entry) {
       unresolved.push(declared.id)
       continue
     }
+    if (id !== declared.id && table.runtimes.some((runtime) => runtime.id === id)) continue
     const imageProbed = Boolean(declared.command && declared.acp)
     if (entry.source === 'curated' && !imageProbed) {
       rejectedCurated.push(declared.id)
@@ -161,15 +163,21 @@ export function declaredRuntimeCatalog(catalog: ResolvedRuntimeCatalog, table: K
       rejectedPackageLaunchers.push(declared.id)
       continue
     }
-    entries[declared.id] = {
+    entries[id] = {
       ...entry,
       runtime,
       ...(entry.source === 'curated' ? { source: 'image' as const } : {}),
       ...(declared.version ? { version: declared.version } : {})
     }
-    runtimes[declared.id] = runtime
-    if (declared.models?.length) models[declared.id] = [...declared.models]
-    if (declared.acp) acp[declared.id] = declared.acp
+    runtimes[id] = runtime
+    if (declared.models?.length) models[id] = [...declared.models]
+    if (declared.acp) acp[id] = declared.acp
+  }
+  for (const [id, entry] of Object.entries(catalog.entries)) {
+    const canonical = entry.aliasOf && entries[entry.aliasOf]
+    if (!canonical) continue
+    entries[id] = { ...canonical, aliasOf: entry.aliasOf }
+    runtimes[id] = canonical.runtime
   }
 
   return { catalog: { entries, runtimes }, unresolved, rejectedCurated, rejectedPackageLaunchers, models, acp }

--- a/packages/daemon/src/runtimes/registry.ts
+++ b/packages/daemon/src/runtimes/registry.ts
@@ -44,6 +44,7 @@ export interface ResolvedRuntimeEntry {
   source: RuntimeSource
   name: string
   version: string
+  aliasOf?: string
   /** Audited skills CLI identity; absent means this harness has not passed the
    * skill-discovery compatibility admission. */
   skillsAgentId: string | null
@@ -256,6 +257,11 @@ export async function resolveRuntimeCatalog(
   }
   for (const [id, runtime] of Object.entries(userRuntimes)) {
     entries[id] = resolvedRuntimeEntry(id, runtime, 'user', id, '')
+  }
+
+  // The registry's Qoder id names the same native CLI; explicit definitions remain independent.
+  if (!userRuntimes.qoder && !userRuntimes['qoder-cli']) {
+    entries.qoder = { ...entries['qoder-cli']!, aliasOf: 'qoder-cli' }
   }
 
   // The legacy explicit id is an operator override for the canonical automatic

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -247,9 +247,13 @@ describe('runChat', () => {
     ).rejects.toThrow(/multiple agents found.*--agent/s)
   })
 
-  it('synchronously admits a curated runtime before creating the real host', async () => {
-    const files = curatedScaffold('omp')
-    const probeRuntimes = vi.fn(async (_runtimes, options) => {
+  it.each(['omp', 'legacy'])('admits and launches %s through its canonical runtime', async (runtimeId) => {
+    const files = curatedScaffold(runtimeId)
+    const resolved = catalog('omp')
+    resolved.entries.legacy = { ...resolved.entries.omp!, aliasOf: 'omp' }
+    resolved.runtimes.legacy = resolved.runtimes.omp!
+    const probeRuntimes = vi.fn(async (runtimes, options) => {
+      expect(Object.keys(runtimes)).toEqual(['omp'])
       expect(options.curated).toBe(true)
       return [{ runtime: 'omp', ok: true, models: [] }]
     })
@@ -263,7 +267,7 @@ describe('runChat', () => {
       ...files,
       message: 'hi',
       out: capture().stream,
-      resolveCatalog: async () => catalog('omp'),
+      resolveCatalog: async () => resolved,
       installed: (runtimes) => runtimes,
       probeRuntimes,
       hostFactory

--- a/packages/daemon/test/k8s-runtimes.test.ts
+++ b/packages/daemon/test/k8s-runtimes.test.ts
@@ -86,6 +86,37 @@ describe('k8s runtime table', () => {
 })
 
 describe('declaredRuntimeCatalog', () => {
+  it.each([{ ids: ['native'] }, { ids: ['legacy'] }, { ids: ['legacy', 'native'] }])(
+    'shares image facts when it declares $ids',
+    ({ ids }) => {
+      const native = {
+        runtime: { command: 'native', args: [], env: [] },
+        source: 'curated' as const,
+        name: 'Native',
+        version: '',
+        skillsAgentId: null
+      }
+      const resolved = {
+        entries: { native, legacy: { ...native, aliasOf: 'native' } },
+        runtimes: { native: native.runtime, legacy: native.runtime }
+      }
+      const result = declaredRuntimeCatalog(resolved, {
+        runtimes: ids.map((id) => ({
+          id,
+          command: '/opt/runtime/bin/native',
+          version: '1.0',
+          models: ['m1'],
+          acp: { protocolVersion: 1 }
+        }))
+      })
+
+      expect(result.catalog.entries.legacy).toEqual({ ...result.catalog.entries.native, aliasOf: 'native' })
+      expect(result.catalog.runtimes.legacy).toBe(result.catalog.runtimes.native)
+      expect(result.models).toEqual({ native: ['m1'] })
+      expect(result.unresolved).toEqual([])
+    }
+  )
+
   it('keeps only declared runtimes and reports the image pin as their version', () => {
     const result = declaredRuntimeCatalog(catalog(), {
       runtimes: [{ id: 'claude', version: '9.9.9', models: ['sonnet', 'opus'] }]

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -497,6 +497,78 @@ describe('daemon last-good advertisement fallback', () => {
 })
 
 describe('daemon auth-required probe fold', () => {
+  it.each(['srt', 'microsandbox'])(
+    'shares one probe and live login state across compatibility ids under %s',
+    async (backend) => {
+      const dir = root()
+      const clock = new FakeClock()
+      clock.advance(10_000)
+      let catalog = catalogOf({})
+      const probe = vi.fn(async (runtimes: Record<string, RuntimeDef>): Promise<RuntimeProbeResult[]> =>
+        Object.keys(runtimes).map((runtime) => ({
+          runtime,
+          ok: true,
+          models: ['m1'],
+          probedVersion: 'host-v1',
+          acpProtocolVersion: 1,
+          mcpCapabilities: { http: true, sse: false }
+        }))
+      )
+      const daemon = new Daemon({
+        root: dir,
+        clock,
+        resolveCatalog: async () => catalog,
+        installed: (r) => r,
+        probeRuntimes: probe,
+        hostFactory: () => ({}) as never,
+        sandboxMechanism: null
+      })
+      try {
+        await daemon.start()
+        catalog = catalogOf({ native: FAKE_RT, legacy: FAKE_RT })
+        catalog.entries.native!.source = 'curated'
+        catalog.entries.legacy = { ...catalog.entries.native!, aliasOf: 'native' }
+        const d = daemon as any
+        d.cfg.sandbox.backend = backend
+        if (backend === 'microsandbox')
+          d.microsandboxTable = {
+            runtimes: [{ id: 'legacy', command: '/image/bin/native', version: 'image-v2', acp: { protocolVersion: 1 } }]
+          }
+        await d.discoverRuntimes(dir, d.cfg, [])
+        stubCatalogSvc(daemon)
+        captureEmits(daemon)
+        await d.runtimeFacts.probeAndEmit(true)
+
+        expect(probe).toHaveBeenCalledTimes(1)
+        expect(Object.keys(probe.mock.calls[0]![0])).toEqual(['native'])
+        expect(d.admittedRuntimeIds()).toEqual(expect.arrayContaining(['native', 'legacy']))
+        expect(d.runtimeFacts.profileFor('legacy')).toEqual({
+          ...d.runtimeFacts.profileFor('native'),
+          runtime: 'legacy',
+          aliasOf: 'native'
+        })
+        expect(d.runtimeFacts.profileFor('native')).toMatchObject({
+          hostAvailable: true,
+          hostVersion: 'host-v1',
+          version: backend === 'microsandbox' ? 'image-v2' : 'host-v1',
+          models: ['m1']
+        })
+        expect(d.runtimeFacts.offeredModels('legacy')).toEqual(['m1'])
+        expect(d.runtimeFacts.mcpCapabilities('legacy')).toEqual({ http: true, sse: false })
+        d.runtimeFacts.noteAuthFromTurn('legacy', true)
+        expect(d.runtimeFacts.profileFor('native').authRequired).toBe(true)
+        expect(d.runtimeFacts.profileFor('legacy').authRequired).toBe(true)
+        d.runtimeFacts.noteAuthFromTurn('native', false)
+        expect(d.runtimeFacts.profileFor('legacy').authRequired).toBeUndefined()
+        await d.runtimeFacts.applySandboxProbe({ runtime: 'legacy', ok: true, models: ['m2'] })
+        expect(d.runtimeFacts.offeredModels('native')).toEqual(['m2'])
+        expect(d.runtimeFacts.offeredModels('legacy')).toEqual(['m2'])
+      } finally {
+        await daemon.stop()
+      }
+    }
+  )
+
   it('flags authRequired in the snapshot on an auth-rejected probe and clears it once a probe succeeds', async () => {
     const dir = root()
     await seedCache(dir, [{ runtimeId: 'fake', models: [{ id: 'm-cached', caps: {} }] }])

--- a/packages/daemon/test/registry.test.ts
+++ b/packages/daemon/test/registry.test.ts
@@ -239,6 +239,35 @@ describe('resolveRuntimes', () => {
 })
 
 describe('curated native ACP runtimes', () => {
+  it('resolves the registry Qoder id to the installed native runtime identity', async () => {
+    const registry = {
+      agents: [
+        {
+          id: 'qoder',
+          name: 'Qoder CLI',
+          version: '0.2.14',
+          distribution: { npx: { package: '@qoder-ai/qodercli@0.2.14', args: ['--acp'] } }
+        }
+      ]
+    }
+    const fetchImpl = (async () => new Response(JSON.stringify(registry))) as typeof fetch
+    const catalog = await resolveRuntimeCatalog({} as any, tmpRoot(), { fetchImpl })
+
+    expect(catalog.entries.qoder).toEqual({ ...catalog.entries['qoder-cli'], aliasOf: 'qoder-cli' })
+    expect(catalog.runtimes.qoder).toBe(catalog.runtimes['qoder-cli'])
+    expect(catalog.runtimes.qoder!.command).toBe('qodercli')
+  })
+
+  it.each(['qoder', 'qoder-cli'])('keeps an explicit %s definition independent', async (id) => {
+    const runtime = { command: 'custom-runtime', args: [], env: [] }
+    const fetchImpl = (async () => new Response(JSON.stringify({ agents: [] }))) as typeof fetch
+    const catalog = await resolveRuntimeCatalog({ runtimes: { [id]: runtime } } as any, tmpRoot(), { fetchImpl })
+
+    expect(catalog.entries[id]).toMatchObject({ source: 'user', runtime })
+    expect(catalog.entries[id]?.aliasOf).toBeUndefined()
+    expect(catalog.entries.qoder?.aliasOf).toBeUndefined()
+  })
+
   it('declares the ten reviewed native ACP commands', () => {
     expect(CURATED_RUNTIME_CATALOG).toEqual({
       'hermes-agent': {

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -305,6 +305,8 @@ export type RuntimeModelCatalog = z.infer<typeof RuntimeModelCatalog>
 
 export const FactsRuntimeProfile = z.object({
   runtime: z.string(), // "claude" / "codex" / ...
+  // A compatibility id shares its canonical runtime's installation, probes, and login state.
+  aliasOf: z.string().optional(),
   version: z.string(),
   // The host probe's version, kept separate from a sandbox image's runtime version.
   hostVersion: z.string().optional(),

--- a/packages/web/src/components/console/FleetDetail.test.ts
+++ b/packages/web/src/components/console/FleetDetail.test.ts
@@ -2,7 +2,7 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import { FleetRuntimesCard, intersectRuntimes, unionRuntimes } from './FleetDetail'
-import type { DaemonRow } from '@/lib/data'
+import { selectableRuntimeIds, type DaemonRow, type Agent } from '@/lib/data'
 
 vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
 vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
@@ -32,6 +32,30 @@ const member = (over: Partial<DaemonRow['runtimeModels'][number]> = {}): DaemonR
   }) as unknown as DaemonRow
 
 describe('runtime aggregation carries model display metadata', () => {
+  it('shows a reported alias once, counts its agents, and preserves a configured alias in the picker', () => {
+    const daemon = member({ runtime: 'native', models: [], modelCatalog: null })
+    daemon.runtimeModels.push({ ...daemon.runtimeModels[0]!, runtime: 'legacy', aliasOf: 'native' })
+    expect(selectableRuntimeIds(daemon)).toEqual(['native'])
+    expect(selectableRuntimeIds(daemon, 'legacy')).toEqual(['legacy'])
+    for (const aggregate of [unionRuntimes, intersectRuntimes]) {
+      const runtimes = aggregate([daemon])
+      expect(runtimes).toHaveLength(1)
+      expect(runtimes[0]).toMatchObject({ runtime: 'native', aliases: ['legacy'] })
+      const html = renderToStaticMarkup(
+        createElement(FleetRuntimesCard, {
+          title: 'Runtimes',
+          runtimes,
+          agents: [{ runtime: 'legacy' } as Agent],
+          empty: 'None'
+        })
+      )
+      expect(html).toContain('1 agent')
+    }
+    delete daemon.runtimeModels[1]!.aliasOf
+    expect(unionRuntimes([daemon])).toHaveLength(2)
+    expect(selectableRuntimeIds(daemon)).toEqual(['native', 'legacy'])
+  })
+
   it('unions the catalog names and blurbs alongside the ids', () => {
     const [rt] = unionRuntimes([member()])
     expect(rt!.models).toEqual(['opus[1m]', 'haiku'])

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -44,6 +44,7 @@ export function barColor(pct: number): string {
 /** A runtime as a whole SET offers it, aggregated over its serving members. */
 export interface FleetRuntime {
   runtime: string
+  aliases?: string[]
   version: string
   /** Members disagree on the version, so there is no single one to quote. */
   versionsDiffer?: boolean
@@ -108,11 +109,12 @@ export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
   const described = new Map<string, Array<Record<string, { name?: string; description?: string }>>>()
   for (const m of members) {
     for (const rt of m.runtimeModels) {
-      described.set(rt.runtime, [...(described.get(rt.runtime) ?? []), modelInfoOf(rt)])
-      const prev = byId.get(rt.runtime)
+      const id = rt.aliasOf ?? rt.runtime
+      described.set(id, [...(described.get(id) ?? []), modelInfoOf(rt)])
+      const prev = byId.get(id)
       if (!prev) {
-        byId.set(rt.runtime, {
-          runtime: rt.runtime,
+        byId.set(id, {
+          runtime: id,
           version: rt.version,
           models: [...rt.models],
           authRequired: rt.authRequired === true,
@@ -126,8 +128,18 @@ export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
       prev.unavailableReason ??= rt.unavailableReason
     }
   }
-  for (const rt of byId.values()) rt.modelInfo = consensusModelInfo(described.get(rt.runtime) ?? [])
+  for (const rt of byId.values()) {
+    rt.modelInfo = consensusModelInfo(described.get(rt.runtime) ?? [])
+    const aliases = runtimeAliases(members, rt.runtime)
+    if (aliases.length) rt.aliases = aliases
+  }
   return [...byId.values()]
+}
+
+function runtimeAliases(members: readonly DaemonRow[], id: string): string[] {
+  return [
+    ...new Set(members.flatMap((member) => member.runtimeModels.filter((r) => r.aliasOf === id).map((r) => r.runtime)))
+  ]
 }
 
 /**
@@ -146,13 +158,16 @@ export function intersectRuntimes(members: readonly DaemonRow[]): FleetRuntime[]
   if (!first) return []
   const out: FleetRuntime[] = []
   for (const rt of first.runtimeModels) {
+    if (rt.aliasOf) continue
     const peers = rest.map((m) => m.runtimeModels.find((other) => other.runtime === rt.runtime))
     // One member without it is enough to make it unavailable to the group.
     if (peers.some((peer) => peer === undefined)) continue
     const all = [rt, ...peers.filter((peer) => peer !== undefined)]
     const versions = new Set(all.map((peer) => peer.version).filter(Boolean))
+    const aliases = runtimeAliases(members, rt.runtime)
     out.push({
       runtime: rt.runtime,
+      ...(aliases.length ? { aliases } : {}),
       version: versions.size === 1 ? [...versions][0]! : '',
       versionsDiffer: versions.size > 1,
       models: rt.models.filter((model) => all.every((peer) => peer.models.includes(model))),
@@ -433,7 +448,9 @@ export function FleetRuntimesCard({
             const label = runtimeLabel(rt.runtime, meta?.name)
             // Id namespaces differ across daemon generations ('claude' vs 'claude-acp'),
             // so agents match on the display family rather than the raw id.
-            const users = agents.filter((a) => a.runtime === rt.runtime || runtimeLabel(a.runtime) === label)
+            const users = agents.filter(
+              (a) => a.runtime === rt.runtime || rt.aliases?.includes(a.runtime) || runtimeLabel(a.runtime) === label
+            )
             const usage = users.length > 0 ? `${users.length} agent${users.length === 1 ? '' : 's'}` : 'no agents'
             const version = rt.versionsDiffer ? 'mixed' : rt.version ? `v${rt.version.replace(/^v/, '')}` : null
             const hasModels = rt.models.length > 0

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -332,7 +332,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     sandboxRequired
   })
   // A selected daemon's reported profiles are authoritative, including an empty list.
-  const runtimeIds = daemon ? selectableRuntimeIds(daemon) : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon ? selectableRuntimeIds(daemon, runtime) : FALLBACK_RUNTIME_IDS
   // Runtimes the daemon reports as logged out. Marked in the picker, never blocked —
   // creating on one is a supported state (docs/designs/preset-agents.md §3.2).
   const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -14,6 +14,7 @@ import {
   groupPlacementValue,
   imageBinaryMissingRuntimeIds,
   loginRequiredRuntimeIds,
+  selectableRuntimeIds,
   agentSlugFinalize,
   agentSlugSanitize,
   effortChoicesFor,
@@ -331,7 +332,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     sandboxRequired
   })
   // A selected daemon's reported profiles are authoritative, including an empty list.
-  const runtimeIds = daemon ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon ? selectableRuntimeIds(daemon) : FALLBACK_RUNTIME_IDS
   // Runtimes the daemon reports as logged out. Marked in the picker, never blocked —
   // creating on one is a supported state (docs/designs/preset-agents.md §3.2).
   const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -8,6 +8,7 @@ import {
   FALLBACK_RUNTIME_IDS,
   imageBinaryMissingRuntimeIds,
   loginRequiredRuntimeIds,
+  selectableRuntimeIds,
   fastModeAvailableFor,
   modelCapability,
   modelOptionsFor,
@@ -470,7 +471,7 @@ export default function EditAgentModal({
   const sourceBlocksSafeMove = daemonChanged && sourceUnavailable && !forceMove
 
   // Preserve the configured runtime while keeping the selected daemon's reported choices authoritative.
-  const reportedRuntimeIds = daemon?.runtimeModels.map((r) => r.runtime) ?? []
+  const reportedRuntimeIds = daemon ? selectableRuntimeIds(daemon, runtime) : []
   const runtimeIds = daemon ? reportedRuntimeIds : FALLBACK_RUNTIME_IDS
   const runtimeOptions = runtime && !runtimeIds.includes(runtime) ? [runtime, ...runtimeIds] : runtimeIds
   // Runtimes the daemon reports as logged out — marked in the picker, never blocked.

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -20,7 +20,8 @@ import {
   poolLabel,
   preferredModelFor,
   imageBinaryMissingRuntimeIds,
-  loginRequiredRuntimeIds
+  loginRequiredRuntimeIds,
+  selectableRuntimeIds
 } from '@/lib/data'
 import type { DaemonRow } from '@/lib/data'
 import type { AgentPlacementTarget, DaemonConnectDto } from '@/lib/api'
@@ -487,7 +488,7 @@ function WhereStep({
 // daemon's reported profiles (else the static fallback), models from the chosen
 // runtime's profile.
 function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model?: string }) {
-  const runtimeIds = daemon ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon ? selectableRuntimeIds(daemon) : FALLBACK_RUNTIME_IDS
   // Logged-out runtimes are marked, not blocked; the default just prefers a signed-in one.
   const runtimesNeedingLogin = daemon ? loginRequiredRuntimeIds(daemon) : []
   const runtimesMissingImageBinary = imageBinaryMissingRuntimeIds(daemon)

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -488,7 +488,9 @@ function WhereStep({
 // daemon's reported profiles (else the static fallback), models from the chosen
 // runtime's profile.
 function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model?: string }) {
-  const runtimeIds = daemon ? selectableRuntimeIds(daemon) : FALLBACK_RUNTIME_IDS
+  // Preserve an existing preset's runtime and any explicit selection across daemon changes.
+  const [runtime, setRuntime] = useState(initial?.runtime ?? '')
+  const runtimeIds = daemon ? selectableRuntimeIds(daemon, runtime) : FALLBACK_RUNTIME_IDS
   // Logged-out runtimes are marked, not blocked; the default just prefers a signed-in one.
   const runtimesNeedingLogin = daemon ? loginRequiredRuntimeIds(daemon) : []
   const runtimesMissingImageBinary = imageBinaryMissingRuntimeIds(daemon)
@@ -496,8 +498,6 @@ function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model
     runtimeIds.find((id) => !runtimesNeedingLogin.includes(id) && !runtimesMissingImageBinary.includes(id)) ??
     runtimeIds[0] ??
     ''
-  // Seeded from the agent's current config (a pool-born preset has one); '' = untouched.
-  const [runtime, setRuntime] = useState(initial?.runtime ?? '')
   const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
   const models = daemon?.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState(initial?.model ?? '')

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1044,6 +1044,7 @@ export interface RuntimeModelCatalogDto {
 // is the list the console offers per (machine, runtime) in the create-agent picker.
 export interface RuntimeProfileDto {
   runtime: string
+  aliasOf?: string | null
   version: string
   models: string[]
   contextWindow: number | null
@@ -2176,6 +2177,7 @@ export function withDaemonCapability(row: DaemonRow, cap: DaemonCapabilityDto | 
     caps: cap.capabilities,
     runtimeModels: cap.runtimeProfiles.map((p) => ({
       runtime: p.runtime,
+      aliasOf: p.aliasOf ?? null,
       version: p.version,
       hostVersion: p.hostVersion ?? null,
       hostAvailable: p.hostAvailable ?? null,
@@ -2227,6 +2229,7 @@ export function daemonFromDto(
     // Per-runtime available models, observed from the daemon's runtime profiles.
     runtimeModels: (d.runtimeProfiles ?? []).map((p) => ({
       runtime: p.runtime,
+      aliasOf: p.aliasOf ?? null,
       version: p.version,
       hostVersion: p.hostVersion ?? null,
       hostAvailable: p.hostAvailable ?? null,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -869,17 +869,16 @@ export function preferredModelFor(daemon: Pick<DaemonRow, 'runtimeModels'> | und
   return dflt && models.includes(dflt) ? dflt : models[0]!
 }
 
-/** Runtime ids the daemon reports as needing a login on its host — its probe (or a
- *  live turn) was rejected with the ACP auth-required error.
- *
- *  This is NOT a launchability signal, and must not be used to gate a choice. The flag
- *  covers two states the facts snapshot cannot tell apart: a curated candidate whose
- *  probe never succeeded (unadmitted), and an admitted, perfectly launchable runtime
- *  whose last live turn happened to be rejected for login. Placement is deliberately
- *  independent of readiness either way — `docs/designs/preset-agents.md` §3.2 makes an
- *  agent on a logged-out runtime an ordinary supported state, and creation/placement
- *  never gate on it. So the pickers MARK these and prefer a signed-in default; they do
- *  not disable them. */
+/** Show each runtime once, preserving an existing agent's selected compatibility id. */
+export function selectableRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'>, selected?: string): string[] {
+  const profiles = daemon.runtimeModels
+  const canonicalSelected = profiles.find((profile) => profile.runtime === selected)?.aliasOf
+  return profiles
+    .filter((profile) => profile.runtime === selected || (!profile.aliasOf && profile.runtime !== canonicalSelected))
+    .map((profile) => profile.runtime)
+}
+
+/** Login warnings mark choices without preventing creation or placement on a logged-out runtime. */
 export function loginRequiredRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'> | undefined): string[] {
   return (daemon?.runtimeModels ?? []).filter((r) => r.authRequired).map((r) => r.runtime)
 }
@@ -2237,6 +2236,7 @@ export interface DaemonRow {
    *  null ⇒ not probed (older daemon) ⇒ assume stdio-only. */
   runtimeModels: {
     runtime: string
+    aliasOf?: string | null
     version: string
     models: string[]
     acpProtocolVersion?: number | null


### PR DESCRIPTION
The ACP registry's `qoder` ID and the native `qoder-cli` ID could advertise the same executable twice with different installation and login state. Resolve the automatic registry ID to the native definition and share its probe, admission, model catalog, and launch policy across host and sandbox execution. Explicit runtime overrides remain independent.

Keep both IDs usable by existing agent configurations. An optional `aliasOf` profile field, persisted by an additive database migration, lets runtime cards and creation pickers show one entry while edit forms preserve a configured compatibility ID. Images declaring either or both IDs remain supported.

Validation: focused daemon discovery, image projection, probe, CLI launch, and model-state tests; Console aggregation and runtime-state tests; PostgreSQL runtime-profile and daemon API integration tests; typechecks for protocol, daemon, Control Plane, and Web; lint and formatting.

Created by Codex . GPT-6
