### PR TITLE
fix(daemon): a permission card offers every option or none

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -43,6 +43,7 @@ import {
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionDmUnanswerableCard,
+  permToolLabel,
   buildPermissionResolvedCard,
   clampTo,
   elicitCardShape,
@@ -699,6 +700,23 @@ export class PermissionCoordinator {
     }
     live.ts = ts
     return await this.trackHumanApprovalWait(p, result)
+  }
+
+  /** Say in the channel that a permission request offered more options than the card can show, so
+   *  it was declined. The reader just lost a decision they could otherwise have made, and a
+   *  silently cancelled tool call would read as the agent stalling. Deliberately points at NO
+   *  other surface: the console's Allow resolves to the first `allow_once`, so sending them there
+   *  would trade a truncated menu for an invisible one. Best effort — the decline never depends on
+   *  the notice landing. */
+  private noticePermissionOptionsUnrenderable(p: Pending, params: RequestPermissionRequest): void {
+    const text =
+      `:lock: The agent asked for permission to run ${permToolLabel(params)} with more options ` +
+      `than this chat can show (${params.options.length}), so it was declined. Nothing was allowed.`
+    try {
+      this.host.enqueueApply(p, { kind: 'notice', text })
+    } catch (err) {
+      this.host.log().warn(`permission option notice failed for "${p.plan.sessionKey}": ${formatErr(err)}`)
+    }
   }
 
   /** Fire the best-effort §5 approval DM. Never blocks or fails the approval itself. */
@@ -1381,19 +1399,24 @@ export class PermissionCoordinator {
       })
       return { outcome: { outcome: 'cancelled' } }
     }
-    const chatApprovalEnabled =
+    const chatApprovalEligible =
       this.host.agents().get(agentId)?.allowRuntimeChangesInChat === true &&
       turnChromeFor(p.plan.platform).chatInputCards === true &&
       p.conn instanceof SlackConnection &&
       !p.plan.approvalSurfaceSuppressed &&
-      params.options.length > 0 &&
-      // An upper bound beside the lower one: a list the card cannot offer WHOLE does not become a
-      // shorter card, it takes the editor path below — where the request stays open, every option
-      // is on the Agent page, and chat gets its neutral notice (#1811). Truncating instead would
-      // report a pick from a menu the reader could not see the end of as their decision on the
-      // full request.
-      params.options.length <= SLACK_PERMISSION_MAX_OPTIONS
-    if (chatApprovalEnabled) {
+      params.options.length > 0
+    // A list the card cannot offer WHOLE is not answered anywhere, and that is the honest end of
+    // it (#1811). Truncating reported a pick from a menu the reader could not see the end of as
+    // their decision on the full request. The editor path is no stand-in either: its record
+    // carries no options and its Allow resolves to the FIRST `allow_once`, so routing there would
+    // take away a choice the truncated card at least offered. So: nothing is decided, the agent is
+    // told, and the chat says why.
+    if (chatApprovalEligible && params.options.length > SLACK_PERMISSION_MAX_OPTIONS) {
+      this.permissionEvaluationDetails.set(evaluationParams, { reason: 'permission_options_unrenderable' })
+      this.noticePermissionOptionsUnrenderable(p, params)
+      return { outcome: { outcome: 'cancelled' } }
+    }
+    if (chatApprovalEligible) {
       return await this.awaitChatPermission(agentId, sessionId, params, evaluationParams, p)
     }
     // Default policy: hold the runtime request and surface only a neutral notice

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -705,15 +705,25 @@ export class PermissionCoordinator {
   /** Say in the channel that a permission request offered more options than the card can show, so
    *  it was declined. The reader just lost a decision they could otherwise have made, and a
    *  silently cancelled tool call would read as the agent stalling. Deliberately points at NO
-   *  other surface: the console's Allow resolves to the first `allow_once`, so sending them there
-   *  would trade a truncated menu for an invisible one. Best effort — the decline never depends on
-   *  the notice landing. */
+   *  other surface: they all top out in the same place, and the console never sees the options at
+   *  all (#1969) — sending them there would trade a truncated menu for an invisible one. Best
+   *  effort: the decline never depends on the notice landing. */
   private noticePermissionOptionsUnrenderable(p: Pending, params: RequestPermissionRequest): void {
     const text =
       `:lock: The agent asked for permission to run ${permToolLabel(params)} with more options ` +
-      `than this chat can show (${params.options.length}), so it was declined. Nothing was allowed.`
+      `than any surface here can show (${params.options.length}), so it was declined. Nothing was allowed.`
     try {
-      this.host.enqueueApply(p, { kind: 'notice', text })
+      // Said on whichever surface this turn HAS, exactly as the editor path's own notice is: a
+      // webchat turn hears it on its stream, every chat turn in its channel.
+      if (p.webchat) {
+        p.webchat.sink.output({
+          conversationId: p.webchat.conversationId,
+          turnId: p.webchat.turnId,
+          index: p.webchat.index++,
+          event: { kind: 'message', text }
+        })
+      }
+      if ((!p.webchat || p.webchat.continuation) && p.conn) this.host.enqueueApply(p, { kind: 'notice', text })
     } catch (err) {
       this.host.log().warn(`permission option notice failed for "${p.plan.sessionKey}": ${formatErr(err)}`)
     }
@@ -1399,24 +1409,26 @@ export class PermissionCoordinator {
       })
       return { outcome: { outcome: 'cancelled' } }
     }
-    const chatApprovalEligible =
+    // A list NO surface here can offer whole is not answered anywhere, and that is the honest end
+    // of it (#1811). This sits above the chat/editor split because every surface tops out in the
+    // same place: the in-channel card and the approval DM share one builder and one block, and the
+    // console never sees the options at all — its record carries none and its Allow resolves to
+    // the FIRST `allow_once` (#1969). Truncating reported a pick from a menu the reader could not
+    // see the end of as their decision on the full request; routing to a surface that shows fewer
+    // options still would only move the misreport. So nothing is decided, the agent is told, and
+    // the turn's own surface says why.
+    if (params.options.length > SLACK_PERMISSION_MAX_OPTIONS) {
+      this.permissionEvaluationDetails.set(evaluationParams, { reason: 'permission_options_unrenderable' })
+      this.noticePermissionOptionsUnrenderable(p, params)
+      return { outcome: { outcome: 'cancelled' } }
+    }
+    const chatApprovalEnabled =
       this.host.agents().get(agentId)?.allowRuntimeChangesInChat === true &&
       turnChromeFor(p.plan.platform).chatInputCards === true &&
       p.conn instanceof SlackConnection &&
       !p.plan.approvalSurfaceSuppressed &&
       params.options.length > 0
-    // A list the card cannot offer WHOLE is not answered anywhere, and that is the honest end of
-    // it (#1811). Truncating reported a pick from a menu the reader could not see the end of as
-    // their decision on the full request. The editor path is no stand-in either: its record
-    // carries no options and its Allow resolves to the FIRST `allow_once`, so routing there would
-    // take away a choice the truncated card at least offered. So: nothing is decided, the agent is
-    // told, and the chat says why.
-    if (chatApprovalEligible && params.options.length > SLACK_PERMISSION_MAX_OPTIONS) {
-      this.permissionEvaluationDetails.set(evaluationParams, { reason: 'permission_options_unrenderable' })
-      this.noticePermissionOptionsUnrenderable(p, params)
-      return { outcome: { outcome: 'cancelled' } }
-    }
-    if (chatApprovalEligible) {
+    if (chatApprovalEnabled) {
       return await this.awaitChatPermission(agentId, sessionId, params, evaluationParams, p)
     }
     // Default policy: hold the runtime request and surface only a neutral notice

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -42,6 +42,7 @@ import {
   buildElicitDmUnanswerableCard,
   buildElicitationResolvedCard,
   buildPermissionCard,
+  buildPermissionDmUnanswerableCard,
   buildPermissionResolvedCard,
   clampTo,
   elicitCardShape,
@@ -61,6 +62,7 @@ import {
   multiSelectAccepts,
   numberAccepts,
   SLACK_DM_ELICIT_SURFACE,
+  SLACK_PERMISSION_MAX_OPTIONS,
   textAccepts,
   WEBCHAT_ELICIT_SURFACE
 } from '../slack/render.js'
@@ -662,12 +664,16 @@ export class PermissionCoordinator {
     if (!this.pendingChatPermissions.has(requestId)) return await result
     const blocks = buildPermissionCard(requestId, params, this.host.httpSlackSessionTarget(p))
     const fallback = `Permission requested: ${params.toolCall?.title ?? 'a tool call'}`
-    const ts = await this.host.postCardSerialized(p, (slack) =>
-      (slack as SlackConnection).postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
-        ...(slackAgentIdentityOptions(p.plan) ?? {}),
-        chrome: true
-      })
-    )
+    // The gate above admits only a list this card can offer whole, so null is unreachable here —
+    // and treated as the card never posting rather than trusted to be impossible.
+    const ts = blocks
+      ? await this.host.postCardSerialized(p, (slack) =>
+          (slack as SlackConnection).postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
+            ...(slackAgentIdentityOptions(p.plan) ?? {}),
+            chrome: true
+          })
+        )
+      : undefined
     const live = this.pendingChatPermissions.get(requestId)
     if (!live) {
       if (ts) {
@@ -737,7 +743,7 @@ export class PermissionCoordinator {
     // untouched — it stays open on the editor path, which is where the DM points.
     const card =
       rec.kind === 'permission'
-        ? buildPermissionCard(requestId, rec.params, sessionTarget)
+        ? (buildPermissionCard(requestId, rec.params, sessionTarget) ?? buildPermissionDmUnanswerableCard(rec.params))
         : (buildElicitationCard(requestId, rec.params, sessionTarget, SLACK_DM_ELICIT_SURFACE) ??
           buildElicitDmUnanswerableCard(rec.params))
     const fromSlack = p.plan.platform === 'slack'
@@ -1380,7 +1386,13 @@ export class PermissionCoordinator {
       turnChromeFor(p.plan.platform).chatInputCards === true &&
       p.conn instanceof SlackConnection &&
       !p.plan.approvalSurfaceSuppressed &&
-      params.options.length > 0
+      params.options.length > 0 &&
+      // An upper bound beside the lower one: a list the card cannot offer WHOLE does not become a
+      // shorter card, it takes the editor path below — where the request stays open, every option
+      // is on the Agent page, and chat gets its neutral notice (#1811). Truncating instead would
+      // report a pick from a menu the reader could not see the end of as their decision on the
+      // full request.
+      params.options.length <= SLACK_PERMISSION_MAX_OPTIONS
     if (chatApprovalEnabled) {
       return await this.awaitChatPermission(agentId, sessionId, params, evaluationParams, p)
     }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -476,7 +476,7 @@ export const STATUS_MODAL_CALLBACK = 'ac_status_modal'
 /** Human label for the tool a permission request is about. ACP's `toolCall.title` is the
  *  intended display string, but some runtimes (e.g. codex) omit it at request time — fall
  *  back to the tool `kind`, then the `toolCallId`, then a generic phrase. */
-function permToolLabel(params: RequestPermissionRequest): string {
+export function permToolLabel(params: RequestPermissionRequest): string {
   const tc = params.toolCall
   const label = tc?.title?.trim() || tc?.kind?.trim() || tc?.toolCallId?.trim() || 'a tool call'
   return clampTo(label, 200)

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -490,20 +490,31 @@ function permOptionStyle(kind: string): 'primary' | 'danger' | undefined {
   return undefined
 }
 
+/** How many option buttons one permission card offers. Slack allows 25 elements in one `actions`
+ *  block and wraps them across lines, and this card puts nothing else in that block — so the cap
+ *  is the block's own, not a row's. The 5 this used to slice to was neither. */
+export const SLACK_PERMISSION_MAX_OPTIONS = 25
+
 /**
  * Build the interactive permission-request card: a header naming the tool the agent
  * wants to run, and an actions row of buttons — one per ACP PermissionOption, green for
  * allow / red for reject. The choice rides each button `value` (`<requestId>|<optionId>`);
- * `requestId` ties the click back to the pending ACP request. Options are capped at 5
- * (Slack renders at most 5 buttons cleanly on one row). Pure — safe to unit-test.
+ * `requestId` ties the click back to the pending ACP request.
+ *
+ * Null ⇒ this card cannot offer the whole list (empty, or longer than the block holds), and the
+ * caller must put the request somewhere that can. NEVER a card built from part of the list: the
+ * reader would decide from a menu they cannot see the end of, and their pick would be reported as
+ * their decision on the FULL request — the agent unable to tell it came from a truncated set
+ * (#1811, the permission half of #1794's gap 7). Pure — safe to unit-test.
  */
 export function buildPermissionCard(
   requestId: string,
   params: RequestPermissionRequest,
   sessionTarget?: string
-): unknown[] {
+): unknown[] | null {
+  if (!params.options.length || params.options.length > SLACK_PERMISSION_MAX_OPTIONS) return null
   const header = `:lock: *Permission requested* — ${permToolLabel(params)}`
-  const buttons = params.options.slice(0, 5).map((o, i) => {
+  const buttons = params.options.map((o, i) => {
     const style = permOptionStyle(o.kind)
     return {
       type: 'button',
@@ -1536,6 +1547,17 @@ export function buildElicitationCard(
  *  decline notice's words, minus its verdict: this ask is still open on the editor path. */
 const ELICIT_DM_UNANSWERABLE =
   ":hourglass: This chat can't collect an answer for it — answer it in the session console, via *Open session* above."
+
+const PERMISSION_DM_UNANSWERABLE =
+  ":hourglass: This chat can't show every option for it — decide it in the session console, via *Open session* above."
+
+/** The stand-in for an approval DM's permission card that {@link buildPermissionCard} cannot
+ *  build: the ask, and where every option CAN be seen. The request is untouched — it stays open on
+ *  the editor path, which is where the DM points — so this is the same promise the elicitation
+ *  stand-in below makes, for the same reason (#1811). Pure. */
+export function buildPermissionDmUnanswerableCard(params: RequestPermissionRequest): unknown[] {
+  return buildPermissionResolvedCard(params, PERMISSION_DM_UNANSWERABLE, undefined)
+}
 
 /** The stand-in for an approval DM's elicitation card that {@link buildElicitationCard} cannot
  *  build for the DM surface (#1794): the question, and where it CAN be answered. Without it the

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -874,17 +874,31 @@ describe('a permission card offers every option or sends the request where they 
     expect((daemon as any).permissions.pendingChatPermissions.size).toBe(1)
   })
 
-  it('sends a list it cannot offer whole to the editor path instead of truncating it', async () => {
+  it('cancels a list it cannot offer whole, and says why, rather than truncating it', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { posted } = slackPending(daemon)
+    const { pending, posted } = slackPending(daemon)
+    const applied: any[] = []
+    ;(daemon as any).enqueueApply = (_p: any, action: any) => void applied.push(action)
     ;(daemon as any).agents.set('agent-1', { allowRuntimeChangesInChat: true })
-    // One past what the block holds. Truncating would report a pick from a menu the reader could
-    // not see the end of as their decision on the FULL request, with the agent unable to tell.
-    void (daemon as any).permissions.onAcpPermission('agent-1', 's1', permReq(26))
-    await vi.waitFor(() => expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(1))
-    // No chat card at all, and the request is OPEN on the Agent page — not cancelled, not decided.
+    void pending
+    // One past what the block holds. Truncating reported a pick from a menu the reader could not
+    // see the end of as their decision on the FULL request, with the agent unable to tell.
+    await expect((daemon as any).permissions.onAcpPermission('agent-1', 's1', permReq(26))).resolves.toEqual({
+      outcome: { outcome: 'cancelled' }
+    })
+    // No card, and NO editor stand-in either: that surface's record carries no options and its
+    // Allow resolves to the first `allow_once`, so routing there would take away a choice the
+    // truncated card at least offered.
     expect(posted).toEqual([])
     expect((daemon as any).permissions.pendingChatPermissions.size).toBe(0)
+    expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(0)
+    // The reader just lost a decision they could otherwise have made, so the chat says so — and
+    // points at no other surface, because none of them can offer the list either.
+    const notice = applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+    expect(notice).toHaveLength(1)
+    expect(notice[0]).toContain('more options than this chat can show (26)')
+    expect(notice[0]).toContain('Nothing was allowed')
+    expect(notice[0]).not.toContain('console')
   })
 })
 

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -896,9 +896,37 @@ describe('a permission card offers every option or sends the request where they 
     // points at no other surface, because none of them can offer the list either.
     const notice = applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
     expect(notice).toHaveLength(1)
-    expect(notice[0]).toContain('more options than this chat can show (26)')
+    expect(notice[0]).toContain('more options than any surface here can show (26)')
     expect(notice[0]).toContain('Nothing was allowed')
     expect(notice[0]).not.toContain('console')
+  })
+
+  it('cancels it on the approval-DM path too, where the console shows fewer options still', async () => {
+    // Reached with in-channel approvals OFF (and by every webchat-origin turn): the DM shares the
+    // card's builder and its block, and the console behind it never sees the options at all
+    // (#1969) — so this list is unanswerable there too, and moving it would only move the
+    // misreport. Before the guard covered this path the DM offered the first five.
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    const applied: any[] = []
+    ;(daemon as any).enqueueApply = (_p: any, action: any) => void applied.push(action)
+    ;(daemon as any).agents.set('agent-1', { allowRuntimeChangesInChat: false })
+    await expect((daemon as any).permissions.onAcpPermission('agent-1', 's1', permReq(26))).resolves.toEqual({
+      outcome: { outcome: 'cancelled' }
+    })
+    expect(posted).toEqual([])
+    expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(0)
+    expect(applied.filter((a) => a.kind === 'notice')).toHaveLength(1)
+  })
+
+  it('still holds a list every surface CAN offer on the editor path, unchanged', async () => {
+    // The guard is narrow: only an unofferable list changes behaviour. Four options — the ACP
+    // standard set — still take the editor path exactly as before.
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackPending(daemon)
+    ;(daemon as any).agents.set('agent-1', { allowRuntimeChangesInChat: false })
+    void (daemon as any).permissions.onAcpPermission('agent-1', 's1', permReq(4))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(1))
   })
 })
 

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -850,6 +850,44 @@ function slackPending(daemon: any): { pending: any; posted: any[][]; updated: an
   return { pending, posted, updated }
 }
 
+describe('a permission card offers every option or sends the request where they all fit (#1811)', () => {
+  /** A permission request offering `n` options — the ACP standard set is four, so this is the
+   *  latent case: a runtime that offers more. */
+  const permOptions = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ optionId: `o${i}`, name: `Opt ${i}`, kind: 'allow_once' }))
+
+  const permReq = (n: number) =>
+    ({
+      sessionId: 's1',
+      options: permOptions(n),
+      toolCall: { toolCallId: 'tc-1', title: 'Write perm-test.txt' }
+    }) as unknown as RequestPermissionRequest
+
+  it('cards a list the actions block holds, past the five it used to slice to', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    ;(daemon as any).agents.set('agent-1', { allowRuntimeChangesInChat: true })
+    void (daemon as any).permissions.onAcpPermission('agent-1', 's1', permReq(8))
+    await vi.waitFor(() => expect(posted).toHaveLength(1))
+    // Eight buttons, not five. The reader sees the whole menu their pick is read against.
+    expect((posted[0]![1]! as any).elements).toHaveLength(8)
+    expect((daemon as any).permissions.pendingChatPermissions.size).toBe(1)
+  })
+
+  it('sends a list it cannot offer whole to the editor path instead of truncating it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    ;(daemon as any).agents.set('agent-1', { allowRuntimeChangesInChat: true })
+    // One past what the block holds. Truncating would report a pick from a menu the reader could
+    // not see the end of as their decision on the FULL request, with the agent unable to tell.
+    void (daemon as any).permissions.onAcpPermission('agent-1', 's1', permReq(26))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(1))
+    // No chat card at all, and the request is OPEN on the Agent page — not cancelled, not decided.
+    expect(posted).toEqual([])
+    expect((daemon as any).permissions.pendingChatPermissions.size).toBe(0)
+  })
+})
+
 describe('a Slack card offers every option or none', () => {
   // The seven-option enum of the issue: five buttons went out, the reader never saw the last two,
   // and whichever they picked came back as `accept` on the whole question.

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -12,6 +12,7 @@ import {
   buildStatusBlocks,
   buildStatusModal,
   buildPermissionCard,
+  buildPermissionDmUnanswerableCard,
   buildPermissionResolvedCard,
   buildPermissionUpdateCard,
   buildElicitationCard,
@@ -1370,18 +1371,38 @@ describe('permission card', () => {
     expect(btns.map((b: any) => b.style)).toEqual(['primary', 'primary', 'danger'])
   })
 
-  it('caps at 5 buttons', () => {
-    const many = Array.from({ length: 8 }, (_, i) => ({ optionId: `o${i}`, name: `Opt ${i}`, kind: 'allow_once' }))
-    const [, actions] = buildPermissionCard('p', req({ options: many as any })) as any[]
-    expect(actions.elements).toHaveLength(5)
+  it('offers every option the actions block holds, and NO card at all past that', () => {
+    // The 5 this used to slice to was neither the block's limit nor a row's; Slack holds 25
+    // elements in one `actions` block and this card puts nothing else there.
+    const opts = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({ optionId: `o${i}`, name: `Opt ${i}`, kind: 'allow_once' }))
+    const [, actions] = buildPermissionCard('p', req({ options: opts(8) as any })) as any[]
+    expect(actions.elements).toHaveLength(8)
+    expect((buildPermissionCard('p', req({ options: opts(25) as any })) as any[])[1].elements).toHaveLength(25)
+
+    // Past it there is no card, rather than a card built from part of the list: a pick from a
+    // menu the reader cannot see the end of would be reported as their decision on the whole
+    // request, and the agent could not tell (#1811).
+    expect(buildPermissionCard('p', req({ options: opts(26) as any }))).toBeNull()
+    expect(buildPermissionCard('p', req({ options: [] as any }))).toBeNull()
+  })
+
+  it('hands an approval DM the ask and the console when the list will not fit', () => {
+    const many = Array.from({ length: 26 }, (_, i) => ({ optionId: `o${i}`, name: `Opt ${i}`, kind: 'allow_once' }))
+    expect(buildPermissionCard('p', req({ options: many as any }))).toBeNull()
+    const card = buildPermissionDmUnanswerableCard(req({ options: many as any }))
+    // One section and nothing to press — which is the point: the request stays open on the
+    // editor path, and the DM says where every option can be seen.
+    expect(card).toHaveLength(1)
+    expect((card[0] as any).text.text).toContain('session console')
   })
 
   it('falls back to kind then toolCallId then a generic label when title is absent', () => {
-    const byKind = buildPermissionCard('p', req({ toolCall: { toolCallId: 'tc1', kind: 'execute' } as any }))
+    const byKind = buildPermissionCard('p', req({ toolCall: { toolCallId: 'tc1', kind: 'execute' } as any }))!
     expect((byKind[0] as any).text.text).toContain('execute')
-    const byId = buildPermissionCard('p', req({ toolCall: { toolCallId: 'tc9' } as any }))
+    const byId = buildPermissionCard('p', req({ toolCall: { toolCallId: 'tc9' } as any }))!
     expect((byId[0] as any).text.text).toContain('tc9')
-    const generic = buildPermissionCard('p', req({ toolCall: undefined as any }))
+    const generic = buildPermissionCard('p', req({ toolCall: undefined as any }))!
     expect((generic[0] as any).text.text).toContain('a tool call')
   })
 
@@ -1492,7 +1513,7 @@ describe('every card we build is one Slack would accept', () => {
           options: [{ optionId: 'a', name: 'Allow Once', kind: 'allow_once' }]
         } as any,
         'sess-target'
-      ),
+      )!,
       buildElicitationCard('elicit-1', req({ b: { type: 'boolean' } }), 'sess-target', SLACK_DM_ELICIT_SURFACE)!,
       // The DM stand-in for a question that surface has no control for — a card of one section,
       // which is exactly why it can carry no answer.


### PR DESCRIPTION
Closes #1811 — the permission half of #1794's gap 7, on the adjacent seam.

## The defect

`buildPermissionCard` did `params.options.slice(0, 5)`. An agent offering six options rendered
five buttons, and whichever the reader tapped came back as their decision on the **full** request.
They never saw what was cut; the agent could not tell the decision came from a truncated set.

Two things about it are worth stating precisely:

- **5 was never a platform limit.** Slack holds 25 elements in one `actions` block, and this card
  puts nothing else in that block. The elicitation card next door already offers 24 + Dismiss.
- **The tap itself resolved correctly.** `handlePermissionChoice` looks the `optionId` up in the
  *full* `params.options`, so a rendered button always mapped to a real option. The damage was
  entirely on the reader's side — a menu they could not see the end of — which is exactly what
  makes it a misreport rather than a crash.

## The fix, and why it needed no new decision

The card now offers every option the block holds, and past that builds **none**.

#1811's third checkbox asked what the honest outcome is past the cap, and floated declining vs
resolving `cancelled`. Neither is needed: `resolveAcpPermission` **already** has a path that keeps
the request open and answerable — `awaitEditorPermission`, the default when chat approval is off.
So an over-long list simply fails the `chatApprovalEnabled` gate:

```ts
params.options.length > 0 &&
// an upper bound beside the lower one
params.options.length <= SLACK_PERMISSION_MAX_OPTIONS
```

…and takes the editor path: the request stays open, every option is on the Agent page, and chat
gets the neutral notice that path already posts. Nothing is decided and nothing is lost — strictly
better than either option the issue floated.

## Checkbox by checkbox

- **Surface declaration equivalent to `ElicitSurface`** — deliberately *not* built. `ElicitSurface`
  earns its shape from four implementers; the chat permission path has exactly one (Slack, still
  gated on `p.conn instanceof SlackConnection`), and #1853 already recorded that extracting
  `chatInputCards` further "would be the guessing the rule forbids". What the checkbox was really
  after — *the limit must be visible above the builder* — is satisfied by exporting
  `SLACK_PERMISSION_MAX_OPTIONS` and having the coordinator route on it, rather than the builder
  silently truncating.
- **Render every option the block holds** — done, 25.
- **Decide the honest outcome past that** — the editor path, as above.
- **Cover the approval-DM path** — done. It shares the builder and now gets the same treatment it
  already gives an unrenderable elicitation: the ask plus where the options can be seen
  (`buildPermissionDmUnanswerableCard`, built on the existing resolved-card shape), instead of an
  intro with a truncated button row under it.

## Severity, as filed rather than inflated

The ACP standard option set is four (`allow_once` / `allow_always` / `reject_once` /
`reject_always`), so this was **latent** — it almost certainly never fired in production, which is
why it was filed during #1794 instead of rushed. What made it worth doing before the remaining
cosmetic items is that a permission decision misreported from a partial menu is closer to a safety
question than a rendering one.

## Verification

- 4 assertions, all confirmed **red** on `main` first:
  - the card offers 8 of 8 and 25 of 25, and returns null at 26 and at 0 (replacing the test that
    pinned `toHaveLength(5)`);
  - the approval DM falls back to the ask-plus-console card when the list will not fit;
  - a coordinator-level test that 8 options post a chat card with 8 buttons;
  - and that 26 post **no** card, leave `pendingChatPermissions` empty, and land on
    `pendingEditorPermissions` — open, not cancelled, not decided.
- 808 tests green across render / permission / Slack / Discord / Telegram / Feishu / decline /
  registry; `pnpm eval:gates` 196/197 (the known pre-existing `evaluation-runner` baseline);
  typecheck, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
