### PR TITLE
chore(deps): keep changelog preset major upgrades manual

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - version-update:semver-major
+      # Preset v10 requires writer v9; upgrade it together with semantic-release tooling.
+      - dependency-name: conventional-changelog-conventionalcommits
+        update-types:
+          - version-update:semver-major
     groups:
       npm-minor-and-patch:
         patterns:


### PR DESCRIPTION
Ignore Dependabot major updates to conventional-changelog-conventionalcommits. Preset v10 requires conventional-changelog-writer v9, while the current release-notes generator uses writer v8, so this upgrade must be coordinated with the release tooling. Updates within the supported v9 major remain automatic.

Validation: Dependabot JSON Schema validation, duplicate-key checking, Prettier, and git diff --check passed.

Created by Codex . GPT-6
