### PR TITLE
test(web): an inline import type is not a value import of protocol

### DIFF
--- a/packages/web/src/protocol-imports.leaf.test.ts
+++ b/packages/web/src/protocol-imports.leaf.test.ts
@@ -23,7 +23,7 @@ function bundledSources(dir: string): string[] {
 }
 
 /** An `import(` in one of these positions opens a TS inline import TYPE, which is erased long before a bundler runs. */
-const TYPE_POSITION = /(?:[:<|&]|\b(?:typeof|keyof|extends|as|satisfies))\s*$/
+const TYPE_POSITION = /(?:(?<![|&])[:<|&]|\b(?:typeof|keyof|extends|as|satisfies))\s*$/
 
 /** Protocol specifiers a file pulls a VALUE from — an `import type` / `export type` clause never reaches a bundler. */
 function protocolValueImports(source: string): string[] {
@@ -36,7 +36,7 @@ function protocolValueImports(source: string): string[] {
   }
   // Side-effect `import 'x'` and dynamic `import('x')`, neither of which has a `from` clause.
   for (const match of code.matchAll(/\bimport\s*(?:\(\s*)?['"]([^'"]+)['"]/g)) {
-    // `=>` and `,` are deliberately not type positions: they front an arrow body or a call argument far more often.
+    // `||` and `&&` are logical, not union/intersection; `=>` and `,` front an arrow body or an argument. None count.
     if (match[1]!.startsWith(PACKAGE) && !TYPE_POSITION.test(code.slice(0, match.index))) found.add(match[1]!)
   }
   return [...found]
@@ -60,11 +60,15 @@ describe('the console value-imports only bundler-safe protocol modules', () => {
     expect(read(`export { sumAmounts } from '${PACKAGE}/decimal-amount'`)).toEqual([`${PACKAGE}/decimal-amount`])
     expect(read(`const m = await import('${PACKAGE}')`)).toEqual([PACKAGE])
     expect(read(`const c = dynamic(() => import('${PACKAGE}'))`)).toEqual([PACKAGE])
+    expect(read(`const p = enabled && import('${PACKAGE}')`)).toEqual([PACKAGE])
+    expect(read(`const p = cached || import('${PACKAGE}')`)).toEqual([PACKAGE])
     expect(read(`import '${PACKAGE}/register'`)).toEqual([`${PACKAGE}/register`])
     expect(read(`import type { HookKind } from '${PACKAGE}'`)).toEqual([])
     expect(read(`return apiGet<import('${PACKAGE}').MemoryEntryListResult>(url)`)).toEqual([])
     expect(read(`function post(body: import('${PACKAGE}').MemoryEntryCreateRequest) {}`)).toEqual([])
     expect(read(`type Client = (typeof import('${PACKAGE}'))['default']`)).toEqual([])
+    expect(read(`type U = HookKind | import('${PACKAGE}').MemoryEntryContent`)).toEqual([])
+    expect(read(`type I = Base & import('${PACKAGE}').MemoryEntryCapabilities`)).toEqual([])
     expect(read(`export type { HookKind } from '${PACKAGE}'`)).toEqual([])
     expect(read(`// see \`import { x } from '${PACKAGE}'\``)).toEqual([])
     expect(read(`import { x } from './data'\nimport type { HookKind } from '${PACKAGE}'`)).toEqual([])

--- a/packages/web/src/protocol-imports.leaf.test.ts
+++ b/packages/web/src/protocol-imports.leaf.test.ts
@@ -22,6 +22,9 @@ function bundledSources(dir: string): string[] {
   })
 }
 
+/** An `import(` in one of these positions opens a TS inline import TYPE, which is erased long before a bundler runs. */
+const TYPE_POSITION = /(?:[:<|&]|\b(?:typeof|keyof|extends|as|satisfies))\s*$/
+
 /** Protocol specifiers a file pulls a VALUE from — an `import type` / `export type` clause never reaches a bundler. */
 function protocolValueImports(source: string): string[] {
   // Comments go first, so prose quoting an import does not read as one.
@@ -33,7 +36,8 @@ function protocolValueImports(source: string): string[] {
   }
   // Side-effect `import 'x'` and dynamic `import('x')`, neither of which has a `from` clause.
   for (const match of code.matchAll(/\bimport\s*(?:\(\s*)?['"]([^'"]+)['"]/g)) {
-    if (match[1]!.startsWith(PACKAGE)) found.add(match[1]!)
+    // `=>` and `,` are deliberately not type positions: they front an arrow body or a call argument far more often.
+    if (match[1]!.startsWith(PACKAGE) && !TYPE_POSITION.test(code.slice(0, match.index))) found.add(match[1]!)
   }
   return [...found]
 }
@@ -55,7 +59,12 @@ describe('the console value-imports only bundler-safe protocol modules', () => {
     expect(read(`import { a, type B } from '${PACKAGE}/code-host'`)).toEqual([`${PACKAGE}/code-host`])
     expect(read(`export { sumAmounts } from '${PACKAGE}/decimal-amount'`)).toEqual([`${PACKAGE}/decimal-amount`])
     expect(read(`const m = await import('${PACKAGE}')`)).toEqual([PACKAGE])
+    expect(read(`const c = dynamic(() => import('${PACKAGE}'))`)).toEqual([PACKAGE])
+    expect(read(`import '${PACKAGE}/register'`)).toEqual([`${PACKAGE}/register`])
     expect(read(`import type { HookKind } from '${PACKAGE}'`)).toEqual([])
+    expect(read(`return apiGet<import('${PACKAGE}').MemoryEntryListResult>(url)`)).toEqual([])
+    expect(read(`function post(body: import('${PACKAGE}').MemoryEntryCreateRequest) {}`)).toEqual([])
+    expect(read(`type Client = (typeof import('${PACKAGE}'))['default']`)).toEqual([])
     expect(read(`export type { HookKind } from '${PACKAGE}'`)).toEqual([])
     expect(read(`// see \`import { x } from '${PACKAGE}'\``)).toEqual([])
     expect(read(`import { x } from './data'\nimport type { HookKind } from '${PACKAGE}'`)).toEqual([])


### PR DESCRIPTION
`packages/web/src/protocol-imports.leaf.test.ts` fails on `main`, so `pnpm --filter @agentconnect.md/web test` is red:

```
FAIL src/protocol-imports.leaf.test.ts > resolves every one to a leaf module
+ "lib/api.ts imports '@agentconnect.md/protocol' -> ./src/index.ts: 60 relative imports, e.g. ./consts.js, ..."
```

## Why

The scan's second matcher exists for the two import forms with no `from` clause — side-effect `import 'x'` and dynamic `import('x')`:

```ts
for (const match of code.matchAll(/\bimport\s*(?:\(\s*)?['"]([^'"]+)['"]/g)) { ... }
```

It also matches TypeScript's inline import type, `import('@agentconnect.md/protocol').MemoryEntryCapabilities`. That form sits in a type position, is erased at compile time, and never reaches a bundler. `lib/api.ts` picked up about fifteen of them in ce3d48230 and value-imports nothing from protocol — its one protocol import is `import type { HookKind }`, which the first matcher already skips correctly.

## What changed

A match is ruled out when the token in front of it opens a type position: `:` `<` `|` `&` `typeof` `keyof` `extends` `as` `satisfies`.

`=>` and `,` are deliberately absent from that list. They front an arrow body (`dynamic(() => import('…'))`) or a call argument far more often than a type, and the two error directions do not cost the same here: over-counting a type is a false failure someone reads and fixes, while under-counting a real dynamic import would let this scan go blind on exactly the thing it guards — a barrel import that 500s every console route while typecheck, Vitest and `next build` stay green.

Measured across `packages/web/src`, the change drops exactly one pair — the `lib/api.ts` false positive — and keeps the other six genuine importers, so the "still finds the console files" guard is not weakened.

## Test

`it('reads value imports and skips type-only ones')`, the block that documents these semantics, gains the inline type in three shapes — generic argument, parameter annotation, and under `typeof` — and now proves the value side explicitly for `await import(…)`, an arrow-body `import(…)`, and a side-effect import.

`pnpm --filter @agentconnect.md/web test` → 220 files, 2526 tests passing. `typecheck`, `eslint` and `prettier --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
