### PR TITLE
fix(web): every icon name resolves to an icon lucide still carries

### DIFF
--- a/packages/web/src/components/console/ApiKeysCard.tsx
+++ b/packages/web/src/components/console/ApiKeysCard.tsx
@@ -312,7 +312,7 @@ function CreateApiKeyModal({
         {minted ? (
           <>
             <div className="mb-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
-              <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+              <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
               <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
                 Copy this key now — it is shown only once and cannot be retrieved. Store it somewhere safe.
               </span>
@@ -447,7 +447,7 @@ function RevokeApiKeyModal({
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name="trash-2" size={16} color="var(--status-error)" />
+          <Icon name="trash" size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Revoke API key</span>
         <button className="iconbtn" onClick={onClose}>
@@ -476,7 +476,7 @@ function RevokeApiKeyModal({
           onClick={() => void onConfirm()}
           className={busy ? 'pointer-events-none opacity-50' : undefined}
         >
-          <Icon name="trash-2" size={15} />
+          <Icon name="trash" size={15} />
           {busy ? 'Revoking…' : 'Revoke'}
         </Button>
       </div>

--- a/packages/web/src/components/console/ConnectAiModal.tsx
+++ b/packages/web/src/components/console/ConnectAiModal.tsx
@@ -112,7 +112,7 @@ const NAV = [
   { label: 'Skills', icon: 'scroll-text', on: false },
   { label: 'Connectors', icon: 'blocks', on: true },
   { label: 'Plugins', icon: 'unplug', on: false },
-  { label: 'Memory', icon: 'history', on: false }
+  { label: 'Memory', icon: 'rotate-ccw-clock', on: false }
 ]
 
 function Frame({ on, children }: { on: boolean; children: ReactNode }) {

--- a/packages/web/src/components/console/ConnectorsModal.tsx
+++ b/packages/web/src/components/console/ConnectorsModal.tsx
@@ -429,7 +429,7 @@ function ConnectionForm({
         </div>
       ) : auth.type === 'no_auth' ? (
         <div className="flex items-start gap-[9px] rounded-md border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px]">
-          <Icon name="check-circle-2" size={15} color="var(--status-online-text)" className="mt-[1px] flex-none" />
+          <Icon name="circle-check" size={15} color="var(--status-online-text)" className="mt-[1px] flex-none" />
           <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
             This connector needs no credentials — just name it and add.
           </span>

--- a/packages/web/src/components/console/DaemonUpgradeBadge.tsx
+++ b/packages/web/src/components/console/DaemonUpgradeBadge.tsx
@@ -22,7 +22,7 @@ export function DaemonUpgradeBadge({
   }`
   // The compact chip names the target version: "Outdated" says which daemons are behind, never what by.
   const label = md ? `Update to ${latest}` : latest
-  const icon = <Icon name="arrow-up-circle" size={md ? 12 : 11} />
+  const icon = <Icon name="circle-arrow-up" size={md ? 12 : 11} />
   if (onClick) {
     return (
       <button

--- a/packages/web/src/components/console/EnvSecretsFields.tsx
+++ b/packages/web/src/components/console/EnvSecretsFields.tsx
@@ -241,7 +241,7 @@ export function EnvSecretsFields({
                   title="Remove"
                   onClick={() => setEnvRows((rs) => rs.filter((_, j) => j !== i))}
                 >
-                  <Icon name="trash-2" size={12} />
+                  <Icon name="trash" size={12} />
                 </button>
               </div>
             )
@@ -323,7 +323,7 @@ export function EnvSecretsFields({
                   title="Remove"
                   onClick={() => setSecretRows((rs) => rs.filter((_, j) => j !== i))}
                 >
-                  <Icon name="trash-2" size={12} />
+                  <Icon name="trash" size={12} />
                 </button>
               </div>
             )

--- a/packages/web/src/components/console/FileBrowser.tsx
+++ b/packages/web/src/components/console/FileBrowser.tsx
@@ -490,7 +490,7 @@ export function FileBrowserHistoryButton({ active, onClick }: { active: boolean;
       aria-pressed={active}
       onClick={onClick}
     >
-      <Icon name="history" size={14} />
+      <Icon name="rotate-ccw-clock" size={14} />
       History
     </button>
   )

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -155,7 +155,7 @@ function ProjectRow({
         )}
         {canWrite && onRemove && (
           <button className="iconbtn h-7 w-7 flex-none" title="Remove this project" onClick={onRemove}>
-            <Icon name="trash-2" size={14} />
+            <Icon name="trash" size={14} />
           </button>
         )}
       </span>
@@ -560,7 +560,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                       disabled={busyId === c.id}
                       onClick={() => setPending({ target: c, remove: true })}
                     >
-                      <Icon name="trash-2" size={13} />
+                      <Icon name="trash" size={13} />
                       Remove
                     </Button>
                   )}
@@ -779,7 +779,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                 )
               }
               verb={pending.remove ? 'Remove' : 'Disconnect'}
-              icon={pending.remove ? 'trash-2' : 'unplug'}
+              icon={pending.remove ? 'trash' : 'unplug'}
               busy={busyId === pending.target.id}
               onClose={() => setPending(null)}
               onConfirm={() => release(pending.target)}
@@ -868,7 +868,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                 </>
               }
               verb="Remove"
-              icon="trash-2"
+              icon="trash"
               busy={busyId === removing.id}
               onClose={() => setRemoving(null)}
               onConfirm={() => remove(removing)}

--- a/packages/web/src/components/console/McpServersCard.tsx
+++ b/packages/web/src/components/console/McpServersCard.tsx
@@ -215,7 +215,7 @@ function ProviderTile({
               <Icon name="pencil" size={12} />
             </button>
             <button className="iconbtn h-6 w-6" title="Remove" onClick={onDelete}>
-              <Icon name="trash-2" size={12} />
+              <Icon name="trash" size={12} />
             </button>
           </>
         ) : undefined
@@ -693,7 +693,7 @@ function EditConnectorModal({ provider, onClose }: { provider: McpProviderDto; o
               {isNoAuth ? (
                 <div className="flex items-start gap-[9px] rounded-md border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px]">
                   <Icon
-                    name="check-circle-2"
+                    name="circle-check"
                     size={15}
                     color="var(--status-online-text)"
                     className="mt-[1px] flex-none"
@@ -845,7 +845,7 @@ function DeleteMcpProviderModal({ provider, onClose }: { provider: McpProviderDt
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name="trash-2" size={16} color="var(--status-error)" />
+          <Icon name="trash" size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Delete MCP server</span>
         <button className="iconbtn" onClick={onClose}>
@@ -871,7 +871,7 @@ function DeleteMcpProviderModal({ provider, onClose }: { provider: McpProviderDt
           onClick={() => void onDelete()}
           className={busy ? 'pointer-events-none opacity-50' : undefined}
         >
-          <Icon name="trash-2" size={15} />
+          <Icon name="trash" size={15} />
           {busy ? 'Deleting…' : 'Delete'}
         </Button>
       </div>

--- a/packages/web/src/components/console/MemoryConnectionsCard.tsx
+++ b/packages/web/src/components/console/MemoryConnectionsCard.tsx
@@ -369,7 +369,7 @@ function ConnectionCard({
                         onDelete()
                       }}
                     >
-                      <Icon name="trash-2" size={15} />
+                      <Icon name="trash" size={15} />
                       Delete connection
                     </button>
                   </div>
@@ -392,7 +392,7 @@ function ConnectionCard({
       <div className="grid grid-cols-1 gap-3 border-t border-(--border-subtle) bg-(--surface-sunken) p-[14px] desktop:grid-cols-[minmax(0,1.2fr)_minmax(210px,.8fr)]">
         <div className="min-w-0 rounded-md border border-(--border-subtle) bg-(--surface-card) p-3">
           <div className="flex items-center gap-[6px] font-sans text-[10.5px] font-semibold leading-normal tracking-[.04em] text-(--text-tertiary) uppercase">
-            <Icon name={isRemote ? 'globe-2' : 'terminal-square'} size={13} />
+            <Icon name={isRemote ? 'earth' : 'square-terminal'} size={13} />
             Connection
           </div>
           <div className="mt-2 font-sans text-[12px] font-medium leading-normal text-(--text-primary)">

--- a/packages/web/src/components/console/OrganizationEnvironmentCard.tsx
+++ b/packages/web/src/components/console/OrganizationEnvironmentCard.tsx
@@ -243,7 +243,7 @@ function EntryRow({
             <Icon name="pencil" size={12} />
           </button>
           <button type="button" className="iconbtn h-[26px] w-[26px]" title="Delete" onClick={onDelete}>
-            <Icon name="trash-2" size={12} />
+            <Icon name="trash" size={12} />
           </button>
         </span>
       </span>

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -253,7 +253,7 @@ function SourceTile({
               <Icon name="pencil" size={12} />
             </button>
             <button className="iconbtn h-6 w-6" onClick={onDelete} title="Delete">
-              <Icon name="trash-2" size={12} />
+              <Icon name="trash" size={12} />
             </button>
           </>
         ) : undefined

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -646,7 +646,7 @@ export function WorkspaceFiles({
                     onClick={() => void confirmDelete()}
                     disabled={deleteDraft.deleting}
                   >
-                    <Icon name="trash-2" size={13} />
+                    <Icon name="trash" size={13} />
                     {deleteDraft.deleting ? 'Deleting…' : 'Delete file'}
                   </Button>
                 </>
@@ -664,7 +664,7 @@ export function WorkspaceFiles({
                   ) : null}
                   {viewerCanDelete ? (
                     <Button variant="secondary" size="xs" className="flex-none" onClick={startDelete}>
-                      <Icon name="trash-2" size={13} />
+                      <Icon name="trash" size={13} />
                       Delete
                     </Button>
                   ) : null}

--- a/packages/web/src/components/console/modals/DaemonLifecycleModal.tsx
+++ b/packages/web/src/components/console/modals/DaemonLifecycleModal.tsx
@@ -88,7 +88,7 @@ export default function DaemonLifecycleModal({
 
   const isUpgrade = mode === 'upgrade'
   const title = isUpgrade ? 'Upgrade daemon' : 'Restart daemon'
-  const icon = isUpgrade ? 'arrow-up-circle' : 'refresh-cw'
+  const icon = isUpgrade ? 'circle-arrow-up' : 'refresh-cw'
   const noTargets = isUpgrade && options.length === 0
   const succeeded = !gone && tracked?.status === 'succeeded'
   const failed = gone || tracked?.status === 'failed'
@@ -108,7 +108,7 @@ export default function DaemonLifecycleModal({
         {!opId ? (
           <>
             <div className="mb-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
-              <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+              <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
               <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
                 {isUpgrade ? (
                   <>
@@ -172,7 +172,7 @@ export default function DaemonLifecycleModal({
             ) : failed ? (
               <>
                 <span className="flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full bg-(--status-error-soft)">
-                  <Icon name="alert-triangle" size={13} color="var(--status-error)" />
+                  <Icon name="triangle-alert" size={13} color="var(--status-error)" />
                 </span>
                 <div className="flex-1">
                   <div className="font-sans text-[13px] font-semibold leading-normal">

--- a/packages/web/src/components/console/modals/DeleteAgentModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteAgentModal.tsx
@@ -34,7 +34,7 @@ export default function DeleteAgentModal({ agent, onClose }: { agent: Agent; onC
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name="trash-2" size={16} color="var(--status-error)" />
+          <Icon name="trash" size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Delete agent</span>
         <button className="iconbtn" onClick={onClose}>
@@ -56,7 +56,7 @@ export default function DeleteAgentModal({ agent, onClose }: { agent: Agent; onC
           Cancel
         </Button>
         <Button variant="danger" onClick={onDelete} className={busy ? 'pointer-events-none opacity-50' : undefined}>
-          <Icon name="trash-2" size={15} />
+          <Icon name="trash" size={15} />
           {busy ? 'Deleting…' : 'Delete'}
         </Button>
       </div>

--- a/packages/web/src/components/console/modals/DeleteBotModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteBotModal.tsx
@@ -35,7 +35,7 @@ export default function DeleteBotModal({ bot, onClose }: { bot: BotDto; onClose:
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name="trash-2" size={16} color="var(--status-error)" />
+          <Icon name="trash" size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Delete bot</span>
         <button className="iconbtn" onClick={onClose}>
@@ -62,7 +62,7 @@ export default function DeleteBotModal({ bot, onClose }: { bot: BotDto; onClose:
           Cancel
         </Button>
         <Button variant="danger" onClick={onDelete} className={busy ? 'pointer-events-none opacity-50' : undefined}>
-          <Icon name="trash-2" size={15} />
+          <Icon name="trash" size={15} />
           {busy ? 'Deleting…' : 'Delete'}
         </Button>
       </div>

--- a/packages/web/src/components/console/modals/DeleteDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteDaemonModal.tsx
@@ -37,7 +37,7 @@ export default function DeleteDaemonModal({ daemon, onClose }: { daemon: DaemonR
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name="trash-2" size={16} color="var(--status-error)" />
+          <Icon name="trash" size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Delete daemon</span>
         <button className="iconbtn" onClick={onClose}>
@@ -52,7 +52,7 @@ export default function DeleteDaemonModal({ daemon, onClose }: { daemon: DaemonR
         </p>
         {hostedCount > 0 && (
           <div className="mt-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
-            <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+            <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
             <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
               {hostedCount} {hostedCount === 1 ? 'agent' : 'agents'} hosted here will be unplaced until reassigned to
               another daemon.
@@ -90,7 +90,7 @@ export default function DeleteDaemonModal({ daemon, onClose }: { daemon: DaemonR
           onClick={onDelete}
           className={matches && !busy ? undefined : 'pointer-events-none opacity-50'}
         >
-          <Icon name="trash-2" size={15} />
+          <Icon name="trash" size={15} />
           {busy ? 'Deleting…' : 'Delete'}
         </Button>
       </div>

--- a/packages/web/src/components/console/modals/DeleteGroupModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteGroupModal.tsx
@@ -34,7 +34,7 @@ export default function DeleteGroupModal({ group, onClose }: { group: MemberSetR
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name="trash-2" size={15} color="var(--status-error)" />
+          <Icon name="trash" size={15} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Delete group</span>
         <button className="iconbtn" onClick={onClose}>

--- a/packages/web/src/components/console/modals/DeleteHookModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteHookModal.tsx
@@ -110,7 +110,7 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
           Cancel
         </Button>
         <Button variant="danger" onClick={onDelete} className={busy ? 'pointer-events-none opacity-50' : undefined}>
-          <Icon name={group ? 'unplug' : 'trash-2'} size={15} />
+          <Icon name={group ? 'unplug' : 'trash'} size={15} />
           {busy ? (group ? 'Disconnecting…' : 'Deleting…') : group ? 'Disconnect' : 'Delete'}
         </Button>
       </div>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -1050,7 +1050,7 @@ export default function EditAgentModal({
 
             {placementRequested && (
               <div className="mt-[18px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
-                <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+                <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
                 {initialPlacement ? (
                   <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
                     This places the unassigned agent on{' '}

--- a/packages/web/src/components/console/modals/EditOrgModal.tsx
+++ b/packages/web/src/components/console/modals/EditOrgModal.tsx
@@ -108,7 +108,7 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
           <span>Only owners can edit these settings. Changing the name updates the organization URL for everyone.</span>
         </div>
         <div className="mt-[18px] flex items-center gap-[11px] rounded-[9px] border border-[rgba(220,75,75,.28)] bg-(--status-error-soft) px-[13px] py-3">
-          <Icon name="trash-2" size={16} color="var(--status-error)" className="flex-none" />
+          <Icon name="trash" size={16} color="var(--status-error)" className="flex-none" />
           <div className="flex-1">
             <div className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
               Delete organization

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -985,7 +985,7 @@ export default function EditWorkspaceModal({
                       disabled={removingAuthorization !== null}
                       onClick={() => void removeAuthorization(authorization)}
                     >
-                      <Icon name={removingAuthorization === authorization.id ? 'loader' : 'trash-2'} size={13} />
+                      <Icon name={removingAuthorization === authorization.id ? 'loader' : 'trash'} size={13} />
                     </button>
                   </div>
                 ))

--- a/packages/web/src/components/console/modals/ReconnectDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/ReconnectDaemonModal.tsx
@@ -65,7 +65,7 @@ export default function ReconnectDaemonModal({ daemon, onClose }: { daemon: Daem
       </div>
       <div className="modalbody">
         <div className="mb-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
-          <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+          <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
           <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
             This issues a fresh connect token for <span className="mono text-(--text-primary)">{daemon.name}</span>. Run
             the command below on its host to bring it back online — its identity and agents are preserved.

--- a/packages/web/src/components/console/modals/RuntimeLoginModal.tsx
+++ b/packages/web/src/components/console/modals/RuntimeLoginModal.tsx
@@ -54,7 +54,7 @@ export default function RuntimeLoginModal({ target, onClose }: { target: Runtime
       </div>
       <div className="modalbody">
         <div className="mb-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
-          <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+          <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
           <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
             <span className="mono text-(--text-primary)">{target.runtimeId}</span> rejected the probe with
             &ldquo;authentication required&rdquo;. Its credential lives in the runtime&apos;s own state on

--- a/packages/web/src/components/console/platforms/slack/profile.tsx
+++ b/packages/web/src/components/console/platforms/slack/profile.tsx
@@ -155,7 +155,7 @@ export function SlackConfigCard() {
                     {accessExpired ? 'Re-enter' : 'Replace'}
                   </Button>
                   <Button variant="ghost" onClick={() => void clear()}>
-                    <Icon name="trash-2" size={13} />
+                    <Icon name="trash" size={13} />
                     {busy ? 'Clearing…' : 'Clear'}
                   </Button>
                 </span>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -823,7 +823,7 @@ export default function AgentDetailView() {
                           openModal('deleteAgent', da)
                         }}
                       >
-                        <Icon name="trash-2" size={15} />
+                        <Icon name="trash" size={15} />
                         Delete
                       </button>
                     </>
@@ -1723,10 +1723,10 @@ export default function AgentDetailView() {
                           title="Recent deliveries"
                           onClick={() => setHookRunsFor(hookRunsFor === h.id ? null : h.id)}
                         >
-                          <Icon name={hookRunsFor === h.id ? 'chevron-up' : 'history'} size={15} />
+                          <Icon name={hookRunsFor === h.id ? 'chevron-up' : 'rotate-ccw-clock'} size={15} />
                         </button>
                         <button className="iconbtn" title="Delete webhook" onClick={() => openModal('deleteHook', h)}>
-                          <Icon name="trash-2" size={15} />
+                          <Icon name="trash" size={15} />
                         </button>
                       </div>
                       {hookRunsFor === h.id && (
@@ -1830,7 +1830,7 @@ export default function AgentDetailView() {
                                         ]
                                       : []),
                                     {
-                                      icon: 'history' as const,
+                                      icon: 'rotate-ccw-clock' as const,
                                       label: hookRunsFor === h.id ? 'Hide recent deliveries' : 'Recent deliveries',
                                       onClick: () => setHookRunsFor(hookRunsFor === h.id ? null : h.id)
                                     }
@@ -1972,7 +1972,7 @@ export default function AgentDetailView() {
                                         ]
                                       : []),
                                     {
-                                      icon: 'history' as const,
+                                      icon: 'rotate-ccw-clock' as const,
                                       label: hookRunsFor === h.id ? 'Hide recent deliveries' : 'Recent deliveries',
                                       onClick: () => setHookRunsFor(hookRunsFor === h.id ? null : h.id)
                                     }
@@ -2390,7 +2390,7 @@ export default function AgentDetailView() {
                 }}
                 className="flex w-full cursor-pointer items-center gap-3 border-0 bg-transparent px-3 py-[13px] text-left font-sans text-[15px] font-medium leading-normal text-(--red-600)"
               >
-                <Icon name="trash-2" size={18} />
+                <Icon name="trash" size={18} />
                 Delete
               </button>
             )}

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -578,7 +578,7 @@ export default function DaemonDetailView() {
               onClick={() => openModal('deleteDaemon', daemon)}
               className="flex h-11 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[14px] font-semibold leading-normal text-(--red-600)"
             >
-              <Icon name="trash-2" size={16} />
+              <Icon name="trash" size={16} />
               Delete daemon
             </button>
           </div>
@@ -734,7 +734,7 @@ export default function DaemonDetailView() {
                         openModal('deleteDaemon', daemon)
                       }}
                     >
-                      <Icon name="trash-2" size={15} />
+                      <Icon name="trash" size={15} />
                       Delete
                     </button>
                   </>

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -298,7 +298,7 @@ function GroupCard({ group, daemons }: { group: MemberSetRow; daemons: DaemonRow
                   openModal('deleteGroup', group)
                 }}
               >
-                <Icon name="trash-2" size={15} />
+                <Icon name="trash" size={15} />
                 Remove group
               </button>
             </span>
@@ -716,7 +716,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
                       openModal('deleteDaemon', m)
                     }}
                   >
-                    <Icon name="trash-2" size={15} />
+                    <Icon name="trash" size={15} />
                     Delete
                   </button>
                 </>

--- a/packages/web/src/components/console/views/GroupDetailView.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.tsx
@@ -167,7 +167,7 @@ export default function GroupDetailView() {
                     openModal('deleteGroup', group)
                   }}
                 >
-                  <Icon name="trash-2" size={15} />
+                  <Icon name="trash" size={15} />
                   Remove group
                 </button>
               </div>

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -509,14 +509,14 @@ function BotsCard({
                   {RowLinks && <RowLinks bot={b} />}
                   {free && canWrite ? (
                     <button className="iconbtn h-7 w-7 flex-none" title={`Delete ${noun}`} onClick={() => onDelete(b)}>
-                      <Icon name="trash-2" size={14} />
+                      <Icon name="trash" size={14} />
                     </button>
                   ) : !free ? (
                     <span
                       title="Uninstall its integration first"
                       className="flex h-7 w-7 flex-none cursor-not-allowed items-center justify-center opacity-45"
                     >
-                      <Icon name="trash-2" size={14} />
+                      <Icon name="trash" size={14} />
                     </span>
                   ) : (
                     <span className="h-7 w-7 flex-none" />

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -549,7 +549,7 @@ function SaveError({ err }: { err: string | null }) {
   if (!err) return null
   return (
     <div className="mt-3 flex items-start gap-2 font-sans text-[12.5px] leading-[1.5] text-(--status-error)">
-      <Icon name="alert-triangle" size={15} className="mt-[1px] flex-none" />
+      <Icon name="triangle-alert" size={15} className="mt-[1px] flex-none" />
       <span>{err}</span>
     </div>
   )

--- a/packages/web/src/components/console/views/ScheduleDetailView.tsx
+++ b/packages/web/src/components/console/views/ScheduleDetailView.tsx
@@ -387,7 +387,7 @@ export default function ScheduleDetailView() {
             onClick={() => void remove()}
             className="flex h-11 w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[14px] font-semibold leading-normal text-(--red-600)"
           >
-            <Icon name="trash-2" size={16} />
+            <Icon name="trash" size={16} />
             Delete schedule
           </button>
         </div>
@@ -441,7 +441,7 @@ export default function ScheduleDetailView() {
                   </button>
                   <div className="dmsep" />
                   <button className="dmi danger" onClick={() => void remove()}>
-                    <Icon name="trash-2" size={14} />
+                    <Icon name="trash" size={14} />
                     Delete
                   </button>
                 </div>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -4874,7 +4874,7 @@ export default function SessionDetailView() {
               )}
               {transcriptPurged && (
                 <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-                  <Icon name="trash-2" size={15} color="var(--text-tertiary)" />
+                  <Icon name="trash" size={15} color="var(--text-tertiary)" />
                   <span>
                     This transcript was deleted on {fmtDate(purgedAt)} by the session retention policy, together with
                     any workspace created just for it. The details on this page are all that remain.
@@ -4883,7 +4883,7 @@ export default function SessionDetailView() {
               )}
               {transcriptPartiallyPurged && (
                 <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-                  <Icon name="trash-2" size={15} color="var(--text-tertiary)" />
+                  <Icon name="trash" size={15} color="var(--text-tertiary)" />
                   <span>
                     Part of this history is missing:{' '}
                     {memberCount > 1

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -81,7 +81,7 @@ function PurgedMark({ session }: { session: Session }) {
       }
       className="inline-flex flex-none"
     >
-      <Icon name="trash-2" size={12} color="var(--text-tertiary)" />
+      <Icon name="trash" size={12} color="var(--text-tertiary)" />
     </span>
   )
 }

--- a/packages/web/src/components/ui.tsx
+++ b/packages/web/src/components/ui.tsx
@@ -10,6 +10,11 @@ function toPascal(name: string): string {
     .join('')
 }
 
+/** Lucide keys `icons` by canonical name, so a rename drops the old one — `icon-names.test.ts` resolves through this. */
+export function lucideIcon(name: string): React.ComponentType<LucideProps> | undefined {
+  return (icons as Record<string, React.ComponentType<LucideProps>>)[toPascal(name)]
+}
+
 export function Icon({
   name,
   size = 16,
@@ -25,7 +30,7 @@ export function Icon({
   style?: CSSProperties
   strokeWidth?: number
 }) {
-  const Cmp = (icons as Record<string, React.ComponentType<LucideProps>>)[toPascal(name)]
+  const Cmp = lucideIcon(name)
   if (!Cmp) return null
   return <Cmp size={size} color={color} strokeWidth={strokeWidth} className={className} style={style} />
 }

--- a/packages/web/src/icon-names.test.ts
+++ b/packages/web/src/icon-names.test.ts
@@ -1,0 +1,88 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { lucideIcon } from '@/components/ui'
+
+const WEB_SRC = fileURLToPath(new URL('.', import.meta.url))
+const COMPONENTS = join(WEB_SRC, 'components')
+
+/** Every console source a name can be shipped from. Tests are excluded: their fixtures name icons that never render. */
+function consoleSources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) return consoleSources(path)
+    if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return []
+    return [path]
+  })
+}
+
+/** Only what the value can EVALUATE to — a comparison operand, an index, and a call argument all test a name here
+ *  rather than being one, as `{t === 'dark' ? 'sun' : 'moon'}` and `{p.includes('/') ? 'file' : 'file-text'}` do. */
+function iconNameLiterals(value: string): string[] {
+  const evaluated = value
+    .replace(/[=!]==?\s*(?:'[^']*'|"[^"]*")/g, '')
+    .replace(/\[[^\]]*\]/g, '')
+    .replace(/\.\w+\([^()]*\)/g, '')
+  return [...evaluated.matchAll(/'([^']*)'|"([^"]*)"/g)].map((match) => match[1] ?? match[2]!)
+}
+
+/** `<Icon name=…>`, both the plain literal and each branch of a `name={cond ? 'a' : 'b'}`. */
+function directIconNames(code: string): string[] {
+  return [...code.matchAll(/<Icon\s[^>]*?\/>/g)].flatMap((tag) => {
+    const attribute = /\bname=(\{[^{}]*\}|'[^']*'|"[^"]*")/.exec(tag[0])
+    return attribute ? iconNameLiterals(attribute[1]!) : []
+  })
+}
+
+/** The `icon` prop, field or local a menu item, confirm dialog or nav tile hands to `<Icon name>` one hop later. */
+function forwardedIconNames(code: string): string[] {
+  return [...code.matchAll(/\bicon\s*[:=]\s*(\{[^{}]*\}|'[^']*'|"[^"]*"|[^\n,;]*)/g)].flatMap((match) =>
+    iconNameLiterals(match[1]!)
+  )
+}
+
+function namesIn(source: string, forwarded: boolean): string[] {
+  // Comments go first, so prose quoting a name does not read as one.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+  return [...directIconNames(code), ...(forwarded ? forwardedIconNames(code) : [])]
+}
+
+describe('every icon name the console renders exists in lucide', () => {
+  // Outside `components/` an `icon` field is something else — a registry URL, an agent's avatar union — so it is scoped.
+  const used = consoleSources(WEB_SRC).flatMap((file) =>
+    namesIn(readFileSync(file, 'utf8'), file.startsWith(COMPONENTS)).map((name) => ({ file, name }))
+  )
+
+  it('reads the names a source ships and skips the ones it only mentions', () => {
+    const read = (source: string) => namesIn(source, true)
+    expect(read(`<Icon name="trash" size={14} />`)).toEqual(['trash'])
+    expect(read(`<Icon name={busy ? 'loader' : 'refresh-cw'} size={14} />`)).toEqual(['loader', 'refresh-cw'])
+    expect(read(`<Icon name={theme === 'dark' ? 'sun' : 'moon'} size={14} />`)).toEqual(['sun', 'moon'])
+    expect(read(`<Icon name={p.includes('/') ? 'file' : 'file-text'} size={13} />`)).toEqual(['file', 'file-text'])
+    expect(read(`{ icon: (tile(f)?.icon ?? 'plus') as Parameters<typeof Icon>[0]['name'] }`)).toEqual(['plus'])
+    expect(read(`<Icon name={a ? 'plus' : b ? 'minus' : 'x'} size={14} />`)).toEqual(['plus', 'minus', 'x'])
+    expect(read(`<Icon\n  name="plus"\n  size={13}\n/>`)).toEqual(['plus'])
+    expect(read(`{ icon: 'settings-2' as const, label: 'Settings' }`)).toEqual(['settings-2'])
+    expect(read(`<Confirm verb="Remove" icon={remove ? 'trash' : 'unplug'} />`)).toEqual(['trash', 'unplug'])
+    expect(read(`<Confirm icon="trash" verb="Remove" />`)).toEqual(['trash'])
+    expect(read(`const icon = isUpgrade ? 'circle-arrow-up' : 'refresh-cw'`)).toEqual(['circle-arrow-up', 'refresh-cw'])
+    expect(read(`<AgentIconView icon={agent?.icon} size={22} />`)).toEqual([])
+    expect(read(`// an <Icon name="not-an-icon" /> in prose`)).toEqual([])
+    expect(read(`/* an <Icon name="not-an-icon" /> in a block */`)).toEqual([])
+  })
+
+  // Each sweep is asserted on its own: a broken matcher would find nothing and pass the check below vacuously.
+  it('still finds the console files that name icons', () => {
+    const forwarded = consoleSources(COMPONENTS).flatMap((file) => forwardedIconNames(readFileSync(file, 'utf8')))
+    expect(used.length).toBeGreaterThan(100)
+    expect(used.some(({ name }) => name === 'trash')).toBe(true)
+    expect(forwarded.length).toBeGreaterThan(0)
+  })
+
+  // A dropped name renders NOTHING — no error, just an empty box, the way `trash-2` emptied every delete control.
+  it('resolves every one to a component', () => {
+    const missing = used.filter(({ name }) => !lucideIcon(name))
+    expect(missing.map(({ file, name }) => `${relative(WEB_SRC, file)}: '${name}'`)).toEqual([])
+  })
+})


### PR DESCRIPTION
Every delete control in the console renders an empty box: the button, its border and its "Delete …" tooltip are all there, with no trash glyph inside.

## Why

Lucide keys its `icons` map by **canonical name only**. When it folds one icon into another, the old name survives as a top-level alias export but leaves that map — and `Icon` resolves through the map, returning `null` for a name it cannot find. No error, no fallback, no console warning: the glyph just stops rendering.

Bumping `lucide-react` 1.35.0 → 1.43.0 (#1958) folded `trash-2` into `trash`, so all **42** `trash-2` call sites across 24 files went blank at once.

Scanning for the rest of the class found six more names that had already been renamed upstream and were silently rendering nothing — including the amber warning triangle in the daemon lifecycle, delete, reconnect, runtime-login and agent modals:

| named in the console | what lucide's alias table points at |
| --- | --- |
| `trash-2` | `trash` |
| `alert-triangle` | `triangle-alert` |
| `check-circle-2` | `circle-check` |
| `arrow-up-circle` | `circle-arrow-up` |
| `terminal-square` | `square-terminal` |
| `globe-2` | `earth` |
| `history` | `rotate-ccw-clock` |

Each glyph is unchanged — 1.43's `trash` is byte-for-byte the old `trash-2` — so this is a rename, not a redesign.

## What changed

- Every stale name moves to the canonical one.
- `lucideIcon()` is factored out of `Icon` so the guard resolves names exactly as the renderer does.
- `packages/web/src/icon-names.test.ts` scans the console for the names it ships — `<Icon name>` including each branch of a ternary, plus the `icon` prop/field a menu item, confirm dialog or nav tile forwards one hop later — and asserts each resolves. Mutating one name back to `trash-2` fails the suite and names the file.

The scan asserts each sweep separately so a broken matcher cannot pass the check vacuously, and it skips comparison operands, indexes and call arguments (`{path.includes('/') ? 'file' : 'file-text'}` names two icons, not three).

## Verification

- `pnpm --filter @agentconnect.md/web lint`, `typecheck`, `format:check` — clean.
- The web suite passes apart from `protocol-imports.leaf.test.ts`, which is red on `main` already and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
