### PR TITLE
feat(web): recall earlier prompts in the session composer with Up/Down

### DIFF
--- a/packages/web/src/components/console/useComposerHistory.test.tsx
+++ b/packages/web/src/components/console/useComposerHistory.test.tsx
@@ -1,13 +1,16 @@
 // @vitest-environment happy-dom
 import { act, useState, type KeyboardEvent } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
-import { composerHistoryFromRows, useComposerHistory } from './useComposerHistory'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { composerHistoryFromRows, useComposerHistory, type ComposerHistoryEntry } from './useComposerHistory'
 
-const HISTORY = ['first', 'second', 'third']
+const entry = (key: string, text = key): ComposerHistoryEntry => ({ key, text })
+const HISTORY = [entry('first'), entry('second'), entry('third')]
 
 let root: Root | null = null
 let container: HTMLDivElement | null = null
+
+beforeAll(() => Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true))
 
 afterEach(() => {
   if (root) act(() => root!.unmount())
@@ -16,16 +19,25 @@ afterEach(() => {
   container = null
 })
 
-function mountHarness(history: readonly string[] = HISTORY) {
+interface Paging {
+  hasEarlier: boolean
+  loadEarlier: () => Promise<void>
+  loadedRows: number
+}
+
+function mountHarness(history: readonly ComposerHistoryEntry[] = HISTORY, paging?: Paging) {
   let api!: ReturnType<typeof useComposerHistory>
   let setDraft!: (v: string) => void
   let getValue!: () => string
+  let setProps!: (next: { history?: readonly ComposerHistoryEntry[]; paging?: Paging }) => void
 
   function Harness() {
     const [value, setValue] = useState('')
-    api = useComposerHistory({ history, value, setValue })
+    const [props, set] = useState({ history, paging })
+    api = useComposerHistory({ history: props.history, value, setValue, ...props.paging })
     setDraft = setValue
     getValue = () => value
+    setProps = (next) => set((prev) => ({ ...prev, ...next }))
     return <textarea value={value} readOnly />
   }
 
@@ -38,6 +50,8 @@ function mountHarness(history: readonly string[] = HISTORY) {
     value: () => getValue(),
     /** Types like the composer's onChange: the draft moves without going through the hook. */
     type: (text: string) => act(() => setDraft(text)),
+    /** A transcript page landing: the pool and row count move together, as the view derives them. */
+    update: (next: { history?: readonly ComposerHistoryEntry[]; paging?: Paging }) => act(() => setProps(next)),
     press: (key: string, composing = false) => {
       let consumed = false
       let prevented = false
@@ -55,6 +69,9 @@ function mountHarness(history: readonly string[] = HISTORY) {
     }
   }
 }
+
+/** Flush the microtasks a settled `loadEarlier` schedules. */
+const settle = () => act(async () => {})
 
 describe('useComposerHistory', () => {
   it('stays inert while the draft has text or the history is empty', () => {
@@ -78,7 +95,7 @@ describe('useComposerHistory', () => {
     expect(h.value()).toBe('second')
     expect(h.label()).toBe('History 2/3')
     h.press('ArrowUp')
-    h.press('ArrowUp') // clamps at the oldest
+    h.press('ArrowUp') // clamps at the oldest when nothing earlier is loadable
     expect(h.value()).toBe('first')
     expect(h.label()).toBe('History 1/3')
 
@@ -147,38 +164,171 @@ describe('useComposerHistory', () => {
     expect(h.press('ArrowUp', true).consumed).toBe(false)
     expect(h.label()).toBeNull()
   })
+
+  it('keeps its place when an earlier page prepends entries', () => {
+    const h = mountHarness()
+    h.press('ArrowUp')
+    h.press('ArrowUp')
+    expect(h.label()).toBe('History 2/3')
+    h.update({ history: [entry('older-a'), entry('older-b'), ...HISTORY] })
+    expect(h.value()).toBe('second')
+    expect(h.label()).toBe('History 4/5')
+    h.press('ArrowUp')
+    expect(h.value()).toBe('first')
+  })
+
+  describe('paging earlier history', () => {
+    it('marks the count open-ended while earlier pages are unloaded', () => {
+      const h = mountHarness(HISTORY, { hasEarlier: true, loadEarlier: vi.fn(async () => {}), loadedRows: 10 })
+      h.press('ArrowUp')
+      expect(h.label()).toBe('History 3/3+')
+    })
+
+    it('Up at the oldest loaded entry pages earlier rows in and lands on the newest arrival', async () => {
+      let release!: () => void
+      const loadEarlier = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve
+          })
+      )
+      const h = mountHarness([entry('third')], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      h.press('ArrowUp')
+      expect(h.label()).toBe('History 1/1+')
+      expect(h.press('ArrowUp').consumed).toBe(true)
+      expect(loadEarlier).toHaveBeenCalledTimes(1)
+      expect(h.label()).toBe('History 1/1+ · loading earlier…')
+      expect(h.value()).toBe('third') // the recalled text holds while the page loads
+
+      // The page lands: two of the viewer's prompts among the new rows, one page still earlier.
+      h.update({
+        history: [entry('first'), entry('second'), entry('third')],
+        paging: { hasEarlier: true, loadEarlier, loadedRows: 30 }
+      })
+      release()
+      await settle()
+      expect(h.value()).toBe('second')
+      expect(h.label()).toBe('History 2/3+')
+      expect(loadEarlier).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps paging through pages with none of the viewer’s prompts, and stops at the start', async () => {
+      // Each read resolves only after its rows landed, as the transcript machine's does.
+      const pages: Array<() => void> = []
+      const loadEarlier = vi.fn(() => new Promise<void>((resolve) => pages.push(resolve)))
+      const h = mountHarness([entry('only')], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      h.press('ArrowUp')
+      h.press('ArrowUp')
+      expect(loadEarlier).toHaveBeenCalledTimes(1)
+      // A page of agent-only rows: more rows, no new prompts, still more history.
+      h.update({ paging: { hasEarlier: true, loadEarlier, loadedRows: 40 } })
+      pages[0]!()
+      await settle()
+      expect(loadEarlier).toHaveBeenCalledTimes(2)
+      expect(h.label()).toBe('History 1/1+ · loading earlier…')
+      // The last page: still nothing of the viewer's, and the transcript starts here.
+      h.update({ paging: { hasEarlier: false, loadEarlier, loadedRows: 55 } })
+      pages[1]!()
+      await settle()
+      expect(loadEarlier).toHaveBeenCalledTimes(2)
+      expect(h.label()).toBe('History 1/1')
+      expect(h.value()).toBe('only')
+    })
+
+    it('gives up on a page that adds no rows instead of looping on a failing read', async () => {
+      const loadEarlier = vi.fn(async () => {})
+      const h = mountHarness([entry('only')], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      h.press('ArrowUp')
+      h.press('ArrowUp')
+      await settle() // settled with nothing new
+      expect(loadEarlier).toHaveBeenCalledTimes(1)
+      expect(h.label()).toBe('History 1/1+')
+    })
+
+    it('Escape and Down cancel a pending page walk', async () => {
+      const loadEarlier = vi.fn(() => new Promise<void>(() => {}))
+      const h = mountHarness([entry('only')], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      h.press('ArrowUp')
+      h.press('ArrowUp')
+      expect(h.label()).toBe('History 1/1+ · loading earlier…')
+      h.press('ArrowDown')
+      expect(h.label()).toBe('History 1/1+')
+      expect(h.value()).toBe('only')
+      h.press('ArrowUp')
+      h.press('Escape')
+      expect(h.label()).toBeNull()
+      expect(h.value()).toBe('')
+      // The page that was in flight lands afterwards and must not recall anything.
+      h.update({ history: [entry('older'), entry('only')], paging: { hasEarlier: false, loadEarlier, loadedRows: 30 } })
+      expect(h.value()).toBe('')
+      expect(h.label()).toBeNull()
+    })
+
+    it('Up on an empty draft with no loaded prompts pages until one arrives', async () => {
+      const loadEarlier = vi.fn(async () => {})
+      const h = mountHarness([], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      expect(h.press('ArrowUp').consumed).toBe(true)
+      expect(h.label()).toBe('History · loading earlier…')
+      expect(loadEarlier).toHaveBeenCalledTimes(1)
+      h.update({ history: [entry('found')], paging: { hasEarlier: true, loadEarlier, loadedRows: 30 } })
+      await settle()
+      expect(h.value()).toBe('found')
+      expect(h.label()).toBe('History 1/1+')
+    })
+
+    it('typing while a page loads cancels the walk and keeps the typed text', async () => {
+      const loadEarlier = vi.fn(async () => {})
+      const h = mountHarness([], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      h.press('ArrowUp')
+      h.type('mine')
+      h.update({ history: [entry('found')], paging: { hasEarlier: false, loadEarlier, loadedRows: 30 } })
+      await settle()
+      expect(h.value()).toBe('mine')
+      expect(h.label()).toBeNull()
+    })
+  })
 })
 
 describe('composerHistoryFromRows', () => {
   const isSelf = (sender: string) => sender === 'me'
+  const keyOf = (row: { seq: number }) => `s#${row.seq}`
 
-  it('keeps only the viewer’s non-empty prompts in order', () => {
+  it('keeps only the viewer’s non-empty prompts in order, keyed by row', () => {
     expect(
       composerHistoryFromRows(
         [
-          { sender: 'me', text: 'one' },
-          { sender: 'agent', text: 'reply' },
-          { sender: 'me', text: '   ' },
-          { sender: 'someone-else', text: 'theirs' },
-          { sender: 'me', text: 'two' }
+          { seq: 1, sender: 'me', text: 'one' },
+          { seq: 2, sender: 'agent', text: 'reply' },
+          { seq: 3, sender: 'me', text: '   ' },
+          { seq: 4, sender: 'someone-else', text: 'theirs' },
+          { seq: 5, sender: 'me', text: 'two' }
         ],
-        isSelf
+        isSelf,
+        keyOf
       )
-    ).toEqual(['one', 'two'])
+    ).toEqual([
+      { key: 's#1', text: 'one' },
+      { key: 's#5', text: 'two' }
+    ])
   })
 
   it('drops merged-conversation copies of one post and back-to-back repeats', () => {
     expect(
       composerHistoryFromRows(
         [
-          { sender: 'me', text: 'hi', postId: 'p1' },
-          { sender: 'me', text: 'hi', postId: 'p1' },
-          { sender: 'me', text: 'again' },
-          { sender: 'me', text: 'again' },
-          { sender: 'me', text: 'hi' }
+          { seq: 1, sender: 'me', text: 'hi', postId: 'p1' },
+          { seq: 2, sender: 'me', text: 'hi', postId: 'p1' },
+          { seq: 3, sender: 'me', text: 'again' },
+          { seq: 4, sender: 'me', text: 'again' },
+          { seq: 5, sender: 'me', text: 'hi' }
         ],
-        isSelf
+        isSelf,
+        keyOf
       )
-    ).toEqual(['hi', 'again', 'hi'])
+    ).toEqual([
+      { key: 'p1', text: 'hi' },
+      { key: 's#3', text: 'again' },
+      { key: 's#5', text: 'hi' }
+    ])
   })
 })

--- a/packages/web/src/components/console/useComposerHistory.test.tsx
+++ b/packages/web/src/components/console/useComposerHistory.test.tsx
@@ -276,6 +276,38 @@ describe('useComposerHistory', () => {
       expect(h.label()).toBe('History 1/1+')
     })
 
+    it('Escape cancels a walk that has not found an entry yet, so the arriving page recalls nothing', async () => {
+      let release!: () => void
+      const loadEarlier = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve
+          })
+      )
+      const h = mountHarness([], { hasEarlier: true, loadEarlier, loadedRows: 10 })
+      h.press('ArrowUp')
+      expect(h.label()).toBe('History · loading earlier…')
+      expect(h.press('Escape')).toEqual({ consumed: true, prevented: true })
+      expect(h.label()).toBeNull()
+      h.update({ history: [entry('found')], paging: { hasEarlier: false, loadEarlier, loadedRows: 30 } })
+      release()
+      await settle()
+      expect(h.value()).toBe('')
+      expect(h.label()).toBeNull()
+    })
+
+    it('Down cancels a walk that has not found an entry yet', () => {
+      const h = mountHarness([], {
+        hasEarlier: true,
+        loadEarlier: vi.fn(() => new Promise<void>(() => {})),
+        loadedRows: 10
+      })
+      h.press('ArrowUp')
+      expect(h.press('ArrowDown').consumed).toBe(true)
+      expect(h.label()).toBeNull()
+      expect(h.value()).toBe('')
+    })
+
     it('typing while a page loads cancels the walk and keeps the typed text', async () => {
       const loadEarlier = vi.fn(async () => {})
       const h = mountHarness([], { hasEarlier: true, loadEarlier, loadedRows: 10 })

--- a/packages/web/src/components/console/useComposerHistory.test.tsx
+++ b/packages/web/src/components/console/useComposerHistory.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+import { act, useState, type KeyboardEvent } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { composerHistoryFromRows, useComposerHistory } from './useComposerHistory'
+
+const HISTORY = ['first', 'second', 'third']
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (root) act(() => root!.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+function mountHarness(history: readonly string[] = HISTORY) {
+  let api!: ReturnType<typeof useComposerHistory>
+  let setDraft!: (v: string) => void
+  let getValue!: () => string
+
+  function Harness() {
+    const [value, setValue] = useState('')
+    api = useComposerHistory({ history, value, setValue })
+    setDraft = setValue
+    getValue = () => value
+    return <textarea value={value} readOnly />
+  }
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root!.render(<Harness />))
+  return {
+    label: () => api.label,
+    value: () => getValue(),
+    /** Types like the composer's onChange: the draft moves without going through the hook. */
+    type: (text: string) => act(() => setDraft(text)),
+    press: (key: string, composing = false) => {
+      let consumed = false
+      let prevented = false
+      const event = {
+        key,
+        nativeEvent: { isComposing: composing },
+        preventDefault: () => {
+          prevented = true
+        }
+      } as unknown as KeyboardEvent<HTMLTextAreaElement>
+      act(() => {
+        consumed = api.handleKeyDown(event)
+      })
+      return { consumed, prevented }
+    }
+  }
+}
+
+describe('useComposerHistory', () => {
+  it('stays inert while the draft has text or the history is empty', () => {
+    const h = mountHarness()
+    h.type('typing')
+    expect(h.press('ArrowUp')).toEqual({ consumed: false, prevented: false })
+    expect(h.label()).toBeNull()
+
+    const empty = mountHarness([])
+    expect(empty.press('ArrowUp').consumed).toBe(false)
+    expect(empty.label()).toBeNull()
+  })
+
+  it('enters on the newest entry from an empty draft and walks with Up/Down', () => {
+    const h = mountHarness()
+    expect(h.press('ArrowUp')).toEqual({ consumed: true, prevented: true })
+    expect(h.value()).toBe('third')
+    expect(h.label()).toBe('History 3/3')
+
+    h.press('ArrowUp')
+    expect(h.value()).toBe('second')
+    expect(h.label()).toBe('History 2/3')
+    h.press('ArrowUp')
+    h.press('ArrowUp') // clamps at the oldest
+    expect(h.value()).toBe('first')
+    expect(h.label()).toBe('History 1/3')
+
+    h.press('ArrowDown')
+    expect(h.value()).toBe('second')
+    expect(h.label()).toBe('History 2/3')
+  })
+
+  it('ArrowDown also enters on the newest entry', () => {
+    const h = mountHarness()
+    h.press('ArrowDown')
+    expect(h.value()).toBe('third')
+    expect(h.label()).toBe('History 3/3')
+  })
+
+  it('ArrowDown past the newest entry returns to an empty prompt', () => {
+    const h = mountHarness()
+    h.press('ArrowUp')
+    expect(h.press('ArrowDown').consumed).toBe(true)
+    expect(h.value()).toBe('')
+    expect(h.label()).toBeNull()
+    // Back on a plain empty draft, so Up recalls from the newest again.
+    h.press('ArrowUp')
+    expect(h.value()).toBe('third')
+  })
+
+  it('editing the recalled text leaves history mode but keeps the text', () => {
+    const h = mountHarness()
+    h.press('ArrowUp')
+    h.type('third edited')
+    expect(h.label()).toBeNull()
+    expect(h.value()).toBe('third edited')
+    // Not empty any more, so Up no longer recalls.
+    expect(h.press('ArrowUp').consumed).toBe(false)
+    expect(h.value()).toBe('third edited')
+  })
+
+  it('Escape leaves history mode and clears the draft', () => {
+    const h = mountHarness()
+    h.press('ArrowUp')
+    h.press('ArrowUp')
+    expect(h.press('Escape')).toEqual({ consumed: true, prevented: true })
+    expect(h.value()).toBe('')
+    expect(h.label()).toBeNull()
+  })
+
+  it('Escape outside history mode is not consumed', () => {
+    const h = mountHarness()
+    expect(h.press('Escape').consumed).toBe(false)
+    h.type('draft')
+    expect(h.press('Escape').consumed).toBe(false)
+    expect(h.value()).toBe('draft')
+  })
+
+  it('leaves history mode when the draft is cleared from outside, as a send does', () => {
+    const h = mountHarness()
+    h.press('ArrowUp')
+    h.type('')
+    expect(h.label()).toBeNull()
+    h.press('ArrowUp')
+    expect(h.value()).toBe('third')
+  })
+
+  it('lets an IME composition keep its arrow keys', () => {
+    const h = mountHarness()
+    expect(h.press('ArrowUp', true).consumed).toBe(false)
+    expect(h.label()).toBeNull()
+  })
+})
+
+describe('composerHistoryFromRows', () => {
+  const isSelf = (sender: string) => sender === 'me'
+
+  it('keeps only the viewer’s non-empty prompts in order', () => {
+    expect(
+      composerHistoryFromRows(
+        [
+          { sender: 'me', text: 'one' },
+          { sender: 'agent', text: 'reply' },
+          { sender: 'me', text: '   ' },
+          { sender: 'someone-else', text: 'theirs' },
+          { sender: 'me', text: 'two' }
+        ],
+        isSelf
+      )
+    ).toEqual(['one', 'two'])
+  })
+
+  it('drops merged-conversation copies of one post and back-to-back repeats', () => {
+    expect(
+      composerHistoryFromRows(
+        [
+          { sender: 'me', text: 'hi', postId: 'p1' },
+          { sender: 'me', text: 'hi', postId: 'p1' },
+          { sender: 'me', text: 'again' },
+          { sender: 'me', text: 'again' },
+          { sender: 'me', text: 'hi' }
+        ],
+        isSelf
+      )
+    ).toEqual(['hi', 'again', 'hi'])
+  })
+})

--- a/packages/web/src/components/console/useComposerHistory.ts
+++ b/packages/web/src/components/console/useComposerHistory.ts
@@ -3,67 +3,145 @@
 // Shell-style recall of the viewer's earlier prompts in the session composer. Up/Down on an
 // EMPTY draft enters history mode on the newest entry; Up walks older, Down walks newer and past
 // the newest returns to the empty prompt. Editing the recalled text leaves history mode but keeps
-// the text; Escape leaves it and clears the draft.
+// the text; Escape leaves it and clears the draft. The pool is only the LOADED transcript window,
+// so Up at the oldest loaded entry pages earlier history in and keeps walking once it arrives.
 
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react'
+
+export interface ComposerHistoryEntry {
+  /** Stable row identity, so a page of earlier rows prepending does not move the recalled entry. */
+  key: string
+  text: string
+}
 
 export interface UseComposerHistoryInput {
-  /** The viewer's own prompts, oldest first. */
-  history: readonly string[]
+  /** The viewer's own prompts in the loaded window, oldest first. */
+  history: readonly ComposerHistoryEntry[]
   value: string
   setValue: (next: string) => void
+  /** The transcript has earlier pages not yet loaded. */
+  hasEarlier?: boolean
+  /** Loads the next earlier page; resolves once the rows are in (or the read failed). */
+  loadEarlier?: () => Promise<void>
+  /** Transcript rows loaded so far — a page that adds none ends the walk, so a failing read cannot loop. */
+  loadedRows?: number
 }
 
 export interface UseComposerHistoryResult {
-  /** `History i/n` while recalling, null otherwise — rendered above the textarea. */
+  /** `History i/n` while recalling (`n+` with earlier pages unloaded), null otherwise. */
   label: string | null
   /** Call from onKeyDown BEFORE the pickers' handlers; `true` means the key was consumed. */
   handleKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean
 }
 
-export function useComposerHistory({ history, value, setValue }: UseComposerHistoryInput): UseComposerHistoryResult {
-  // Index into `history` while recalling; null when the composer is a plain draft.
-  const [index, setIndex] = useState<number | null>(null)
+// Sentinel `pending` value: no entry yet, land on the newest one the next page brings.
+const ENTER_ON_ARRIVAL = ''
+
+export function useComposerHistory({
+  history,
+  value,
+  setValue,
+  hasEarlier = false,
+  loadEarlier,
+  loadedRows
+}: UseComposerHistoryInput): UseComposerHistoryResult {
+  // Key of the recalled entry while in history mode; null for a plain draft.
+  const [current, setCurrent] = useState<string | null>(null)
+  // Key of the entry an Up is waiting to walk past once an earlier page lands (or ENTER_ON_ARRIVAL).
+  const [pending, setPending] = useState<string | null>(null)
   // The text this hook last wrote, so a draft that moved on (an edit, a send clearing it) is detectable.
   const recalledRef = useRef<string | null>(null)
+  const inflightRef = useRef(false)
+  // Progress measure when the last page was requested; null before the first request of a walk.
+  const rowsAtRequestRef = useRef<number | null>(null)
+  // Bumps after each page settles so the walk re-evaluates even when the pool identity did not change.
+  const [settled, setSettled] = useState(0)
+
+  const found = current === null ? -1 : history.findIndex((entry) => entry.key === current)
+  const index = found === -1 ? null : found
+  const rows = loadedRows ?? history.length
 
   useEffect(() => {
-    if (index !== null && value !== recalledRef.current) {
-      setIndex(null)
+    if ((current !== null || pending !== null) && value !== recalledRef.current) {
+      setCurrent(null)
+      setPending(null)
       recalledRef.current = null
     }
-  }, [value, index])
+  }, [value, current, pending])
 
-  const recall = (next: number): void => {
-    const text = history[next]
-    if (text === undefined) return
-    recalledRef.current = text
-    setIndex(next)
-    setValue(text)
-  }
+  const recall = useCallback(
+    (next: number): void => {
+      const entry = history[next]
+      if (!entry) return
+      recalledRef.current = entry.text
+      setCurrent(entry.key)
+      setValue(entry.text)
+    },
+    [history, setValue]
+  )
   const leave = (clear: boolean): void => {
     recalledRef.current = clear ? '' : null
-    setIndex(null)
+    setCurrent(null)
+    setPending(null)
     if (clear) setValue('')
   }
+  const startWalk = (from: string): void => {
+    rowsAtRequestRef.current = null
+    setPending(from)
+  }
+
+  // Resolve a pending walk against the pool as pages arrive.
+  useEffect(() => {
+    if (pending === null) return
+    const from = pending === ENTER_ON_ARRIVAL ? history.length : history.findIndex((entry) => entry.key === pending)
+    if (from > 0) {
+      setPending(null)
+      recall(from - 1)
+      return
+    }
+    if (inflightRef.current) return
+    const grew = rowsAtRequestRef.current === null || rows > rowsAtRequestRef.current
+    if (from === -1 || !hasEarlier || !loadEarlier || !grew) {
+      setPending(null)
+      return
+    }
+    inflightRef.current = true
+    rowsAtRequestRef.current = rows
+    void loadEarlier().finally(() => {
+      inflightRef.current = false
+      setSettled((n) => n + 1)
+    })
+  }, [pending, history, rows, hasEarlier, loadEarlier, settled, recall])
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
     if (event.nativeEvent.isComposing) return false
     if (index === null) {
-      if (value !== '' || history.length === 0) return false
+      if (value !== '' || pending !== null) return false
       if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
-      event.preventDefault()
-      recall(history.length - 1)
-      return true
+      if (history.length > 0) {
+        event.preventDefault()
+        recall(history.length - 1)
+        return true
+      }
+      if (event.key === 'ArrowUp' && hasEarlier && loadEarlier) {
+        event.preventDefault()
+        recalledRef.current = ''
+        startWalk(ENTER_ON_ARRIVAL)
+        return true
+      }
+      return false
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault()
+      if (pending !== null) return true
       if (index > 0) recall(index - 1)
+      else if (hasEarlier && loadEarlier && current !== null) startWalk(current)
       return true
     }
     if (event.key === 'ArrowDown') {
       event.preventDefault()
-      if (index < history.length - 1) recall(index + 1)
+      if (pending !== null) setPending(null)
+      else if (index < history.length - 1) recall(index + 1)
       else leave(true)
       return true
     }
@@ -75,15 +153,23 @@ export function useComposerHistory({ history, value, setValue }: UseComposerHist
     return false
   }
 
-  return { label: index === null ? null : `History ${index + 1}/${history.length}`, handleKeyDown }
+  const loading = pending !== null
+  const label =
+    index !== null
+      ? `History ${index + 1}/${history.length}${hasEarlier ? '+' : ''}${loading ? ' · loading earlier…' : ''}`
+      : loading
+        ? 'History · loading earlier…'
+        : null
+  return { label, handleKeyDown }
 }
 
 /** The viewer's own prompts from transcript rows, oldest first, without empty or repeated entries. */
-export function composerHistoryFromRows(
-  rows: ReadonlyArray<{ sender: string; text: string; postId?: string }>,
-  isSelf: (sender: string) => boolean
-): string[] {
-  const out: string[] = []
+export function composerHistoryFromRows<Row extends { sender: string; text: string; postId?: string }>(
+  rows: ReadonlyArray<Row>,
+  isSelf: (sender: string) => boolean,
+  keyOf: (row: Row) => string
+): ComposerHistoryEntry[] {
+  const out: ComposerHistoryEntry[] = []
   const seenPosts = new Set<string>()
   for (const row of rows) {
     if (!isSelf(row.sender)) continue
@@ -92,8 +178,8 @@ export function composerHistoryFromRows(
       seenPosts.add(row.postId)
     }
     const text = row.text
-    if (!text.trim() || out[out.length - 1] === text) continue
-    out.push(text)
+    if (!text.trim() || out[out.length - 1]?.text === text) continue
+    out.push({ key: row.postId ?? keyOf(row), text })
   }
   return out
 }

--- a/packages/web/src/components/console/useComposerHistory.ts
+++ b/packages/web/src/components/console/useComposerHistory.ts
@@ -1,0 +1,99 @@
+'use client'
+
+// Shell-style recall of the viewer's earlier prompts in the session composer. Up/Down on an
+// EMPTY draft enters history mode on the newest entry; Up walks older, Down walks newer and past
+// the newest returns to the empty prompt. Editing the recalled text leaves history mode but keeps
+// the text; Escape leaves it and clears the draft.
+
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+
+export interface UseComposerHistoryInput {
+  /** The viewer's own prompts, oldest first. */
+  history: readonly string[]
+  value: string
+  setValue: (next: string) => void
+}
+
+export interface UseComposerHistoryResult {
+  /** `History i/n` while recalling, null otherwise — rendered above the textarea. */
+  label: string | null
+  /** Call from onKeyDown BEFORE the pickers' handlers; `true` means the key was consumed. */
+  handleKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean
+}
+
+export function useComposerHistory({ history, value, setValue }: UseComposerHistoryInput): UseComposerHistoryResult {
+  // Index into `history` while recalling; null when the composer is a plain draft.
+  const [index, setIndex] = useState<number | null>(null)
+  // The text this hook last wrote, so a draft that moved on (an edit, a send clearing it) is detectable.
+  const recalledRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (index !== null && value !== recalledRef.current) {
+      setIndex(null)
+      recalledRef.current = null
+    }
+  }, [value, index])
+
+  const recall = (next: number): void => {
+    const text = history[next]
+    if (text === undefined) return
+    recalledRef.current = text
+    setIndex(next)
+    setValue(text)
+  }
+  const leave = (clear: boolean): void => {
+    recalledRef.current = clear ? '' : null
+    setIndex(null)
+    if (clear) setValue('')
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (event.nativeEvent.isComposing) return false
+    if (index === null) {
+      if (value !== '' || history.length === 0) return false
+      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
+      event.preventDefault()
+      recall(history.length - 1)
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      if (index > 0) recall(index - 1)
+      return true
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      if (index < history.length - 1) recall(index + 1)
+      else leave(true)
+      return true
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      leave(true)
+      return true
+    }
+    return false
+  }
+
+  return { label: index === null ? null : `History ${index + 1}/${history.length}`, handleKeyDown }
+}
+
+/** The viewer's own prompts from transcript rows, oldest first, without empty or repeated entries. */
+export function composerHistoryFromRows(
+  rows: ReadonlyArray<{ sender: string; text: string; postId?: string }>,
+  isSelf: (sender: string) => boolean
+): string[] {
+  const out: string[] = []
+  const seenPosts = new Set<string>()
+  for (const row of rows) {
+    if (!isSelf(row.sender)) continue
+    if (row.postId) {
+      if (seenPosts.has(row.postId)) continue
+      seenPosts.add(row.postId)
+    }
+    const text = row.text
+    if (!text.trim() || out[out.length - 1] === text) continue
+    out.push(text)
+  }
+  return out
+}

--- a/packages/web/src/components/console/useComposerHistory.ts
+++ b/packages/web/src/components/console/useComposerHistory.ts
@@ -115,8 +115,16 @@ export function useComposerHistory({
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
     if (event.nativeEvent.isComposing) return false
+    // A page walk in flight, with or without an entry under it yet: Escape and Down cancel it.
+    if (pending !== null) {
+      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Escape') return false
+      event.preventDefault()
+      if (event.key === 'Escape') leave(true)
+      else if (event.key === 'ArrowDown') setPending(null)
+      return true
+    }
     if (index === null) {
-      if (value !== '' || pending !== null) return false
+      if (value !== '') return false
       if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
       if (history.length > 0) {
         event.preventDefault()
@@ -133,15 +141,13 @@ export function useComposerHistory({
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault()
-      if (pending !== null) return true
       if (index > 0) recall(index - 1)
       else if (hasEarlier && loadEarlier && current !== null) startWalk(current)
       return true
     }
     if (event.key === 'ArrowDown') {
       event.preventDefault()
-      if (pending !== null) setPending(null)
-      else if (index < history.length - 1) recall(index + 1)
+      if (index < history.length - 1) recall(index + 1)
       else leave(true)
       return true
     }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -96,6 +96,7 @@ import { ContextWindowIndicator } from '@/components/console/ContextWindowIndica
 import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { MentionMenu, type MentionOption } from '@/components/console/MentionMenu'
 import { useMentionAutocomplete } from '@/components/console/useMentionAutocomplete'
+import { composerHistoryFromRows, useComposerHistory } from '@/components/console/useComposerHistory'
 import { CommandMenu } from '@/components/console/CommandMenu'
 import { useCommandAutocomplete } from '@/components/console/useCommandAutocomplete'
 import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
@@ -257,12 +258,15 @@ function ComposerTextarea({
   onPickMention,
   onMentionJoiningChange,
   onCommandPick,
-  commands
+  commands,
+  history
 }: {
   sessionId: string
   placeholder: string
   onSend: () => void
   onImageFile?: (file: File) => void
+  /** The viewer's earlier prompts in this session, oldest first — Up/Down on an empty draft recalls them. */
+  history: readonly string[]
   mentionCandidates: MentionOption[]
   onPickMention: (option: MentionOption) => void | Promise<boolean>
   /** Mirrors `mention.joining` up to the parent so the (separately isolated)
@@ -280,6 +284,7 @@ function ComposerTextarea({
   const draft = usePgDraft(sessionId)
   const { setPgInput } = usePlayground()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const recall = useComposerHistory({ history, value: draft, setValue: (v) => setPgInput(sessionId, v) })
   // @mention picker (webchat-multi-agents.md §9.1/§9.2) — same contract as the
   // Home composer's: picking a candidate inserts "@Name " and typedMentionIds()
   // resolves that text back into a structural mention on send.
@@ -307,6 +312,15 @@ function ComposerTextarea({
   })
   return (
     <div className="relative">
+      {recall.label && (
+        <div
+          aria-live="polite"
+          data-testid="composer-history"
+          className="px-[15px] pt-[9px] -mb-[7px] font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)"
+        >
+          {recall.label}
+        </div>
+      )}
       <textarea
         ref={textareaRef}
         className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
@@ -334,6 +348,8 @@ function ComposerTextarea({
           onImageFile(image)
         }}
         onKeyDown={(e) => {
+          // History first: a recalled `/cmd` or `@name` must not hand Up/Down to a picker mid-walk.
+          if (recall.handleKeyDown(e)) return
           if (command.handleKeyDown(e)) return
           if (mention.handleKeyDown(e)) return
           // Enter sends — but NOT while an IME is composing (that Enter
@@ -3208,6 +3224,11 @@ export default function SessionDetailView() {
   const isSelf = (sender?: string | null): boolean => isSelfSender(sender, me)
   const senderLabel = (sender: string | null | undefined, fallback?: string): string =>
     sessionSenderLabel(sender, fallback, agentNameById, memberNameByIdentity, me)
+  // The composer's Up/Down recall pool: the viewer's own prompts in transcript order.
+  const composerHistory = useMemo(
+    () => composerHistoryFromRows(visibleMsgs ?? [], (sender) => isSelfSender(sender, me)),
+    [visibleMsgs, me]
+  )
 
   const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
   useEffect(() => {
@@ -5360,6 +5381,7 @@ export default function SessionDetailView() {
                             commandPickRef.current = target
                           }}
                           commands={commandParticipants}
+                          history={composerHistory}
                         />
                         <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
                           {attachmentsEnabled && (

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -3242,17 +3242,25 @@ export default function SessionDetailView() {
   const isSelf = (sender?: string | null): boolean => isSelfSender(sender, me)
   const senderLabel = (sender: string | null | undefined, fallback?: string): string =>
     sessionSenderLabel(sender, fallback, agentNameById, memberNameByIdentity, me)
-  // The composer's Up/Down recall pool: the viewer's own prompts in transcript order.
-  const composerHistory = useMemo(
-    () =>
-      composerHistoryFromRows(
+  // The composer's Up/Down recall pool: the viewer's own prompts in transcript order, read from
+  // whichever source the page renders — fetched rows, or the steps a playground session carries.
+  const sessionSteps = session?.steps
+  const sessionUser = session?.user
+  const composerHistory = useMemo(() => {
+    const isSelf = (sender: string) => isSelfSender(sender, me)
+    if (wantTranscript) {
+      // Source session + `seq`, as rowAnchor below: immutable, and a prepended page cannot move it.
+      return composerHistoryFromRows(
         visibleMsgs ?? [],
-        (sender) => isSelfSender(sender, me),
-        // Source session + `seq`, as rowAnchor below: immutable, and a prepended page cannot move it.
+        isSelf,
         (m) => `${conversationSourceSessionByMessageRef.current.get(m) ?? sid ?? ''}#${m.seq}`
-      ),
-    [visibleMsgs, me, sid]
-  )
+      )
+    }
+    const prompts = (sessionSteps ?? []).flatMap((stp) =>
+      stp.kind === 'msg' ? [{ ...stp, sender: stp.who ?? sessionUser ?? '' }] : []
+    )
+    return composerHistoryFromRows(prompts, isSelf, (stp) => `live:${stp.turnId}`)
+  }, [wantTranscript, visibleMsgs, sessionSteps, sessionUser, me, sid])
 
   const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
   useEffect(() => {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -96,7 +96,11 @@ import { ContextWindowIndicator } from '@/components/console/ContextWindowIndica
 import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { MentionMenu, type MentionOption } from '@/components/console/MentionMenu'
 import { useMentionAutocomplete } from '@/components/console/useMentionAutocomplete'
-import { composerHistoryFromRows, useComposerHistory } from '@/components/console/useComposerHistory'
+import {
+  composerHistoryFromRows,
+  useComposerHistory,
+  type ComposerHistoryEntry
+} from '@/components/console/useComposerHistory'
 import { CommandMenu } from '@/components/console/CommandMenu'
 import { useCommandAutocomplete } from '@/components/console/useCommandAutocomplete'
 import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
@@ -259,14 +263,21 @@ function ComposerTextarea({
   onMentionJoiningChange,
   onCommandPick,
   commands,
-  history
+  history,
+  hasEarlier,
+  loadEarlier,
+  loadedRows
 }: {
   sessionId: string
   placeholder: string
   onSend: () => void
   onImageFile?: (file: File) => void
-  /** The viewer's earlier prompts in this session, oldest first — Up/Down on an empty draft recalls them. */
-  history: readonly string[]
+  /** The viewer's earlier prompts in the loaded window, oldest first — Up/Down on an empty draft recalls them. */
+  history: readonly ComposerHistoryEntry[]
+  /** Transcript paging, so Up at the oldest loaded prompt pages earlier history in. */
+  hasEarlier: boolean
+  loadEarlier: () => Promise<void>
+  loadedRows: number
   mentionCandidates: MentionOption[]
   onPickMention: (option: MentionOption) => void | Promise<boolean>
   /** Mirrors `mention.joining` up to the parent so the (separately isolated)
@@ -284,7 +295,14 @@ function ComposerTextarea({
   const draft = usePgDraft(sessionId)
   const { setPgInput } = usePlayground()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const recall = useComposerHistory({ history, value: draft, setValue: (v) => setPgInput(sessionId, v) })
+  const recall = useComposerHistory({
+    history,
+    value: draft,
+    setValue: (v) => setPgInput(sessionId, v),
+    hasEarlier,
+    loadEarlier,
+    loadedRows
+  })
   // @mention picker (webchat-multi-agents.md §9.1/§9.2) — same contract as the
   // Home composer's: picking a candidate inserts "@Name " and typedMentionIds()
   // resolves that text back into a structural mention on send.
@@ -3226,8 +3244,14 @@ export default function SessionDetailView() {
     sessionSenderLabel(sender, fallback, agentNameById, memberNameByIdentity, me)
   // The composer's Up/Down recall pool: the viewer's own prompts in transcript order.
   const composerHistory = useMemo(
-    () => composerHistoryFromRows(visibleMsgs ?? [], (sender) => isSelfSender(sender, me)),
-    [visibleMsgs, me]
+    () =>
+      composerHistoryFromRows(
+        visibleMsgs ?? [],
+        (sender) => isSelfSender(sender, me),
+        // Source session + `seq`, as rowAnchor below: immutable, and a prepended page cannot move it.
+        (m) => `${conversationSourceSessionByMessageRef.current.get(m) ?? sid ?? ''}#${m.seq}`
+      ),
+    [visibleMsgs, me, sid]
   )
 
   const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
@@ -5382,6 +5406,9 @@ export default function SessionDetailView() {
                           }}
                           commands={commandParticipants}
                           history={composerHistory}
+                          hasEarlier={visibleHasEarlier}
+                          loadEarlier={loadEarlierConversation}
+                          loadedRows={visibleMsgs?.length ?? 0}
                         />
                         <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
                           {attachmentsEnabled && (

--- a/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.viewer.test.tsx
@@ -41,7 +41,11 @@ const wire = vi.hoisted(() => ({
   /** Non-null holds every PR probe until released, so the strip is observable while the linkage is unknown. */
   prGate: null as null | Array<() => void>,
   /** A synthetic playground session the daemon has not created yet — its route id names no canonical session the lease could be keyed by. */
-  playground: false
+  playground: false,
+  /** Overrides the session's steps: a playground session renders these instead of fetching a transcript. */
+  steps: undefined as unknown[] | undefined,
+  /** Every draft the composer wrote through `setPgInput`, newest last; the mocked `usePgDraft` reads the newest. */
+  drafts: [] as string[]
 }))
 
 // The reader's role in the org. `viewer` is what the CP 403s on every git-write route, so the console withholds those controls.
@@ -206,7 +210,8 @@ vi.mock('@/lib/data-context', () => ({
         workspaceIsolation: wire.isolation,
         contentPurgedAt: wire.contentPurgedAt,
         ...(wire.agentless ? { agentId: '', agentName: '' } : {}),
-        ...(wire.playground ? { platform: 'playground' } : {})
+        ...(wire.playground ? { platform: 'playground' } : {}),
+        ...(wire.steps ? { steps: wire.steps } : {})
       }
     ],
     getSessions: () => [session],
@@ -274,10 +279,12 @@ vi.mock('@/components/console/PlaygroundProvider', () => ({
     pgSetFast: () => {},
     pgSetWorktree: () => {},
     pgCancel: () => {},
-    setPgInput: () => {}
+    setPgInput: (_id: string, value: string) => {
+      wire.drafts.push(value)
+    }
   }),
-  usePgDraft: () => '',
-  usePgDraftHasText: () => false
+  usePgDraft: () => wire.drafts[wire.drafts.length - 1] ?? '',
+  usePgDraftHasText: () => (wire.drafts[wire.drafts.length - 1] ?? '') !== ''
 }))
 
 import SessionDetailView from './SessionDetailView'
@@ -338,6 +345,8 @@ beforeEach(() => {
   org.role = 'collaborator'
   wire.agentless = false
   wire.playground = false
+  wire.steps = undefined
+  wire.drafts = []
   wire.rail = []
   wire.tasks = { sessionId: 'session-1', tracked: true, tasks: [], truncated: false }
   wire.taskCalls = []
@@ -374,6 +383,47 @@ describe('the session page in conversation mode', () => {
     expect(text()).toContain('TRANSCRIPT MARKER')
     expect(viewer()).toBeNull()
     expect(pane()?.className).toBe('contents')
+  })
+})
+
+describe('the composer recalls earlier prompts', () => {
+  /** Press a key in the composer the way the browser delivers it, so React's onKeyDown sees it. */
+  async function keyInComposer(key: string) {
+    const textarea = container?.querySelector<HTMLTextAreaElement>('textarea')
+    if (!textarea) throw new Error('no composer')
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+      await Promise.resolve()
+    })
+  }
+
+  it('recalls a prompt a new conversation keeps in its steps, not in a fetched transcript', async () => {
+    // A conversation started from the console has its prompts in `session.steps` and never fetches a transcript; recall must read that source too, or Up on the cleared composer does nothing right after the first send.
+    wire.playground = true
+    wire.steps = [
+      { kind: 'msg', who: '@you', turnId: 't1', text: 'deploy the thing' },
+      { kind: 'text', who: 'Ops bot', turnId: 't1', agentId: 'agent-1', text: 'on it' },
+      { kind: 'msg', who: '@you', turnId: 't2', text: 'and run the smoke test' }
+    ]
+    await render()
+    await keyInComposer('ArrowUp')
+    expect(wire.drafts).toEqual(['and run the smoke test'])
+    expect(container?.querySelector('[data-testid="composer-history"]')?.textContent).toBe('History 2/2')
+    await keyInComposer('ArrowUp')
+    expect(wire.drafts.at(-1)).toBe('deploy the thing')
+    expect(container?.querySelector('[data-testid="composer-history"]')?.textContent).toBe('History 1/2')
+    await keyInComposer('Escape')
+    expect(wire.drafts.at(-1)).toBe('')
+    expect(container?.querySelector('[data-testid="composer-history"]')).toBeNull()
+  })
+
+  it('recalls nothing from another person’s prompts', async () => {
+    wire.playground = true
+    wire.steps = [{ kind: 'msg', who: 'sam', turnId: 't1', text: 'TRANSCRIPT MARKER' }]
+    await render()
+    await keyInComposer('ArrowUp')
+    expect(wire.drafts).toEqual([])
+    expect(container?.querySelector('[data-testid="composer-history"]')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## What

Shell-style prompt recall in the Session Detail composer.

- **Enter history mode:** with an empty draft, Up or Down recalls the viewer's most recent prompt in this session and shows a `History i/n` label at the top of the input box.
- **Walk:** Up moves to older prompts, Down moves to newer; Down past the newest returns to the empty prompt.
- **Leave:** editing the recalled text leaves history mode but keeps the text; Escape leaves history mode and clears the input.
- **Paging:** the transcript loads only its newest page, so Up at the oldest loaded prompt pages earlier history in and lands on the newest prompt that arrives. The label reads `History i/n+` while earlier pages are unloaded and shows a loading hint while a page is in flight.

## Why

Re-sending or tweaking an earlier prompt currently means scrolling the transcript and copying it by hand. Terminal users expect Up on an empty prompt to bring the last input back.

## How

- `useComposerHistory` (new) holds the recalled entry and key handling; `composerHistoryFromRows` builds the pool from transcript rows: the viewer's own rows (`isSelfSender`), oldest first, skipping blanks, back-to-back repeats, and duplicate copies of one webchat `postId` in a merged conversation.
- Entries carry a stable row key (`postId`, else source session + `seq`, the same identity `rowAnchor` uses), and the hook tracks its place by key, so a page of earlier rows prepending does not move the recalled entry.
- Up at the oldest loaded entry calls the transcript's `loadEarlier`. Pages with none of the viewer's prompts keep paging while `hasEarlier` holds; a page that adds no rows ends the walk, so a failing read cannot loop. Escape, Down, and typing cancel a pending walk.
- `ComposerTextarea` runs the history handler before the `/` command and `@` mention pickers, so a recalled `/cmd` or `@name` does not hand Up/Down to a picker mid-walk. IME composition keeps its arrow keys.
- `SessionDetailView` derives the pool with `useMemo` over the visible transcript and passes it down with `hasEarlier`, `loadEarlier`, and the loaded row count; the composer stays the isolated node it was for typing performance.
- A send clears the draft, which the hook detects and leaves history mode, so the next Up starts from the newest prompt again.

## Tests

- New `useComposerHistory.test.tsx`: 19 cases covering entry, walking and clamping, Down-past-newest, edit-keeps-text, Escape-clears, external clear, IME, place-keeping across a prepend, paging through prompt-less pages, the no-progress stop, cancelling a pending walk, and pool construction.
- Existing `SessionDetailView` suites (85 cases), `pnpm typecheck`, eslint and prettier pass on the changed files.

## Reviewer notes

- Judgment calls not in the original ask: Down past the newest entry returns to the empty prompt (shell behavior), Down on an empty draft also enters on the newest entry, and Up on an empty draft with no loaded prompts pages earlier history until one is found.
- Not verified against a live backend in this session; the behavior is covered by the hook tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
