### PR TITLE
fix(daemon): a typed field is bounded by the surface's own box

### DIFF
--- a/packages/daemon/src/platforms/discord/elicit-card.ts
+++ b/packages/daemon/src/platforms/discord/elicit-card.ts
@@ -113,6 +113,9 @@ const DISCORD_ELICIT_MARK: Record<ElicitCardMark, string> = {
  */
 export const DISCORD_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
+  // A modal text input holds 4000, under the 4096 a card accepts, so the reduction bounds a typed
+  // field to what this dialog can actually take rather than the builder quietly trimming it.
+  textLimits: { maxLength: DISCORD_TEXT_INPUT_CAP },
   optionLimits: {
     enum: { maxOptions: DISCORD_ELICIT_MAX_BUTTONS },
     'multi-enum': { maxOptions: DISCORD_SELECT_MAX_OPTIONS }
@@ -228,6 +231,7 @@ export function buildDiscordElicitModal(
         // Single-line unless the schema asks for room: `maxLength` is the only signal we have.
         style: (target.maxLength ?? 0) > 200 ? 2 : 1,
         required: need,
+        // Already bounded by the reduction; the floor is kept as one, not as a second opinion.
         max_length: Math.min(target.maxLength ?? DISCORD_TEXT_INPUT_CAP, DISCORD_TEXT_INPUT_CAP),
         ...(target.defaultValue !== undefined ? { value: String(target.defaultValue) } : {})
       }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -625,12 +625,22 @@ export type ElicitKind = 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
  *  values ({@link elicitOptionToken}), so no surface refuses a long one (#1794). */
 export interface ElicitSurface {
   kinds: ReadonlySet<ElicitKind>
+  /** The longest typed answer this surface's own control accepts, when that is shorter than
+   *  {@link ELICIT_TEXT_CAP}. Declared here for the same reason an option limit is: a bound left
+   *  in a card builder is one the REDUCTION cannot see, so a field the surface could never take
+   *  whole is discovered at build time, when the only move left is to withhold the entire card.
+   *  Applied here instead, an unanswerable field is simply not a field — and `elicitForm` then
+   *  declines the ask only when the schema actually REQUIRED it. */
+  textLimits?: { maxLength?: number }
   /** Per-kind option limits, because one surface's controls do not all hold the same list: on
    *  Slack a row of buttons and a select menu do not take the same number of options. A kind
    *  absent from the map is unlimited — webchat renders them all. Widening one kind's limit
    *  never widens another's. */
   optionLimits?: Partial<Record<ElicitKind, { maxOptions?: number }>>
 }
+
+/** Slack's own cap on a `plain_text_input`'s `min_length`/`max_length`. */
+const SLACK_INPUT_LENGTH_CAP = 3000
 
 /** Slack allows 25 elements in one `actions` block and wraps them across lines, so the card can
  *  offer every option of a list this long and still keep its Dismiss button. A longer list is
@@ -686,6 +696,7 @@ export function elicitCardValues(target: ElicitTarget, carried: string | string[
  *  one number for the surface. */
 export const SLACK_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
+  textLimits: { maxLength: SLACK_INPUT_LENGTH_CAP },
   optionLimits: {
     enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS },
     'multi-enum': { maxOptions: SLACK_SELECT_MAX_OPTIONS }
@@ -870,7 +881,7 @@ function itemBound(value: unknown): number | undefined {
 
 /** Build the `text` target for a bare string property, or null when a constraint makes it
  *  unrenderable: an unsupported `format`, a pattern we refuse to run, an impossible length. */
-function textTarget(name: string, prop: Record<string, unknown>): ElicitTarget | null {
+function textTarget(name: string, prop: Record<string, unknown>, surfaceMax?: number): ElicitTarget | null {
   const format = prop.format
   if (format !== undefined && !ELICIT_FORMATS.includes(format as ElicitFormat)) return null
   const pattern = prop.pattern
@@ -880,7 +891,10 @@ function textTarget(name: string, prop: Record<string, unknown>): ElicitTarget |
   // The ceiling this surface can actually enforce. A declared minimum above it is
   // unanswerable — dropping it would accept a short answer the schema forbids — and the
   // effective maximum is carried on the target so the browser bounds its own draft by it.
-  const ceiling = effectiveTextMax(typeof pattern === 'string' ? pattern : undefined)
+  // Three ceilings, and the lowest wins: what a card accepts at all, what a pattern is cheap over,
+  // and what THIS surface's own box holds — a Slack `plain_text_input` takes 3000 where the card
+  // cap is 4096, so the same ask is a narrower box there and a shorter one is no answer at all.
+  const ceiling = Math.min(effectiveTextMax(typeof pattern === 'string' ? pattern : undefined), surfaceMax ?? Infinity)
   const max = declared === undefined ? ceiling : Math.min(declared, ceiling)
   if (min !== undefined && min > max) return null
   if (max === 0) return null
@@ -1073,7 +1087,7 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
         keep({ propName: name, kind: 'enum', options })
       // Free text is the string with nothing to choose from — an enumerated one is a pick,
       // and typing into it would let an unoffered value through.
-      if (!options.length && renderable.has('text')) keep(textTarget(name, prop))
+      if (!options.length && renderable.has('text')) keep(textTarget(name, prop, surface.textLimits?.maxLength))
     }
     if ((prop?.type === 'number' || prop?.type === 'integer') && renderable.has('number'))
       keep(numberTarget(name, prop))
@@ -1542,9 +1556,6 @@ export function buildElicitationResolvedCard(params: CreateElicitationRequest, d
 
 // ── Elicitation form cards (`input` blocks in the message, issue #1794's last Slack item) ────
 
-/** Slack's own cap on a `plain_text_input`'s `min_length`/`max_length`. */
-const SLACK_INPUT_LENGTH_CAP = 3000
-
 /** The longest list `checkboxes` and `radio_buttons` hold — past ten Slack answers `no more than
  *  10 items allowed`, so a longer list falls back to the select menu, which holds a hundred. */
 const SLACK_CHOICE_MAX_OPTIONS = 10
@@ -1566,8 +1577,11 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
   const action_id = ELICIT_FORM_INPUT_ACTION as string
   if (target.kind === 'text') {
     const min = target.minLength
-    if (min !== undefined && min > SLACK_INPUT_LENGTH_CAP) return null
+    // Bounded by the REDUCTION, which drops a field whose own minimum is past this surface's box
+    // ({@link SLACK_ELICIT_SURFACE.textLimits}) — so a target that reaches here already fits, and
+    // this clamp is a floor under a bug rather than the place the limit is decided.
     const max = Math.min(target.maxLength ?? SLACK_INPUT_LENGTH_CAP, SLACK_INPUT_LENGTH_CAP)
+    if (min !== undefined && min > max) return null
     return {
       type: 'plain_text_input',
       action_id,

--- a/packages/daemon/test/discord-elicit-card.test.ts
+++ b/packages/daemon/test/discord-elicit-card.test.ts
@@ -119,6 +119,14 @@ describe('the dialog one reduction becomes', () => {
     expect(note.component.required).toBe(false)
   })
 
+  it("bounds a typed field by the modal's own box, which is under the card cap", () => {
+    // A Discord text input holds 4000 where a card accepts 4096, so the reduction offers 4000 —
+    // the surface's limit applied where every other surface limit is applied.
+    const ask = form({ note: { type: 'string', maxLength: 4096 } })
+    expect(field(build(ask)!, 0).component.max_length).toBe(4000)
+    expect(elicitTarget(ask, DISCORD_ELICIT_SURFACE)?.maxLength).toBe(4000)
+  })
+
   it('lets an optional select take nothing, and SAYS it is optional', () => {
     const modal = build(form(CHECKS))!
     expect(field(modal, 0).component.min_values).toBe(0)

--- a/packages/daemon/test/slack-elicit-form.test.ts
+++ b/packages/daemon/test/slack-elicit-form.test.ts
@@ -20,6 +20,7 @@ import {
   ELICIT_DISMISS_ACTION,
   SLACK_DM_ELICIT_SURFACE,
   SLACK_ELICIT_SURFACE,
+  WEBCHAT_ELICIT_SURFACE,
   buildElicitationCard,
   buildElicitationFormCard,
   elicitCardShape,
@@ -132,10 +133,29 @@ describe('the in-message card a filled-in answer is given on', () => {
     expect(card[0].text.text).not.toContain('<https://evil.example/y|here>')
   })
 
-  it('is withheld when a field cannot BE an input block, so no card is ever posted dead', () => {
-    // A minimum length no input can hold. (An option value past Slack's 75 no longer withholds
-    // anything: the option carries its position instead — #1794.)
-    expect(cardFor(form({ a: { type: 'string', minLength: 3500 }, b: { type: 'boolean' } }))).toBeNull()
+  it("drops a field this surface's box could never hold, and keeps the rest of the card", () => {
+    // A minimum length past Slack's `plain_text_input` (3000). It is the REDUCTION that decides
+    // this now, so an unanswerable OPTIONAL field is simply not a field — where it used to cost
+    // the whole card, taking the answerable questions down with it.
+    const card = cardFor(form({ a: { type: 'string', minLength: 3500 }, b: { type: 'boolean' } }))
+    expect(card).not.toBeNull()
+    expect(card!.filter((b: any) => b.type === 'input')).toHaveLength(1)
+
+    // Required, though, and there is no honest card at all: `elicitForm` refuses the ask and the
+    // caller declines it with the notice.
+    expect(elicitForm(form({ a: { type: 'string', minLength: 3500 } }, ['a']), SLACK_ELICIT_SURFACE)).toBeNull()
+  })
+
+  it("bounds a typed field by the SURFACE's own box, so each surface offers what it can take", () => {
+    // The same ask, reduced twice: Slack's `plain_text_input` holds 3000, webchat's box holds the
+    // 4096 a card accepts. The daemon still validates each answer against the bound it offered.
+    const ask = form({ note: { type: 'string', maxLength: 4096 } })
+    expect(elicitTarget(ask, SLACK_ELICIT_SURFACE)?.maxLength).toBe(3000)
+    expect(elicitTarget(ask, WEBCHAT_ELICIT_SURFACE)?.maxLength).toBe(4096)
+    // And a field declaring less than either keeps its own bound on both.
+    const short = form({ note: { type: 'string', maxLength: 120 } })
+    expect(elicitTarget(short, SLACK_ELICIT_SURFACE)?.maxLength).toBe(120)
+    expect(elicitTarget(short, WEBCHAT_ELICIT_SURFACE)?.maxLength).toBe(120)
   })
 })
 


### PR DESCRIPTION
#1794's Slack length item. It turned out to be the limit-in-the-wrong-place this file already warns
about, and the visible symptom was the smaller half of the problem.

## What was actually wrong

`SLACK_INPUT_LENGTH_CAP` (3000) lived inside `elicitFormInputElement` — the card builder — where
the reduction cannot see it. `ElicitSurface`'s own doc comment already says why that is the wrong
home:

> Every surface limit belongs here: a limit left inside a card builder is one the reduction cannot
> see, which is exactly how an over-long option list used to be quietly cut to fit.

Two consequences:

- **A `minLength` past 3000 killed the whole card.** `elicitFormInputElement` returned null, so
  `buildElicitationFormCard` returned null, so the ask was declined — even when the over-long field
  was **optional** and every other question was perfectly answerable. One unanswerable field took
  the form down with it.
- **The 3000-vs-4096 narrowing was invisible above the builder.** Nothing in the reduction knew the
  box was smaller than the answer the daemon would go on to accept.

## The fix

`ElicitSurface` gains `textLimits.maxLength`, beside the `optionLimits` it already carries. The
reduction bounds a typed field by the lowest of three ceilings:

| ceiling | what it is |
|---|---|
| `ELICIT_TEXT_CAP` (4096) | what a card accepts at all — an elicitation asks a question, not for a file |
| `ELICIT_PATTERN_INPUT_CAP` (256) | what a `pattern` is cheap to run over |
| `textLimits.maxLength` | **new** — what this surface's own box holds |

So an unanswerable field is simply not a field, and `elicitForm` declines the ask only when the
schema actually **required** it.

## Who declares what

- **Slack — 3000.** Its `plain_text_input` cap.
- **Discord — 4000.** Its modal text input, verified against the installed `discord-api-types`
  during #1961. Under the card cap, so it was silently narrowing too.
- **Telegram — none.** Its box is a `force_reply` answer, i.e. a message, at the same 4096 a card
  accepts.
- **Feishu — none.** Its bound is not one this repo can check, and an unverified number stated as a
  limit would be worse than no number at all.

## Verification

- 3 assertions, all confirmed **red** on `main` first:
  - an optional over-long field is dropped and the rest of the card still renders — where it
    previously returned null (this replaces a test that pinned the old behaviour);
  - the same field **required** still declines the whole ask;
  - the same ask reduces to `maxLength` 3000 on Slack, 4096 on webchat, 4000 on Discord, and a
    field declaring less than any of them keeps its own bound everywhere.
- 664 tests green across the Slack/Discord/Telegram/Feishu/render/decline/registry suites;
  `pnpm eval:gates` 196/197 (the known pre-existing `evaluation-runner` baseline); typecheck,
  eslint, prettier clean.

Refs #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
