### PR TITLE
feat(daemon): a Feishu elicitation is answered in a card form

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -470,6 +470,7 @@ import {
 } from './platforms/telegram/turn-output.js'
 import { parseTelegramElicit, telegramElicitCards } from './platforms/telegram/elicit-card.js'
 import { discordElicitCards } from './platforms/discord/elicit-card.js'
+import { feishuElicitCards } from './platforms/feishu/elicit-card.js'
 import { applyDiscordAction as applyDiscordActionExternal } from './platforms/discord/turn-output.js'
 import { applyFeishuAction as applyFeishuActionExternal, type FeishuTurnState } from './platforms/feishu/turn-output.js'
 import { LinearConnection } from './platforms/linear/connection.js'
@@ -1027,6 +1028,7 @@ export class Daemon {
       })
       registry.register({
         platform: 'feishu',
+        elicitCards: feishuElicitCards,
         createConverger: (ctx) => new FeishuConverger(ctx.mode as never, ctx.resolveFileLink),
         initialTurnState: (): FeishuTurnState => ({}),
         apply: (p, action) => this.applyFeishuAction(p, action as FeishuAction),

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -9,6 +9,7 @@ import type {
   WireFeishuCardActionResponse,
   WireFeishuCardActionTarget
 } from '@agentconnect.md/protocol'
+import { parseFeishuElicit } from '../platforms/feishu/elicit-card.js'
 import type { Agent } from '../agents/agent-schema.js'
 import { integrationCore, platformIntegrationConfig } from '../platforms/integration-config.js'
 import type { ReplyAttributionInfo } from '../messages/attribution.js'
@@ -116,6 +117,14 @@ export interface FeishuDeps {
   /** Fired when a user selects Cancel run from an active reply card's overflow menu.
    * The connection resolves the callback message id to the turn's local session key. */
   onStatusAction?: (a: { kind: 'cancel'; sessionKey: string; actor?: InteractionActor }) => void
+  /** A tapped elicitation option, or Dismiss (`token` null) — §7.3. */
+  onElicitChoice?: (a: { requestId: string; token: string | null; actor?: InteractionActor }) => Promise<void>
+  /** One submitted elicitation form: every named control's value, as CardKit reports them. */
+  onElicitSubmit?: (a: {
+    requestId: string
+    values: Record<string, string | string[]>
+    actor?: InteractionActor
+  }) => Promise<void>
   newTraceId: () => string
   log?: Logger
   /** Min spacing (ms) between outbound writes (serialized send-queue). Tests pass 0. */
@@ -760,6 +769,11 @@ export class FeishuConnection implements PlatformConnection {
     const channel = event.context?.open_chat_id ?? event.open_chat_id
     const actorId = event.operator?.open_id ?? event.operator?.user_id
     const value = asRecord(event.action?.value)
+    // An elicitation card carries the request in its OWN payload, so it needs no message-to-session
+    // registry and is matched before the session-control card below. Anyone who can see it may
+    // answer it, which is the same rule its buttons follow on every other surface.
+    const elicit = parseFeishuElicit(value)
+    if (elicit) return this.onElicitCardAction(event, elicit, actorId)
     if (
       !messageId ||
       !actorId ||
@@ -778,6 +792,32 @@ export class FeishuConnection implements PlatformConnection {
       actor: { userId: actorId }
     })
     return { toast: { type: 'info', content: 'Cancellation requested.' } }
+  }
+
+  /** Route one interaction on an elicitation card: a Confirm carries every named control at once
+   *  in `form_value`, and every other control is a whole answer in itself. The toast is what tells
+   *  the reader the tap landed — a CardKit callback that answers nothing shows them nothing. */
+  private onElicitCardAction(
+    event: FeishuRawCardActionEvent,
+    elicit: { requestId: string; token: string | null },
+    actorId?: string
+  ): FeishuCardActionResponse | undefined {
+    const actor: InteractionActor | undefined = actorId ? { userId: actorId } : undefined
+    const form = event.action?.form_value
+    if (form && this.deps.onElicitSubmit) {
+      const values: Record<string, string | string[]> = {}
+      for (const [name, raw] of Object.entries(form)) {
+        // A text input answers with a string and a select with one or a list; the FIELD each
+        // belongs to is what says which, and core reconciles that against the card's own form.
+        if (typeof raw === 'string') values[name] = raw
+        else if (Array.isArray(raw)) values[name] = raw.filter((v): v is string => typeof v === 'string')
+      }
+      void this.deps.onElicitSubmit({ requestId: elicit.requestId, values, ...(actor ? { actor } : {}) })
+      return undefined
+    }
+    if (!this.deps.onElicitChoice) return undefined
+    void this.deps.onElicitChoice({ requestId: elicit.requestId, token: elicit.token, ...(actor ? { actor } : {}) })
+    return undefined
   }
 
   /** Send one chunk: reply INTO the topic thread when `anchor` is a message id (the
@@ -806,6 +846,38 @@ export class FeishuConnection implements PlatformConnection {
     return anchor && anchor.startsWith('om_')
       ? this.handle.api.replyCard(anchor, card)
       : this.handle.api.createCard(channel, card)
+  }
+
+  /** Post one elicitation card (§7.3), returning the message id its settlement addresses. Best
+   *  effort like every other card post: undefined when the platform refused it, which core reads
+   *  as an ask nobody could be shown. */
+  async postElicitCard(
+    channel: string,
+    anchor: string | undefined,
+    card: Record<string, unknown>
+  ): Promise<string | undefined> {
+    return this.queue.enqueue(async () => {
+      try {
+        const res = await this.sendPermissionCard(channel, anchor, card)
+        return res.messageId
+      } catch (err) {
+        this.rememberPermissionIssue(err, channel)
+        this.deps.log?.debug(`feishu: elicitation card post failed (ch=${channel}): ${(err as Error).message}`)
+        return undefined
+      }
+    })
+  }
+
+  /** Rewrite a posted elicitation card as settled — the CardKit analog of Slack's `chat.update`.
+   *  Best effort by construction: no ACP outcome depends on it. */
+  async updateElicitCard(messageId: string, card: Record<string, unknown>): Promise<void> {
+    await this.queue.enqueue(async () => {
+      try {
+        await this.handle.api.patchCardMessage(messageId, card)
+      } catch (err) {
+        this.deps.log?.debug(`feishu: elicitation card update failed (id=${messageId}): ${(err as Error).message}`)
+      }
+    })
   }
 
   private sendCardEntity(channel: string, anchor: string | undefined, cardId: string): Promise<{ messageId?: string }> {

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -2055,7 +2055,8 @@ export class PermissionCoordinator {
   }
 
   /**
-   * Answer a card from its DIALOG's submission — {@link openElicitEditor}'s other half.
+   * Answer a card from a submitted set of NAMED VALUES — a Discord dialog's fields, a Feishu
+   * form's controls. {@link openElicitEditor}'s other half where the surface has a dialog at all.
    *
    * A dialog's controls report their arity by SHAPE: a list-taking control answers with a list
    * even where it was configured to take one. The FIELD is what says which it was, so a
@@ -2069,7 +2070,7 @@ export class PermissionCoordinator {
     actor?: InteractionActor
   }): Promise<void> {
     const rec = this.pendingElicits.get(a.requestId)
-    if (!rec || rec.surface !== 'chat' || !rec.facet.editor) return
+    if (!rec || rec.surface !== 'chat') return
     const form = this.cardForm(rec)
     if (!form) return
     const fields: Record<string, string | string[]> = {}

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -714,6 +714,8 @@ export class ConnectionReconciler {
           this.host.onInbound(msg, this.host.srcIntegrationIds(conn))
         },
         onStatusAction: (a) => this.host.handleStatusAction(a),
+        onElicitChoice: (a) => this.host.handleElicitCardTap(a),
+        onElicitSubmit: (a) => this.host.submitElicitEditor(a),
         log: this.log
       })
       try {

--- a/packages/daemon/src/platforms/feishu/elicit-card.ts
+++ b/packages/daemon/src/platforms/feishu/elicit-card.ts
@@ -1,0 +1,312 @@
+/**
+ * Feishu's **elicitation-card facet** (§7.3) — the fourth implementer of {@link ElicitCardFacet},
+ * and the last chat surface #1794 was waiting on.
+ *
+ * WHAT FEISHU HAS is a CardKit 2.0 `form` container: named controls — a text `input`, a
+ * `select_static`, a `multi_select_static` — around one submit button, whose callback carries
+ * every control's value at once in `action.form_value`. That is the same shape Slack's message
+ * card has and the same shape Discord's dialog has, in the message rather than over a modal, so
+ * the reduction maps onto it without a second level or a round trip.
+ *
+ * ONE EXCEPTION, and it is the one every surface makes: a lone single-select or boolean is a row
+ * of buttons, because one tap already answers it and a form would ask the reader to submit a
+ * decision they have already made.
+ *
+ * WHAT IS NOT VERIFIED HERE, and is stated rather than implied: unlike Discord — whose modal
+ * components this repo could check against the installed `discord-api-types` — the Lark SDK ships
+ * no card schema at all, since a CardKit card is opaque JSON. The `form` container is documented
+ * behaviour, not behaviour this repo can prove, so the bounds below are OUR conservative choices
+ * and are named as such. A card the platform refuses is a card that never posts, which core
+ * already treats as an ask nobody could answer.
+ */
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { elicitFormBlockId } from '@agentconnect.md/protocol'
+import type {
+  ElicitCardAsk,
+  ElicitCardDraft,
+  ElicitCardFacet,
+  ElicitCardHandle,
+  ElicitCardHost,
+  ElicitCardMark,
+  ElicitCardSettlement,
+  ElicitCardTap,
+  ElicitCardTapTarget,
+  ElicitCardTurn
+} from '../elicit-card.js'
+import type { FeishuConnection } from '../../feishu/connection.js'
+import { FEISHU_MESSAGE_LIMIT } from '../../feishu/render.js'
+import {
+  clampTo,
+  elicitFormFieldHint,
+  elicitFormFieldLabel,
+  elicitOptionToken,
+  elicitRequiredProps,
+  type ElicitKind,
+  type ElicitSurface,
+  type ElicitTarget
+} from '../../slack/render.js'
+
+/** Our own cap on how many options one card offers. Feishu publishes no number this code can
+ *  check, so this is Slack's button cap re-used deliberately rather than a platform limit dressed
+ *  up as one: a list past it is declined whole, never trimmed to fit. */
+const FEISHU_ELICIT_MAX_OPTIONS = 24
+
+/** Our own cap on one label, for the same reason — the 75 characters a reduced option label
+ *  already clamps to. */
+const FEISHU_LABEL_CAP = 75
+
+/** How much of the answer a settled card echoes back. What the READER sees is clamped; what the
+ *  AGENT receives is not (#1844), because the accepted content is built from the raw answer. */
+const FEISHU_ELICIT_DECISION_CAP = 300
+
+/** How much of the question one card carries: whatever is left once the settlement line is
+ *  reserved, so the rewrite still fits after the ask did. */
+const FEISHU_ELICIT_MESSAGE_CAP = FEISHU_MESSAGE_LIMIT - FEISHU_ELICIT_DECISION_CAP - 8
+
+/** How Feishu spells each settlement mark. Literal emoji: a CardKit markdown element has no
+ *  shortcode vocabulary, so Slack's `:white_check_mark:` would reach the reader as source text. */
+const FEISHU_ELICIT_MARK: Record<ElicitCardMark, string> = {
+  answered: '✅',
+  dismissed: '🚫',
+  waiting: '⏳',
+  blocked: '🔒'
+}
+
+/** What this card's callbacks name themselves, so a tap on a session-control card is never read
+ *  as an answer and vice versa. */
+export const FEISHU_ELICIT_ACTION = 'agentconnect_elicit'
+
+/** The token a Dismiss button carries. Not a position, because Dismiss answers no option. */
+const FEISHU_ELICIT_DISMISS = 'x'
+
+/** The token the Confirm button of a form carries. It names no option: it submits the lot. */
+const FEISHU_ELICIT_CONFIRM = 'ok'
+
+/** The `element_id` a form container and its submit button are known by. */
+const FEISHU_ELICIT_FORM_ID = 'agentconnect_elicit_form'
+
+/**
+ * What a Feishu elicitation card can render AND collect: every kind, because a CardKit form has a
+ * control for every kind — a text input for what must be typed, a select for one of a list, a
+ * multi-select for several.
+ */
+export const FEISHU_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
+  optionLimits: {
+    enum: { maxOptions: FEISHU_ELICIT_MAX_OPTIONS },
+    'multi-enum': { maxOptions: FEISHU_ELICIT_MAX_OPTIONS }
+  }
+}
+
+/** The payload one of this card's controls carries back, as CardKit hands it to us: an object,
+ *  not a string, so the request and the token ride as their own fields rather than being parsed
+ *  out of one. Pure. */
+export function feishuElicitValue(requestId: string, token: string): Record<string, string> {
+  return { action: FEISHU_ELICIT_ACTION, request: requestId, token }
+}
+
+/** The request and the token one card callback names — null for a payload this scheme did not
+ *  mint, which is how a session-control tap stays a session-control tap. Dismiss reads as no
+ *  answer, exactly as it does on every other surface. Pure. */
+export function parseFeishuElicit(value: unknown): { requestId: string; token: string | null } | null {
+  if (!value || typeof value !== 'object') return null
+  const v = value as Record<string, unknown>
+  if (v.action !== FEISHU_ELICIT_ACTION) return null
+  const requestId = typeof v.request === 'string' ? v.request : ''
+  const token = typeof v.token === 'string' ? v.token : ''
+  if (!requestId || !token) return null
+  return { requestId, token: token === FEISHU_ELICIT_DISMISS ? null : token }
+}
+
+/** The card's own heading: the question, on the same speech-balloon line every surface opens
+ *  with. A CardKit `markdown` element renders the agent's words as markup, so they are clamped
+ *  here and never given a link syntax of our own to inherit. Pure. */
+export function feishuElicitText(message: string): string {
+  return `💬 ${clampTo(message, FEISHU_ELICIT_MESSAGE_CAP)}`
+}
+
+function feishuDismissButton(requestId: string): Record<string, unknown> {
+  return {
+    tag: 'button',
+    text: { tag: 'plain_text', content: 'Dismiss' },
+    type: 'default',
+    behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, FEISHU_ELICIT_DISMISS) }]
+  }
+}
+
+/** The ONE-TAP card: one button per option plus Dismiss, each carrying its option's POSITION and
+ *  never its own value — the rule every surface shares (#1844), so an enum of paths or ids can be
+ *  offered at all. Pure. */
+export function buildFeishuElicitButtons(
+  requestId: string,
+  message: string,
+  options: readonly { label: string }[]
+): Record<string, unknown> {
+  return feishuCard([
+    { tag: 'markdown', content: feishuElicitText(message) },
+    {
+      tag: 'action',
+      layout: 'flow',
+      actions: [
+        ...options.map((o, i) => ({
+          tag: 'button',
+          text: { tag: 'plain_text', content: clampTo(o.label, FEISHU_LABEL_CAP) },
+          type: 'default',
+          behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, elicitOptionToken(i)) }]
+        })),
+        feishuDismissButton(requestId)
+      ]
+    }
+  ])
+}
+
+/**
+ * The FORM card: one named control per field inside a CardKit `form`, then the single Confirm that
+ * submits the lot and a Dismiss beside it.
+ *
+ * Every control is named by the same {@link elicitFormBlockId} a Slack Confirm submits under, and
+ * every option carries its POSITION — so what comes back out of this form is validated by core's
+ * one re-derivation (#1815) with nothing Feishu-shaped left in it.
+ *
+ * Null when a field has no control here: an option list past what this card offers. Declined
+ * whole, never trimmed, for the same reason every other surface declines one. Pure.
+ */
+export function buildFeishuElicitForm(
+  requestId: string,
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[]
+): Record<string, unknown> | null {
+  if (!form.length) return null
+  const required = new Set(elicitRequiredProps(params))
+  const elements: Record<string, unknown>[] = []
+  for (const [index, target] of form.entries()) {
+    const name = elicitFormBlockId(index)
+    const label = clampTo(elicitFormFieldLabel(params, target), FEISHU_LABEL_CAP)
+    const hint = elicitFormFieldHint(target)
+    const need = required.has(target.propName)
+    if (target.kind === 'text' || target.kind === 'number') {
+      elements.push({
+        tag: 'input',
+        name,
+        required: need,
+        label: { tag: 'plain_text', content: label },
+        ...(hint ? { placeholder: { tag: 'plain_text', content: clampTo(hint, FEISHU_LABEL_CAP) } } : {}),
+        ...(target.defaultValue !== undefined ? { default_value: String(target.defaultValue) } : {})
+      })
+      continue
+    }
+    if (!target.options.length || target.options.length > FEISHU_ELICIT_MAX_OPTIONS) return null
+    elements.push({
+      tag: target.kind === 'multi-enum' ? 'multi_select_static' : 'select_static',
+      name,
+      required: need,
+      label: { tag: 'plain_text', content: label },
+      ...(hint ? { placeholder: { tag: 'plain_text', content: clampTo(hint, FEISHU_LABEL_CAP) } } : {}),
+      options: target.options.map((o, n) => ({
+        text: { tag: 'plain_text', content: clampTo(o.label, FEISHU_LABEL_CAP) },
+        value: elicitOptionToken(n)
+      }))
+    })
+  }
+  return feishuCard([
+    { tag: 'markdown', content: feishuElicitText((params as { message?: string }).message?.trim() ?? '') },
+    {
+      tag: 'form',
+      name: FEISHU_ELICIT_FORM_ID,
+      elements: [
+        ...elements,
+        {
+          tag: 'action',
+          layout: 'flow',
+          actions: [
+            {
+              tag: 'button',
+              text: { tag: 'plain_text', content: 'Confirm' },
+              type: 'primary',
+              // The one control that reads every named field above and sends them together.
+              form_action_type: 'submit',
+              name: `${FEISHU_ELICIT_FORM_ID}_submit`,
+              behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, FEISHU_ELICIT_CONFIRM) }]
+            },
+            feishuDismissButton(requestId)
+          ]
+        }
+      ]
+    }
+  ])
+}
+
+/** The settled card: the question with the decision under it, and no control left to press. */
+export function buildFeishuElicitSettled(message: string, decision: string): Record<string, unknown> {
+  return feishuCard([
+    { tag: 'markdown', content: clampTo(`${feishuElicitText(message)}\n${decision}`, FEISHU_MESSAGE_LIMIT) }
+  ])
+}
+
+/** The CardKit 2.0 envelope every card here shares. */
+function feishuCard(elements: Record<string, unknown>[]): Record<string, unknown> {
+  return { schema: '2.0', config: { update_multi: true }, body: { elements } }
+}
+
+/** Whether this reduction is answered by ONE TAP, or needs the form. The same line every surface
+ *  draws, and the only place Feishu decides it. Pure. */
+export function feishuUsesForm(form: readonly ElicitTarget[]): boolean {
+  const only = form.length === 1 ? form[0]! : null
+  return !(only && (only.kind === 'enum' || only.kind === 'boolean') && only.options.length > 0)
+}
+
+/** Feishu's per-turn elicitation draft: the whole card, ready to post. */
+interface FeishuElicitDraft {
+  card: Record<string, unknown>
+}
+
+export const feishuElicitCards: ElicitCardFacet = {
+  platform: 'feishu',
+  reduction: FEISHU_ELICIT_SURFACE,
+
+  build(_host: ElicitCardHost, _turn: ElicitCardTurn, ask: ElicitCardAsk): ElicitCardDraft | null {
+    // No consent control: a CardKit link button opens the page but reports nothing back, so the
+    // daemon would never learn the reader consented — and consent is all that seam decides.
+    if (ask.url || !ask.form?.length) return null
+    if (!feishuUsesForm(ask.form)) {
+      const target = ask.form[0]!
+      if (target.options.length > FEISHU_ELICIT_MAX_OPTIONS) return null
+      return { card: buildFeishuElicitButtons(ask.requestId, ask.message, target.options) } satisfies FeishuElicitDraft
+    }
+    const card = buildFeishuElicitForm(ask.requestId, ask.params, ask.form)
+    return card ? ({ card } satisfies FeishuElicitDraft) : null
+  },
+
+  async send(
+    host: ElicitCardHost,
+    turn: ElicitCardTurn,
+    _ask: ElicitCardAsk,
+    draft: ElicitCardDraft
+  ): Promise<string | undefined> {
+    const d = draft as FeishuElicitDraft
+    // The card anchors exactly as every other post of this turn does — on `plan.thread`, which is
+    // what `applyFeishuAction` hands every send. A Feishu id prefix is what separates "reply into
+    // this thread" (`om_…`) from "post to this chat" (`oc_…`), so one field is the whole anchor.
+    return await host.postCardSerialized(turn, (conn) =>
+      (conn as FeishuConnection).postElicitCard(turn.plan.channel, turn.plan.thread, d.card)
+    )
+  },
+
+  /** A one-tap card's option, and nothing else: a form card is answered by its Confirm, which
+   *  arrives with every field at once and reaches core through `submitElicitForm`. */
+  tap(_handle: ElicitCardHandle, card: ElicitCardTapTarget, token: string): ElicitCardTap | null {
+    // A Confirm with no fields at all still submits: an all-optional form may answer empty, and
+    // core is what decides whether that is an answer.
+    if (feishuUsesForm(card.form) && token === FEISHU_ELICIT_CONFIRM) return { kind: 'submit', fields: {} }
+    return null
+  },
+
+  settle(handle: ElicitCardHandle, card: ElicitCardSettlement): void {
+    if (handle.ts === undefined) return
+    const message = (card.params as { message?: string }).message?.trim() || 'The agent needs your input'
+    const decision = `${FEISHU_ELICIT_MARK[card.mark]} ${clampTo(card.text, FEISHU_ELICIT_DECISION_CAP)}`
+    void (handle.conn as FeishuConnection)
+      .updateElicitCard(handle.ts, buildFeishuElicitSettled(message, decision))
+      .catch(() => {})
+  }
+}

--- a/packages/daemon/src/platforms/feishu/elicit-card.ts
+++ b/packages/daemon/src/platforms/feishu/elicit-card.ts
@@ -125,6 +125,18 @@ export function feishuElicitText(message: string): string {
   return `💬 ${clampTo(message, FEISHU_ELICIT_MESSAGE_CAP)}`
 }
 
+/** A row of buttons, as CardKit 2.0 spells one: buttons live directly in `elements`, and a
+ *  `column_set` is what puts several on one line — the same layout this repo's own reply card
+ *  already uses. JSON 2.0 has no `tag: 'action'` wrapper at all. Pure. */
+function feishuButtonRow(buttons: Record<string, unknown>[]): Record<string, unknown> {
+  return {
+    tag: 'column_set',
+    flex_mode: 'flow',
+    horizontal_spacing: '8px',
+    columns: buttons.map((button) => ({ tag: 'column', width: 'auto', elements: [button] }))
+  }
+}
+
 function feishuDismissButton(requestId: string): Record<string, unknown> {
   return {
     tag: 'button',
@@ -144,25 +156,22 @@ export function buildFeishuElicitButtons(
 ): Record<string, unknown> {
   return feishuCard([
     { tag: 'markdown', content: feishuElicitText(message) },
-    {
-      tag: 'action',
-      layout: 'flow',
-      actions: [
-        ...options.map((o, i) => ({
-          tag: 'button',
-          text: { tag: 'plain_text', content: clampTo(o.label, FEISHU_LABEL_CAP) },
-          type: 'default',
-          behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, elicitOptionToken(i)) }]
-        })),
-        feishuDismissButton(requestId)
-      ]
-    }
+    feishuButtonRow([
+      ...options.map((o, i) => ({
+        tag: 'button',
+        text: { tag: 'plain_text', content: clampTo(o.label, FEISHU_LABEL_CAP) },
+        type: 'default',
+        behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, elicitOptionToken(i)) }]
+      })),
+      feishuDismissButton(requestId)
+    ])
   ])
 }
 
 /**
- * The FORM card: one named control per field inside a CardKit `form`, then the single Confirm that
- * submits the lot and a Dismiss beside it.
+ * The FORM card: one named control per field inside a CardKit `form`, the single Confirm that
+ * submits the lot, and a Dismiss OUTSIDE the container — a form button is submit or reset, and a
+ * submit validates the required fields, which is exactly the state a refusal has to work in.
  *
  * Every control is named by the same {@link elicitFormBlockId} a Slack Confirm submits under, and
  * every option carries its POSITION — so what comes back out of this form is validated by core's
@@ -215,24 +224,23 @@ export function buildFeishuElicitForm(
       name: FEISHU_ELICIT_FORM_ID,
       elements: [
         ...elements,
+        // The one control that reads every named field above and sends them together. A button
+        // INSIDE a form needs both a `name` and a `form_action_type`, and submit is the only one
+        // of the two that carries values — reset merely clears them.
         {
-          tag: 'action',
-          layout: 'flow',
-          actions: [
-            {
-              tag: 'button',
-              text: { tag: 'plain_text', content: 'Confirm' },
-              type: 'primary',
-              // The one control that reads every named field above and sends them together.
-              form_action_type: 'submit',
-              name: `${FEISHU_ELICIT_FORM_ID}_submit`,
-              behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, FEISHU_ELICIT_CONFIRM) }]
-            },
-            feishuDismissButton(requestId)
-          ]
+          tag: 'button',
+          text: { tag: 'plain_text', content: 'Confirm' },
+          type: 'primary',
+          form_action_type: 'submit',
+          name: `${FEISHU_ELICIT_FORM_ID}_submit`,
+          behaviors: [{ type: 'callback', value: feishuElicitValue(requestId, FEISHU_ELICIT_CONFIRM) }]
         }
       ]
-    }
+    },
+    // Dismiss stands OUTSIDE the form, and has to: a form button is submit or reset, and submit
+    // validates the required fields. The reader's one explicit refusal must work precisely when
+    // those fields are empty, which is the case a submit would refuse.
+    feishuButtonRow([feishuDismissButton(requestId)])
   ])
 }
 

--- a/packages/daemon/test/feishu-elicit-card.test.ts
+++ b/packages/daemon/test/feishu-elicit-card.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Feishu's elicitation card — the fourth implementer of the Layer-2 elicitation-card facet
+ * (#1794), and the last chat surface it was waiting on. A CardKit 2.0 `form` container holds a
+ * named control per field around one submit button, so the whole reduction is answered in the
+ * message; a lone single-select or boolean keeps the button row every surface gives it.
+ *
+ * These tests pin the CARD WE BUILD and the answer we take back from it. They cannot pin what
+ * Feishu accepts — a CardKit card is opaque JSON and the Lark SDK ships no schema — which is the
+ * one thing about this surface that a live check has to settle.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { elicitFormBlockId } from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { FeishuConnection } from '../src/feishu/connection.js'
+import { elicitForm, elicitOptionToken, elicitTarget } from '../src/slack/render.js'
+import {
+  FEISHU_ELICIT_ACTION,
+  FEISHU_ELICIT_SURFACE,
+  buildFeishuElicitForm,
+  feishuElicitValue,
+  feishuUsesForm,
+  parseFeishuElicit
+} from '../src/platforms/feishu/elicit-card.js'
+
+const REQUEST_ID = '11111111-2222-4333-8444-555555555555'
+
+function form(properties: Record<string, unknown>, required: string[] = []): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'form',
+    message: 'Which branch should I cut from?',
+    requestedSchema: { type: 'object', properties, required }
+  } as CreateElicitationRequest
+}
+
+const BRANCH = { branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' } }
+const CHECKS = { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] }, title: 'Checks' } }
+
+/** The card's top-level elements. */
+function elements(card: any): any[] {
+  return card.body.elements
+}
+
+/** The `form` container's own child elements. */
+function formElements(card: any): any[] {
+  return elements(card).find((e: any) => e.tag === 'form').elements
+}
+
+describe('the payload a Feishu elicitation comes back on', () => {
+  it('names itself, so a session-control tap is never read as an answer', () => {
+    expect(parseFeishuElicit(feishuElicitValue(REQUEST_ID, elicitOptionToken(2)))).toEqual({
+      requestId: REQUEST_ID,
+      token: elicitOptionToken(2)
+    })
+    // Dismiss is no answer, so it decodes as none.
+    expect(parseFeishuElicit(feishuElicitValue(REQUEST_ID, 'x'))).toEqual({ requestId: REQUEST_ID, token: null })
+    // The reply card's own overflow payload, which this decoder must never claim.
+    expect(parseFeishuElicit({ action: 'agentconnect_reply' })).toBeNull()
+    expect(parseFeishuElicit({ action: FEISHU_ELICIT_ACTION })).toBeNull()
+    expect(parseFeishuElicit('ac_el:x:y')).toBeNull()
+    expect(parseFeishuElicit(undefined)).toBeNull()
+  })
+})
+
+describe('what Feishu declares it can collect, and which card collects it', () => {
+  it('claims every kind, because a CardKit form has a control for every kind', () => {
+    expect([...FEISHU_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum', 'multi-enum', 'number', 'text'])
+  })
+
+  it('answers a lone single-select or boolean with a tap, and everything else in the form', () => {
+    expect(feishuUsesForm(elicitForm(form(BRANCH), FEISHU_ELICIT_SURFACE)!)).toBe(false)
+    expect(feishuUsesForm(elicitForm(form({ ok: { type: 'boolean' } }), FEISHU_ELICIT_SURFACE)!)).toBe(false)
+    expect(feishuUsesForm(elicitForm(form(CHECKS), FEISHU_ELICIT_SURFACE)!)).toBe(true)
+    expect(feishuUsesForm(elicitForm(form({ note: { type: 'string' } }), FEISHU_ELICIT_SURFACE)!)).toBe(true)
+    expect(feishuUsesForm(elicitForm(form({ ...BRANCH, ...CHECKS }), FEISHU_ELICIT_SURFACE)!)).toBe(true)
+  })
+
+  it('reduces every kind rather than dropping one, a typed field included', () => {
+    expect(elicitTarget(form(BRANCH), FEISHU_ELICIT_SURFACE)?.kind).toBe('enum')
+    expect(elicitTarget(form(CHECKS), FEISHU_ELICIT_SURFACE)?.kind).toBe('multi-enum')
+    expect(elicitTarget(form({ note: { type: 'string' } }), FEISHU_ELICIT_SURFACE)?.kind).toBe('text')
+    expect(elicitTarget(form({ n: { type: 'integer' } }), FEISHU_ELICIT_SURFACE)?.kind).toBe('number')
+  })
+})
+
+describe('the form card one reduction becomes', () => {
+  const build = (params: CreateElicitationRequest) =>
+    buildFeishuElicitForm(REQUEST_ID, params, elicitForm(params, FEISHU_ELICIT_SURFACE)!)
+
+  it('gives each field its own named control, and the whole card ONE Confirm', () => {
+    const params = form({ ...BRANCH, ...CHECKS, note: { type: 'string', title: 'Notes' } }, ['branch'])
+    const card = build(params)!
+    expect(card.schema).toBe('2.0')
+    const inside = formElements(card)
+
+    // A single-select, a multi-select and a typed box — one control each, named by the very key
+    // a Slack Confirm submits under.
+    expect(inside.slice(0, 3).map((e: any) => [e.tag, e.name])).toEqual([
+      ['select_static', elicitFormBlockId(0)],
+      ['multi_select_static', elicitFormBlockId(1)],
+      ['input', elicitFormBlockId(2)]
+    ])
+    // Required-ness is the schema's, per field.
+    expect(inside.map((e: any) => e.required)).toEqual([true, false, false, undefined])
+    // Every option carries its POSITION, never its own value.
+    expect(inside[0].options.map((o: any) => o.value)).toEqual([elicitOptionToken(0), elicitOptionToken(1)])
+    expect(inside[0].options.map((o: any) => o.text.content)).toEqual(['main', 'develop'])
+
+    // One Confirm for the whole card, and it is the control that reads every field above.
+    const actions = inside.at(-1).actions
+    expect(actions.map((a: any) => a.text.content)).toEqual(['Confirm', 'Dismiss'])
+    expect(actions[0].form_action_type).toBe('submit')
+    expect(actions[0].behaviors[0].value).toEqual(feishuElicitValue(REQUEST_ID, 'ok'))
+    expect(actions[1].behaviors[0].value).toEqual(feishuElicitValue(REQUEST_ID, 'x'))
+  })
+
+  it('declines an option list past what this card offers, rather than showing part of it', () => {
+    const many = (n: number) => ({ pick: { type: 'string', enum: Array.from({ length: n }, (_, i) => `o${i}`) } })
+    // The reduction refuses it first, which is the surface's own limit doing its job.
+    expect(elicitForm(form(many(25)), FEISHU_ELICIT_SURFACE)).toBeNull()
+    expect(elicitForm(form(many(24)), FEISHU_ELICIT_SURFACE)).not.toBeNull()
+  })
+})
+
+// -- the coordinator, on a Feishu turn --------------------------------------------------------
+
+interface Harness {
+  daemon: any
+  conn: any
+  cards: { channel: string; anchor?: string; card: any }[]
+  edits: { messageId: string; card: any }[]
+  notices: () => string[]
+}
+
+function feishuTurn(turn: { thread?: string } = {}): Harness {
+  const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+  daemon.store = {
+    getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: () => new Map(),
+    upsertElicit: vi.fn(async () => {})
+  }
+  const cards: { channel: string; anchor?: string; card: any }[] = []
+  const edits: { messageId: string; card: any }[] = []
+  const conn = Object.create(FeishuConnection.prototype)
+  conn.postElicitCard = async (channel: string, anchor: string | undefined, card: any) => {
+    cards.push({ channel, anchor, card })
+    return 'om_4242'
+  }
+  conn.updateElicitCard = async (messageId: string, card: any) => void edits.push({ messageId, card })
+  daemon.pending.set(JSON.stringify(['agent-1', 's1']), {
+    plan: {
+      platform: 'feishu',
+      agentId: 'agent-1',
+      sessionKey: 'k1',
+      requesterId: 'turn-user',
+      channel: 'oc_chat',
+      transcriptChannel: 'oc_chat',
+      statusThread: 'T1',
+      agentName: 'agent',
+      isDm: false,
+      approvalSurfaceSuppressed: false,
+      ...(turn.thread !== undefined ? { thread: turn.thread } : {})
+    },
+    hostKey: 'agent-1',
+    outwardSessionId: 'sess-1',
+    conn,
+    turnState: {},
+    chrome: {},
+    reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
+    signals: { applyChain: Promise.resolve() },
+    approval: { waitMs: 0, depth: 0 },
+    builtinSystemToolCallIds: new Set<string>(),
+    conv: { onUpdate: () => [], hasBuffered: () => false },
+    rec: { onUpdate: () => [] },
+    termOut: new TerminalOutputFolder()
+  })
+  const applied: any[] = []
+  daemon.enqueueApply = (_p: any, action: any) => void applied.push(action)
+  return {
+    daemon,
+    conn,
+    cards,
+    edits,
+    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+  }
+}
+
+async function raise(h: Harness, req: CreateElicitationRequest): Promise<{ requestId: string; result: Promise<any> }> {
+  const result = h.daemon.permissions.onAcpElicit('agent-1', 's1', req)
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.size).toBe(1))
+  const requestId = [...h.daemon.permissions.pendingElicits.keys()][0] as string
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.get(requestId).ts).toBe('om_4242'))
+  return { requestId, result }
+}
+
+describe('a Feishu turn posts an elicitation card and settles it in place', () => {
+  it('answers a lone single-select with one tap, and rewrites the card with the answer', async () => {
+    const h = feishuTurn()
+    const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
+    const actions = elements(h.cards[0]!.card).find((e: any) => e.tag === 'action').actions
+    expect(actions.map((a: any) => a.text.content)).toEqual(['main', 'develop', 'Dismiss'])
+
+    await h.daemon.permissions.handleElicitCardTap({ requestId, token: elicitOptionToken(1) })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop' } })
+    expect(h.edits[0]!.messageId).toBe('om_4242')
+    expect(elements(h.edits[0]!.card)[0].content).toBe('💬 Which branch should I cut from?\n✅ develop')
+    // Nothing is left to press on an answered card.
+    expect(elements(h.edits[0]!.card)).toHaveLength(1)
+  })
+
+  it('takes a whole form back from one Confirm', async () => {
+    const h = feishuTurn()
+    const params = form({ ...CHECKS, note: { type: 'string', title: 'Notes' } }, ['checks'])
+    const { requestId, result } = await raise(h, params)
+    // A multi-select answers with a list and a text input with words; the FIELD says which.
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(0)]: [elicitOptionToken(0), elicitOptionToken(1)], [elicitFormBlockId(1)]: 'ship' }
+    })
+    await expect(result).resolves.toEqual({
+      action: 'accept',
+      content: { checks: ['lint', 'test'], note: 'ship' }
+    })
+    expect(elements(h.edits.at(-1)!.card)[0].content).toContain('Checks: lint, test')
+  })
+
+  it('reads a single-select control as the one value it holds, list or not', async () => {
+    const h = feishuTurn()
+    const { requestId, result } = await raise(h, form({ ...BRANCH, ...CHECKS }, ['branch']))
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(0)]: elicitOptionToken(0) }
+    })
+    // The untouched optional multi-select is an OMISSION, not an empty answer.
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('refuses a Confirm missing a required field, and leaves the card live', async () => {
+    const h = feishuTurn()
+    const { requestId } = await raise(h, form({ ...CHECKS, note: { type: 'string' } }, ['checks']))
+    await h.daemon.permissions.submitElicitEditor({ requestId, values: { [elicitFormBlockId(1)]: 'ship' } })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain('Checks')
+  })
+
+  it('refuses an option position the card never offered', async () => {
+    const h = feishuTurn()
+    const { requestId } = await raise(h, form(CHECKS, ['checks']))
+    await h.daemon.permissions.submitElicitEditor({
+      requestId,
+      values: { [elicitFormBlockId(0)]: [elicitOptionToken(9)] }
+    })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.notices().at(-1)).toContain("wasn't accepted")
+  })
+
+  it('reads Dismiss as the decline it is, on either card', async () => {
+    const h = feishuTurn()
+    const { requestId, result } = await raise(h, form(CHECKS, ['checks']))
+    await h.daemon.permissions.handleElicitCardTap({ requestId, token: null })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(elements(h.edits.at(-1)!.card)[0].content).toContain('Dismissed')
+  })
+
+  it('anchors the card into the turn thread when the turn has one', async () => {
+    const h = feishuTurn({ thread: 'om_root' })
+    await raise(h, form(BRANCH, ['branch']))
+    expect(h.cards[0]!.anchor).toBe('om_root')
+    expect(h.cards[0]!.channel).toBe('oc_chat')
+  })
+
+  it('declines URL mode, whose consent a CardKit link button could never report', async () => {
+    const h = feishuTurn()
+    const req = {
+      sessionId: 's1',
+      mode: 'url',
+      message: 'Sign in to continue',
+      url: 'https://example.com/oauth',
+      elicitationId: 'e1'
+    } as unknown as CreateElicitationRequest
+    await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
+    expect(h.cards).toEqual([])
+    expect(h.notices().at(-1)).toContain("can't collect an answer for")
+  })
+
+  it('cancels an abandoned card and says so on the card itself', async () => {
+    const h = feishuTurn()
+    const { result } = await raise(h, form(CHECKS, ['checks']))
+    await h.daemon.permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+    expect(elements(h.edits.at(-1)!.card)[0].content).toContain('Cancelled')
+  })
+})

--- a/packages/daemon/test/feishu-elicit-card.test.ts
+++ b/packages/daemon/test/feishu-elicit-card.test.ts
@@ -19,6 +19,7 @@ import { elicitForm, elicitOptionToken, elicitTarget } from '../src/slack/render
 import {
   FEISHU_ELICIT_ACTION,
   FEISHU_ELICIT_SURFACE,
+  buildFeishuElicitButtons,
   buildFeishuElicitForm,
   feishuElicitValue,
   feishuUsesForm,
@@ -47,6 +48,11 @@ function elements(card: any): any[] {
 /** The `form` container's own child elements. */
 function formElements(card: any): any[] {
   return elements(card).find((e: any) => e.tag === 'form').elements
+}
+
+/** The buttons of one `column_set` row — CardKit 2.0's way of putting several on a line. */
+function rowButtons(row: any): any[] {
+  return row.columns.map((c: any) => c.elements[0])
 }
 
 describe('the payload a Feishu elicitation comes back on', () => {
@@ -109,12 +115,36 @@ describe('the form card one reduction becomes', () => {
     expect(inside[0].options.map((o: any) => o.value)).toEqual([elicitOptionToken(0), elicitOptionToken(1)])
     expect(inside[0].options.map((o: any) => o.text.content)).toEqual(['main', 'develop'])
 
-    // One Confirm for the whole card, and it is the control that reads every field above.
-    const actions = inside.at(-1).actions
-    expect(actions.map((a: any) => a.text.content)).toEqual(['Confirm', 'Dismiss'])
-    expect(actions[0].form_action_type).toBe('submit')
-    expect(actions[0].behaviors[0].value).toEqual(feishuElicitValue(REQUEST_ID, 'ok'))
-    expect(actions[1].behaviors[0].value).toEqual(feishuElicitValue(REQUEST_ID, 'x'))
+    // One Confirm for the whole card, INSIDE the form, carrying both fields a form button needs.
+    const confirm = inside.at(-1)
+    expect(confirm.tag).toBe('button')
+    expect(confirm.text.content).toBe('Confirm')
+    expect(confirm.form_action_type).toBe('submit')
+    expect(typeof confirm.name).toBe('string')
+    expect(confirm.behaviors[0].value).toEqual(feishuElicitValue(REQUEST_ID, 'ok'))
+
+    // Dismiss stands OUTSIDE the container: a submit validates the required fields, and a refusal
+    // has to work precisely when those are empty.
+    const outside = elements(card).at(-1)
+    expect(outside.tag).toBe('column_set')
+    const dismiss = rowButtons(outside)[0]
+    expect(dismiss.text.content).toBe('Dismiss')
+    expect(dismiss.form_action_type).toBeUndefined()
+    expect(dismiss.behaviors[0].value).toEqual(feishuElicitValue(REQUEST_ID, 'x'))
+  })
+
+  it('uses no JSON 1.0 `action` container anywhere, which CardKit 2.0 does not have', () => {
+    const cards = [
+      build(form({ ...BRANCH, ...CHECKS }, ['branch']))!,
+      buildFeishuElicitButtons(REQUEST_ID, 'q', [{ label: 'main' }])
+    ]
+    const tags = (node: unknown): string[] => {
+      if (Array.isArray(node)) return node.flatMap(tags)
+      if (!node || typeof node !== 'object') return []
+      const o = node as Record<string, unknown>
+      return [...(typeof o.tag === 'string' ? [o.tag] : []), ...Object.values(o).flatMap(tags)]
+    }
+    for (const card of cards) expect(tags(card)).not.toContain('action')
   })
 
   it('declines an option list past what this card offers, rather than showing part of it', () => {
@@ -200,8 +230,8 @@ describe('a Feishu turn posts an elicitation card and settles it in place', () =
   it('answers a lone single-select with one tap, and rewrites the card with the answer', async () => {
     const h = feishuTurn()
     const { requestId, result } = await raise(h, form(BRANCH, ['branch']))
-    const actions = elements(h.cards[0]!.card).find((e: any) => e.tag === 'action').actions
-    expect(actions.map((a: any) => a.text.content)).toEqual(['main', 'develop', 'Dismiss'])
+    const row = elements(h.cards[0]!.card).find((e: any) => e.tag === 'column_set')
+    expect(rowButtons(row).map((b: any) => b.text.content)).toEqual(['main', 'develop', 'Dismiss'])
 
     await h.daemon.permissions.handleElicitCardTap({ requestId, token: elicitOptionToken(1) })
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop' } })

--- a/packages/daemon/test/platform-registry-drift.test.ts
+++ b/packages/daemon/test/platform-registry-drift.test.ts
@@ -71,11 +71,11 @@ describe('daemon platform registry (audit F16)', () => {
 
   it('pins which surfaces declare an elicitation card, and lets no other origin inherit one', () => {
     // #1794 gap 6: the facet is OPTIONAL, so this is not a drift check against `platformIds()` —
-    // it is the pin on today's true set. Feishu is the fourth implementer and gets its own
-    // change; adding one must fail here first.
+    // it is the pin on today's true set, which is now EVERY chat platform. A new one arriving
+    // without a card must fail here rather than silently declining every ask.
     const daemon = new Daemon({ root: bareRoot() }) as any
     const withCards = platformIds().filter((id: string) => daemon.turnSurfaces.exact(id)?.elicitCards)
-    expect(withCards).toEqual(['slack', 'telegram', 'discord'])
+    expect(withCards).toEqual(['slack', 'telegram', 'discord', 'feishu'])
     // Exact lookup, so a webchat / hook / dream turn rendering through the core (Slack) surface
     // does not inherit Slack's cards — webchat's own card is core-owned.
     for (const origin of ['webchat', 'hook', 'dream']) {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -419,7 +419,12 @@ export const WireFeishuCardActionEvent = z.object({
       value: z.unknown().optional(),
       tag: z.string().optional(),
       name: z.string().optional(),
-      option: z.string().optional()
+      option: z.string().optional(),
+      /** Every named control inside a submitted CardKit `form`, keyed by its own `name`. Present
+       *  only on a form submit; a plain button carries its payload in `value` as it always has.
+       *  Values are unknown by design — a text input answers with a string, a select with one or
+       *  a list — and the FIELD each belongs to is what says which. */
+      form_value: z.record(z.string(), z.unknown()).optional()
     })
     .optional()
 })


### PR DESCRIPTION
The last chat surface #1794 was waiting on.

## A CardKit form is the shape we already have twice

Feishu 2.0 has a `form` container: named controls — a text `input`, a `select_static`, a
`multi_select_static` — around one submit button, whose callback carries every control's value at
once in `action.form_value`. That is Slack's shape in the message and Discord's shape without the
modal, so the reduction maps onto it with no second level and no round trip.

```
💬 Which branch, what checks, and any notes?
┌──────────────────────────────────────┐
│ Base branch      [ main        ▾ ]   │  select_static      (required)
│ Checks           [ lint ×  test × ]  │  multi_select_static
│ Notes            [________________]  │  input
│              Confirm      Dismiss    │  ← one submit for the whole card
└──────────────────────────────────────┘
```

A lone single-select or boolean stays a row of buttons, as on every surface: one tap already
answers it, and a form would ask the reader to submit a decision they have already made.

## Nothing Feishu-shaped reaches the answer

Every control is named by the same `elicitFormBlockId` a Slack Confirm submits under, and every
option carries its **position**. So `submitElicitEditor` — already core's reconciler for a set of
named values, written for Discord's dialog — validates this form through the one re-derivation
(#1815) every other answer goes through: a missing required field named, an unoffered position
refused, the card left live either way.

Its guard widens from "a surface with a dialog" to any chat card, because a form *in the message*
is the same set of named values arriving from a different place.

One wire addition: `WireFeishuCardActionEvent` gains `form_value`. A plain button still carries its
payload in `value` as it always has, so the existing overflow/cancel path is untouched.

## What this change cannot prove

Stated plainly, because it is the one real risk here. A CardKit card is **opaque JSON** and the
Lark SDK ships no schema — unlike Discord, where `discord-api-types` proved every modal component
before I designed to it. So the `form` container is *documented* behaviour this repo cannot verify,
and the option/label bounds are **our** conservative choices (24 options, 75-char labels — Slack's
numbers reused deliberately), named as such in the module rather than dressed up as platform
limits.

The tests below pin the card we build and the answer we take back from it. They cannot pin what
Feishu accepts. **I'd like one live check on a real tenant before this merges** — the same loop
that caught the Slack `multi_static_select` failure earlier in this issue, and that validated the
Telegram multi-select. If the container shape is wrong, the failure mode is a card that never
posts, which core already treats as an ask nobody could answer.

## Verification

- `packages/daemon/test/feishu-elicit-card.test.ts` — 15 tests.
- Covers: the callback payload naming itself so a session-control tap is never read as an answer;
  the surface claiming every kind; which reductions take the form; the form card's per-field
  control, names, required-ness and positional option values; one Confirm plus Dismiss with
  `form_action_type: 'submit'`; an over-long option list declined by the reduction; and end to end
  — one-tap answer and rewrite, a whole form from one Confirm, a single-select read as one value
  whether it arrives as a scalar or a list, a missing required field and an unoffered position both
  refused with the card live, Dismiss, thread anchoring, URL mode declined, and cancellation.
- `platform-registry-drift.test.ts` — the pin is now `['slack', 'telegram', 'discord', 'feishu']`,
  i.e. **every** chat platform declares an elicitation card. A new platform arriving without one
  must fail there rather than silently declining every ask.
- typecheck, eslint, prettier clean; the elicitation, Feishu and registry suites all green
  (172 tests across 14 files).

Refs #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
