### PR TITLE
perf(sandbox): prepare images before daemon upgrade activation

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -28,7 +28,7 @@
 # The shim's own build (tsdown.shim.config.ts) inlines every dependency so this image installs
 # no node_modules for it. That separation is asserted at build time by the daemon package's
 # assert-self-contained step and re-asserted here against the copied artifact.
-FROM node:24-bookworm-slim AS shim-builder
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS shim-builder
 WORKDIR /build
 ENV PNPM_HOME=/pnpm \
   PATH=/pnpm:$PATH
@@ -64,7 +64,7 @@ RUN pnpm --filter "@agentconnect.md/daemon^..." build \
 # layer receives only the verified binary and never sees the curl this needs, so "the shim and nothing the shim
 # does not need" still holds. Pinned by version AND sha256 — an unpinned download would make the contents of an
 # image that runs half-trusted code a function of whatever a mirror served on build day.
-FROM node:24-bookworm-slim AS gh-cli
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS gh-cli
 ARG GH_CLI_VERSION=2.97.0
 ARG GH_CLI_SHA256_AMD64=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
 ARG GH_CLI_SHA256_ARM64=73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5
@@ -89,7 +89,7 @@ RUN set -eu; \
 # ─────────────────────────── Chrome for Testing ─────────────────────────────
 # Baked so a browser turn costs no download: `agent-browser install` fetches 391 MB into $HOME, per workspace VOLUME.
 # Own stage, version- and sha256-pinned, for the reasons gh's is. No --version here — that needs the runtime layer's libraries.
-FROM node:24-bookworm-slim AS chrome
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS chrome
 ARG CHROME_VERSION=152.0.7977.75
 ARG CHROME_SHA256_AMD64=a16d36890636bd72251133b27f05825f7f9269c2425b3408fa3a76e10dccd8f1
 ARG TARGETARCH
@@ -108,7 +108,7 @@ RUN set -eu; \
   chmod -R a-w /out
 
 # Standalone runtimes for the full image; their downloads never enter the pool image.
-FROM node:24-bookworm-slim AS full-native-runtimes
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS full-native-runtimes
 ARG OMP_VERSION=17.0.5
 ARG OMP_SHA256_AMD64=319d08ab8e5fb80c73f734907d5f47aa8bbd4ea31f7a19bacf8611c5aba26c31
 ARG ANTIGRAVITY_VERSION=1.1.1
@@ -142,7 +142,7 @@ RUN curl --retry 5 -fsSL -o /tmp/devin.tar.gz \
   && rm -rf /tmp/devin.tar.gz /tmp/bin
 
 # ─────────────────────────────── runtime ────────────────────────────────────
-FROM node:24-bookworm-slim AS runtime-base
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS runtime-base
 
 # Exact pins keep the published runtime table truthful.
 ARG CLAUDE_ACP_VERSION=0.75.1

--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -151,9 +151,19 @@ been reused, not merely because the lock is old.
 
 ## 3. Local upgrade
 
-`agentconnect upgrade` resolves and installs a target, then switches `current`
-to it. The target comes from `--to <version>` or the selected `stable` or `rc`
-channel.
+`agentconnect upgrade` resolves and installs a target, prepares it, then switches
+`current` to it. The target comes from `--to <version>` or the selected `stable`
+or `rc` channel.
+
+When the target includes `dist/prepare-upgrade.js`, the CLI runs that entry with
+the selected root and optional config path before switching versions or stopping
+the running daemon. The target owns config validation and image selection. For
+microsandbox it installs its pinned SDK and prepares the target image's layered
+artifacts without creating, stopping, or resuming VMs. A preparation failure
+leaves `current`, rollback metadata, and the running daemon unchanged. Older
+bundles without the entry keep their existing upgrade behavior. This preparation
+step requires an updated CLI; an older CLI still prepares the image on daemon
+startup.
 
 Without `--restart`, the running daemon is unchanged. The selected version takes
 effect on its next launch.

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -329,13 +329,17 @@ directory at `/tmp/agentconnect` as the image's ordinary user; the pool keeps it
 existing `/run/agentconnect` paths.
 
 In pinned version `0.6.17`, starting a retained flat-disk VM still validates the
-OCI image's VMDK cache. The manager therefore runs the official
-`msb pull <image> --materialize all --quiet` before its VM probe, preparing both
-image forms, and tests stop/start. Retained flat VMs continue to use their original disk. This
-uses the upstream CLI and package without an upstream source patch; cold image
-preparation includes the extra materialization cost.
+OCI image's VMDK cache. The manager runs the official
+`msb pull <image> --materialize layered --quiet` before its VM probe, preparing
+the shared layers and VMDK without generating an unused flat base disk. Retained
+flat VMs continue to use their original disk. The same image preparation runs
+before version activation during CLI upgrades; startup still verifies VM
+boot and stop/start, reusing the prepared image cache.
 
 ### Release image selection and Docker
+
+All runtime image build stages pin the Node base image by version and digest;
+updating the base is an explicit source change rather than an incidental tag refresh.
 
 The release build bundles `dist/release.json` with a `runtimeSandboxImage` OCI
 reference. It names the current release's `runtime-sandbox-full:v<version>` alias.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -324,6 +324,7 @@ async function main(): Promise<void> {
       try {
         await runUpgrade(root, {
           to: o.to,
+          configPath: program.opts().config,
           channel: asChannel(o.channel),
           restart: Boolean(o.restart),
           keep: keepOption(o.keep)

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -1,11 +1,9 @@
-/**
- * `agentconnect upgrade` orchestration (cli-daemon-split.md §5.2): install the
- * target → flip `current` → optionally restart → health-check → auto-rollback on
- * failure. The caller wraps this in the version lock; the steps here assume it is
- * held. Dependencies are injected so the control flow (esp. rollback) is testable
- * without a registry or a real service.
- */
+// Install and prepare before activation; the caller holds the version lock through restart and rollback.
 import { resolveController } from './service/index.js'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { spawnDaemon } from './delegate.js'
+import { versionDir } from './paths.js'
 import { checkServiceHealthy, type HealthResult } from './health.js'
 import { installTarget, resolveTarget } from './install.js'
 import type { ResolvedTarget } from './registry.js'
@@ -16,6 +14,7 @@ export interface UpgradeOpts {
   to?: string
   channel?: Channel
   restart?: boolean
+  configPath?: string
   /** Retention for the post-upgrade prune (default DEFAULT_KEEP_VERSIONS); 0 disables it. */
   keep?: number
 }
@@ -23,6 +22,7 @@ export interface UpgradeOpts {
 export interface UpgradeDeps {
   resolve: (o: { to?: string; channel: Channel }) => Promise<ResolvedTarget>
   install: (root: string, target: ResolvedTarget, log: (m: string) => void) => Promise<string>
+  prepare: (root: string, version: string, configPath?: string) => Promise<void>
   serviceInstalled: () => boolean
   restartService: () => Promise<void>
   health: () => Promise<HealthResult>
@@ -35,6 +35,7 @@ export function realUpgradeDeps(root: string, log: (m: string) => void): Upgrade
   return {
     resolve: resolveTarget,
     install: installTarget,
+    prepare: prepareDaemonUpgrade,
     serviceInstalled: () => resolveController({ root }).isInstalled(),
     restartService: async () => {
       const c = resolveController({ root })
@@ -44,6 +45,17 @@ export function realUpgradeDeps(root: string, log: (m: string) => void): Upgrade
     health: () => checkServiceHealthy(() => resolveController({ root }).status()),
     prune: (opts) => autoPrune(root, log, opts),
     log
+  }
+}
+
+// The target bundle owns sandbox configuration and release image selection.
+export async function prepareDaemonUpgrade(root: string, version: string, configPath?: string): Promise<void> {
+  const entry = join(versionDir(root, version), 'dist', 'prepare-upgrade.js')
+  if (!existsSync(entry)) return
+  const args = ['--root', root, ...(configPath ? ['--config', configPath] : [])]
+  const result = await spawnDaemon(entry, args).done
+  if (result.code !== 0) {
+    throw new Error(`daemon ${version} upgrade preparation failed (${result.signal ?? result.code}); current unchanged`)
   }
 }
 
@@ -67,6 +79,7 @@ export async function upgrade(root: string, opts: UpgradeOpts, deps: UpgradeDeps
     return
   }
 
+  await deps.prepare(root, target.version, opts.configPath)
   useVersion(root, target.version) // records `before` as previous (rollback target)
   if (opts.channel && opts.channel !== meta.channel) {
     writeMeta(root, { ...readMeta(root), channel: opts.channel })

--- a/packages/cli/src/version-commands.ts
+++ b/packages/cli/src/version-commands.ts
@@ -112,7 +112,7 @@ export async function versionReinstallLatest(root: string): Promise<string> {
 
 export async function runUpgrade(
   root: string,
-  opts: { to?: string; channel?: Channel; restart?: boolean; keep?: number }
+  opts: { to?: string; channel?: Channel; restart?: boolean; keep?: number; configPath?: string }
 ): Promise<void> {
   await withVersionLock(root, 'upgrade', () => upgrade(root, opts, realUpgradeDeps(root, note)), { wait: true })
 }

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { upgrade, type UpgradeDeps } from '../src/upgrade.js'
+import { prepareDaemonUpgrade, upgrade, type UpgradeDeps } from '../src/upgrade.js'
 import { checkServiceHealthy } from '../src/health.js'
 import { currentVersion, readMeta } from '../src/version-store.js'
 import type { ResolvedTarget } from '../src/registry.js'
@@ -19,6 +19,7 @@ function deps(over: Partial<UpgradeDeps> = {}): UpgradeDeps {
       install(r, t.version)
       return t.version
     },
+    prepare: vi.fn(async () => {}),
     serviceInstalled: () => true,
     restartService: vi.fn(async () => {}),
     health: async () => ({ healthy: true, reason: 'stable pid 1' }),
@@ -29,6 +30,67 @@ function deps(over: Partial<UpgradeDeps> = {}): UpgradeDeps {
 }
 
 describe('upgrade', () => {
+  it('keeps the old version active until target preparation completes', async () => {
+    const r = root()
+    install(r, '1.0.0')
+    const { useVersion } = await import('../src/version-ops.js')
+    useVersion(r, '1.0.0')
+    let release!: () => void
+    const pending = new Promise<void>((resolve) => (release = resolve))
+    const prepare = vi.fn(async () => pending)
+    const restart = vi.fn(async () => {})
+    const upgrading = upgrade(
+      r,
+      { to: '2.0.0', restart: true, configPath: '/custom/config.json' },
+      deps({ prepare, restartService: restart })
+    )
+    await vi.waitFor(() => expect(prepare).toHaveBeenCalledWith(r, '2.0.0', '/custom/config.json'))
+    expect(currentVersion(r)).toBe('1.0.0')
+    expect(restart).not.toHaveBeenCalled()
+    release()
+    await upgrading
+    expect(currentVersion(r)).toBe('2.0.0')
+    expect(restart).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves current, rollback metadata and the running service intact when preparation fails', async () => {
+    const r = root()
+    install(r, '1.0.0')
+    const { useVersion } = await import('../src/version-ops.js')
+    useVersion(r, '1.0.0')
+    const before = readMeta(r)
+    const d = deps({
+      prepare: async () => {
+        throw new Error('image unavailable')
+      }
+    })
+    await expect(upgrade(r, { to: '2.0.0', restart: true }, d)).rejects.toThrow('image unavailable')
+    expect(currentVersion(r)).toBe('1.0.0')
+    expect(readMeta(r)).toEqual(before)
+    expect(d.restartService).not.toHaveBeenCalled()
+    expect(d.prune).not.toHaveBeenCalled()
+  })
+
+  it('runs the target bundle preparation entry and propagates its failure', async () => {
+    const r = root()
+    const dist = join(r, 'versions', '2.0.0', 'dist')
+    mkdirSync(dist, { recursive: true })
+    await prepareDaemonUpgrade(r, '1.0.0')
+    writeFileSync(
+      join(dist, 'prepare-upgrade.js'),
+      'require("node:fs").writeFileSync(__dirname + "/prepared.json", JSON.stringify(process.argv.slice(2)))'
+    )
+    await prepareDaemonUpgrade(r, '2.0.0', '/custom/config.json')
+    expect(JSON.parse(readFileSync(join(dist, 'prepared.json'), 'utf8'))).toEqual([
+      '--root',
+      r,
+      '--config',
+      '/custom/config.json'
+    ])
+    writeFileSync(join(dist, 'prepare-upgrade.js'), 'process.exit(7)')
+    await expect(prepareDaemonUpgrade(r, '2.0.0')).rejects.toThrow('upgrade preparation failed (7)')
+  })
+
   it('prunes with the default retention after switching, protecting the target', async () => {
     const r = root()
     install(r, '1.0.0')

--- a/packages/daemon/scripts/assert-self-contained.mjs
+++ b/packages/daemon/scripts/assert-self-contained.mjs
@@ -8,15 +8,31 @@
 //
 // This check turns that silent degradation into a hard build failure. It runs
 // after tsdown in the daemon's `build` script; it ships nowhere (files: ["dist"]).
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { builtinModules } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const nodeBuiltins = new Set(builtinModules.flatMap((spec) => [spec, `node:${spec}`]))
 
 const bundlePath = new URL('../dist/index.js', import.meta.url)
 const bundle = readFileSync(bundlePath, 'utf8')
+
+const prepareRoot = mkdtempSync(join(tmpdir(), 'ac-prepare-upgrade-'))
+try {
+  const prepared = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('../dist/prepare-upgrade.js', import.meta.url)), '--root', prepareRoot],
+    { encoding: 'utf8', timeout: 10_000, env: { PATH: process.env.PATH ?? '' } }
+  )
+  if (prepared.status !== 0 || existsSync(join(prepareRoot, 'microsandbox'))) {
+    throw new Error(`bundled SRT upgrade preparation failed: ${prepared.stderr}`)
+  }
+} finally {
+  rmSync(prepareRoot, { recursive: true, force: true })
+}
 
 // These packages must be embedded because the published manifest has no runtime
 // dependencies. Cover both static imports and the dynamic import used by the

--- a/packages/daemon/src/bootstrap-upgrade.ts
+++ b/packages/daemon/src/bootstrap-upgrade.ts
@@ -32,7 +32,7 @@ interface BootstrapControlPlane {
 
 export interface BootstrapUpgradeDeps {
   connect: (url: string) => Promise<Transport>
-  install: (cliEntry: string, targetVersion: string, root: string, log: UpgradeLog) => Promise<boolean>
+  install: typeof runCliUpgrade
   log: UpgradeLog
 }
 
@@ -125,7 +125,7 @@ export async function runBootstrapUpgrade(
     const lifecycle = (reply.payload as AuthOk).lifecycle
     if (!lifecycle || lifecycle.action !== 'upgrade' || lifecycle.targetVersion === DAEMON_VERSION) return 'continue'
 
-    const installed = await deps.install(cliEntry, lifecycle.targetVersion, root, deps.log)
+    const installed = await deps.install(cliEntry, lifecycle.targetVersion, root, deps.log, opts.configPath)
     if (!installed) {
       await reportResult(transport, correlator, lifecycle, 'failed', `failed to install ${lifecycle.targetVersion}`)
       return 'continue'

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1467,6 +1467,7 @@ export class Daemon {
       supervisor: () => this.opts.supervisor,
       k8s: () => this.k8s,
       root: () => this.opts.root,
+      configPath: () => this.opts.configPath,
       upgradeInstaller: () => this.opts.upgradeInstaller,
       stop: () => this.stop(),
       requestExit: (code) => this.requestExit(code)

--- a/packages/daemon/src/lifecycle/cli-upgrade.ts
+++ b/packages/daemon/src/lifecycle/cli-upgrade.ts
@@ -22,11 +22,14 @@ export async function runCliUpgrade(
   cliEntry: string,
   targetVersion: string,
   root: string,
-  log: UpgradeLog
+  log: UpgradeLog,
+  configPath?: string
 ): Promise<boolean> {
   log.info(`cp: installing daemon ${targetVersion} via ${cliEntry}`)
   return await new Promise<boolean>((resolve) => {
-    const child = spawn(process.execPath, [cliEntry, 'upgrade', '--to', targetVersion, '--root', root], {
+    const args = [cliEntry, 'upgrade', '--to', targetVersion, '--root', root]
+    if (configPath) args.push('--config', configPath)
+    const child = spawn(process.execPath, args, {
       stdio: 'inherit'
     })
     child.on('exit', (code) => {

--- a/packages/daemon/src/lifecycle/fleet-upgrade.ts
+++ b/packages/daemon/src/lifecycle/fleet-upgrade.ts
@@ -16,6 +16,7 @@ export interface FleetUpgradeHost {
   supervisor: () => string | undefined
   k8s: () => boolean
   root: () => string | undefined
+  configPath: () => string | undefined
   upgradeInstaller: () => typeof runCliUpgrade | undefined
   stop: () => Promise<void>
   requestExit: (code: number) => void
@@ -82,7 +83,9 @@ export class FleetUpgradeCoordinator {
   private startFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
     const log = this.host.log()
     const installation = Promise.resolve()
-      .then(() => (this.host.upgradeInstaller() ?? runCliUpgrade)(cliEntry, targetVersion, root, log))
+      .then(() =>
+        (this.host.upgradeInstaller() ?? runCliUpgrade)(cliEntry, targetVersion, root, log, this.host.configPath())
+      )
       .catch((err) => {
         log.error(`cp: could not install daemon ${targetVersion}: ${formatErr(err)}`)
         return false

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -92,6 +92,18 @@ export class MicrosandboxManager {
     return (this.preparation ??= this.probe())
   }
 
+  async prepareImage(): Promise<void> {
+    const started = performance.now()
+    const { command, args } = this.options.msbCommand
+    this.options.log?.info(`microsandbox: preparing image ${this.options.config.image}`)
+    await runFile(command, [...args, 'pull', this.options.config.image, '--materialize', 'layered', '--quiet'], {
+      env: { ...process.env, MSB_HOME: join(this.options.root, 'microsandbox'), MSB_BACKEND: 'local' },
+      timeout: 5 * 60_000,
+      maxBuffer: 1024 * 1024
+    })
+    this.options.log?.info(`microsandbox: image prepared in ${((performance.now() - started) / 1000).toFixed(1)}s`)
+  }
+
   driverFor(environment: MicrosandboxEnvironment): SpawnDriver {
     return { launch: (request) => this.launch(environment, request) }
   }
@@ -251,12 +263,7 @@ export class MicrosandboxManager {
         }
       }
     }
-    const { command, args } = this.options.msbCommand
-    await runFile(command, [...args, 'pull', this.options.config.image, '--materialize', 'all', '--quiet'], {
-      env: { ...process.env, MSB_HOME: join(this.options.root, 'microsandbox'), MSB_BACKEND: 'local' },
-      timeout: 5 * 60_000,
-      maxBuffer: 1024 * 1024
-    })
+    await this.prepareImage()
     const name = `${this.name('probe')}-${randomUUID().slice(0, 8)}`
     let sandbox = await this.builder(name, []).create()
     try {

--- a/packages/daemon/src/prepare-upgrade.ts
+++ b/packages/daemon/src/prepare-upgrade.ts
@@ -1,0 +1,19 @@
+import { parseArgs } from 'node:util'
+import { loadConfig } from './config/load-config.js'
+import { gitcredSocketPath } from './cp/gitcred-server.js'
+import { makeLogger } from './log.js'
+import { installMicrosandbox } from './microsandbox/install.js'
+import { mcpSocketPath, resolveRoot } from './paths.js'
+
+const { values } = parseArgs({ options: { root: { type: 'string' }, config: { type: 'string' } } })
+const root = resolveRoot(values.root)
+const config = loadConfig({ root, configPath: values.config, optional: true })
+if (config.sandbox.backend === 'microsandbox') {
+  const manager = await installMicrosandbox({
+    root,
+    config: config.sandbox.microsandbox,
+    sockets: { mcp: mcpSocketPath(root), gitcred: gitcredSocketPath(root) },
+    log: makeLogger(config.logging.level)
+  })
+  await manager.prepareImage()
+}

--- a/packages/daemon/test/bootstrap-upgrade.test.ts
+++ b/packages/daemon/test/bootstrap-upgrade.test.ts
@@ -77,6 +77,7 @@ describe('auth-only daemon bootstrap upgrade', () => {
     const run = runBootstrapUpgrade(
       {
         root: rootWithCli(),
+        configPath: '/custom/config.json',
         supervisor: 'service',
         overrides: { apiUrl: 'ws://cp.test', apiKey: 'key' }
       },
@@ -103,6 +104,12 @@ describe('auth-only daemon bootstrap upgrade', () => {
     transport.pushInbound(encode(buildEnvelope('ack', { ok: true }, { corr: result.id as string })))
 
     await expect(run).resolves.toBe('restart')
-    expect(install).toHaveBeenCalledWith(expect.any(String), '9.9.9', expect.any(String), expect.any(Object))
+    expect(install).toHaveBeenCalledWith(
+      expect.any(String),
+      '9.9.9',
+      expect.any(String),
+      expect.any(Object),
+      '/custom/config.json'
+    )
   })
 })

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -276,6 +276,32 @@ async function fixture() {
 }
 
 describe('microsandbox process and VM ownership', () => {
+  it('prepares only layered image artifacts without stopping an existing VM', async () => {
+    const { manager, options, environment, request, created } = await fixture()
+    const runtime = await manager.driverFor(environment).launch(request)
+    const argsFile = join(options.root, 'pull.json')
+    options.msbCommand = {
+      command: process.execPath,
+      args: [
+        '-e',
+        `require('node:fs').writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(1)))`
+      ]
+    }
+    await manager.prepareImage()
+    expect(JSON.parse(await readFile(argsFile, 'utf8'))).toEqual([
+      'pull',
+      'test-image',
+      '--materialize',
+      'layered',
+      '--quiet'
+    ])
+    expect(created).toHaveLength(1)
+    expect(created[0]!.status).toBe('running')
+    expect(created[0]!.stopWithTimeout).not.toHaveBeenCalled()
+    await runtime.stop(0)
+    await manager.discard(environment.id)
+  })
+
   it('retains Docker data across manager restarts and retries failed volume cleanup without losing ownership', async () => {
     const { manager, options, environment, request, created, volumes, removeVolume } = await fixture()
     const runtime = await manager.driverFor(environment).launch(request)

--- a/packages/daemon/tsdown.config.ts
+++ b/packages/daemon/tsdown.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
   // accidentally read the daemon manifest instead.
   entry: {
     index: 'src/index.ts',
+    'prepare-upgrade': 'src/prepare-upgrade.ts',
     'skills/dist/cli': skillsCliEntry,
     'skills/workspace-mutation': 'src/skills/skill-workspace-mutation-cli.ts'
   },


### PR DESCRIPTION
Daemon upgrades prepared both layered and flat copies of the runtime image after the old process stopped. Prepare only the layered image used by new VMs, and have the CLI run the target bundle's preparation entry before activating it. Image preparation is shared with daemon startup, uses the target release metadata and selected config, and does not change existing VM state. Failure preserves the active version and running daemon.

Pin every runtime image stage to Node 24.21.0 and its verified multi-platform digest so an upstream tag update cannot unexpectedly rebuild the full image. The pre-activation step requires an updated CLI; older CLIs remain compatible and benefit from layered preparation on daemon startup.

Validation:
- CLI upgrade tests cover preparation ordering, failure preservation, target entry execution, and custom config forwarding; daemon tests cover image-only preparation and lifecycle coordination.
- CLI and daemon typechecks, repository lint, formatting, and daemon build/self-contained bundle checks pass. The packaged preparation entry is a no-op for SRT.
- On an isolated Linux/KVM state directory, the same full image took 53.6 seconds to prepare from an empty cache, versus 148 seconds observed during the previous upgrade. Warm image preparation took 0.1 seconds; VM boot/stop/resume validation passed in 12.0 seconds without producing a flat image. These are single-run observations, not a controlled benchmark.
- A retained flat-root VM resumed with its data intact after removing only its test flat-image cache and preparing layered artifacts.

Created by Codex . GPT-6
