### PR TITLE
chore(deps): group all GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,6 @@ updates:
       prefix: chore
       include: scope
     groups:
-      actions-minor-and-patch:
+      github-actions:
         patterns:
           - '*'
-        update-types:
-          - minor
-          - patch


### PR DESCRIPTION
Major GitHub Actions updates such as actions/checkout and actions/setup-node currently open separate Dependabot PRs because the group accepts only minor and patch updates. Remove that filter and rename the group to github-actions so all Actions version updates can share one PR.

Validation: Dependabot JSON Schema validation, duplicate-key checking, Prettier, and git diff --check passed. The new grouping takes effect after this configuration reaches the default branch and Dependabot runs again.

Created by Codex . GPT-6
