### PR TITLE
fix(daemon): a failed skill install keeps the skills it could not rebuild

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -545,11 +545,28 @@ node <bundled skills@1.5.21 bin> add <absoluteSnapshot> \
   destination is unowned is skipped and reported as a conflict rather than failing
   the workspace: leaving that path untouched is what the refusal wanted, and one
   foreign directory must not cost the agent its other skills or its host startup.
-- A source/CLI failure clears previously owned content and starts without managed
-  skills. A ref check that cannot be answered is NOT such a failure: it resolves to
-  the installed commit and nothing is rebuilt, so a moving ref cannot turn an
-  upstream outage into an agent losing its skills. A refused stale removal, corrupt journal, or failed rollback blocks the
-  workspace so disabled executable instructions cannot remain silently active.
+- **A failure to build a source never costs the agent that skill.** An install that
+  cannot acquire a source, or whose CLI faults, says nothing about whether the
+  operator still wants the skill — only that this run could not rebuild it — and the
+  bytes already published are that same source's own older commit. So:
+  - a git source that cannot be acquired keeps its published bundles exactly as they
+    are (no republish, no removal); the run records the error, keeps naming the
+    installed commit in the ledger, and writes a failed fingerprint so the next
+    preparation retries. Its siblings still install normally: one unavailable source
+    is not a reason to strand the others;
+  - a removal is a different statement and is still enacted: a source the desired set
+    no longer names has no candidate and is not preserved, so its bundles go. That
+    removal needs no source, which is why it can be honored while another fails;
+  - the whole-run failure path (anything that throws past the per-source handling)
+    keeps what is published, because a published bundle's source key names its
+    acquisition identity rather than its repository — that pass cannot tell a
+    re-pinned source from a removed one, and must not guess. Pruning waits for the
+    next run that actually computes a desired set. An EMPTY desired set is the
+    exception: that is a complete statement, and disabled executable content must not
+    survive it.
+  - A ref check that cannot be answered is likewise not a failure: it resolves to the
+    installed commit and nothing is rebuilt. A refused stale removal, corrupt journal, or failed rollback blocks the
+    workspace so disabled executable instructions cannot remain silently active.
 - A tracking Git ref is re-resolved per preparation but fetched only when its head
   moved: the resolved commit participates in the plan fingerprint, so an unmoved
   head still takes the unchanged fast path and a moved one cannot be served from

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -369,7 +369,7 @@ async function installSkillsLocked(
         // subset still fails the transaction.
         const selection = await resolveSkillSelections(entry.name, destination, snapshot.files, entry.skills)
         prepared.push({
-          key: `git:${index}:${definitionDigest}:${resolvedCommit}${entry.skills.length > 0 ? `:${fingerprint(entry.skills)}` : ''}`,
+          key: `git:${index}:${definitionDigest}:${resolvedCommit}:${gitEntryScopeDigest(entry)}`,
           name: entry.name,
           sourceDir: destination,
           skills: selection.cliSelections,
@@ -380,7 +380,7 @@ async function installSkillsLocked(
         const message = error instanceof Error ? error.message : 'unknown Git skill source error'
         result.errors.push({ source: entry.name, error: message })
         opts.warn?.(`skills: Git source ${entry.name} unavailable (${message}); keeping what is installed`)
-        unresolvedScopes.add(gitSourceScope(definitionDigest, entry.skills))
+        unresolvedScopes.add(gitSourceScope(definitionDigest, entry))
         // The ledger must keep naming the commit that is ON DISK — the tracking
         // check may have dropped this retention to force the (now failed) rebuild.
         const installed = installedByDefinition.get(definitionDigest)
@@ -755,12 +755,18 @@ export function currentGitResolutions(
     .sort((a, b) => a.definitionDigest.localeCompare(b.definitionDigest))
 }
 
-/** One ENTRY's publication scope: its acquisition identity plus its selections.
- * Sibling entries share a repository and ref — the acquisition identity excludes
- * the subdirectory and the selection set — so identity alone would preserve a
- * sibling that was just disabled. */
-export function gitSourceScope(definitionDigest: string, skills: readonly string[]): string {
-  return `${definitionDigest}|${skills.length > 0 ? fingerprint([...skills]) : ''}`
+/** What separates one entry from a sibling that shares its acquisition identity:
+ * the subdirectory it publishes from and the skills it selects. The identity is
+ * repository + ref by design (one tarball serves every entry on it), so neither is
+ * in it, and both are needed to tell a still-desired entry from a disabled one. */
+export function gitEntryScopeDigest(entry: AgentSkillEntry): string {
+  const source = resolveBoundedGitSkillSource(entry)
+  return fingerprint({ subDir: source.subDir ?? '', skills: [...entry.skills] })
+}
+
+/** One ENTRY's publication scope: its acquisition identity plus that entry digest. */
+export function gitSourceScope(definitionDigest: string, entry: AgentSkillEntry): string {
+  return `${definitionDigest}|${gitEntryScopeDigest(entry)}`
 }
 
 /** The same scope read back out of a published bundle's source key

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -326,53 +326,83 @@ async function installSkillsLocked(
     const resolutionsByDefinition = new Map(
       retainedGitResolutions.map((resolution) => [resolution.definitionDigest, resolution.resolvedCommit])
     )
+    const installedByDefinition = new Map(
+      installedResolutions.map((resolution) => [resolution.definitionDigest, resolution.resolvedCommit])
+    )
+    // Acquisition identities this run wanted but could not build. Their installed
+    // bundles are kept: the source is still desired and the bytes on disk are its
+    // own older commit, so removing them would cost the agent a working skill for
+    // an upstream outage. See §6.3.
+    const unresolvedDefinitions = new Set<string>()
     for (const [index, entry] of gitSources.entries()) {
-      const acquisitionDir = join(scratch, 'acquired', `git-${index}`)
-      await fsp.mkdir(dirname(acquisitionDir), { recursive: true, mode: 0o700 })
-      await fsp.mkdir(acquisitionDir, { mode: 0o700 })
       const definitionDigest = gitResolutionDigest(entry)
-      // A sibling entry that shares this acquisition identity has already resolved
-      // it in THIS run, and both must land on identical bytes; otherwise take what
-      // the plan says (the tracked head, a pin, or the installed commit).
-      const plannedCommit = resolutionsByDefinition.get(definitionDigest) ?? plannedCommits.get(definitionDigest)
-      const acquisitionEntry = plannedCommit ? { ...entry, ref: plannedCommit } : entry
-      const acquired = await (opts.acquireGit ?? acquireGitSkillSource)(acquisitionEntry, {
-        destination: acquisitionDir,
-        agentId: agent.id,
-        useGitCredential: opts.useGitCredential === true
-      })
-      const resolvedCommit = acquired.resolvedCommit.toLowerCase()
-      if (!/^[a-f0-9]{40}$/.test(resolvedCommit) || (plannedCommit && resolvedCommit !== plannedCommit)) {
-        throw new Error(`Git source "${entry.name}" did not resolve to its planned commit`)
+      try {
+        const acquisitionDir = join(scratch, 'acquired', `git-${index}`)
+        await fsp.mkdir(dirname(acquisitionDir), { recursive: true, mode: 0o700 })
+        await fsp.mkdir(acquisitionDir, { mode: 0o700 })
+        // A sibling entry that shares this acquisition identity has already resolved
+        // it in THIS run, and both must land on identical bytes; otherwise take what
+        // the plan says (the tracked head, a pin, or the installed commit).
+        const plannedCommit = resolutionsByDefinition.get(definitionDigest) ?? plannedCommits.get(definitionDigest)
+        const acquisitionEntry = plannedCommit ? { ...entry, ref: plannedCommit } : entry
+        const acquired = await (opts.acquireGit ?? acquireGitSkillSource)(acquisitionEntry, {
+          destination: acquisitionDir,
+          agentId: agent.id,
+          useGitCredential: opts.useGitCredential === true
+        })
+        const resolvedCommit = acquired.resolvedCommit.toLowerCase()
+        if (!/^[a-f0-9]{40}$/.test(resolvedCommit) || (plannedCommit && resolvedCommit !== plannedCommit)) {
+          throw new Error(`Git source "${entry.name}" did not resolve to its planned commit`)
+        }
+        resolutionsByDefinition.set(definitionDigest, resolvedCommit)
+        const destination = join(scratch, 'inputs', `git-${index}`)
+        await prepareSnapshotDestination(destination)
+        const snapshot = await snapshotLocalSkillSource(acquired.sourceDir, destination, {
+          limits: GIT_SKILL_SOURCE_SNAPSHOT_LIMITS
+        })
+        accountInput(snapshot.fileCount, snapshot.totalBytes)
+        // The CLI matches `-s` values against SKILL.md frontmatter names but the
+        // wire carries canonical leaf names, so resolve each selection against
+        // the snapshot first (#371). One source invocation carries all selected
+        // skills; we independently require the exact resolved leaf-name set
+        // below, so a CLI that returns success after installing only a valid
+        // subset still fails the transaction.
+        const selection = await resolveSkillSelections(entry.name, destination, snapshot.files, entry.skills)
+        prepared.push({
+          key: `git:${index}:${definitionDigest}:${resolvedCommit}${entry.skills.length > 0 ? `:${fingerprint(entry.skills)}` : ''}`,
+          name: entry.name,
+          sourceDir: destination,
+          skills: selection.cliSelections,
+          expectedLeaves: selection.expectedLeaves,
+          contentDigest: snapshot.sha256
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'unknown Git skill source error'
+        result.errors.push({ source: entry.name, error: message })
+        opts.warn?.(`skills: Git source ${entry.name} unavailable (${message}); keeping what is installed`)
+        unresolvedDefinitions.add(definitionDigest)
+        // The ledger must keep naming the commit that is ON DISK — the tracking
+        // check may have dropped this retention to force the (now failed) rebuild.
+        const installed = installedByDefinition.get(definitionDigest)
+        if (installed !== undefined) resolutionsByDefinition.set(definitionDigest, installed)
       }
-      resolutionsByDefinition.set(definitionDigest, resolvedCommit)
-      const destination = join(scratch, 'inputs', `git-${index}`)
-      await prepareSnapshotDestination(destination)
-      const snapshot = await snapshotLocalSkillSource(acquired.sourceDir, destination, {
-        limits: GIT_SKILL_SOURCE_SNAPSHOT_LIMITS
-      })
-      accountInput(snapshot.fileCount, snapshot.totalBytes)
-      // The CLI matches `-s` values against SKILL.md frontmatter names but the
-      // wire carries canonical leaf names, so resolve each selection against
-      // the snapshot first (#371). One source invocation carries all selected
-      // skills; we independently require the exact resolved leaf-name set
-      // below, so a CLI that returns success after installing only a valid
-      // subset still fails the transaction.
-      const selection = await resolveSkillSelections(entry.name, destination, snapshot.files, entry.skills)
-      prepared.push({
-        key: `git:${index}:${definitionDigest}:${resolvedCommit}${entry.skills.length > 0 ? `:${fingerprint(entry.skills)}` : ''}`,
-        name: entry.name,
-        sourceDir: destination,
-        skills: selection.cliSelections,
-        expectedLeaves: selection.expectedLeaves,
-        contentDigest: snapshot.sha256
-      })
     }
     prepared.push(...localPrepared)
     const nextGitResolutions = currentGitResolutions(
       gitSources,
       [...resolutionsByDefinition].map(([definitionDigest, resolvedCommit]) => ({ definitionDigest, resolvedCommit }))
     )
+    // Owned bundles belonging to a source this run could not build: still desired,
+    // so the publication leaves them exactly as they are instead of removing them.
+    const preserveOwned =
+      unresolvedDefinitions.size > 0
+        ? (ledger?.owned ?? [])
+            .filter((bundle) => {
+              const digest = gitSourceKeyDefinition(bundle.sourceKey)
+              return digest !== undefined && unresolvedDefinitions.has(digest)
+            })
+            .map((bundle) => bundle.relativeRoot)
+        : []
     // What the publication layer stores and compares: the commits actually acquired.
     const installedFingerprint = fingerprintFor(plannedGitCommits(gitSources, nextGitResolutions, new Map()))
 
@@ -471,8 +501,11 @@ async function installSkillsLocked(
       agentId: agent.id,
       runtime: agent.runtime,
       cliVersion: PINNED_SKILLS_CLI_VERSION,
-      fingerprint: installedFingerprint,
+      // A run that could not build every desired source has not met its plan, so
+      // its fingerprint must not let the next preparation skip the retry.
+      fingerprint: unresolvedDefinitions.size > 0 ? `failed:${randomUUID()}` : installedFingerprint,
       candidates,
+      ...(preserveOwned.length > 0 ? { preserveOwned } : {}),
       gitResolutions: nextGitResolutions,
       legacyOwned: legacyState.owned,
       lockHeld: true,
@@ -501,6 +534,16 @@ async function installSkillsLocked(
       }
       retainedGitResolutions = currentGitResolutions(gitSources, cleanupLedger?.gitResolutions ?? [])
       assertNoUnmigratedLegacyState(legacyState)
+      // An install that threw says nothing about whether the operator still wants
+      // these skills — only that this run could not rebuild them — and a published
+      // bundle's source key names its acquisition identity, not its repository, so
+      // this pass cannot even tell a re-pinned source from a removed one. It
+      // therefore keeps what is published and leaves pruning to the next run that
+      // actually computes a desired set. An EMPTY desired set is the exception: that
+      // is a complete statement, and disabled executable content must not stay
+      // active on it (§6.3).
+      const nothingDesired = gitSources.length === 0 && (opts.localSkills ?? []).length === 0
+      const keep = nothingDesired ? [] : (cleanupLedger?.owned ?? []).map((bundle) => bundle.relativeRoot)
       const cleared = await reconcileSkillBundles({
         cwd,
         stateDir,
@@ -509,6 +552,7 @@ async function installSkillsLocked(
         cliVersion: PINNED_SKILLS_CLI_VERSION,
         fingerprint: `failed:${randomUUID()}`,
         candidates: [],
+        ...(keep.length > 0 ? { preserveOwned: keep } : {}),
         gitResolutions: retainedGitResolutions,
         legacyOwned: legacyState.owned,
         lockHeld: true,
@@ -709,6 +753,14 @@ export function currentGitResolutions(
   return resolutions
     .filter((resolution) => desired.has(resolution.definitionDigest))
     .sort((a, b) => a.definitionDigest.localeCompare(b.definitionDigest))
+}
+
+/** The acquisition identity inside a published git bundle's source key
+ * (`git:<index>:<definitionDigest>:<commit>[:selections]`), or undefined for a
+ * bundle that did not come from a git source. */
+export function gitSourceKeyDefinition(sourceKey: string): string | undefined {
+  const parts = sourceKey.split(':')
+  return parts[0] === 'git' && parts.length >= 4 ? parts[2] : undefined
 }
 
 export function gitResolutionDigest(entry: AgentSkillEntry): string {

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -333,7 +333,7 @@ async function installSkillsLocked(
     // bundles are kept: the source is still desired and the bytes on disk are its
     // own older commit, so removing them would cost the agent a working skill for
     // an upstream outage. See §6.3.
-    const unresolvedDefinitions = new Set<string>()
+    const unresolvedScopes = new Set<string>()
     for (const [index, entry] of gitSources.entries()) {
       const definitionDigest = gitResolutionDigest(entry)
       try {
@@ -380,7 +380,7 @@ async function installSkillsLocked(
         const message = error instanceof Error ? error.message : 'unknown Git skill source error'
         result.errors.push({ source: entry.name, error: message })
         opts.warn?.(`skills: Git source ${entry.name} unavailable (${message}); keeping what is installed`)
-        unresolvedDefinitions.add(definitionDigest)
+        unresolvedScopes.add(gitSourceScope(definitionDigest, entry.skills))
         // The ledger must keep naming the commit that is ON DISK — the tracking
         // check may have dropped this retention to force the (now failed) rebuild.
         const installed = installedByDefinition.get(definitionDigest)
@@ -395,11 +395,11 @@ async function installSkillsLocked(
     // Owned bundles belonging to a source this run could not build: still desired,
     // so the publication leaves them exactly as they are instead of removing them.
     const preserveOwned =
-      unresolvedDefinitions.size > 0
+      unresolvedScopes.size > 0
         ? (ledger?.owned ?? [])
             .filter((bundle) => {
-              const digest = gitSourceKeyDefinition(bundle.sourceKey)
-              return digest !== undefined && unresolvedDefinitions.has(digest)
+              const scope = gitSourceKeyScope(bundle.sourceKey)
+              return scope !== undefined && unresolvedScopes.has(scope)
             })
             .map((bundle) => bundle.relativeRoot)
         : []
@@ -503,7 +503,7 @@ async function installSkillsLocked(
       cliVersion: PINNED_SKILLS_CLI_VERSION,
       // A run that could not build every desired source has not met its plan, so
       // its fingerprint must not let the next preparation skip the retry.
-      fingerprint: unresolvedDefinitions.size > 0 ? `failed:${randomUUID()}` : installedFingerprint,
+      fingerprint: unresolvedScopes.size > 0 ? `failed:${randomUUID()}` : installedFingerprint,
       candidates,
       ...(preserveOwned.length > 0 ? { preserveOwned } : {}),
       gitResolutions: nextGitResolutions,
@@ -755,12 +755,21 @@ export function currentGitResolutions(
     .sort((a, b) => a.definitionDigest.localeCompare(b.definitionDigest))
 }
 
-/** The acquisition identity inside a published git bundle's source key
+/** One ENTRY's publication scope: its acquisition identity plus its selections.
+ * Sibling entries share a repository and ref — the acquisition identity excludes
+ * the subdirectory and the selection set — so identity alone would preserve a
+ * sibling that was just disabled. */
+export function gitSourceScope(definitionDigest: string, skills: readonly string[]): string {
+  return `${definitionDigest}|${skills.length > 0 ? fingerprint([...skills]) : ''}`
+}
+
+/** The same scope read back out of a published bundle's source key
  * (`git:<index>:<definitionDigest>:<commit>[:selections]`), or undefined for a
  * bundle that did not come from a git source. */
-export function gitSourceKeyDefinition(sourceKey: string): string | undefined {
+export function gitSourceKeyScope(sourceKey: string): string | undefined {
   const parts = sourceKey.split(':')
-  return parts[0] === 'git' && parts.length >= 4 ? parts[2] : undefined
+  if (parts[0] !== 'git' || parts.length < 4) return undefined
+  return `${parts[2]}|${parts[4] ?? ''}`
 }
 
 export function gitResolutionDigest(entry: AgentSkillEntry): string {

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -511,9 +511,11 @@ async function reconcileSkillBundlesLocked(
       if (!candidateRoots.has(canonical)) preserved.add(canonical)
     }
     const kept = prior.filter((entry) => preserved.has(entry.relativeRoot))
-    const planned = prior.filter((entry) => !preserved.has(entry.relativeRoot))
     const paths = [
-      ...new Set([...planned.map((entry) => entry.relativeRoot), ...candidates.map((entry) => entry.relativeRoot)])
+      ...new Set([
+        ...prior.filter((entry) => !preserved.has(entry.relativeRoot)).map((entry) => entry.relativeRoot),
+        ...candidates.map((entry) => entry.relativeRoot)
+      ])
     ].sort()
     const operations: JournalOperation[] = paths.map((relativeRoot) => ({
       relativeRoot,
@@ -532,11 +534,13 @@ async function reconcileSkillBundlesLocked(
       cliVersion: options.cliVersion,
       ...(options.publicationOperationId ? { publicationOperationId: options.publicationOperationId } : {}),
       // A pruned set is no longer what that fingerprint described, and recovery cannot see the prune: leaving it would let the next plan skip the reinstall.
-      ...(ledger?.fingerprint && planned.length + kept.length === recorded.length
-        ? { priorFingerprint: ledger.fingerprint }
-        : {}),
+      ...(ledger?.fingerprint && prior.length === recorded.length ? { priorFingerprint: ledger.fingerprint } : {}),
       priorGitResolutions: ledger?.gitResolutions ?? [],
-      prior: planned,
+      // Preserved receipts stay in the durable recovery state — recovery rebuilds
+      // `owned` from here, and a crash mid-publication must not orphan the files
+      // this run deliberately left alone. Their paths carry no operation, which is
+      // what keeps them untouched.
+      prior,
       pending: candidates.map(stripCandidate),
       operations
     }
@@ -627,7 +631,7 @@ async function reconcileSkillBundlesLocked(
       fingerprint: conflicts.length > 0 ? `conflicts:${randomUUID()}` : options.fingerprint,
       owned,
       gitResolutions,
-      cleanup: { operations, prior: planned }
+      cleanup: { operations, prior }
     }
     await writeSkillLedger(location.file, readyWithCleanup, options.publicationKey)
     recoveryLedger = readyWithCleanup

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -137,6 +137,13 @@ export interface ReconcileSkillBundlesOptions {
   /** Untrusted compatibility hints from old workspace-local markers. They may
    * improve a conflict error, but never confer deletion or replacement rights. */
   legacyOwned?: string[]
+  /** Owned bundles this run could not rebuild but that are STILL DESIRED — a
+   * source whose bytes were unavailable (upstream down, rate-limited, a CLI that
+   * failed). They are left exactly as they are: no operation is planned for them,
+   * so they are neither republished nor removed, and they stay in `owned` for the
+   * next run to rebuild. Anything absent from BOTH the candidates and this list is
+   * no longer desired and is still removed. */
+  preserveOwned?: readonly string[]
   /** The caller already holds `withSkillWorkspaceLock` across acquisition. */
   lockHeld?: boolean
   /** Reports a bundle skipped because its destination is not this ledger's to write. */
@@ -494,8 +501,19 @@ async function reconcileSkillBundlesLocked(
       options.warn?.(`skills: skipped unowned skill ${candidate.relativeRoot}: ${detail}`)
     }
 
+    // A preserved bundle is untouched: it is not a candidate to publish and not a
+    // removal to plan, so it never enters the journal. A candidate claiming the
+    // same root wins — rebuilding beats keeping.
+    const candidateRoots = new Set(candidates.map((entry) => entry.relativeRoot))
+    const preserved = new Set<string>()
+    for (const root of options.preserveOwned ?? []) {
+      const canonical = await canonicalizeRelativeRoot(options.cwd, root)
+      if (!candidateRoots.has(canonical)) preserved.add(canonical)
+    }
+    const kept = prior.filter((entry) => preserved.has(entry.relativeRoot))
+    const planned = prior.filter((entry) => !preserved.has(entry.relativeRoot))
     const paths = [
-      ...new Set([...prior.map((entry) => entry.relativeRoot), ...candidates.map((entry) => entry.relativeRoot)])
+      ...new Set([...planned.map((entry) => entry.relativeRoot), ...candidates.map((entry) => entry.relativeRoot)])
     ].sort()
     const operations: JournalOperation[] = paths.map((relativeRoot) => ({
       relativeRoot,
@@ -514,9 +532,11 @@ async function reconcileSkillBundlesLocked(
       cliVersion: options.cliVersion,
       ...(options.publicationOperationId ? { publicationOperationId: options.publicationOperationId } : {}),
       // A pruned set is no longer what that fingerprint described, and recovery cannot see the prune: leaving it would let the next plan skip the reinstall.
-      ...(ledger?.fingerprint && prior.length === recorded.length ? { priorFingerprint: ledger.fingerprint } : {}),
+      ...(ledger?.fingerprint && planned.length + kept.length === recorded.length
+        ? { priorFingerprint: ledger.fingerprint }
+        : {}),
       priorGitResolutions: ledger?.gitResolutions ?? [],
-      prior,
+      prior: planned,
       pending: candidates.map(stripCandidate),
       operations
     }
@@ -527,7 +547,7 @@ async function reconcileSkillBundlesLocked(
     recoveryLedger = nextApplying
 
     const candidatesByPath = new Map(candidates.map((entry) => [entry.relativeRoot, entry]))
-    const owned: OwnedSkillBundle[] = [...adopted]
+    const owned: OwnedSkillBundle[] = [...adopted, ...kept]
     for (const operation of operations) {
       const priorEntry = priorByPath.get(operation.relativeRoot)
       const candidate = candidatesByPath.get(operation.relativeRoot)
@@ -607,7 +627,7 @@ async function reconcileSkillBundlesLocked(
       fingerprint: conflicts.length > 0 ? `conflicts:${randomUUID()}` : options.fingerprint,
       owned,
       gitResolutions,
-      cleanup: { operations, prior }
+      cleanup: { operations, prior: planned }
     }
     await writeSkillLedger(location.file, readyWithCleanup, options.publicationKey)
     recoveryLedger = readyWithCleanup
@@ -627,8 +647,9 @@ async function reconcileSkillBundlesLocked(
     }
     return {
       installed: candidates.map((entry) => entry.relativeRoot),
-      // The whole previously-owned set, the paths that had already vanished included: none of it is owned once this returns.
-      removed: recorded.map((entry) => entry.relativeRoot),
+      // Everything previously owned that this run did not keep, the paths that had
+      // already vanished included: none of THAT is owned once this returns.
+      removed: recorded.filter((entry) => !preserved.has(entry.relativeRoot)).map((entry) => entry.relativeRoot),
       skipped: null,
       conflicts,
       owned

--- a/packages/daemon/test/skill-install-failure.test.ts
+++ b/packages/daemon/test/skill-install-failure.test.ts
@@ -195,6 +195,42 @@ describe('a failed install keeps what is still desired', () => {
     expect(await installedRoots()).toEqual(['git-skill'])
   })
 
+  // Sibling entries share a repository and ref, so the acquisition identity alone
+  // would preserve a sibling that was just disabled — leaving explicitly disabled
+  // executable content active, which is the one thing the old clearing pass got right.
+  it('preserves the failed entry, not every entry sharing its acquisition identity', async () => {
+    const oneDir = await writeSkill(join(sources, 'catalog'), 'one', 'one')
+    const twoDir = await writeSkill(join(sources, 'catalog'), 'two', 'two')
+    const cli = fakeCli(() => '.runtime')
+    const one = { name: 'one', source: 'acme/skills', githubRepoId: '42', subDir: 'catalog/one', skills: ['one'] }
+    const two = { name: 'two', source: 'acme/skills', githubRepoId: '42', subDir: 'catalog/two', skills: ['two'] }
+    const acquireGit = async (candidate: { subDir?: string; ref?: string }) => ({
+      sourceDir: candidate.subDir === 'catalog/one' ? oneDir : twoDir,
+      resolvedCommit: candidate.ref ?? FIRST
+    })
+
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [one, two] } as never, cwd, {
+      stateDir,
+      acquireGit,
+      resolveGitRef: async () => FIRST,
+      runCli: cli.run
+    })
+    expect(await installedRoots()).toEqual(['one', 'two'])
+
+    // `two` is disabled and `one` cannot be acquired: only `one` is preserved.
+    const pruned = await installSkills({ id: 'a1', runtime: 'claude', skills: [one] } as never, cwd, {
+      stateDir,
+      acquireGit: async () => {
+        throw new Error('unavailable')
+      },
+      resolveGitRef: async () => FIRST,
+      runCli: cli.run
+    })
+    expect(pruned.errors.map((e) => e.source)).toEqual(['one'])
+    expect(await installedRoots()).toEqual(['one'])
+    expect(pruned.removed).toEqual(['.runtime/skills/two'])
+  })
+
   it('clears on failure only when nothing is desired at all — that is a complete statement', async () => {
     const gitDir = await writeSkill(sources, 'git-skill', 'git')
     const cli = fakeCli(() => '.runtime')

--- a/packages/daemon/test/skill-install-failure.test.ts
+++ b/packages/daemon/test/skill-install-failure.test.ts
@@ -1,0 +1,253 @@
+/**
+ * What survives a failed install (shared-skills.md §6.3). An install that cannot
+ * build a source says nothing about whether the operator still wants that skill —
+ * only that this run could not rebuild it — so the bytes already published stay.
+ * A source the desired set no longer names is a different thing entirely, and is
+ * still removed: that removal needs no source, and leaving disabled executable
+ * content active is what the clearing pass exists for.
+ */
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  installSkills,
+  type SkillsCliInvocation,
+  type SkillsCliInvocationResult
+} from '../src/skills/install-skills.js'
+
+const skillBody = (name: string, marker = name) =>
+  `---\nname: ${name}\ndescription: ${name} fixture\n---\n# ${marker}\n`
+
+async function writeSkill(root: string, name: string, marker = name): Promise<string> {
+  const dir = join(root, name)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'SKILL.md'), skillBody(name, marker))
+  return dir
+}
+
+function digest(body: string): string {
+  return createHash('sha256').update(body).digest('hex')
+}
+
+/** The same deterministic CLI seam the unified installer suite uses: it decides
+ * the harness directory and copies the selected bundle into the private cell. */
+function fakeCli(rootForAgent: (agentId: string) => string) {
+  const calls: SkillsCliInvocation[] = []
+  const run = async (input: SkillsCliInvocation): Promise<SkillsCliInvocationResult> => {
+    calls.push(input)
+    const name = input.skills[0] ?? 'git-skill'
+    const relativeRoot = [rootForAgent(input.agentId), 'skills', name].filter(Boolean).join('/')
+    const bundleDir = join(input.cellDir, ...relativeRoot.split('/'))
+    await mkdir(bundleDir, { recursive: true })
+    const body = await readFile(join(input.sourceDir, 'SKILL.md'), 'utf8')
+    await writeFile(join(bundleDir, 'SKILL.md'), body)
+    return {
+      bundles: [
+        {
+          relativeRoot,
+          sourceDir: bundleDir,
+          treeDigest: digest(body),
+          files: [{ path: 'SKILL.md', mode: 0o600, size: Buffer.byteLength(body), sha256: digest(body) }]
+        }
+      ],
+      stdoutDigest: digest('ok'),
+      stderrDigest: digest('')
+    }
+  }
+  return { calls, run }
+}
+
+describe('a failed install keeps what is still desired', () => {
+  let root: string
+  let cwd: string
+  let stateDir: string
+  let sources: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'ac-skill-failure-'))
+    cwd = join(root, 'workspace')
+    stateDir = join(root, 'trusted-state')
+    sources = join(root, 'sources')
+    await mkdir(cwd)
+    await mkdir(sources)
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const FIRST = 'a'.repeat(40)
+  const MOVED = 'b'.repeat(40)
+  const entry = (name: string, skills: string[], over: Record<string, unknown> = {}) => ({
+    name,
+    source: `acme/${name}`,
+    githubRepoId: name === 'git' ? '42' : '43',
+    skills,
+    ...over
+  })
+
+  async function installedRoots(): Promise<string[]> {
+    const bundles = await readdir(join(cwd, '.runtime', 'skills')).catch(() => [] as string[])
+    return bundles.sort()
+  }
+
+  it('keeps the published bundle when the tracked head cannot be acquired', async () => {
+    const gitDir = await writeSkill(sources, 'git-skill', 'first version')
+    const cli = fakeCli(() => '.runtime')
+    let head = FIRST
+    let acquire = async (candidate: { ref?: string }) => ({
+      sourceDir: gitDir,
+      resolvedCommit: candidate.ref ?? FIRST
+    })
+    const install = () =>
+      installSkills({ id: 'a1', runtime: 'claude', skills: [entry('git', ['git-skill'])] }, cwd, {
+        stateDir,
+        acquireGit: (candidate: { ref?: string }) => acquire(candidate),
+        resolveGitRef: async () => head,
+        runCli: cli.run
+      })
+
+    await install()
+    expect(await installedRoots()).toEqual(['git-skill'])
+    const before = await readFile(join(cwd, '.runtime', 'skills', 'git-skill', 'SKILL.md'), 'utf8')
+
+    // The head moved, and acquiring it fails — a rate limit, an outage, anything.
+    head = MOVED
+    acquire = async () => {
+      throw new Error('skill GitHub commit resolution failed with status 403')
+    }
+    const failed = await install()
+    expect(failed.errors).toEqual([{ source: 'git', error: 'skill GitHub commit resolution failed with status 403' }])
+    expect(await installedRoots()).toEqual(['git-skill'])
+    expect(await readFile(join(cwd, '.runtime', 'skills', 'git-skill', 'SKILL.md'), 'utf8')).toBe(before)
+    // The ledger still names the commit that is on disk, so a later unknown answer
+    // has something to fall back to.
+    expect(failed.owned).toEqual(['.runtime/skills/git-skill'])
+  })
+
+  it('one unavailable source does not cost the others their skills', async () => {
+    const gitDir = await writeSkill(sources, 'git-skill', 'git')
+    const otherDir = await writeSkill(sources, 'other-skill', 'other')
+    const cli = fakeCli(() => '.runtime')
+    const skills = [entry('git', ['git-skill']), entry('other', ['other-skill'])]
+    let failOther = false
+    const acquireGit = async (candidate: { name?: string; ref?: string }) => {
+      if (failOther && candidate.name === 'other') throw new Error('unavailable')
+      return { sourceDir: candidate.name === 'other' ? otherDir : gitDir, resolvedCommit: candidate.ref ?? FIRST }
+    }
+    void MOVED
+    const install = () =>
+      installSkills({ id: 'a1', runtime: 'claude', skills }, cwd, {
+        stateDir,
+        acquireGit,
+        resolveGitRef: async () => FIRST,
+        runCli: cli.run
+      })
+
+    await install()
+    expect(await installedRoots()).toEqual(['git-skill', 'other-skill'])
+
+    // Move the head so the run genuinely rebuilds: `git` acquires it, `other` cannot.
+    failOther = true
+    const partial = await installSkills({ id: 'a1', runtime: 'claude', skills }, cwd, {
+      stateDir,
+      acquireGit,
+      resolveGitRef: async () => MOVED,
+      runCli: cli.run
+    })
+    expect(partial.errors.map((e) => e.source)).toEqual(['other'])
+    expect(await installedRoots()).toEqual(['git-skill', 'other-skill'])
+  })
+
+  it('still removes a source the desired set no longer names', async () => {
+    const gitDir = await writeSkill(sources, 'git-skill', 'git')
+    const otherDir = await writeSkill(sources, 'other-skill', 'other')
+    const cli = fakeCli(() => '.runtime')
+    const acquireGit = async (candidate: { name?: string; ref?: string }) => ({
+      sourceDir: candidate.name === 'other' ? otherDir : gitDir,
+      resolvedCommit: candidate.ref ?? FIRST
+    })
+    const install = (skills: unknown[]) =>
+      installSkills({ id: 'a1', runtime: 'claude', skills } as never, cwd, {
+        stateDir,
+        acquireGit,
+        resolveGitRef: async () => FIRST,
+        runCli: cli.run
+      })
+
+    await install([entry('git', ['git-skill']), entry('other', ['other-skill'])])
+    expect(await installedRoots()).toEqual(['git-skill', 'other-skill'])
+
+    // `other` is disabled AND `git` cannot be built: the disabled one still goes.
+    const acquireFailing = async (candidate: { name?: string }) => {
+      if (candidate.name === 'git') throw new Error('unavailable')
+      return { sourceDir: gitDir, resolvedCommit: FIRST }
+    }
+    const pruned = await installSkills({ id: 'a1', runtime: 'claude', skills: [entry('git', ['git-skill'])] }, cwd, {
+      stateDir,
+      acquireGit: acquireFailing,
+      resolveGitRef: async () => FIRST,
+      runCli: cli.run
+    })
+    expect(pruned.errors.map((e) => e.source)).toEqual(['git'])
+    expect(await installedRoots()).toEqual(['git-skill'])
+  })
+
+  it('clears on failure only when nothing is desired at all — that is a complete statement', async () => {
+    const gitDir = await writeSkill(sources, 'git-skill', 'git')
+    const cli = fakeCli(() => '.runtime')
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [entry('git', ['git-skill'])] }, cwd, {
+      stateDir,
+      acquireGit: async (candidate: { ref?: string }) => ({
+        sourceDir: gitDir,
+        resolvedCommit: candidate.ref ?? FIRST
+      }),
+      resolveGitRef: async () => FIRST,
+      runCli: cli.run
+    })
+    expect(await installedRoots()).toEqual(['git-skill'])
+
+    // Every source disabled, and the run throws on the way to enacting that.
+    const emptied = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, {
+      stateDir,
+      runCli: async () => {
+        throw new Error('skills CLI exited 1')
+      }
+    })
+    expect(await installedRoots()).toEqual([])
+    expect(emptied.owned).toEqual([])
+  })
+
+  it('keeps them when the CLI itself fails, which is not a statement about intent', async () => {
+    const gitDir = await writeSkill(sources, 'git-skill', 'git')
+    const cli = fakeCli(() => '.runtime')
+    const acquireGit = async (candidate: { ref?: string }) => ({
+      sourceDir: gitDir,
+      resolvedCommit: candidate.ref ?? FIRST
+    })
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [entry('git', ['git-skill'])] }, cwd, {
+      stateDir,
+      acquireGit,
+      resolveGitRef: async () => FIRST,
+      runCli: cli.run
+    })
+    expect(await installedRoots()).toEqual(['git-skill'])
+
+    const broken = await installSkills(
+      { id: 'a1', runtime: 'claude', skills: [entry('git', ['git-skill'], { ref: MOVED })] },
+      cwd,
+      {
+        stateDir,
+        acquireGit: async () => ({ sourceDir: gitDir, resolvedCommit: MOVED }),
+        runCli: async () => {
+          throw new Error('skills CLI exited 1')
+        }
+      }
+    )
+    expect(broken.errors.map((e) => e.source)).toEqual(['*'])
+    expect(await installedRoots()).toEqual(['git-skill'])
+    expect(broken.owned).toEqual(['.runtime/skills/git-skill'])
+  })
+})

--- a/packages/daemon/test/skill-install-failure.test.ts
+++ b/packages/daemon/test/skill-install-failure.test.ts
@@ -231,6 +231,47 @@ describe('a failed install keeps what is still desired', () => {
     expect(pruned.removed).toEqual(['.runtime/skills/two'])
   })
 
+  // Same shape with no explicit selections: only the subdirectory tells the two
+  // entries apart, so the scope has to carry it.
+  it('separates install-all siblings by the subdirectory they publish from', async () => {
+    const oneDir = await writeSkill(join(sources, 'catalog'), 'one', 'one')
+    const twoDir = await writeSkill(join(sources, 'catalog'), 'two', 'two')
+    const cli = fakeCli(() => '.runtime')
+    const one = { name: 'one', source: 'acme/skills', githubRepoId: '42', subDir: 'catalog/one', skills: [] }
+    const two = { name: 'two', source: 'acme/skills', githubRepoId: '42', subDir: 'catalog/two', skills: [] }
+    // An install-all entry names no selection, so the CLI's leaf comes from the
+    // source's own frontmatter — the fixture's shared fake keys off the selection.
+    const runCli = async (input: Parameters<typeof cli.run>[0]) => {
+      const body = await readFile(join(input.sourceDir, 'SKILL.md'), 'utf8')
+      const leaf = /name:\s*(\S+)/.exec(body)?.[1] ?? 'unknown'
+      return cli.run({ ...input, skills: [leaf] })
+    }
+    const acquireGit = async (candidate: { subDir?: string; ref?: string }) => ({
+      sourceDir: candidate.subDir === 'catalog/one' ? oneDir : twoDir,
+      resolvedCommit: candidate.ref ?? FIRST
+    })
+
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [one, two] } as never, cwd, {
+      stateDir,
+      acquireGit,
+      resolveGitRef: async () => FIRST,
+      runCli
+    })
+    expect(await installedRoots()).toEqual(['one', 'two'])
+
+    const pruned = await installSkills({ id: 'a1', runtime: 'claude', skills: [one] } as never, cwd, {
+      stateDir,
+      acquireGit: async () => {
+        throw new Error('unavailable')
+      },
+      resolveGitRef: async () => FIRST,
+      runCli
+    })
+    expect(pruned.errors.map((e) => e.source)).toEqual(['one'])
+    expect(await installedRoots()).toEqual(['one'])
+    expect(pruned.removed).toEqual(['.runtime/skills/two'])
+  })
+
   it('clears on failure only when nothing is desired at all — that is a complete statement', async () => {
     const gitDir = await writeSkill(sources, 'git-skill', 'git')
     const cli = fakeCli(() => '.runtime')

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -643,7 +643,12 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     expect(cli.calls).toHaveLength(0)
   })
 
-  it('clears a previously owned bundle when a changed source can no longer be staged', async () => {
+  // A source that can no longer be staged is refused, and that refusal protects
+  // the workspace from the NEW content — it says nothing about the bundle already
+  // published from the same source's earlier, validated bytes. That bundle stays
+  // (§6.3): the skill is still desired, and losing it would punish the agent for
+  // an upstream change it did not make.
+  it('refuses unstageable new content without taking down the bundle already published', async () => {
     const sourceDir = await writeSkill(sources, 'revoked', 'safe')
     const cli = fakeCli(() => '.runtime')
     const localSkills: LocalSkillSource[] = [{ kind: 'dream', key: 'dream:revoked', name: 'revoked', sourceDir }]
@@ -659,8 +664,12 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     })
 
     expect(failed.errors[0]?.error).toMatch(/link/i)
-    expect(failed.removed).toContain('.runtime/skills/revoked')
-    expect(existsSync(join(cwd, '.runtime/skills/revoked'))).toBe(false)
+    expect(failed.removed).not.toContain('.runtime/skills/revoked')
+    // The published bundle is the earlier, validated content — unchanged, and the
+    // symlink the refusal was about was never published.
+    expect(await readFile(join(cwd, '.runtime/skills/revoked/SKILL.md'), 'utf8')).toContain('safe')
+    expect(existsSync(join(cwd, '.runtime/skills/revoked/new-link'))).toBe(false)
+    expect(failed.owned).toContain('.runtime/skills/revoked')
   })
 
   it('blocks startup on unmigrated legacy executable state instead of silently preserving stale skills', async () => {


### PR DESCRIPTION
## Why

Caught in a live run of my own tracking-ref change (#1962): an org skill repository's head moved, acquiring the new commit hit GitHub's **unauthenticated 60/hour** rate limit, and the installer's failure path did what it has always done — cleared every managed skill. The agent lost both of its skills to a transient 403 and told its user the skill *"isn't available in this session's skill catalog"*.

Before tracking refs that exposure did not exist: a pinned commit meant no acquisition ever ran. Making the check routine made the clearing routine too, so the policy has to change. A failure to **build** a source says nothing about whether the operator still wants the skill — only that this run could not rebuild it — and the bytes already published are that same source's own earlier commit.

## What

- **A git source that cannot be acquired keeps its published bundles untouched** — no republish, no removal. The run records the error, keeps naming the installed commit in the ledger (the tracking check may have dropped that retention to force the rebuild that then failed), and writes a failed fingerprint so the next preparation retries. **Siblings install normally**: one unavailable source no longer strands the others.
- **A removal still happens.** A source the desired set no longer names has no candidate, is not preserved, and goes — that removal needs no source, which is exactly why it can be honored while another source fails. This is the property the old clearing pass was really protecting.
- **The whole-run failure path keeps what is published.** A published bundle's source key names its acquisition identity, not its repository, so that path cannot tell a re-pinned source from a removed one and must not guess; pruning waits for the next run that computes a desired set. An **empty** desired set is the exception — that is a complete statement, and disabled executable content must not survive it.

`preserveOwned` carries this through the publication transaction. Two places had to change beyond the obvious one, and the suite caught both: a preserved bundle must be excluded from the **ready-cleanup** (which otherwise finishes the very removal being avoided) and must not be reported as `removed`.

## Verification

- New `test/skill-install-failure.test.ts` — 5 cases: the bundle survives an unacquirable tracked head; one unavailable source does not cost the others; a no-longer-desired source is still removed *while another fails*; nothing-desired still clears; the CLI faulting keeps them.
- `test/unified-skills.test.ts`'s clearing case rewritten around the new contract: refusing unstageable new content must not take down the bundle already published from that source's earlier, validated bytes (and the refused symlink is still never published).
- Full `packages/daemon` suite green locally; typecheck, eslint, prettier clean.

Design: `shared-skills.md` §6.3 now states the four cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
