### PR TITLE
fix(daemon): pin microsandbox images per session

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -343,6 +343,21 @@ USER 10001:10001
 # the runtime only after the channel is bound.
 ENTRYPOINT ["/usr/bin/tini", "--", "node", "/opt/agentconnect/shim/index.js"]
 
+# Codex needs --argv0 to re-enter its sandbox while its credential directory stays hidden.
+FROM node:24-bookworm-slim AS bubblewrap-builder
+ARG BUBBLEWRAP_VERSION=0.11.2
+ARG BUBBLEWRAP_SHA256=69abc30005d2186baf7737feacd8da35633b93cf5af38838ecff17c5f8e924f6
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y ca-certificates curl gcc libc6-dev meson pkg-config libcap-dev xz-utils \
+  && curl -fsSL --retry 5 "https://github.com/containers/bubblewrap/releases/download/v${BUBBLEWRAP_VERSION}/bubblewrap-${BUBBLEWRAP_VERSION}.tar.xz" -o /tmp/bubblewrap.tar.xz \
+  && printf '%s  %s\n' "${BUBBLEWRAP_SHA256}" /tmp/bubblewrap.tar.xz | sha256sum --check --strict \
+  && mkdir /src \
+  && tar -xJf /tmp/bubblewrap.tar.xz -C /src --strip-components=1 \
+  && meson setup /build /src --prefix=/usr/local -Dman=disabled -Dtests=false \
+    -Dselinux=disabled -Dbash_completion=disabled -Dzsh_completion=disabled -Dsupport_setuid=false \
+  && meson compile -C /build \
+  && DESTDIR=/out meson install -C /build
+
 # Self-hosted daemon VMs add the broader runtime catalog, native shields and Docker.
 FROM runtime-base AS runtime-sandbox-full
 USER root
@@ -360,8 +375,10 @@ ARG CONTAINERD_VERSION=2.3.5-1~debian.12~bookworm
 ARG DOCKER_BUILDX_VERSION=0.37.0-1~debian.12~bookworm
 ARG DOCKER_COMPOSE_VERSION=5.5.1-1~debian.12~bookworm
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y bubblewrap socat ripgrep \
+  && apt-get install --no-install-recommends -y libcap2 socat ripgrep \
   && rm -rf /var/lib/apt/lists/*
+COPY --from=bubblewrap-builder --chown=0:0 /out/usr/local/bin/bwrap /usr/local/bin/bwrap
+RUN bwrap --help | rg -- '--argv0'
 
 # pi-acp delegates to the separately installed pi CLI; all launches use local executables.
 RUN export HOME=/root \

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -162,10 +162,13 @@ missing or changed bindings and configuration rather than silently recreating th
 VM. Each new session owns a VM using the image configured at creation, including
 sessions that share workspace files. Its private HOME lives under
 `runtime-homes/<session-leaf>/home` unless it already owns a confined session
-directory. Image changes apply to new sessions; resume keeps the original image,
-runtime versions, HOME and disks until session retention removes them. Sessions
-created in a legacy shared agent VM continue using that VM until its last session
-retires. Resource and mount changes still require environment recreation. Image
+directory. For shared workspaces, native-memory directories mount the agent's
+existing memory store so Console reads and edits reach every session; runtime
+credentials stay in the session's HOME. Image changes apply to new sessions;
+resume keeps the original image, runtime versions, HOME and disks until session
+retention removes them. Sessions created in a legacy shared agent VM continue
+using that VM until its last session retires. Resource and mount changes still
+require environment recreation. Image
 digest resolution and in-place disk migration remain proposed.
 
 Kubernetes mode retains `K8sDriver`, its resource configuration, and image rollout.

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -159,10 +159,14 @@ Podman/runsc with systrap remains a future no-KVM option, not a hidden fallback.
 The manager persists each environment ID, sandbox ID, requested image/resources/
 mount specification, and a hash of the SDK's saved configuration. Reuse rejects
 missing or changed bindings and configuration rather than silently recreating the
-VM. A retained VM keeps its original configuration. Restarting the daemon does
-not upgrade it or migrate its disk; configuration changes require an explicit
-retirement/recreation or a future data-migration operation. Image digest
-resolution and upgrade tooling remain proposed.
+VM. Each new session owns a VM using the image configured at creation, including
+sessions that share workspace files. Its private HOME lives under
+`runtime-homes/<session-leaf>/home` unless it already owns a confined session
+directory. Image changes apply to new sessions; resume keeps the original image,
+runtime versions, HOME and disks until session retention removes them. Sessions
+created in a legacy shared agent VM continue using that VM until its last session
+retires. Resource and mount changes still require environment recreation. Image
+digest resolution and in-place disk migration remain proposed.
 
 Kubernetes mode retains `K8sDriver`, its resource configuration, and image rollout.
 An explicitly configured local microsandbox backend
@@ -270,9 +274,9 @@ publication. A Python process bridges MCP and Git credential sockets over vsock;
 the image's Kubernetes
 entrypoint and control connection are not started.
 
-VM identity follows workspace placement. Shared mode reuses the agent's
-`agent/agent` environment. An isolated session uses its own `agent/session-…`
-environment, writable runtime HOME, disk, and guest network namespace. Existing
+New sessions use their own `agent/session-…` environment, writable runtime HOME,
+disk, and guest network namespace. Retained legacy sessions and canonical
+workspace preparation continue using the `agent/agent` environment. Existing
 shared-workspace versus session-workspace choices still govern repository data;
 separate VMs do not make a deliberately shared host mount private. Linked-worktree
 Git metadata, secondary repositories, and file attachments keep consistent guest
@@ -369,12 +373,13 @@ AVX in the guest CPU; amd64 emulation without AVX cannot run that runtime.
 
 An explicit daemon image overrides this metadata. Development builds remove
 release metadata and require an explicit image; they do not derive a default
-from the development package version. Upgrading to a different default image
-reference remains a configuration change under the persisted-VM checks above.
-Pin an explicit image to retain the same reference across daemon upgrades.
+from the development package version. Release defaults and explicit image
+overrides select the image for newly created VMs. Retained VMs continue using
+their recorded image.
 
-The full image contains `bubblewrap` and `socat` for native Claude credential
-shields, plus pinned Docker Engine, CLI, containerd, Buildx, and Compose packages.
+The full image contains `bubblewrap` and `socat` for native credential shields;
+bubblewrap supports `--argv0` so Codex can start while its state directory is
+hidden. It also includes pinned Docker Engine, CLI, containerd, Buildx, and Compose packages.
 The pool image does not include those tools or the Docker sudo grant.
 The full image's ordinary container user and shim entrypoint remain in
 place. Image construction installs and verifies the tools; it does not start

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3777,6 +3777,7 @@ export class Daemon {
     const launch = prepareMicrosandboxLaunch({
       runtimeId: runtimeEntry?.aliasOf ?? agent.runtime,
       runtime,
+      nativeMemory: memoryKindOf(agent) === 'native',
       scopeDir: agent.dir,
       cwd: placement.trustedSessionDir ?? (key && hostKeySessionKey(key) ? cwd : agent.workspace.path),
       hostKey: key,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2483,6 +2483,7 @@ export class Daemon {
   /** Phase 16 — the local (or data-plane) store plus the one rule table every row retention runs from. */
   private async openStoreAndRetention(root: string): Promise<void> {
     this.store = this.dataPlane?.store ?? (await LocalStore.open(statePath(root)))
+    await this.hydrateMicrosandboxSessions()
     this.store.setTranscriptMutationListener((mutation) => this.scheduleSessionActivity(mutation))
     // Every table's row retention, from one rule table. This member owns the cache rows it
     // stamped, so a peer's are reclaimed on the shorter window; no control-plane read here.
@@ -3902,6 +3903,24 @@ export class Daemon {
   // What each session's row says its isolation is, as the requests that reached this member reported it — the one fact host keying needs without a store round trip.
   private readonly sessionIsolation = new Map<string, 'shared' | 'session'>()
 
+  // Sessions created before VM ownership became per-session still resume in their original shared VM.
+  private readonly legacyMicrosandboxSessions = new Set<HostKey>()
+
+  private async hydrateMicrosandboxSessions(): Promise<void> {
+    this.legacyMicrosandboxSessions.clear()
+    if (!this.microsandbox) return
+    const environments = new Set(await this.microsandbox.environmentIds())
+    for (const session of await this.store.listSessions()) {
+      const key = sessionHostKey(session.agentId, session.key)
+      if (
+        environments.has(`${session.agentId}/agent`) &&
+        !environments.has(`${session.agentId}/${hostKeyDirName(key)}`)
+      ) {
+        this.legacyMicrosandboxSessions.add(key)
+      }
+    }
+  }
+
   /**
    * git-workspace-model §11: whether one logical session is served on the CONFINED tier — its own
    * clones, its own ACP host (its own pod on a pool member), its own private HOME. The single rule
@@ -3915,7 +3934,7 @@ export class Daemon {
    */
   private confinedSession(agent: Agent, sessionKey?: string): boolean {
     if (sessionKey === undefined) return false
-    // A shared session has no tier of its own at all: no host, no pod, no HOME, no directory.
+    // Workspace isolation is independent of whether the runtime owns a VM.
     if (!this.sessionIsolated(agent, sessionKey)) return false
     return this.workspaces.confinedSessionTier(agent, sessionKey, this.k8s || this.agentRunsInSandbox(agent))
   }
@@ -3938,11 +3957,14 @@ export class Daemon {
     return effectiveSessionIsolation(agent) === 'session'
   }
 
-  /** The host that serves `sessionKey` of this agent: its own when the session is confined, else the shared one. */
+  // Microsandbox sessions own their runtime even when they share workspace files.
   private hostKeyFor(agentId: string, sessionKey?: string): HostKey {
     const agent = this.agents.get(agentId)
-    return sessionKey !== undefined && agent && this.confinedSession(agent, sessionKey)
-      ? sessionHostKey(agentId, sessionKey)
+    if (sessionKey === undefined || !agent) return agentHostKey(agentId)
+    const key = sessionHostKey(agentId, sessionKey)
+    return this.confinedSession(agent, sessionKey) ||
+      (this.usesMicrosandbox(agent) && !this.legacyMicrosandboxSessions.has(key))
+      ? key
       : agentHostKey(agentId)
   }
 
@@ -5607,7 +5629,9 @@ export class Daemon {
     } catch (error) {
       await this.microsandbox
         ?.discard(`${agent.id}/${hostKeyDirName(dreamHostKey)}`)
-        .then(() => rm(join(agent.dir, 'sessions', hostKeyDirName(dreamHostKey)), { recursive: true, force: true }))
+        .then(() =>
+          rm(join(agent.dir, 'runtime-homes', hostKeyDirName(dreamHostKey)), { recursive: true, force: true })
+        )
         .catch((error: unknown) => {
           this.log.warn(`microsandbox: could not discard extraction VM (${formatErr(error)})`)
         })
@@ -5625,7 +5649,9 @@ export class Daemon {
       await host.stop().catch(() => {})
       await this.microsandbox
         ?.discard(`${agent.id}/${hostKeyDirName(dreamHostKey)}`)
-        .then(() => rm(join(agent.dir, 'sessions', hostKeyDirName(dreamHostKey)), { recursive: true, force: true }))
+        .then(() =>
+          rm(join(agent.dir, 'runtime-homes', hostKeyDirName(dreamHostKey)), { recursive: true, force: true })
+        )
         .catch((error: unknown) => {
           this.log.warn(`microsandbox: could not discard extraction VM (${formatErr(error)})`)
         })
@@ -16431,6 +16457,7 @@ export class Daemon {
           this.memoryWriteGrants.delete(rec.key)
           if (rec.acpSessionId)
             this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
+          this.legacyMicrosandboxSessions.delete(sessionHostKey(rec.agentId, rec.key))
           await this.modelSessions.release(rec.key)
           if (!this.microsandbox) {
             await this.stopSessionHost(rec.agentId, rec.key, { ...sessionHost, row: rec })
@@ -16931,12 +16958,24 @@ export class Daemon {
     }
   }
 
-  /** Cluster only: a retired session's pod goes with its row — the claim, and the clones and HOME on its volume (§11). Best effort like the agent's; the orphan reconciler collects a leftover. */
+  // Retire a session's VM and HOME with its row; a legacy shared VM lives until its last session retires.
   private async discardSessionSandbox(agentId: string, sessionKey: string): Promise<void> {
-    await this.microsandbox?.discard(`${agentId}/${hostKeyDirName(sessionHostKey(agentId, sessionKey))}`)
+    const key = sessionHostKey(agentId, sessionKey)
+    const leaf = hostKeyDirName(key)
+    if (this.microsandbox) {
+      if (this.legacyMicrosandboxSessions.has(key)) {
+        if ([...this.legacyMicrosandboxSessions].some((other) => other !== key && hostKeyAgentId(other) === agentId))
+          return
+        await this.stopHostByKey(agentHostKey(agentId))
+        await this.microsandbox.discard(`${agentId}/agent`)
+      } else {
+        await this.microsandbox.discard(`${agentId}/${leaf}`)
+        const agent = this.agents.get(agentId)
+        if (agent) await rm(join(agent.dir, 'runtime-homes', leaf), { recursive: true, force: true })
+      }
+    }
     const plane = this.k8sPlane
     if (!plane) return
-    const leaf = hostKeyDirName(sessionHostKey(agentId, sessionKey))
     try {
       await plane.discardSession(agentId, leaf)
     } catch (err) {

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -194,7 +194,7 @@ export function composeRuntimeLaunch(opts: {
       ? runtimeSandboxReadRoots(opts.runtime, stateSourceEnv)
       : undefined
   const launch = prepareRuntimeLaunch({
-    ...(opts.microsandbox ? { microsandbox: opts.microsandbox } : {}),
+    ...(opts.microsandbox ? { microsandbox: { ...opts.microsandbox, nativeMemory: opts.provider === 'native' } } : {}),
     ...(opts.k8s === true ? { k8s: true } : {}),
     runtimeId: opts.runtimeId,
     runtime: opts.runtime,

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -215,6 +215,7 @@ export function prepareRuntimeLaunch(opts: {
   hostPackageCache?: boolean
   microsandbox?: {
     mounts: SandboxMount[]
+    nativeMemory?: boolean
     trustedSessionDir?: string
     trustedMounts?: SandboxMount[]
   }

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, readdir, realpath, rename, rm, writeFile } from 'node:
 import { dirname, join, posix } from 'node:path'
 import { promisify } from 'node:util'
 import type { Sandbox, SandboxHandle } from 'microsandbox'
+import { z } from 'zod'
 import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-driver.js'
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
@@ -78,6 +79,8 @@ interface Binding {
   environmentId: string
   dockerVolume?: string
 }
+
+const SpecImageSchema = z.object({ config: z.object({ image: z.string().min(1) }) })
 
 /** Owns VM lifecycle while exposing the existing ACP process-stream contract. */
 export class MicrosandboxManager {
@@ -206,10 +209,10 @@ export class MicrosandboxManager {
     return join(this.options.root, 'microsandbox', 'bindings', `${this.name(id)}.json`)
   }
 
-  private spec(environment: MicrosandboxEnvironment): string {
+  private spec(environment: MicrosandboxEnvironment, image = this.options.config.image): string {
     return stableJson({
       version: 2,
-      config: this.options.config,
+      config: { ...this.options.config, image },
       environment: { ...environment, mounts: [...environment.mounts].sort((a, b) => a.target.localeCompare(b.target)) },
       sockets: this.options.sockets
     })
@@ -365,8 +368,10 @@ export class MicrosandboxManager {
 
   private async open(environment: MicrosandboxEnvironment): Promise<Sandbox> {
     const name = this.name(environment.id)
-    const spec = this.spec(environment)
     const binding = await this.readBinding(environment.id)
+    // Image changes apply to new environments; retained disks keep their original image.
+    const image = binding ? SpecImageSchema.parse(JSON.parse(binding.spec)).config.image : this.options.config.image
+    const spec = this.spec(environment, image)
     const existing = await this.find(name)
     if (binding || existing) {
       let matchingSpec = binding?.spec === spec
@@ -381,10 +386,13 @@ export class MicrosandboxManager {
         if (source) {
           matchingSpec =
             binding.spec ===
-            this.spec({
-              ...environment,
-              mounts: [...environment.mounts, { source, target: '/opt/agentconnect-local/guest.js', readOnly: true }]
-            })
+            this.spec(
+              {
+                ...environment,
+                mounts: [...environment.mounts, { source, target: '/opt/agentconnect-local/guest.js', readOnly: true }]
+              },
+              image
+            )
         }
       }
       if (

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -71,10 +71,10 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   }
   const scopeDir = realpathSync(resolve(opts.scopeDir))
   const hostEnv = opts.stateSourceEnv ?? process.env
-  let runtimeHome =
-    opts.hostKey && hostKeySessionKey(opts.hostKey) !== undefined
-      ? join(scopeDir, SESSIONS_DIR, hostKeyDirName(opts.hostKey), 'home')
-      : privateRuntimeHomeFor(scopeDir, undefined)
+  let runtimeHome = privateRuntimeHomeFor(scopeDir, opts.hostKey)
+  if (opts.hostKey && hostKeySessionKey(opts.hostKey) !== undefined && runtimeHome === join(scopeDir, 'home')) {
+    runtimeHome = join(scopeDir, 'runtime-homes', hostKeyDirName(opts.hostKey), 'home')
+  }
   const sessionDir = opts.trustedSessionDir ? realpathSync(opts.trustedSessionDir) : undefined
   if (sessionDir) {
     const parts = relative(scopeDir, sessionDir).split(sep)
@@ -209,7 +209,7 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
       ...(sessionDir
         ? { sessionGitMetadataRoots: gitMetadataWriteRoots }
         : { writableGitMetadataRoots: gitMetadataWriteRoots }),
-      ...(sessionDir ? { sessionHomeRoot: runtimeHome } : {}),
+      ...(sessionDir || (opts.hostKey && hostKeySessionKey(opts.hostKey)) ? { sessionHomeRoot: runtimeHome } : {}),
       sharedWriteRoots,
       allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true,
       disableUnifiedExec: true

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -6,6 +6,7 @@ import { applyCodexPermissionProfile } from '../acp/codex-permission-profiles.js
 import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
 import { GITCRED_SOCKET_ENV } from '../gitcred/env.js'
 import { privateRuntimeHomeFor, runtimeGitMetadataRoots, type PreparedRuntimeLaunch } from '../launch/prepare.js'
+import { nativeRuntimeMemorySpecFor } from '../memory/runtime/capabilities.js'
 import {
   claudeProviderCredentialFiles,
   isClaudeRuntimeDef,
@@ -49,6 +50,7 @@ export interface PrepareMicrosandboxLaunchOptions {
   hostKey?: HostKey
   explicitEnv?: Record<string, string>
   stateSourceEnv?: NodeJS.ProcessEnv
+  nativeMemory?: boolean
   trustedSessionDir?: string
   trustedWorkspaceWriteRoots?: string[]
   trustedRuntimeReadRoots?: string[]
@@ -116,15 +118,25 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
     return source
   }
   const writeRoots = compactReadRoots(writable.map(automaticSource))
+  const nativeMemory = opts.nativeMemory && nativeRuntimeMemorySpecFor(opts.runtime, opts.runtimeId)
+  const memoryMounts: SandboxMount[] = []
+  if (nativeMemory && !sessionDir && runtimeHome !== join(scopeDir, 'home')) {
+    const source = scopePath(nativeMemory.readRoot(join(scopeDir, 'home')))
+    const target = scopePath(nativeMemory.readRoot(runtimeHome))
+    for (const path of [source, target]) mkdirSync(path, { recursive: true, mode: 0o700 })
+    memoryMounts.push({ source, target, readOnly: false })
+  }
   const automatic: SandboxMount[] = [
     ...compactReadRoots([...configDirs, ...readRoots].map(automaticSource))
       .filter((path) => !writeRoots.some((write) => contains(write, path)))
       .map((source) => ({ source, target: source, readOnly: true })),
     ...writeRoots.map((source) => ({ source, target: source, readOnly: false })),
-    ...normalizeSandboxMounts(opts.trustedMounts ?? [], hostEnv, 'microsandbox').map((mount) => ({
-      ...mount,
-      source: automaticSource(mount.source)
-    }))
+    ...normalizeSandboxMounts([...(opts.trustedMounts ?? []), ...memoryMounts], hostEnv, 'microsandbox').map(
+      (mount) => ({
+        ...mount,
+        source: automaticSource(mount.source)
+      })
+    )
   ]
   const configured = normalizeSandboxMounts(opts.mounts, hostEnv, 'microsandbox')
   const ownedTargets = [

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -44,7 +44,7 @@ import {
   originOnManagedHost,
   type ManagedCredentialScope
 } from './git-injection.js'
-import { LocalGitRunner, type GitRunner } from './git-runner.js'
+import { GitTransportError, LocalGitRunner, type GitRunner } from './git-runner.js'
 import { localWorkspaceFs, type WorkspaceFs, type WorkspacePlacement } from './workspace-fs.js'
 import { gitmoduleRepos } from './gitmodules.js'
 import {
@@ -983,6 +983,7 @@ export class WorkspaceManager {
     try {
       current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
     } catch (cause) {
+      if (cause instanceof GitTransportError) throw cause
       if (root.githubApp) throw new UntrustedGithubWorkspaceOriginError({ cause })
       return
     }

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -105,6 +105,21 @@ function makeRoutable(daemon: Daemon): void {
   })
 }
 
+function useMicrosandbox(daemon: Daemon, environments: string[] = []) {
+  const manager = {
+    environmentIds: vi.fn(async () => environments),
+    suspend: vi.fn(async () => {}),
+    suspendIdle: vi.fn(async () => {}),
+    stopAll: vi.fn(async () => {}),
+    discard: vi.fn(async () => {})
+  }
+  ;(daemon as any).cfg.sandbox.backend = 'microsandbox'
+  ;(daemon as any).microsandbox = manager
+  ;(daemon as any).microsandboxCatalog = (daemon as any).runtimeCatalog
+  ;(daemon as any).microsandboxTable = { mcpBridge: { command: 'node', args: ['/image/mcp-bridge.js'] } }
+  return manager
+}
+
 const dm = (ts: string, text: string, thread: string) => ({
   msgId: `slack:C1:${ts}`,
   traceId: ts,
@@ -253,6 +268,76 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect(privateRuntimeHomeFor(agentDir, sessionHostKey('bot-a', KEY('T1')))).toBe(join(agentDir, 'home'))
     expect(existsSync(join(agentDir, 'sessions'))).toBe(false)
     await daemon.stop()
+  })
+
+  it('gives new microsandbox sessions separate hosts while keeping their shared workspace', async () => {
+    const root = scaffold({}, 'shared')
+    const { daemon, hosts, factory } = await startDaemon(root)
+    useMicrosandbox(daemon)
+    try {
+      await (daemon as any).hydrateMicrosandboxSessions()
+      await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+      await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+      expect(factory).toHaveBeenCalledTimes(2)
+      for (const [index, thread] of ['T1', 'T2'].entries()) {
+        const key = sessionHostKey('bot-a', KEY(thread))
+        expect((daemon as any).hosts.get(key)).toBe(hosts[index])
+        expect((daemon as any).hostLaunch.get(key).cwd).toBe(join(root, 'agents', 'bot-a', 'workspace'))
+      }
+      await (daemon as any).stopHost('bot-a')
+      await (daemon as any).dispatch('bot-a', dm('300', 'resume', 'T1'), 'int-a')
+      expect(hosts[2]!.loadSession).toHaveBeenCalled()
+      expect(hosts[2]!.newSession).not.toHaveBeenCalled()
+    } finally {
+      await daemon.stop()
+    }
+  })
+
+  it('preserves legacy shared VM sessions through restart and retires that VM only with its last session', async () => {
+    const root = scaffold({}, 'shared')
+    const { daemon, hosts } = await startDaemon(root)
+    try {
+      await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+      await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+      await (daemon as any).stopHost('bot-a')
+      const environments = ['bot-a/agent']
+      const manager = useMicrosandbox(daemon, environments)
+      await (daemon as any).hydrateMicrosandboxSessions()
+      await (daemon as any).dispatch('bot-a', dm('300', 'resume', 'T1'), 'int-a')
+      expect((daemon as any).hosts.get(agentHostKey('bot-a'))).toBe(hosts[1])
+      expect(hosts[1]!.loadSession).toHaveBeenCalled()
+      await (daemon as any).dispatch('bot-a', dm('400', 'new', 'T3'), 'int-a')
+      const fresh = sessionHostKey('bot-a', KEY('T3'))
+      expect((daemon as any).hosts.get(fresh)).toBe(hosts[2])
+      environments.push(`bot-a/${hostKeyDirName(fresh)}`)
+      await (daemon as any).hydrateMicrosandboxSessions()
+      expect((daemon as any).hostKeyFor('bot-a', KEY('T1'))).toBe(agentHostKey('bot-a'))
+      expect((daemon as any).hostKeyFor('bot-a', KEY('T3'))).toBe(fresh)
+
+      const store = (daemon as any).store
+      const expire = async (thread: string) => {
+        await store.db.prepare('UPDATE sessions SET updatedAt = ? WHERE key = ?').run(1, KEY(thread))
+        await (daemon as any).sweepExpiredSessions()
+        expect(await store.getSession(KEY(thread))).toBeUndefined()
+      }
+      await expire('T1')
+      expect(manager.discard).not.toHaveBeenCalledWith('bot-a/agent')
+      await expire('T2')
+      expect(manager.discard).toHaveBeenCalledWith('bot-a/agent')
+      expect(hosts[2]!.stop).not.toHaveBeenCalled()
+      const home = join(root, 'agents', 'bot-a', 'runtime-homes', hostKeyDirName(fresh), 'home')
+      mkdirSync(home, { recursive: true })
+      manager.discard.mockRejectedValueOnce(new Error('disk is still busy'))
+      await store.db.prepare('UPDATE sessions SET updatedAt = ? WHERE key = ?').run(1, KEY('T3'))
+      await (daemon as any).sweepExpiredSessions()
+      expect(await store.getSession(KEY('T3'))).toBeDefined()
+      expect(existsSync(home)).toBe(true)
+      await expire('T3')
+      expect(manager.discard).toHaveBeenCalledWith(`bot-a/${hostKeyDirName(fresh)}`)
+      expect(existsSync(home)).toBe(false)
+    } finally {
+      await daemon.stop()
+    }
   })
 
   // A session is served in the tier it was BORN in (§11): its clones record that, so losing the

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -188,8 +188,10 @@ function fakeSdk() {
       },
       builder(name: string) {
         let dockerVolume: string | undefined
+        let image = 'test-image'
         const builder = {
-          image() {
+          image(value: string) {
+            image = value
             return builder
           },
           rootDisk() {
@@ -232,6 +234,7 @@ function fakeSdk() {
               volumes.set(dockerVolume, { attached: true })
             }
             const sandbox = new FakeSandbox(name, dockerVolume)
+            sandbox.spec.image = image
             created.push(sandbox)
             sandboxes.set(name, sandbox)
             return sandbox
@@ -456,6 +459,38 @@ describe('microsandbox process and VM ownership', () => {
     await manager.discard(environment.id)
   })
 
+  it('pins retained VM images while new environments use the configured image', async () => {
+    const { manager, options, environment, request, created } = await fixture()
+    await (await manager.driverFor(environment).launch(request)).stop(0)
+    await manager.stopAll()
+    const upgraded = { ...options, config: { ...options.config, image: 'next-image' } }
+    await expect(
+      new MicrosandboxManager({ ...upgraded, config: { ...upgraded.config, cpus: 4 } })
+        .driverFor(environment)
+        .launch(request)
+    ).rejects.toThrow('changed persisted configuration')
+    const resumed = new MicrosandboxManager(upgraded)
+    await expect(
+      resumed
+        .driverFor({ ...environment, mounts: [{ source: '/extra', target: '/extra', readOnly: true }] })
+        .launch(request)
+    ).rejects.toThrow('changed persisted configuration')
+    await (await resumed.driverFor(environment).launch(request)).stop(0)
+    expect(created).toHaveLength(1)
+    expect(created[0]!.spec.image).toBe('test-image')
+    expect(created[0]!.destroy).not.toHaveBeenCalled()
+    const next = { ...environment, id: 'agent/new-session' }
+    await (await resumed.driverFor(next).launch(request)).stop(0)
+    expect(created[1]!.spec.image).toBe('next-image')
+    await resumed.stopAll()
+    const restarted = new MicrosandboxManager({ ...upgraded, config: { ...upgraded.config, image: 'later-image' } })
+    for (const env of [environment, next]) {
+      await (await restarted.driverFor(env).launch(request)).stop(0)
+      await restarted.discard(env.id)
+    }
+    expect(created).toHaveLength(2)
+  })
+
   it('resumes the retained VM after retiring only the known guest helper mount', async () => {
     const { manager, options, environment, request, created } = await fixture()
     const helpers = join(options.root, 'microsandbox', 'helpers')
@@ -469,7 +504,10 @@ describe('microsandbox process and VM ownership', () => {
     const runtime = await manager.driverFor(legacy).launch(request)
     await runtime.stop(0)
     await manager.stopAll()
-    const resumed = new MicrosandboxManager(options)
+    const resumed = new MicrosandboxManager({
+      ...options,
+      config: { ...options.config, image: 'next-image' }
+    })
     await expect(
       resumed
         .driverFor({

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -193,10 +193,23 @@ describe('prepareMicrosandboxLaunch', () => {
     const cwd = join(opts.scopeDir, 'memory', 'extraction', 'input')
     mkdirSync(cwd, { recursive: true })
     const launch = prepareMicrosandboxLaunch({ ...opts, cwd, hostKey })
-    const home = join(opts.scopeDir, 'sessions', hostKeyDirName(hostKey), 'home')
+    const home = join(opts.scopeDir, 'runtime-homes', hostKeyDirName(hostKey), 'home')
     expect(launch.runtimeHome).toBe(home)
     expect(launch.microsandbox.mounts).toContainEqual({ source: home, target: home, readOnly: false })
     expect(launch.microsandbox.mounts.some((mount) => mount.source === dirname(home))).toBe(false)
+    expect(existsSync(join(opts.scopeDir, 'sessions'))).toBe(false)
+  })
+
+  it('gives shared-workspace sessions separate homes without creating isolated workspace directories', () => {
+    const opts = fixture()
+    const first = prepareMicrosandboxLaunch({ ...opts, hostKey: sessionHostKey('agent', 'first') })
+    const second = prepareMicrosandboxLaunch({ ...opts, hostKey: sessionHostKey('agent', 'second') })
+    expect(first.runtimeHome).not.toBe(second.runtimeHome)
+    for (const launch of [first, second]) {
+      expect(launch.microsandbox.mounts).toContainEqual({ source: opts.cwd, target: opts.cwd, readOnly: false })
+    }
+    expect(first.microsandbox.mounts.some(({ target }) => target === second.runtimeHome)).toBe(false)
+    expect(existsSync(join(opts.scopeDir, 'sessions'))).toBe(false)
   })
 
   it('preserves the host Git helper and protects its guest alias and nested Git config as read-only mounts', () => {

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -18,6 +18,9 @@ import { microsandboxSupportMounts } from '../src/microsandbox/support.js'
 import { gitcredShimPath } from '../src/cp/gitcred-server.js'
 import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
+import { composeRuntimeLaunch } from '../src/launch/compose.js'
+import { nativeRuntimeMemorySpecFor } from '../src/memory/runtime/capabilities.js'
+import { nativeMemoryRead, nativeMemoryWrite } from '../src/memory/runtime/native.js'
 import * as credentials from '../src/runtimes/runtime-credentials.js'
 import {
   CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV,
@@ -211,6 +214,36 @@ describe('prepareMicrosandboxLaunch', () => {
     expect(first.microsandbox.mounts.some(({ target }) => target === second.runtimeHome)).toBe(false)
     expect(existsSync(join(opts.scopeDir, 'sessions'))).toBe(false)
   })
+
+  it.each(['claude-acp', 'codex-acp'])(
+    'keeps %s native memory on the Console store across shared-workspace VMs',
+    async (runtimeId) => {
+      const opts = fixture()
+      const runtime = { command: runtimeId, args: [], env: [] }
+      const agentHome = join(opts.scopeDir, 'home')
+      const memory = nativeRuntimeMemorySpecFor(runtime, runtimeId)!
+      const source = memory.readRoot(agentHome)
+      for (const session of ['first', 'second']) {
+        const { launch } = composeRuntimeLaunch({
+          ...opts,
+          runtimeId,
+          runtime,
+          provider: 'native',
+          hostKey: sessionHostKey('agent', session),
+          runInSandbox: true,
+          microsandbox: { mounts: [] }
+        })
+        const mounts = launch.microsandbox!.mounts
+        expect(mounts).toContainEqual({ source, target: memory.readRoot(launch.runtimeHome!), readOnly: false })
+        expect(mounts.some((mount) => mount.source === agentHome)).toBe(false)
+        expect(mounts.some((mount) => mount.source === join(agentHome, '.codex'))).toBe(false)
+        writeFileSync(join(source, 'MEMORY.md'), session)
+        expect((await nativeMemoryRead(agentHome, runtime, 'MEMORY.md')).content).toBe(session)
+        await nativeMemoryWrite(agentHome, runtime, 'MEMORY.md', 'console edit')
+        expect(readFileSync(join(source, 'MEMORY.md'), 'utf8')).toBe('console edit')
+      }
+    }
+  )
 
   it('preserves the host Git helper and protects its guest alias and nested Git config as read-only mounts', () => {
     const opts = fixture()

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import type { Agent } from '../src/agents/agent-schema.js'
+import { GitTransportError } from '../src/workspace/git-runner.js'
 import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
 import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
@@ -1056,6 +1057,19 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       'origin',
       'https://github.com/acme/new-name'
     ])
+  })
+
+  it('preserves sandbox startup failures instead of reporting an untrusted Git origin', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-ws-transport-'))
+    mkdirSync(join(dir, '.git'))
+    const error = new GitTransportError('sandbox could not resume its persisted configuration')
+    rawMock.mockRejectedValueOnce(error)
+    try {
+      await expect(workspaces.prepareWorkspace(githubAppAgent(dir))).rejects.toBe(error)
+      expect(pullMock).not.toHaveBeenCalled()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('refuses to run an App-backed checkout whose origin is not GitHub', async () => {


### PR DESCRIPTION
Image changes could reject retained microsandbox disks before Git or ACP started. Pin each session to its original image, give new sessions their own VM and HOME even with a shared workspace, and retain legacy shared VMs until their last session is cleaned up. Mount native-memory storage from the existing agent store for shared-workspace sessions so Console reads and edits still reach the runtime. Preserve VM transport failures instead of reporting them as an untrusted Git origin.

Build bubblewrap 0.11.2 into the full runtime image so Codex can initialize while its credential directory remains hidden.

Validation: 166 focused tests, daemon typecheck and targeted ESLint; amd64 bubblewrap image stage build; retained-VM Git resume; real Codex ACP new/prompt/load with a local model fixture; protected-file access remains denied. Native-memory round trips passed in two VMs each for Claude and Codex; host edits appeared after the backend's approximately five-second filesystem cache refresh.

Created by Codex . GPT-6
