### PR TITLE
feat(control-plane): the caller can check its own GitHub access before asking for write

### DIFF
--- a/docs/designs/agent-assistant.md
+++ b/docs/designs/agent-assistant.md
@@ -225,6 +225,7 @@ Tools **call the CP service layer directly or reuse route-handler logic**, prese
 | `listIntegrations` / `setChannelTrigger` / `removeIntegration` | GET · PATCH channels/:channelId · DELETE                   | –/✎(🔥) |
 | `listBots` / `listMembers` / `listAgentHooks` / `listHookRuns` | GET (metadata only, no secret)                             | –       |
 | `listGithubInstallations` / `listGithubRepositories`           | GET /github/installations(/:id/repositories)               | –       |
+| `getGithubRepositoryAccess`                                    | GET /github/installations/:id/repositories/:o/:r/access    | –       |
 | `getOperation` / `listOperations`                              | GET /agents/:id/webchat/:conversationId/mcp-operations(…)  | –       |
 | `createGithubTrigger`                                          | POST /hooks (`kind:"github"` only)                         | ✎       |
 

--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -62,6 +62,7 @@ const ARGS: Record<string, Record<string, unknown>> = {
   listAgentHooks: { agentId: 'agent-1' },
   listHookRuns: { hookId: 'hook-1' },
   getOperation: { operationId: '0a5f4b3c-2d1e-4f6a-9b8c-7d6e5f4a3b2c' },
+  getGithubRepositoryAccess: { installationId: 'ins-1', owner: 'acme', repo: 'api' },
   createAgent: { name: 'my-agent', runtime: 'claude' },
   updateAgent: { agentId: AGENT_UUID, model: 'opus' },
   setAgentWorkspace: { agentId: AGENT_UUID, confirm: 'my-agent', mode: 'git', gitRepo: 'acme/api', access: 'write' },

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -458,6 +458,28 @@ export const MCP_TOOLS: McpToolDef[] = [
       })
   },
   {
+    // The workspace write goes out under the CALLER's GitHub authority, so this is
+    // the preflight for it: without it the only way to learn that the caller lacks
+    // write is a 403 from createAgent, after the user has answered every question.
+    name: 'getGithubRepositoryAccess',
+    description:
+      'YOUR own effective GitHub permission on one repository (admin / write / read / none), and whether it is enough to read or to push. Check it before asking for a workspace at `write` access: that write is granted under your GitHub identity, not the App’s, so a caller with read gets a 403 at creation time. 404 means this deployment does not gate repository access per user, and nothing needs checking.',
+    schema: z
+      .object({
+        installationId: z
+          .string()
+          .min(1)
+          .describe('The installation’s `id` from listGithubInstallations (that row id, not GitHub’s numeric one)'),
+        owner: z.string().min(1).describe('Repository owner (the part before the slash)'),
+        repo: z.string().min(1).describe('Repository name (the part after the slash)')
+      })
+      .strict(),
+    call: (ctx, a) =>
+      ctx.get(
+        org(ctx, `/github/installations/${seg(a.installationId)}/repositories/${seg(a.owner)}/${seg(a.repo)}/access`)
+      )
+  },
+  {
     name: 'listBots',
     description: 'List the durable bot identities of the organization (metadata only — never token material).',
     schema: NoArgs,

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -751,6 +751,7 @@ describe('POST /api/v1/mcp — tools act with the caller’s own authority', () 
       removeIntegration: { integrationId: randomUUID(), confirm: 'x' },
       setAgentWorkspace: { agentId: randomUUID(), confirm: 'x', mode: 'scratch' },
       getOperation: { operationId: randomUUID() },
+      getGithubRepositoryAccess: { installationId: randomUUID(), owner: 'acme', repo: 'api' },
       listGithubRepositories: { installationId: randomUUID() },
       createGithubTrigger: {
         agentId: randomUUID(),
@@ -768,10 +769,14 @@ describe('POST /api/v1/mcp — tools act with the caller’s own authority', () 
         slug: 'agentconnect-test',
         installUrl: async () => 'https://github.com/apps/agentconnect-test/installations/new',
         outdatedInstallations: async () => new Map()
+      } as never,
+      // The per-user access route exists only where this gate is configured.
+      githubUserAuthz: {
+        accessFor: async () => ({ permission: 'read', canRead: true, canWrite: false, identityRequired: true })
       } as never
     })
     const githubKey = await mintKeyAs(DEFAULT_OWNER_ID)
-    const GITHUB_GATED = new Set(['listGithubInstallations', 'listGithubRepositories'])
+    const GITHUB_GATED = new Set(['listGithubInstallations', 'listGithubRepositories', 'getGithubRepositoryAccess'])
     for (const tool of MCP_TOOLS) {
       const target = GITHUB_GATED.has(tool.name) ? { app: githubApp, key: githubKey } : { app, key }
       const out = await callTool(target.app, target.key, tool.name, idArgs[tool.name])


### PR DESCRIPTION
## Why

A workspace at `write` is granted under the **caller's own** GitHub authority, not the App's. A caller with read learns that from

```
403 github: you do not have write access to <owner>/<repo> on GitHub (effective: read)
```

at `createAgent` time — after a guided flow has already asked the user every question. That is what happened in a live run of the create-agent flow: repository picked, installation verified, cards answered, confirmation given, and only then the refusal.

The console never had this problem: it probes the caller's access per picked repository to gate its Allow-push toggle. The tool catalog simply could not.

## What

`getGithubRepositoryAccess` exposes that same route (`GET /github/installations/:id/repositories/:owner/:repo/access`): the caller's effective permission (`admin` / `write` / `read` / `none`), `canRead` / `canWrite`, and `identityRequired`. A **404** means the deployment does not gate repository access per user, and nothing needs checking — the same signal the console treats as "no per-user gating here".

It is a read, so it needs no approval, and it turns a late 403 into something an assistant can act on **before** it asks anything: request write access, or offer the read-only shape it can build today.

## Verification

- `vitest run --project unit src/http/mcp/tools.test.ts` — 37 passed
- `vitest run --project integration test/integration/mcp.route.test.ts` — 34 passed; the route-drift guard now also stubs `githubUserAuthz`, because this route is registered only where that gate is configured
- typecheck, eslint, prettier clean; `agent-assistant.md` §6.2 lists the tool

The consuming skill change (guide the user to grant the access, then re-check and continue the same flow) is agentconnect-md/agentconnect-skill#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
