### PR TITLE
feat(daemon): a Discord elicitation is answered in a dialog

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -463,6 +463,7 @@ import {
   type TelegramTurnState
 } from './platforms/telegram/turn-output.js'
 import { parseTelegramElicit, telegramElicitCards } from './platforms/telegram/elicit-card.js'
+import { discordElicitCards } from './platforms/discord/elicit-card.js'
 import { applyDiscordAction as applyDiscordActionExternal } from './platforms/discord/turn-output.js'
 import { applyFeishuAction as applyFeishuActionExternal, type FeishuTurnState } from './platforms/feishu/turn-output.js'
 import { LinearConnection } from './platforms/linear/connection.js'
@@ -1013,6 +1014,7 @@ export class Daemon {
       })
       registry.register({
         platform: 'discord',
+        elicitCards: discordElicitCards,
         createConverger: (ctx) => new DiscordConverger(ctx.mode as never, ctx.resolveFileLink),
         initialTurnState: () => ({}),
         apply: (p, action) => this.applyDiscordAction(p, action as DiscordAction)
@@ -1644,6 +1646,9 @@ export class Daemon {
       handleElicitChoice: (a) => this.permissions.handleElicitChoice(a),
       handleElicitFormSubmit: (a) => void this.permissions.submitElicitForm(a),
       handleDiscordSelect: (a) => this.commands.handleDiscordSelect(a),
+      openElicitEditor: (a) => this.permissions.openElicitEditor(a.requestId),
+      handleElicitCardTap: async (a) => await this.permissions.handleElicitCardTap(a),
+      submitElicitEditor: async (a) => await this.permissions.submitElicitEditor(a),
       handleTelegramCallback: (cb, conn) => this.handleTelegramCallback(cb, conn),
       slackShortcutSession: (shortcut, srcIntegrationIds) =>
         this.commands.slackShortcutSession(shortcut, srcIntegrationIds),

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -6,7 +6,9 @@ import {
   MessageFlags,
   type Message,
   type Channel,
-  type ChatInputCommandInteraction
+  type ChatInputCommandInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction
 } from 'discord.js'
 import type { Agent } from '../agents/agent-schema.js'
 import { platformIntegrationConfig } from '../platforms/integration-config.js'
@@ -24,6 +26,7 @@ import {
   type DiscordComponents,
   type DiscordSelectKind
 } from './render.js'
+import { DISCORD_ELICIT_MODAL, DISCORD_ELICIT_OPEN, parseDiscordElicit } from '../platforms/discord/elicit-card.js'
 import type {
   InteractionActor,
   PlatformChannelHistoryOptions,
@@ -105,6 +108,19 @@ export interface DiscordDeps {
     sessionKey: string
     actor?: InteractionActor
   }) => Promise<{ text: string; components: DiscordComponents } | undefined>
+  /** The DIALOG one elicitation card's Answer button opens (§7.3) — Discord's modal, built by
+   *  core from the card's own params. Undefined ⇒ nothing to open, and the tap is merely acked.
+   *  Synchronous by necessity: a modal must be the interaction's FIRST response, and Discord
+   *  allows three seconds for it, so there is no room to go and ask. */
+  onElicitOpen?: (a: { requestId: string; actor?: InteractionActor }) => unknown | undefined
+  /** A tapped elicitation option, or Dismiss (`token` null). */
+  onElicitChoice?: (a: { requestId: string; token: string | null; actor?: InteractionActor }) => Promise<void>
+  /** One submitted elicitation dialog: every field's value under the id its component carried. */
+  onElicitSubmit?: (a: {
+    requestId: string
+    values: Record<string, string | string[]>
+    actor?: InteractionActor
+  }) => Promise<void>
   newTraceId: () => string
   log?: Logger
   /** Min spacing (ms) between outbound writes (serialized send-queue). Tests pass 0. */
@@ -260,7 +276,21 @@ export class DiscordConnection implements PlatformConnection {
         this.onSlashCommand(interaction)
         return
       }
+      // A submitted elicitation dialog carries every answer at once; it belongs to no status card.
+      if (interaction.isModalSubmit()) {
+        this.onElicitModalSubmit(interaction)
+        return
+      }
       if (!interaction.isButton()) return
+      // Elicitation components are routed BEFORE the ack: opening a modal must be the
+      // interaction's FIRST response, and a deferred update has already spent it. They are also
+      // routed before the status-key lookup, since an elicitation card is not a status card — its
+      // own `custom_id` carries the request, so it needs no message-to-session registry.
+      const elicit = parseDiscordElicit(interaction.customId)
+      if (elicit) {
+        await this.onElicitInteraction(interaction, elicit)
+        return
+      }
       void interaction.deferUpdate().catch(() => {})
       const channel = interaction.channelId
       const sessionKey = this.statusKeys.get(`${channel}:${interaction.message.id}`)
@@ -326,6 +356,49 @@ export class DiscordConnection implements PlatformConnection {
    * and the tappable cards all reuse handleCommand. The real output posts to the
    * channel/thread (public), matching how a typed `/command` behaves today.
    */
+  /** Route one tap on an elicitation card. The Answer button opens the dialog core built for this
+   *  card; every other component is an answer in itself and is acked before it is applied, so the
+   *  client's spinner clears whatever the answer turns out to be worth. */
+  private async onElicitInteraction(
+    interaction: ButtonInteraction,
+    elicit: { requestId: string; token: string | null }
+  ): Promise<void> {
+    const actor: InteractionActor = { userId: interaction.user.id, isBot: interaction.user.bot }
+    if (elicit.token === DISCORD_ELICIT_OPEN) {
+      const modal = this.deps.onElicitOpen?.({ requestId: elicit.requestId, actor })
+      // Nothing to open — a settled card, or one this surface answers with a tap — so the tap is
+      // acked and the card left as it is, rather than the client being left spinning.
+      if (!modal) {
+        void interaction.deferUpdate().catch(() => {})
+        return
+      }
+      await interaction
+        // Typed off `showModal` itself rather than through a `discord-api-types` import: that
+        // package is discord.js's own transitive dependency, not one this daemon declares.
+        .showModal(modal as Parameters<ButtonInteraction['showModal']>[0])
+        .catch((err: Error) => this.deps.log?.debug(`discord: showModal failed: ${err.message}`))
+      return
+    }
+    void interaction.deferUpdate().catch(() => {})
+    await this.deps.onElicitChoice?.({ requestId: elicit.requestId, token: elicit.token, actor })
+  }
+
+  /** Read one submitted dialog: every field under the id its component carried, a list where the
+   *  control answers with one (a select) and a string where it answers with words (a text input).
+   *  The FIELD decides which of those it was, which is core's to say and not this connection's. */
+  private onElicitModalSubmit(interaction: ModalSubmitInteraction): void {
+    const elicit = parseDiscordElicit(interaction.customId)
+    if (!elicit || elicit.token !== DISCORD_ELICIT_MODAL) return
+    void interaction.deferUpdate().catch(() => {})
+    const values: Record<string, string | string[]> = {}
+    for (const [customId, data] of interaction.fields.fields) {
+      if ('values' in data) values[customId] = [...data.values]
+      else if ('value' in data && typeof data.value === 'string') values[customId] = data.value
+    }
+    const actor: InteractionActor = { userId: interaction.user.id, isBot: interaction.user.bot }
+    void this.deps.onElicitSubmit?.({ requestId: elicit.requestId, values, actor })
+  }
+
   private onSlashCommand(interaction: ChatInputCommandInteraction): void {
     const text = this.slashCommandText(interaction)
     void interaction.reply({ content: text, flags: MessageFlags.Ephemeral }).catch(() => {})

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -1552,7 +1552,9 @@ export class PermissionCoordinator {
       surface: 'chat',
       facet,
       conn: p.conn,
-      channel: p.plan.channel,
+      // Where the card actually LANDS, which is not always the turn's channel: a Discord thread is
+      // a channel of its own, and a card edited against its parent is a card never edited at all.
+      channel: facet.cardChannel?.(p) ?? p.plan.channel,
       answerConv: p.plan.transcriptChannel,
       // An MCP approval keeps its durable record in `permission_requests` and its own console
       // surface, so it is not also a transcript card.
@@ -1597,7 +1599,10 @@ export class PermissionCoordinator {
     if (!live) {
       const settled = this.takeSettledBeforePost(requestId)
       if (ts && settled)
-        facet.settle({ conn: p.conn, channel: p.plan.channel, ts }, elicitSettlement(params, !!url, settled))
+        facet.settle(
+          { conn: p.conn, channel: facet.cardChannel?.(p) ?? p.plan.channel, ts },
+          elicitSettlement(params, !!url, settled)
+        )
       return await result
     }
     if (!ts) {

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -18,6 +18,7 @@ import type {
   ElicitCard,
   ElicitOutcome
 } from '@agentconnect.md/protocol'
+import { elicitFormBlockId } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from '../log.js'
 import type { LocalStore } from '../store/local-store.js'
@@ -2027,6 +2028,59 @@ export class PermissionCoordinator {
       return true
     }
     return false
+  }
+
+  /**
+   * The dialog one live card opens, for a surface whose answer is collected somewhere other than
+   * the message — Discord's modal, the only place that platform takes a typed answer.
+   *
+   * Undefined for every other card: an unknown request, a settled one, a surface that answers in
+   * place, or a card of this surface that one tap already answers. The caller then simply does not
+   * open anything, which on Discord means acknowledging the tap and leaving the card standing.
+   *
+   * Its submission comes back through {@link submitElicitForm}, keyed exactly as a Slack Confirm
+   * is — so a dialog is a different PLACE to answer, never a different answer.
+   */
+  openElicitEditor(requestId: string): unknown | undefined {
+    const rec = this.pendingElicits.get(requestId)
+    if (!rec || rec.surface !== 'chat' || !rec.facet.editor) return undefined
+    const form = this.cardForm(rec) ?? elicitForm(rec.params, surfaceOf(rec))
+    if (!form) return undefined
+    return rec.facet.editor(rec, { requestId, params: rec.params, form }) ?? undefined
+  }
+
+  /**
+   * Answer a card from its DIALOG's submission — {@link openElicitEditor}'s other half.
+   *
+   * A dialog's controls report their arity by SHAPE: a list-taking control answers with a list
+   * even where it was configured to take one. The FIELD is what says which it was, so a
+   * single-valued control's list is read as the one value it holds and an empty one as nothing
+   * filled in — and everything after that is {@link submitElicitForm}, the same re-derivation,
+   * per-field validation and refusal wording a Confirm goes through.
+   */
+  async submitElicitEditor(a: {
+    requestId: string
+    values: Record<string, string | readonly string[]>
+    actor?: InteractionActor
+  }): Promise<void> {
+    const rec = this.pendingElicits.get(a.requestId)
+    if (!rec || rec.surface !== 'chat' || !rec.facet.editor) return
+    const form = this.cardForm(rec)
+    if (!form) return
+    const fields: Record<string, string | string[]> = {}
+    for (const [index, target] of form.entries()) {
+      const blockId = elicitFormBlockId(index)
+      const raw = a.values[blockId]
+      if (raw === undefined) continue
+      if (target.kind === 'multi-enum') fields[blockId] = Array.isArray(raw) ? [...raw] : [raw]
+      else {
+        const one = Array.isArray(raw) ? raw[0] : raw
+        // A blank text input and an untouched select are both "nothing filled in", which core
+        // reads as an omission — legal for an optional field, named as missing for a required one.
+        if (typeof one === 'string' && one !== '') fields[blockId] = one
+      }
+    }
+    await this.submitElicitForm({ requestId: a.requestId, fields, ...(a.actor ? { actor: a.actor } : {}) })
   }
 
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -76,6 +76,9 @@ export interface PlatformActionSink {
   handleElicitChoice: NonNullable<SlackDeps['onElicitChoice']>
   handleElicitFormSubmit: NonNullable<SlackDeps['onElicitFormSubmit']>
   handleDiscordSelect: NonNullable<DiscordDeps['onSelectAction']>
+  openElicitEditor: NonNullable<DiscordDeps['onElicitOpen']>
+  handleElicitCardTap: NonNullable<DiscordDeps['onElicitChoice']>
+  submitElicitEditor: NonNullable<DiscordDeps['onElicitSubmit']>
   handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): Promise<void>
   slackShortcutSession(
     shortcut: { channel: string; thread: string },
@@ -636,6 +639,9 @@ export class ConnectionReconciler {
         },
         onStatusAction: (a) => this.host.handleStatusAction(a),
         onSelectAction: (a) => this.host.handleDiscordSelect(a),
+        onElicitOpen: (a) => this.host.openElicitEditor(a),
+        onElicitChoice: (a) => this.host.handleElicitCardTap(a),
+        onElicitSubmit: (a) => this.host.submitElicitEditor(a),
         log: this.log
       })
       try {

--- a/packages/daemon/src/platforms/discord/elicit-card.ts
+++ b/packages/daemon/src/platforms/discord/elicit-card.ts
@@ -1,0 +1,352 @@
+/**
+ * Discord's **elicitation-card facet** (§7.3) — the third implementer of {@link ElicitCardFacet},
+ * and the first surface that can put a whole form in front of the reader as one dialog.
+ *
+ * WHAT DISCORD ACTUALLY HAS is two places to put a control, and they take different ones. A
+ * MESSAGE takes buttons and select menus but no typed box at all; a MODAL takes `Label`-wrapped
+ * text inputs, select menus, radio groups and checkbox groups — verified against the installed
+ * `discord-api-types@0.38.54` (`APIComponentInLabel`) and `discord.js@14.27`, which both sends raw
+ * modal JSON (`showModal`) and reads every one of those back (`ModalSubmitFields.getField`).
+ *
+ * So the reader gets ONE dialog with every question in it, submitted atomically — closer to what
+ * `elicitation/create` describes than any message-level card can be. The modal is not the Slack
+ * modal that was removed in #1794: Slack had message-level input state, which made its modal a
+ * second way to do what the card already did. Discord has NO way to type into a message, so the
+ * modal is not a choice between surfaces — it is the only surface that can take a typed answer.
+ *
+ * ONE EXCEPTION, and it is the same one every other surface makes: a lone single-select or boolean
+ * is a row of buttons in the message, because one tap already answers it and a dialog would be a
+ * round trip for nothing.
+ *
+ * SELECT MENUS DO THE OPTION FIELDS, not radio and checkbox groups, though the modal takes all
+ * three. A radio group is prettier but holds 2–10 options against a select's 25, and its arity is
+ * a different component rather than a different bound — so choosing it would buy nicer pixels for
+ * two more code paths and two more cliffs. One control, one bound, one read path.
+ */
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { elicitFormBlockId } from '@agentconnect.md/protocol'
+import type {
+  ElicitCardAsk,
+  ElicitCardDraft,
+  ElicitCardFacet,
+  ElicitCardHandle,
+  ElicitCardHost,
+  ElicitCardMark,
+  ElicitCardSettlement,
+  ElicitCardTap,
+  ElicitCardTapTarget,
+  ElicitCardTurn
+} from '../elicit-card.js'
+import type { DiscordConnection } from '../../discord/connection.js'
+import type { DiscordButton, DiscordComponents } from '../../discord/render.js'
+import { DISCORD_MESSAGE_LIMIT } from '../../discord/render.js'
+import {
+  clampTo,
+  elicitFormFieldHint,
+  elicitFormFieldLabel,
+  elicitOptionToken,
+  elicitRequiredProps,
+  type ElicitKind,
+  type ElicitSurface,
+  type ElicitTarget
+} from '../../slack/render.js'
+
+/** One `actions` row holds five buttons and a message holds five rows, so a one-tap card offers
+ *  24 options and keeps its Dismiss. A longer list is declined whole, never trimmed to fit. */
+const DISCORD_ELICIT_MAX_BUTTONS = 24
+
+/** A select menu's own cap on `options` — the bound every FORM field is held to, whatever its
+ *  arity, because one control is what a select is for both. */
+const DISCORD_SELECT_MAX_OPTIONS = 25
+
+/** How many components one modal takes (`APIModalInteractionResponseCallbackData.components`:
+ *  "between 1 and 5"). A reduction with more fields than this has no dialog to be shown in and is
+ *  declined whole — a modal missing its sixth question would collect an answer to a form the
+ *  reader never saw. */
+export const DISCORD_MODAL_MAX_FIELDS = 5
+
+/** Discord's own caps on the strings a modal carries. */
+const DISCORD_MODAL_TITLE_CAP = 45
+const DISCORD_LABEL_CAP = 45
+const DISCORD_LABEL_DESCRIPTION_CAP = 100
+const DISCORD_OPTION_LABEL_CAP = 100
+/** A `custom_id` anywhere in the component tree. */
+const DISCORD_CUSTOM_ID_CAP = 100
+/** What one text input accepts, and what a button's label holds. */
+const DISCORD_TEXT_INPUT_CAP = 4000
+const DISCORD_BUTTON_LABEL_CAP = 80
+
+const DISCORD_ELICIT_PREFIX = 'ac_el'
+
+/** The token a Dismiss button carries. Not a position, because Dismiss answers no option. */
+const DISCORD_ELICIT_DISMISS = 'x'
+
+/** The token the button that OPENS THE DIALOG carries. It answers nothing: it asks for the form. */
+export const DISCORD_ELICIT_OPEN = 'ed'
+
+/** The token the modal itself carries back on submit. */
+export const DISCORD_ELICIT_MODAL = 'm'
+
+/** How much of the answer a settled card echoes back, for the same reason Telegram's is bounded:
+ *  the decision core supplies is not, and Discord's message limit is 2000 — a quarter of what a
+ *  Slack block takes. What the READER sees is clamped; what the AGENT receives is not (#1844). */
+const DISCORD_ELICIT_DECISION_CAP = 300
+
+/** How much of the question one card carries: whatever is left once the settlement line is
+ *  reserved, so the rewrite still fits after the ask did. Derived from the decision cap rather
+ *  than written beside it — the two drifting apart is how a settlement stops landing. */
+const DISCORD_ELICIT_MESSAGE_CAP = DISCORD_MESSAGE_LIMIT - DISCORD_ELICIT_DECISION_CAP - 8
+
+/** How Discord spells each settlement mark. Literal emoji: a Discord message has no shortcode
+ *  vocabulary, so Slack's `:white_check_mark:` would reach the reader as its own source text. */
+const DISCORD_ELICIT_MARK: Record<ElicitCardMark, string> = {
+  answered: '✅',
+  dismissed: '🚫',
+  waiting: '⏳',
+  blocked: '🔒'
+}
+
+/**
+ * What a Discord elicitation card can render AND collect: every kind, because the modal has a
+ * control for every kind. The option bound is the BUTTON row's, not the select's, since the
+ * reduction runs before the shape is known and a one-tap card is the tighter of the two.
+ */
+export const DISCORD_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
+  optionLimits: {
+    enum: { maxOptions: DISCORD_ELICIT_MAX_BUTTONS },
+    'multi-enum': { maxOptions: DISCORD_SELECT_MAX_OPTIONS }
+  }
+}
+
+/** One component's `custom_id`: the request and what the component is. Pure. */
+export function discordElicitId(requestId: string, token: string): string {
+  return `${DISCORD_ELICIT_PREFIX}:${requestId}:${token}`
+}
+
+/** Whether every id this card mints fits Discord's 100-character `custom_id`. The widest is the
+ *  last option's, so that one answers for all of them. Pure. */
+export function discordElicitIdFits(requestId: string, options: number): boolean {
+  return discordElicitId(requestId, elicitOptionToken(Math.max(0, options - 1))).length <= DISCORD_CUSTOM_ID_CAP
+}
+
+/** Decode a tapped elicitation component: the request, and what was tapped — null for Dismiss,
+ *  which settles the card as a decline. Null for ids this scheme did not mint (`ac_sel:…`, a
+ *  status-bar verb, a stray one alike). Pure. */
+export function parseDiscordElicit(id: string): { requestId: string; token: string | null } | null {
+  const m = /^ac_el:([0-9a-fA-F-]{1,64}):([A-Za-z0-9_]{1,16})$/.exec(id)
+  if (!m) return null
+  const token = m[2] as string
+  return { requestId: m[1] as string, token: token === DISCORD_ELICIT_DISMISS ? null : token }
+}
+
+/** The card's own text: the question, on the same speech-balloon line every surface opens with.
+ *  Discord renders message content as markdown, so the agent's words are fenced rather than
+ *  defused — a fence shows them verbatim and makes no link, no mention and no header. Pure. */
+export function discordElicitText(message: string): string {
+  const body = clampTo(message, DISCORD_ELICIT_MESSAGE_CAP)
+  return `💬 ${body}`
+}
+
+/** One tappable button per option, plus Dismiss, five to a row — the one-tap card. Each carries
+ *  its option's POSITION, never its value: a `custom_id` holds 100 characters and an enum of paths
+ *  or ids would not fit its own values (#1844's rule, which every surface now shares). Pure. */
+export function discordElicitButtons(requestId: string, options: readonly { label: string }[]): DiscordComponents {
+  const buttons: DiscordButton[] = options.map((o, i) => ({
+    type: 2,
+    style: 2,
+    label: clampTo(o.label, DISCORD_BUTTON_LABEL_CAP),
+    custom_id: discordElicitId(requestId, elicitOptionToken(i))
+  }))
+  buttons.push(discordDismissButton(requestId))
+  const rows: DiscordComponents = []
+  for (let i = 0; i < buttons.length; i += 5) rows.push({ type: 1, components: buttons.slice(i, i + 5) })
+  return rows
+}
+
+function discordDismissButton(requestId: string): DiscordButton {
+  return { type: 2, style: 2, label: 'Dismiss', custom_id: discordElicitId(requestId, DISCORD_ELICIT_DISMISS) }
+}
+
+/** The card that opens a DIALOG: one button that asks for the form, and Dismiss. There is no
+ *  Confirm here — the modal has its own submit, and the answer never passes through the message.
+ *  Pure. */
+export function discordElicitOpenButtons(requestId: string): DiscordComponents {
+  return [
+    {
+      type: 1,
+      components: [
+        { type: 2, style: 1, label: 'Answer', custom_id: discordElicitId(requestId, DISCORD_ELICIT_OPEN) },
+        discordDismissButton(requestId)
+      ]
+    }
+  ]
+}
+
+/** A Discord modal, in the wire shape `showModal` takes. Opaque to core. */
+export interface DiscordModal {
+  custom_id: string
+  title: string
+  components: unknown[]
+}
+
+/**
+ * The dialog one reduction becomes: a `Label` per field wrapping the control that collects it — a
+ * text input for a typed field, a select menu for an option field, single or multiple by its own
+ * `min_values`/`max_values`.
+ *
+ * Every option carries its POSITION, and every field is keyed by the same `elicitFormBlockId` a
+ * Slack Confirm submits under, so what comes back out of this dialog is validated by core's ONE
+ * re-derivation (#1815) with nothing Discord-shaped left in it.
+ *
+ * Null when the reduction has no dialog: more fields than a modal holds, or an option list past
+ * what a select holds. Declined whole — a modal missing a question would collect an answer to a
+ * form the reader never saw. Pure.
+ */
+export function buildDiscordElicitModal(
+  requestId: string,
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[]
+): DiscordModal | null {
+  if (!form.length || form.length > DISCORD_MODAL_MAX_FIELDS) return null
+  const required = new Set(elicitRequiredProps(params))
+  const components: unknown[] = []
+  for (const [index, target] of form.entries()) {
+    const id = elicitFormBlockId(index)
+    const hint = elicitFormFieldHint(target)
+    const label = {
+      type: 18,
+      label: clampTo(elicitFormFieldLabel(params, target), DISCORD_LABEL_CAP),
+      ...(hint ? { description: clampTo(hint, DISCORD_LABEL_DESCRIPTION_CAP) } : {}),
+      component: {} as unknown
+    }
+    const need = required.has(target.propName)
+    if (target.kind === 'text' || target.kind === 'number') {
+      label.component = {
+        type: 4,
+        custom_id: id,
+        // Single-line unless the schema asks for room: `maxLength` is the only signal we have.
+        style: (target.maxLength ?? 0) > 200 ? 2 : 1,
+        required: need,
+        max_length: Math.min(target.maxLength ?? DISCORD_TEXT_INPUT_CAP, DISCORD_TEXT_INPUT_CAP),
+        ...(target.defaultValue !== undefined ? { value: String(target.defaultValue) } : {})
+      }
+    } else {
+      if (!target.options.length || target.options.length > DISCORD_SELECT_MAX_OPTIONS) return null
+      const multi = target.kind === 'multi-enum'
+      // The field's own bounds, inside what a select can promise. A required single-select must
+      // take exactly one; an optional field may take none, which is how it stays omittable.
+      const min = multi ? (need ? Math.max(target.minItems ?? 1, 1) : (target.minItems ?? 0)) : need ? 1 : 0
+      const max = multi ? Math.min(target.maxItems ?? target.options.length, target.options.length) : 1
+      label.component = {
+        type: 3,
+        custom_id: id,
+        min_values: Math.min(min, max),
+        max_values: max,
+        options: target.options.map((o, n) => ({
+          label: clampTo(o.label, DISCORD_OPTION_LABEL_CAP),
+          value: elicitOptionToken(n),
+          ...(target.defaultValue === o.value ? { default: true } : {})
+        }))
+      }
+    }
+    components.push(label)
+  }
+  return {
+    custom_id: discordElicitId(requestId, DISCORD_ELICIT_MODAL),
+    title: clampTo(elicitModalTitle(params), DISCORD_MODAL_TITLE_CAP),
+    components
+  }
+}
+
+/** What the dialog is called. The question itself where it fits — a modal title is 45 characters,
+ *  which most questions are not, and a truncated question read as a heading says less than a plain
+ *  one. The question is on the card above either way. Pure. */
+function elicitModalTitle(params: CreateElicitationRequest): string {
+  const message = (params as { message?: string }).message?.trim() ?? ''
+  return message && message.length <= DISCORD_MODAL_TITLE_CAP ? message : 'The agent needs your input'
+}
+
+/** Discord's per-turn elicitation draft: the message and the components under it. */
+interface DiscordElicitDraft {
+  text: string
+  components: DiscordComponents
+}
+
+/** Whether this reduction is answered by ONE TAP, or needs the dialog. The same line every surface
+ *  draws, and the only place Discord decides it. Pure. */
+export function discordUsesModal(form: readonly ElicitTarget[]): boolean {
+  const only = form.length === 1 ? form[0]! : null
+  return !(only && (only.kind === 'enum' || only.kind === 'boolean') && only.options.length > 0)
+}
+
+export const discordElicitCards: ElicitCardFacet = {
+  platform: 'discord',
+  reduction: DISCORD_ELICIT_SURFACE,
+
+  build(_host: ElicitCardHost, _turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null {
+    // No consent control: a Discord link button opens the page but delivers no interaction, so the
+    // daemon would never learn the reader consented — and consent is all that seam decides (#1810).
+    if (ask.url || !ask.form?.length) return null
+    const modal = discordUsesModal(ask.form)
+    const widest = modal ? Math.max(...ask.form.map((t) => t.options.length), 1) : ask.form[0]!.options.length
+    if (!discordElicitIdFits(ask.requestId, widest)) return null
+    if (modal) {
+      // Built here and thrown away, so a reduction the dialog cannot hold is declined BEFORE the
+      // request is recorded as open, rather than posting a card whose button opens nothing.
+      if (!buildDiscordElicitModal(ask.requestId, ask.params, ask.form)) return null
+      return {
+        text: discordElicitText(ask.message),
+        components: discordElicitOpenButtons(ask.requestId)
+      } satisfies DiscordElicitDraft
+    }
+    return {
+      text: discordElicitText(ask.message),
+      components: discordElicitButtons(ask.requestId, ask.form[0]!.options)
+    } satisfies DiscordElicitDraft
+  },
+
+  async send(
+    host: ElicitCardHost,
+    turn: ElicitCardTurn,
+    _ask: ElicitCardAsk,
+    draft: ElicitCardDraft
+  ): Promise<string | undefined> {
+    const d = draft as DiscordElicitDraft
+    return await host.postCardSerialized(turn, (conn) =>
+      (conn as DiscordConnection).postChrome(turn.plan.channel, d.text, {
+        keyboard: d.components,
+        ...(turn.plan.thread !== undefined ? { threadTs: turn.plan.thread } : {})
+      })
+    )
+  },
+
+  /** The dialog this card's Answer button opens, rebuilt from the card's OWN params so it offers
+   *  the very fields the ask reduced to (#1815). Null for a card answered by one tap. */
+  editor(_handle: ElicitCardHandle, card: ElicitCardTapTarget): unknown | null {
+    if (!discordUsesModal(card.form)) return null
+    return buildDiscordElicitModal(card.requestId, card.params, card.form)
+  },
+
+  /** A one-tap card's option, and nothing else: every other Discord card is answered in its dialog
+   *  and reaches core through `submitElicitForm` without passing through here. */
+  tap(_handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null {
+    if (discordUsesModal(card.form) || token !== DISCORD_ELICIT_OPEN) return null
+    // Opening the dialog is not an answer, so the card stays exactly as open as it was.
+    return { kind: 'pending' }
+  },
+
+  settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void {
+    if (handle.ts === undefined) return
+    const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+    const decision = `${DISCORD_ELICIT_MARK[card.mark]} ${clampTo(card.text, DISCORD_ELICIT_DECISION_CAP)}`
+    // Belt to the reserve's braces, as Telegram's has: the reserve only holds while both halves
+    // are bounded, and an edit refused for length lands AFTER ACP accepted and the pending record
+    // went — nothing is left to retry against, so the card would keep offering a dead button.
+    const text = clampTo(`${discordElicitText(message)}\n${decision}`, DISCORD_MESSAGE_LIMIT)
+    // No components: the answered card stays readable, with nothing left to press.
+    void (handle.conn as DiscordConnection)
+      .updateMessage(handle.channel, handle.ts, text, { keyboard: [] })
+      .catch(() => {})
+  }
+}

--- a/packages/daemon/src/platforms/discord/elicit-card.ts
+++ b/packages/daemon/src/platforms/discord/elicit-card.ts
@@ -241,6 +241,9 @@ export function buildDiscordElicitModal(
       label.component = {
         type: 3,
         custom_id: id,
+        // Stated rather than defaulted: Discord defaults `required` to true and refuses a zero
+        // `min_values` under it, so an optional field would fail the WHOLE dialog to open.
+        required: need,
         min_values: Math.min(min, max),
         max_values: max,
         options: target.options.map((o, n) => ({
@@ -306,6 +309,13 @@ export const discordElicitCards: ElicitCardFacet = {
     } satisfies DiscordElicitDraft
   },
 
+  /** A Discord THREAD is a channel of its own, so that is where a card of this turn lands and the
+   *  only place its settlement can address. `postChrome` resolves the same target from the same
+   *  two fields; naming it here is what keeps core's handle pointing at the real message. */
+  cardChannel(turn: ElicitCardTurn): string {
+    return turn.plan.thread || turn.plan.channel
+  },
+
   async send(
     host: ElicitCardHost,
     turn: ElicitCardTurn,
@@ -314,9 +324,9 @@ export const discordElicitCards: ElicitCardFacet = {
   ): Promise<string | undefined> {
     const d = draft as DiscordElicitDraft
     return await host.postCardSerialized(turn, (conn) =>
-      (conn as DiscordConnection).postChrome(turn.plan.channel, d.text, {
-        keyboard: d.components,
-        ...(turn.plan.thread !== undefined ? { threadTs: turn.plan.thread } : {})
+      // Posted to the same coordinates `cardChannel` names, so the settlement finds it there.
+      (conn as DiscordConnection).postChrome(discordElicitCards.cardChannel!(turn), d.text, {
+        keyboard: d.components
       })
     )
   },

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -181,6 +181,12 @@ export interface ElicitCardFacet {
    *  `form` is re-derived by core from the card's own params, so it is the very field list the
    *  card rendered. Null ⇒ the tap named nothing this card offers, and core refuses it aloud. */
   tap?(handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null
+  /** Where a card of this surface is POSTED, when that is not the turn's own channel. Absent ⇒ it
+   *  is — which is true of Slack (a thread is a `ts` within its channel) and of Telegram (a topic
+   *  is a field on a send). A Discord thread is a CHANNEL of its own, so a card posted in one is
+   *  edited there and nowhere else; core records what this returns as the card's coordinates, so
+   *  the settlement addresses the very message the ask posted. */
+  cardChannel?(turn: ElicitCardTurn): string
   /** The payload of a SECONDARY surface this card's own control opens — Discord's modal, which is
    *  the only place that platform accepts a typed answer. Absent ⇒ the card is answered where it
    *  was posted, which is what Slack's and Telegram's are; null ⇒ this particular card is too

--- a/packages/daemon/src/platforms/elicit-card.ts
+++ b/packages/daemon/src/platforms/elicit-card.ts
@@ -181,6 +181,15 @@ export interface ElicitCardFacet {
    *  `form` is re-derived by core from the card's own params, so it is the very field list the
    *  card rendered. Null ⇒ the tap named nothing this card offers, and core refuses it aloud. */
   tap?(handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null
+  /** The payload of a SECONDARY surface this card's own control opens — Discord's modal, which is
+   *  the only place that platform accepts a typed answer. Absent ⇒ the card is answered where it
+   *  was posted, which is what Slack's and Telegram's are; null ⇒ this particular card is too
+   *  (Discord's one-tap row). Opaque to core, which only hands it to the connection that asked.
+   *
+   *  It is rebuilt from the card's own params on every open rather than held from the post, so the
+   *  dialog offers the very fields the ask reduced to (#1815) — and so a card outliving the
+   *  process that posted it opens the same form. */
+  editor?(handle: ElicitCardHandle, card: ElicitCardTapTarget): unknown | null
   /** Whether this typed message answers THIS card, and with what. Absent ⇒ the surface collects no
    *  typed answer and every message in its chats is a prompt, which is what a Slack card's is.
    *  Null ⇒ not this card's answer, and core keeps looking. The fields are keyed as a Confirm's

--- a/packages/daemon/test/discord-elicit-card.test.ts
+++ b/packages/daemon/test/discord-elicit-card.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Discord's elicitation card — the third implementer of the Layer-2 elicitation-card facet
+ * (#1794). Discord is the first surface that can put a WHOLE FORM in front of the reader as one
+ * dialog: a message takes buttons but no typed box, while a modal takes `Label`-wrapped text
+ * inputs and select menus, so everything but a one-tap question is answered in a modal.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { elicitFormBlockId } from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { DiscordConnection } from '../src/discord/connection.js'
+import type { DiscordComponents } from '../src/discord/render.js'
+import { elicitForm, elicitOptionToken, elicitTarget } from '../src/slack/render.js'
+import {
+  DISCORD_ELICIT_SURFACE,
+  DISCORD_MODAL_MAX_FIELDS,
+  buildDiscordElicitModal,
+  discordElicitButtons,
+  discordElicitId,
+  discordUsesModal,
+  parseDiscordElicit
+} from '../src/platforms/discord/elicit-card.js'
+
+const REQUEST_ID = '11111111-2222-4333-8444-555555555555'
+
+function form(properties: Record<string, unknown>, required: string[] = []): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'form',
+    message: 'Which branch should I cut from?',
+    requestedSchema: { type: 'object', properties, required }
+  } as CreateElicitationRequest
+}
+
+const BRANCH = { branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' } }
+const CHECKS = { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] }, title: 'Checks' } }
+
+/** The one Label wrapping field `index`, as the modal built it. */
+function field(modal: any, index: number): any {
+  return modal.components[index]
+}
+
+describe('the wire a Discord elicitation comes back on', () => {
+  it("fits Discord's 100-character custom_id for the widest card this scheme can mint", () => {
+    expect(discordElicitId(REQUEST_ID, elicitOptionToken(24)).length).toBeLessThanOrEqual(100)
+    expect(parseDiscordElicit(discordElicitId(REQUEST_ID, elicitOptionToken(3)))).toEqual({
+      requestId: REQUEST_ID,
+      token: elicitOptionToken(3)
+    })
+    // Dismiss is no answer, so it decodes as none.
+    expect(parseDiscordElicit(discordElicitId(REQUEST_ID, 'x'))).toEqual({ requestId: REQUEST_ID, token: null })
+    // The session-control cards' own schemes, which this decoder must never claim.
+    expect(parseDiscordElicit('ac_sel:m:2')).toBeNull()
+    expect(parseDiscordElicit('ac_cb:cancel')).toBeNull()
+    expect(parseDiscordElicit('')).toBeNull()
+  })
+
+  it('lays a one-tap card out five buttons to a row, each holding a POSITION', () => {
+    const rows = discordElicitButtons(
+      REQUEST_ID,
+      Array.from({ length: 6 }, (_, i) => ({ label: `o${i}` }))
+    )
+    // Six options plus Dismiss = seven buttons over two rows, since a row holds five.
+    expect(rows.map((r) => r.components.length)).toEqual([5, 2])
+    expect(rows[0]!.components[0]!.custom_id).toBe(discordElicitId(REQUEST_ID, elicitOptionToken(0)))
+    expect(rows[1]!.components.at(-1)!.label).toBe('Dismiss')
+  })
+})
+
+describe('what Discord declares it can collect, and which card collects it', () => {
+  it('claims every kind, because the dialog has a control for every kind', () => {
+    expect([...DISCORD_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum', 'multi-enum', 'number', 'text'])
+  })
+
+  it('answers a lone single-select or boolean with a tap, and everything else in the dialog', () => {
+    expect(discordUsesModal(elicitForm(form(BRANCH), DISCORD_ELICIT_SURFACE)!)).toBe(false)
+    expect(discordUsesModal(elicitForm(form({ ok: { type: 'boolean' } }), DISCORD_ELICIT_SURFACE)!)).toBe(false)
+    expect(discordUsesModal(elicitForm(form(CHECKS), DISCORD_ELICIT_SURFACE)!)).toBe(true)
+    expect(discordUsesModal(elicitForm(form({ note: { type: 'string' } }), DISCORD_ELICIT_SURFACE)!)).toBe(true)
+    expect(discordUsesModal(elicitForm(form({ ...BRANCH, ...CHECKS }), DISCORD_ELICIT_SURFACE)!)).toBe(true)
+  })
+
+  it('reduces every kind rather than dropping one, a typed field included', () => {
+    expect(elicitTarget(form(BRANCH), DISCORD_ELICIT_SURFACE)?.kind).toBe('enum')
+    expect(elicitTarget(form(CHECKS), DISCORD_ELICIT_SURFACE)?.kind).toBe('multi-enum')
+    expect(elicitTarget(form({ note: { type: 'string' } }), DISCORD_ELICIT_SURFACE)?.kind).toBe('text')
+    expect(elicitTarget(form({ n: { type: 'integer' } }), DISCORD_ELICIT_SURFACE)?.kind).toBe('number')
+  })
+})
+
+describe('the dialog one reduction becomes', () => {
+  const build = (params: CreateElicitationRequest) =>
+    buildDiscordElicitModal(REQUEST_ID, params, elicitForm(params, DISCORD_ELICIT_SURFACE)!)
+
+  it('wraps each field in a Label carrying the control that collects it', () => {
+    const params = form({ ...CHECKS, note: { type: 'string', title: 'Notes' } }, ['checks'])
+    const modal = build(params)!
+    expect(modal.custom_id).toBe(discordElicitId(REQUEST_ID, 'm'))
+    expect(modal.components).toHaveLength(2)
+
+    // A multi-select is one select menu, bounded by its own field rather than by the control.
+    const checks = field(modal, 0)
+    expect(checks.type).toBe(18)
+    expect(checks.label).toBe('Checks')
+    expect(checks.component.type).toBe(3)
+    expect(checks.component.custom_id).toBe(elicitFormBlockId(0))
+    expect(checks.component.max_values).toBe(2)
+    // Required, so at least one; every option carries its POSITION and never its own value.
+    expect(checks.component.min_values).toBe(1)
+    expect(checks.component.options.map((o: any) => o.value)).toEqual([elicitOptionToken(0), elicitOptionToken(1)])
+    expect(checks.component.options.map((o: any) => o.label)).toEqual(['lint', 'test'])
+
+    // A typed field is a text input, and this one is optional.
+    const note = field(modal, 1)
+    expect(note.component.type).toBe(4)
+    expect(note.component.custom_id).toBe(elicitFormBlockId(1))
+    expect(note.component.required).toBe(false)
+  })
+
+  it('lets an optional select take nothing, which is how a field stays omittable', () => {
+    const modal = build(form(CHECKS))!
+    expect(field(modal, 0).component.min_values).toBe(0)
+  })
+
+  it('has no dialog for more fields than a modal holds, and declines rather than dropping one', () => {
+    const many: Record<string, unknown> = {}
+    for (let i = 0; i <= DISCORD_MODAL_MAX_FIELDS; i++) many[`f${i}`] = { type: 'string' }
+    expect(build(form(many))).toBeNull()
+    const fits: Record<string, unknown> = {}
+    for (let i = 0; i < DISCORD_MODAL_MAX_FIELDS; i++) fits[`f${i}`] = { type: 'string' }
+    expect(build(form(fits))).not.toBeNull()
+  })
+})
+
+// -- the coordinator, on a Discord turn ------------------------------------------------------
+
+interface Harness {
+  daemon: any
+  conn: any
+  cards: { text: string; components: DiscordComponents }[]
+  edits: { text: string; components?: DiscordComponents }[]
+  notices: () => string[]
+}
+
+function discordTurn(): Harness {
+  const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+  daemon.store = {
+    getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: () => new Map(),
+    upsertElicit: vi.fn(async () => {})
+  }
+  const cards: { text: string; components: DiscordComponents }[] = []
+  const edits: { text: string; components?: DiscordComponents }[] = []
+  const conn = Object.create(DiscordConnection.prototype)
+  conn.postChrome = async (_c: string, text: string, opts: { keyboard?: DiscordComponents } = {}) => {
+    cards.push({ text, components: opts.keyboard ?? [] })
+    return '4242'
+  }
+  conn.updateMessage = async (_c: string, _id: string, text: string, opts: { keyboard?: DiscordComponents } = {}) => {
+    edits.push({ text, ...(opts.keyboard !== undefined ? { components: opts.keyboard } : {}) })
+  }
+  daemon.pending.set(JSON.stringify(['agent-1', 's1']), {
+    plan: {
+      platform: 'discord',
+      agentId: 'agent-1',
+      sessionKey: 'k1',
+      requesterId: 'turn-user',
+      channel: 'C1',
+      transcriptChannel: 'C1discord:bot-a',
+      statusThread: 'T1',
+      agentName: 'agent',
+      isDm: false,
+      approvalSurfaceSuppressed: false
+    },
+    hostKey: 'agent-1',
+    outwardSessionId: 'sess-1',
+    conn,
+    turnState: {},
+    chrome: {},
+    reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
+    signals: { applyChain: Promise.resolve() },
+    approval: { waitMs: 0, depth: 0 },
+    builtinSystemToolCallIds: new Set<string>(),
+    conv: { onUpdate: () => [], hasBuffered: () => false },
+    rec: { onUpdate: () => [] },
+    termOut: new TerminalOutputFolder()
+  })
+  const applied: any[] = []
+  daemon.enqueueApply = (_p: any, action: any) => void applied.push(action)
+  return {
+    daemon,
+    conn,
+    cards,
+    edits,
+    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+  }
+}
+
+async function raise(h: Harness, req: CreateElicitationRequest): Promise<{ requestId: string; result: Promise<any> }> {
+  const result = h.daemon.permissions.onAcpElicit('agent-1', 's1', req)
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.size).toBe(1))
+  const requestId = [...h.daemon.permissions.pendingElicits.keys()][0] as string
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.get(requestId).ts).toBe('4242'))
+  return { requestId, result }
+}
+
+describe('a Discord turn posts an elicitation card and settles it in place', () => {
+  it('answers a lone single-select with one tap, and never opens a dialog for it', async () => {
+    const h = discordTurn()
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    expect(h.cards[0]!.text).toBe('💬 Which branch should I cut from?')
+    expect(h.cards[0]!.components[0]!.components.map((b) => b.label)).toEqual(['main', 'develop', 'Dismiss'])
+    // There is no dialog behind a card one tap answers.
+    expect(h.daemon.permissions.openElicitEditor(requestId)).toBeUndefined()
+
+    await h.daemon.permissions.handleElicitCardTap({ requestId, token: elicitOptionToken(1) })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop' } })
+    expect(h.edits[0]!.text).toBe('💬 Which branch should I cut from?\n✅ develop')
+    // Nothing is left to press on an answered card.
+    expect(h.edits[0]!.components).toEqual([])
+  })
+
+  it('opens the dialog for everything else, and takes the whole form back at once', async () => {
+    const h = discordTurn()
+    const params = form({ ...CHECKS, note: { type: 'string', title: 'Notes' } }, ['checks'])
+    const { requestId, result } = await raise(h, params)
+    // The card itself only offers the way in — the answer never passes through the message.
+    expect(h.cards[0]!.components[0]!.components.map((b) => b.label)).toEqual(['Answer', 'Dismiss'])
+    const modal = h.daemon.permissions.openElicitEditor(requestId) as any
+    expect(modal.custom_id).toBe(discordElicitId(requestId, 'm'))
+
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(0)]: [elicitOptionToken(1)], [elicitFormBlockId(1)]: 'ship it' }
+    })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['test'], note: 'ship it' } })
+    expect(h.edits.at(-1)!.text).toContain('Checks: test')
+  })
+
+  it('reads a single-valued control list as the one value it holds', async () => {
+    // A select answers with a list even where it was configured to take one; the FIELD says which.
+    const h = discordTurn()
+    const { requestId, result } = await raise(h, form({ ...BRANCH, ...CHECKS }, ['branch']))
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(0)]: [elicitOptionToken(0)], [elicitFormBlockId(1)]: [] }
+    })
+    // And an untouched optional select is an OMISSION, not an empty answer.
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('refuses a dialog missing a required field, and leaves the card live', async () => {
+    const h = discordTurn()
+    const { requestId } = await raise(h, form({ ...CHECKS, note: { type: 'string' } }, ['checks']))
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(1)]: 'ship it' }
+    })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain('Checks')
+  })
+
+  it('refuses an option position the dialog never offered', async () => {
+    const h = discordTurn()
+    const { requestId } = await raise(h, form(CHECKS, ['checks']))
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(0)]: [elicitOptionToken(9)] }
+    })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain("wasn't accepted")
+  })
+
+  it('reads Dismiss as the decline it is, on either card', async () => {
+    const h = discordTurn()
+    const { requestId, result } = await raise(h, form(CHECKS, ['checks']))
+    await h.daemon.permissions.handleElicitCardTap({ requestId, token: null })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(h.edits.at(-1)!.text).toContain('Dismissed')
+  })
+
+  it('declines URL mode, whose consent a Discord link button could never report', async () => {
+    const h = discordTurn()
+    const req = {
+      sessionId: 's1',
+      mode: 'url',
+      message: 'Sign in to continue',
+      url: 'https://example.com/oauth',
+      elicitationId: 'e1'
+    } as unknown as CreateElicitationRequest
+    await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
+    expect(h.cards).toEqual([])
+    expect(h.notices().at(-1)).toContain("can't collect an answer for")
+  })
+
+  it('cancels an abandoned card and says so on the card itself', async () => {
+    const h = discordTurn()
+    const { requestId, result } = await raise(h, form(CHECKS, ['checks']))
+    await h.daemon.permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+    expect(h.edits.at(-1)!.text).toContain('Cancelled')
+    expect(h.daemon.permissions.openElicitEditor(requestId)).toBeUndefined()
+  })
+})

--- a/packages/daemon/test/discord-elicit-card.test.ts
+++ b/packages/daemon/test/discord-elicit-card.test.ts
@@ -119,9 +119,13 @@ describe('the dialog one reduction becomes', () => {
     expect(note.component.required).toBe(false)
   })
 
-  it('lets an optional select take nothing, which is how a field stays omittable', () => {
+  it('lets an optional select take nothing, and SAYS it is optional', () => {
     const modal = build(form(CHECKS))!
     expect(field(modal, 0).component.min_values).toBe(0)
+    // Discord defaults `required` to true and refuses a zero `min_values` under it, so leaving the
+    // flag off would fail the whole dialog to open rather than merely mislabel one field.
+    expect(field(modal, 0).component.required).toBe(false)
+    expect(field(build(form(CHECKS, ['checks']))!, 0).component.required).toBe(true)
   })
 
   it('has no dialog for more fields than a modal holds, and declines rather than dropping one', () => {
@@ -139,27 +143,32 @@ describe('the dialog one reduction becomes', () => {
 interface Harness {
   daemon: any
   conn: any
-  cards: { text: string; components: DiscordComponents }[]
-  edits: { text: string; components?: DiscordComponents }[]
+  cards: { channel: string; text: string; components: DiscordComponents }[]
+  edits: { channel: string; text: string; components?: DiscordComponents }[]
   notices: () => string[]
 }
 
-function discordTurn(): Harness {
+function discordTurn(turn: { thread?: string } = {}): Harness {
   const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
   daemon.store = {
     getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
     getDisplayNames: () => new Map(),
     upsertElicit: vi.fn(async () => {})
   }
-  const cards: { text: string; components: DiscordComponents }[] = []
-  const edits: { text: string; components?: DiscordComponents }[] = []
+  const cards: { channel: string; text: string; components: DiscordComponents }[] = []
+  const edits: { channel: string; text: string; components?: DiscordComponents }[] = []
   const conn = Object.create(DiscordConnection.prototype)
-  conn.postChrome = async (_c: string, text: string, opts: { keyboard?: DiscordComponents } = {}) => {
-    cards.push({ text, components: opts.keyboard ?? [] })
+  conn.postChrome = async (channel: string, text: string, opts: { keyboard?: DiscordComponents } = {}) => {
+    cards.push({ channel, text, components: opts.keyboard ?? [] })
     return '4242'
   }
-  conn.updateMessage = async (_c: string, _id: string, text: string, opts: { keyboard?: DiscordComponents } = {}) => {
-    edits.push({ text, ...(opts.keyboard !== undefined ? { components: opts.keyboard } : {}) })
+  conn.updateMessage = async (
+    channel: string,
+    _id: string,
+    text: string,
+    opts: { keyboard?: DiscordComponents } = {}
+  ) => {
+    edits.push({ channel, text, ...(opts.keyboard !== undefined ? { components: opts.keyboard } : {}) })
   }
   daemon.pending.set(JSON.stringify(['agent-1', 's1']), {
     plan: {
@@ -172,7 +181,8 @@ function discordTurn(): Harness {
       statusThread: 'T1',
       agentName: 'agent',
       isDm: false,
-      approvalSurfaceSuppressed: false
+      approvalSurfaceSuppressed: false,
+      ...(turn.thread !== undefined ? { thread: turn.thread } : {})
     },
     hostKey: 'agent-1',
     outwardSessionId: 'sess-1',
@@ -293,6 +303,17 @@ describe('a Discord turn posts an elicitation card and settles it in place', () 
     await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
     expect(h.cards).toEqual([])
     expect(h.notices().at(-1)).toContain("can't collect an answer for")
+  })
+
+  it('posts a threaded card IN its thread, and settles it there', async () => {
+    // A Discord thread is a channel of its own: a card edited against the parent is a card never
+    // edited at all, and the reader is left looking at live buttons that answer nothing.
+    const h = discordTurn({ thread: 'T-thread' })
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    expect(h.cards[0]!.channel).toBe('T-thread')
+    await h.daemon.permissions.handleElicitCardTap({ requestId, token: elicitOptionToken(0) })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+    expect(h.edits[0]!.channel).toBe('T-thread')
   })
 
   it('cancels an abandoned card and says so on the card itself', async () => {

--- a/packages/daemon/test/platform-registry-drift.test.ts
+++ b/packages/daemon/test/platform-registry-drift.test.ts
@@ -71,11 +71,11 @@ describe('daemon platform registry (audit F16)', () => {
 
   it('pins which surfaces declare an elicitation card, and lets no other origin inherit one', () => {
     // #1794 gap 6: the facet is OPTIONAL, so this is not a drift check against `platformIds()` —
-    // it is the pin on today's true set. Discord and Feishu are the third and fourth implementers
-    // and get their own changes; adding one must fail here first.
+    // it is the pin on today's true set. Feishu is the fourth implementer and gets its own
+    // change; adding one must fail here first.
     const daemon = new Daemon({ root: bareRoot() }) as any
     const withCards = platformIds().filter((id: string) => daemon.turnSurfaces.exact(id)?.elicitCards)
-    expect(withCards).toEqual(['slack', 'telegram'])
+    expect(withCards).toEqual(['slack', 'telegram', 'discord'])
     // Exact lookup, so a webchat / hook / dream turn rendering through the core (Slack) surface
     // does not inherit Slack's cards — webchat's own card is core-owned.
     for (const origin of ['webchat', 'hook', 'dream']) {


### PR DESCRIPTION
## Discord turns out to be the best elicitation surface we have

It declined every ask before this. But a Discord **message** takes buttons and no typed box, while
a **modal** takes `Label`-wrapped text inputs *and* select menus — so the reader gets the whole
form as one dialog, submitted atomically. That is closer to what `elicitation/create` describes
than any message-level card can be.

Verified against what is actually installed, not assumed:

| claim | evidence |
|---|---|
| a modal holds selects, radio/checkbox groups and text inputs | `discord-api-types@0.38.54` → `APIComponentInLabel` |
| raw modal JSON can be sent | `discord.js@14.27` → `showModal(APIModalInteractionResponseCallbackData)` |
| every control reads back | `ModalSubmitFields.getField` → `TextInputModalData.value`, `SelectMenuModalData.values` |
| 1–5 components per modal, label ≤ 45, select ≤ 25 options | the same typings' own doc comments |

## What the reader sees

```
💬 Which checks should I run, and any notes?
┌──────────────────────┐
│  Answer    Dismiss   │   ← the card only offers the way in
└──────────────────────┘
        ↓ Answer
╔══════════════════════════════════╗
║ The agent needs your input       ║
║ Checks                           ║
║  [ lint ▾ ]  (select, min 1)     ║
║ Notes                            ║
║  [________________________]      ║
║              Cancel   Submit     ║
╚══════════════════════════════════╝
```

**One exception**, the same one every surface makes: a lone single-select or boolean stays a row of
buttons in the channel, because one tap already answers it and a dialog would be a round trip for
nothing.

## Choices worth stating

- **Select menus for every option field**, though the modal also takes radio and checkbox groups.
  A radio group is prettier but holds 2–10 options against a select's 25, and its arity is a
  different *component* rather than a different bound — so choosing it buys nicer pixels for two
  more code paths and two more cliffs. One control, one bound, one read path.
- **This is not the Slack modal removed earlier in #1794.** Slack has message-level input state,
  which made its modal a second way to do what the card already did. Discord has no way at all to
  type into a message, so the dialog is not a choice between surfaces — it is the only surface that
  can take a typed answer.
- **Interactions route before the ack.** `showModal` must be the interaction's *first* response and
  the existing handler defers immediately, so elicitation components are matched ahead of it — and
  ahead of the status-key lookup, since an elicitation card is not a status card: its own
  `custom_id` carries the request, so it needs no message-to-session registry.

## Nothing Discord-shaped reaches the answer

Every option carries its **position** and every field is keyed by the same `elicitFormBlockId` a
Slack Confirm submits under, so core's one re-derivation (#1815) validates a dialog exactly as it
validates a Confirm. `submitElicitEditor` reconciles the single thing that differs on the way in:
a list-taking control answers with a list even where it was configured to take one, and the *field*
says which it was.

New optional facet member `editor(handle, card)` — the payload of a secondary surface a card opens.
Absent on Slack and Telegram, which answer where they were posted; null for Discord's own one-tap
row. Rebuilt from the card's own params on each open, so the dialog offers the very fields the ask
reduced to.

## Still declined on Discord

- **More than five fields** — a modal holds five. Declined whole, since a dialog missing a question
  would collect an answer to a form the reader never saw.
- **URL mode** — a Discord link button opens the page but delivers no interaction, so consent could
  never be observed, and consent is all that seam decides.

## Verification

- `packages/daemon/test/discord-elicit-card.test.ts` — 16 tests, green first run.
- Covers: the `custom_id` codec and its refusal of the status-card schemes; the one-tap card's
  five-to-a-row layout; the surface claiming every kind; which reductions take a dialog; the modal's
  Label/control shape with positions as values and the field's own bounds as `min_values`/
  `max_values`; an optional select taking nothing; a >5-field reduction declined; the one-tap and
  dialog paths end to end; a single-valued control's list read as one value; a missing required
  field and an unoffered position both refused with the card left live; Dismiss; URL mode declined;
  and an abandoned card cancelled.
- `platform-registry-drift.test.ts` — the pin on which surfaces declare a card went red on this
  change and is updated deliberately to `['slack', 'telegram', 'discord']`.
- `pnpm eval:gates` 196/197 (the known pre-existing `evaluation-runner` baseline); typecheck,
  eslint and prettier clean.

Refs #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
