### PR TITLE
chore(deps): keep Node type major upgrades manual

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # Upgrade Node types across majors together with the manually managed Node runtime.
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
     groups:
       npm-minor-and-patch:
         patterns:


### PR DESCRIPTION
Dependabot offered @types/node 26 while the project uses a Node 24 runtime baseline. Ignore major updates to @types/node so its API definitions advance alongside a manually reviewed Node runtime upgrade. Minor and patch updates within the current major can still be grouped normally.

Validation: Dependabot JSON Schema validation, duplicate-key checking, Prettier, and git diff --check passed. The ignore rule takes effect once merged into the default branch.

Created by Codex . GPT-6
