### PR TITLE
feat(daemon): add session-owned overlay mounts

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -136,7 +136,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--max-agents <n>`               | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
 | `--require-sandbox`              | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
 | n/a (config only)                | `sandbox.backend`              | Select the local sandbox backend; defaults to `srt`; `microsandbox` selects Linux VMs with an explicit image.                                      |
-| n/a (config only)                | `sandbox.mounts`               | Operator-owned host path mappings; `readOnly` defaults to true. SRT requires equal normalized source and target paths.                             |
+| n/a (config only)                | `sandbox.mounts`               | Host mappings: `readonly` (default), `writable`, or microsandbox-only `overlay`. SRT requires equal source/target paths.                           |
 | `--k8s`                          | n/a (mode switch)              | Run runtimes in cluster sandbox pods instead of on this host; see section 2.6 for what that changes.                                               |
 | `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only service for session-scoped model credentials, http or https as the deployment chooses; see [key-server.md](key-server.md).              |
 | `--key-server-token-path <path>` | `KEY_SERVER_TOKEN_PATH`        | File re-read as the key-server bearer token on every request.                                                                                      |
@@ -331,8 +331,8 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
 
   // ---------- Local sandbox backend and shared host directories ----------
   "sandbox": {
-    "backend": "srt", // Default and currently the only supported backend.
-    // Entries: { source, target, readOnly }; readOnly defaults to true.
+    "backend": "srt", // Default; microsandbox is also supported on Linux.
+    // Entries: { source, target, mode }; mode defaults to readonly.
     // SRT requires existing paths and equal normalized source/target paths.
     "mounts": []
   },
@@ -397,7 +397,7 @@ roots, any operator-declared `sandbox.mounts` (host toolchains such as
 nvm's node or a rustup toolchain, made readable in every sandbox regardless
 of runtime), and the runtime's selected host credential path. Writes are limited to
 the workspace, private HOME, managed memory, SRT temporary storage, that
-credential path, and mounts with `readOnly: false` (such as a shared
+credential path, and mounts with `mode: "writable"` (such as a shared
 package-manager store). Outbound domains are approved by a provider callback and Unix sockets remain
 compatibility-open during this rollout. Proxy-aware HTTP(S) clients retain web
 egress, and the provider sets `NODE_USE_ENV_PROXY=1` so Node's built-in `fetch`

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -42,7 +42,7 @@ that default:
       {
         "source": "/srv/agent-cache/pnpm",
         "target": "/cache/pnpm",
-        "readOnly": false
+        "mode": "writable"
       }
     ],
     "microsandbox": {
@@ -63,14 +63,14 @@ also overrides the release default. Networking is fixed backend behavior; the
 strict VM configuration has no network modes, port mappings, or outbound-proxy
 settings.
 
-| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                          |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sandbox.backend`              | Implemented: `srt` is the default; `microsandbox` selects the Linux VM implementation for sandboxed launches.                                                                                                                                                                        |
-| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                          |
-| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                     |
-| `sandbox.microsandbox.image`   | Implemented: optional, non-empty OCI override. Release builds default to their bundled shared-image reference; development builds require an explicit image. No Kubernetes image lookup is used.                                                                                     |
-| `cpus`, `memoryMiB`, `diskGiB` | Per-VM CPU allocation, memory limit, and capacity of each writable disk; defaults are `2`, `2048`, and `10`. New VMs have a root upper disk and a Docker data disk, each capped by `diskGiB`. Both are sparse; host capacity planning remains the operator's responsibility.         |
-| `sandbox.mounts`               | Implemented: operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `readOnly` (default `true`). SRT requires equal normalized host paths; microsandbox accepts absolute guest targets. Workspace, HOME, and runtime state remain automatically provisioned. |
+| Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sandbox.backend`              | Implemented: `srt` is the default; `microsandbox` selects the Linux VM implementation for sandboxed launches.                                                                                                                                                                                                                               |
+| `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                                                                                 |
+| Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                                            |
+| `sandbox.microsandbox.image`   | Implemented: optional, non-empty OCI override. Release builds default to their bundled shared-image reference; development builds require an explicit image. No Kubernetes image lookup is used.                                                                                                                                            |
+| `cpus`, `memoryMiB`, `diskGiB` | Per-VM CPU allocation, memory limit, and capacity of each writable disk; defaults are `2`, `2048`, and `10`. New VMs have a root upper disk and a Docker data disk, plus one disk when overlay mounts are configured, each capped by `diskGiB`. All are sparse; host capacity planning remains the operator's responsibility.               |
+| `sandbox.mounts`               | Operator-owned filesystem mappings, default `[]`, with `source`, `target`, and `mode` (`readonly` by default, or `writable` / `overlay`). SRT requires equal normalized host paths; microsandbox accepts absolute guest targets and `~/` relative to the session HOME. Workspace, HOME, and runtime state remain automatically provisioned. |
 
 ### Shared mounts and manual conversion
 
@@ -79,10 +79,14 @@ settings.
 automatically migrate or retain a compatibility path for them. Convert existing
 configuration manually using this table, then remove the old fields:
 
-| Previous entry                                          | Entry to add to `sandbox.mounts`                                                              |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `security.sandboxReadRoots: ["/opt/toolchain"]`         | `{ "source": "/opt/toolchain", "target": "/opt/toolchain", "readOnly": true }`                |
-| `security.sandboxWriteRoots: ["/srv/agent-cache/pnpm"]` | `{ "source": "/srv/agent-cache/pnpm", "target": "/srv/agent-cache/pnpm", "readOnly": false }` |
+| Previous entry                                          | Entry to add to `sandbox.mounts`                                                               |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `security.sandboxReadRoots: ["/opt/toolchain"]`         | `{ "source": "/opt/toolchain", "target": "/opt/toolchain", "mode": "readonly" }`               |
+| `security.sandboxWriteRoots: ["/srv/agent-cache/pnpm"]` | `{ "source": "/srv/agent-cache/pnpm", "target": "/srv/agent-cache/pnpm", "mode": "writable" }` |
+
+The former mount-level `readOnly` field is also removed: replace `true` with
+`mode: "readonly"` and `false` with `mode: "writable"` when upgrading the daemon.
+Ordinary mount identities in retained VM bindings remain unchanged by this rename.
 
 Keep a previously writable path writable when converting duplicate legacy
 entries. Launch preparation consumes only `sandbox.mounts`. Normalization expands
@@ -97,7 +101,9 @@ writable children of read-only parents rather than collapsing nested paths.
 microsandbox applies actual guest mount flags: a nested read-only mount restricts
 that subtree even inside a writable parent, and a writable child remains writable
 inside a read-only parent. Keep these nested mappings. User mappings that overlap
-the VM's automatically provisioned paths are rejected in either direction.
+the VM's automatically provisioned paths are rejected, except for children of
+the session HOME. Runtime credentials, settings, sockets, and internal overlay
+paths remain protected.
 
 SRT uses the configured paths at their host locations: its filesystem rules do
 not rename a host path inside the sandbox. Normalize `source` and `target` as
@@ -117,7 +123,7 @@ For example, SRT uses the same common configuration shape:
       {
         "source": "/srv/agent-cache/pnpm",
         "target": "/srv/agent-cache/pnpm",
-        "readOnly": false
+        "mode": "writable"
       }
     ]
   }
@@ -130,6 +136,44 @@ the actual tool process. Mount configuration does not rewrite package-manager
 settings: point the package manager at the effective target path. Do not mount
 an entire host HOME to make an isolated runtime work. Session retirement detaches
 operator-owned mounts without deleting their host contents.
+
+### Shared bases with session-local writes
+
+microsandbox also accepts `mode: "overlay"` for directory sources. Multiple
+sessions, including sessions belonging to different agents, can read the same
+host base while keeping additions, changes, and deletions on their own writable
+layer. `readonly` rejects guest writes; `writable` writes directly to the host;
+`overlay` never writes back to its host source. SRT rejects overlay mode.
+
+For example, when pnpm's default store is under the session's XDG data directory:
+
+```json
+{
+  "source": "/srv/agent-cache/pnpm",
+  "target": "~/.local/share/pnpm/store",
+  "mode": "overlay"
+}
+```
+
+The source must be an existing, populated host store directory. `~` in `source`
+uses the daemon's HOME; `~` in a microsandbox `target` uses the session HOME.
+Verify the effective target with `pnpm store path` in the actual session and
+project, since package-manager versions, environment, and filesystem layout
+affect the default. Mounting at that default avoids a separate store setting.
+This shares store contents only; each session still has its own `node_modules`.
+
+The daemon mounts each base read-only at an internal path and allocates one
+session-owned ext4 disk for all its overlay upper/work directories. Before
+starting session processes, it mounts the merged directories as root through
+the SDK. Suspension retains the disk; resume recreates the mounts; session
+deletion removes the disk. Root setup rejects symlinks in target directories.
+Overlay targets cannot overlap other configured mounts. Changes to the configured
+mount layout still require discarding a retained VM before recreating it.
+
+Use a stable base while sessions have it mounted. Live host mutation consistency
+and cache invalidation controls are separate work; this mode does not make an
+OverlayFS lower layer safe to modify in place. Guest cache misses stay private
+and are not automatically published for other sessions.
 
 Configuration is machine-local desired state. Agent configuration can select a
 runtime and request sandboxing, but cannot supply backend executables, images,

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -68,7 +68,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   // Validate operator mounts before selecting or probing a runtime.
   const mounts = normalizeSandboxMounts(cfg.sandbox.mounts)
   const operatorReadRoots = mounts.map((mount) => mount.source)
-  const operatorWriteRoots = mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source)
+  const operatorWriteRoots = mounts.filter((mount) => mount.mode === 'writable').map((mount) => mount.source)
   const agent = selectAgent(cfg.agentsDir!, opts.agentName)
   await persistSkillSandboxRequirement(root)
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -129,7 +129,7 @@ const SandboxMountSchema = z
   .object({
     source: z.string().min(1),
     target: z.string().min(1),
-    readOnly: z.boolean().default(true)
+    mode: z.enum(['readonly', 'writable', 'overlay']).default('readonly')
   })
   .strict()
 export type SandboxMount = z.infer<typeof SandboxMountSchema>

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1939,7 +1939,7 @@ export class Daemon {
               const environment = manager?.environment(this.microsandboxPlacement(agent, path).id)
               const mounted = environment?.mounts.some(
                 (mount) =>
-                  !mount.readOnly &&
+                  mount.mode === 'writable' &&
                   mount.source === mount.target &&
                   (path === mount.target || path.startsWith(`${mount.target}${sep}`))
               )
@@ -1955,7 +1955,9 @@ export class Daemon {
               const environment = manager?.environment(this.microsandboxPlacement(agent, path).id)
               if (
                 !manager ||
-                !environment?.mounts.some((mount) => !mount.readOnly && mount.source === path && mount.target === path)
+                !environment?.mounts.some(
+                  (mount) => mount.mode === 'writable' && mount.source === path && mount.target === path
+                )
               ) {
                 return false
               }
@@ -4804,7 +4806,7 @@ export class Daemon {
                 )
             : undefined,
         runtimeWriteRoots: runInSandbox
-          ? this.cfg.sandbox.mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source)
+          ? this.cfg.sandbox.mounts.filter((mount) => mount.mode === 'writable').map((mount) => mount.source)
           : undefined,
         // A session host with its own clones (§11) writes its session directory alone; the launch derives its Git grants from it.
         trustedWorkspaceWriteRoots: runInSandbox

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -12,6 +12,7 @@ import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-run
 import { SinkRelPathSchema } from '../shim/file-sink.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../shim/sandbox-paths.js'
 import { MICROSANDBOX_SOCKET_BRIDGE_COMMAND, MICROSANDBOX_SOCKET_BRIDGE_ARGS } from './socket-bridge.js'
+import { overlayMounts, OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT, prepareOverlayMounts } from './overlay.js'
 import {
   MICROSANDBOX_NODE,
   openExecStream,
@@ -78,6 +79,7 @@ interface Binding {
   configHash: string
   environmentId: string
   dockerVolume?: string
+  overlayVolume?: string
 }
 
 const SpecImageSchema = z.object({ config: z.object({ image: z.string().min(1) }) })
@@ -225,7 +227,15 @@ export class MicrosandboxManager {
     return stableJson({
       version: 2,
       config: { ...this.options.config, image },
-      environment: { ...environment, mounts: [...environment.mounts].sort((a, b) => a.target.localeCompare(b.target)) },
+      environment: {
+        ...environment,
+        // Keep ordinary bind identities stable when the public configuration changes from readOnly to mode.
+        mounts: environment.mounts
+          .map(({ mode, ...mount }) =>
+            mode === 'overlay' ? { ...mount, mode } : { ...mount, readOnly: mode === 'readonly' }
+          )
+          .sort((a, b) => a.target.localeCompare(b.target))
+      },
       sockets: this.options.sockets
     })
   }
@@ -244,10 +254,19 @@ export class MicrosandboxManager {
         volume.namedWith(`${name}-docker`, 'create', 'disk', this.options.config.diskGiB * 1024)
       )
       .quietLogs()
-    for (const mount of mounts) {
+    const overlays = overlayMounts(mounts)
+    if (overlays.length) {
+      builder.volume(OVERLAY_STATE_ROOT, (volume) =>
+        volume.namedWith(`${name}-overlays`, 'create', 'disk', this.options.config.diskGiB * 1024)
+      )
+      for (const mount of overlays) {
+        builder.volume(`${OVERLAY_BASE_ROOT}/${mount.key}`, (volume) => volume.bind(mount.source).readonly())
+      }
+    }
+    for (const mount of mounts.filter((mount) => mount.mode !== 'overlay')) {
       builder.volume(mount.target, (volume) => {
         volume.bind(mount.source)
-        return mount.readOnly ? volume.readonly() : volume
+        return mount.mode === 'readonly' ? volume.readonly() : volume
       })
     }
     return builder
@@ -288,7 +307,7 @@ export class MicrosandboxManager {
     } finally {
       await (await this.options.sdk.Sandbox.get(name)).destroy({ timeoutMs: STOP_TIMEOUT_MS })
       await sandbox.detach()
-      await this.removeDockerVolume(`${name}-docker`)
+      await this.removeVolume(`${name}-docker`)
     }
   }
 
@@ -323,7 +342,7 @@ export class MicrosandboxManager {
     }
   }
 
-  private async removeDockerVolume(name: string): Promise<void> {
+  private async removeVolume(name: string): Promise<void> {
     try {
       await this.retryDiskOperation(() => this.options.sdk.Volume.remove(name))
     } catch (error) {
@@ -362,7 +381,8 @@ export class MicrosandboxManager {
         typeof binding.spec !== 'string' ||
         typeof binding.sandboxId !== 'string' ||
         typeof binding.configHash !== 'string' ||
-        (binding.dockerVolume !== undefined && binding.dockerVolume !== `${this.name(id)}-docker`)
+        (binding.dockerVolume !== undefined && binding.dockerVolume !== `${this.name(id)}-docker`) ||
+        (binding.overlayVolume !== undefined && binding.overlayVolume !== `${this.name(id)}-overlays`)
       ) {
         throw new Error('invalid binding')
       }
@@ -396,7 +416,10 @@ export class MicrosandboxManager {
             this.spec(
               {
                 ...environment,
-                mounts: [...environment.mounts, { source, target: '/opt/agentconnect-local/guest.js', readOnly: true }]
+                mounts: [
+                  ...environment.mounts,
+                  { source, target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }
+                ]
               },
               image
             )
@@ -418,6 +441,7 @@ export class MicrosandboxManager {
       }
       const sandbox = await this.retryDiskOperation(() => existing.connectOrStart({ detached: true }))
       try {
+        await prepareOverlayMounts(sandbox, environment.mounts)
         await this.startBridge(environment.id, sandbox)
         return sandbox
       } catch (error) {
@@ -438,7 +462,8 @@ export class MicrosandboxManager {
         spec,
         sandboxId: persisted.id,
         configHash: hash(stableJson(persisted.config())),
-        dockerVolume: `${name}-docker`
+        dockerVolume: `${name}-docker`,
+        ...(overlayMounts(environment.mounts).length ? { overlayVolume: `${name}-overlays` } : {})
       }
       const path = this.bindingPath(environment.id)
       await mkdir(dirname(path), { recursive: true, mode: 0o700 })
@@ -449,12 +474,14 @@ export class MicrosandboxManager {
       } finally {
         await rm(temporary, { force: true })
       }
+      await prepareOverlayMounts(sandbox, environment.mounts)
       await this.startBridge(environment.id, sandbox)
       return sandbox
     } catch (error) {
       await sandbox.destroy({ timeoutMs: STOP_TIMEOUT_MS })
       await sandbox.detach()
-      await this.removeDockerVolume(`${name}-docker`)
+      await this.removeVolume(`${name}-docker`)
+      if (overlayMounts(environment.mounts).length) await this.removeVolume(`${name}-overlays`)
       await rm(this.bindingPath(environment.id), { force: true })
       throw error
     }
@@ -679,7 +706,11 @@ export class MicrosandboxManager {
         }
         if (state) await (await state.sandbox).detach()
         this.environments.delete(id)
-        if (remove && binding?.dockerVolume) await this.removeDockerVolume(binding.dockerVolume)
+        if (remove) {
+          for (const volume of [binding?.dockerVolume, binding?.overlayVolume]) {
+            if (volume) await this.removeVolume(volume)
+          }
+        }
         if (remove) await rm(this.bindingPath(id), { force: true })
       } finally {
         if (state) state.closing = undefined

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -18,6 +18,7 @@ import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../run
 import { prepareRuntimeHome, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
 import { SESSIONS_DIR } from '../workspace/session-layout.js'
 import { MICROSANDBOX_SOCKET_BRIDGES, MICROSANDBOX_TUNNEL_PATHS } from './socket-bridge.js'
+import { OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT } from './overlay.js'
 
 const IMAGE_PATH = '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 const HOST_IPC_ENV = [
@@ -124,13 +125,13 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
     const source = scopePath(nativeMemory.readRoot(join(scopeDir, 'home')))
     const target = scopePath(nativeMemory.readRoot(runtimeHome))
     for (const path of [source, target]) mkdirSync(path, { recursive: true, mode: 0o700 })
-    memoryMounts.push({ source, target, readOnly: false })
+    memoryMounts.push({ source, target, mode: 'writable' })
   }
   const automatic: SandboxMount[] = [
     ...compactReadRoots([...configDirs, ...readRoots].map(automaticSource))
       .filter((path) => !writeRoots.some((write) => contains(write, path)))
-      .map((source) => ({ source, target: source, readOnly: true })),
-    ...writeRoots.map((source) => ({ source, target: source, readOnly: false })),
+      .map((source) => ({ source, target: source, mode: 'readonly' as const })),
+    ...writeRoots.map((source) => ({ source, target: source, mode: 'writable' as const })),
     ...normalizeSandboxMounts([...(opts.trustedMounts ?? []), ...memoryMounts], hostEnv, 'microsandbox').map(
       (mount) => ({
         ...mount,
@@ -138,16 +139,26 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
       })
     )
   ]
-  const configured = normalizeSandboxMounts(opts.mounts, hostEnv, 'microsandbox')
+  const configured = normalizeSandboxMounts(opts.mounts, hostEnv, 'microsandbox', runtimeHome)
   const ownedTargets = [
     '/run',
     '/var/run',
     '/var/lib/docker',
+    OVERLAY_BASE_ROOT,
+    OVERLAY_STATE_ROOT,
+    join(runtimeHome, '.run'),
     ...automatic.map((mount) => mount.target),
     ...MICROSANDBOX_SOCKET_BRIDGES.map((bridge) => bridge.path)
   ]
   for (const mount of configured) {
-    if (ownedTargets.some((target) => contains(mount.target, target) || contains(target, mount.target))) {
+    const withinHome = mount.target !== runtimeHome && contains(runtimeHome, mount.target)
+    if (
+      ownedTargets.some(
+        (target) =>
+          contains(mount.target, target) ||
+          (contains(target, mount.target) && !(withinHome && contains(target, runtimeHome)))
+      )
+    ) {
       throw new Error(`sandbox.mounts target overlaps an automatic microsandbox mount: ${mount.target}`)
     }
   }
@@ -181,19 +192,22 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   const claudeSettings = claudeRuntime ? prepareClaudeProtectedSettings(scopeDir, env) : undefined
-  const privateState = (
+  const privateStateTargets =
     credentialProfile === 'codex'
       ? [join(runtimeHome, '.codex')]
       : claudeRuntime
         ? [join(runtimeHome, '.claude'), join(runtimeHome, '.claude.json')]
         : []
-  )
-    .filter(existsSync)
-    .map((path) => realpathSync(path))
+  const privateState = privateStateTargets.filter(existsSync).map((path) => realpathSync(path))
   const credentialSources = [...(credentials?.writablePaths ?? []), ...privateState].map((path) =>
     existsSync(path) ? realpathSync(path) : path
   )
   const providerFiles = claudeSettings ? claudeProviderCredentialFiles(env, opts.cwd).map(({ path }) => path) : []
+  for (const { target } of configured) {
+    if ([...privateStateTargets, ...providerFiles].some((path) => contains(path, target) || contains(target, path))) {
+      throw new Error(`sandbox.mounts target overlaps protected runtime state: ${target}`)
+    }
+  }
   for (const path of providerFiles) {
     const mount = mounts
       .filter(({ target }) => contains(target, path))
@@ -210,10 +224,12 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
     )
   ])
   const sharedWriteRoots = configured
-    .filter(({ readOnly, target }) => !readOnly && !protectedCredentialRoots.some((root) => contains(root, target)))
+    .filter(
+      ({ mode, target }) => mode !== 'readonly' && !protectedCredentialRoots.some((root) => contains(root, target))
+    )
     .map(({ target }) => target)
   const gitMetadataWriteRoots = runtimeGitMetadataRoots(scopeDir, opts.trustedPrimaryCheckout, sessionDir).filter(
-    (path) => mounts.some(({ target, readOnly }) => !readOnly && contains(target, path))
+    (path) => mounts.some(({ target, mode }) => mode !== 'readonly' && contains(target, path))
   )
   if (credentialProfile === 'codex') {
     applyCodexPermissionProfile(env, {

--- a/packages/daemon/src/microsandbox/overlay.ts
+++ b/packages/daemon/src/microsandbox/overlay.ts
@@ -1,0 +1,82 @@
+import { createHash } from 'node:crypto'
+import type { Sandbox } from 'microsandbox'
+import { z } from 'zod'
+import type { SandboxMount } from '../config/config-schema.js'
+
+export const OVERLAY_BASE_ROOT = '/opt/agentconnect-overlay-base'
+export const OVERLAY_STATE_ROOT = '/var/lib/agentconnect-overlay'
+
+export function overlayMounts(mounts: readonly SandboxMount[]) {
+  return mounts
+    .filter((mount) => mount.mode === 'overlay')
+    .sort((a, b) => a.target.localeCompare(b.target))
+    .map((mount) => ({ ...mount, key: createHash('sha256').update(mount.target).digest('hex').slice(0, 24) }))
+}
+
+const ConfigSchema = z.object({ runtime: z.object({ user: z.string().nullish() }) })
+
+// Run once per VM boot, before any session process; only the ext4 write layer survives suspension.
+const MOUNT_SCRIPT = `
+import grp, json, os, pwd, subprocess, sys
+config = json.loads(sys.argv[1])
+user, _, group = config['user'].partition(':')
+account = pwd.getpwuid(int(user)) if user.isdigit() else pwd.getpwnam(user)
+uid = account.pw_uid
+gid = (int(group) if group.isdigit() else grp.getgrnam(group).gr_gid) if group else account.pw_gid
+
+def directory(path, owner=None):
+    fd = os.open('/', os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for part in path.strip('/').split('/'):
+            if part in ('', '.', '..'):
+                raise ValueError('invalid overlay directory')
+            created = False
+            try:
+                os.mkdir(part, 0o755, dir_fd=fd)
+                created = True
+            except FileExistsError:
+                pass
+            child = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = child
+            if created and owner:
+                os.fchown(fd, *owner)
+        return fd
+    except:
+        os.close(fd)
+        raise
+
+state = directory(config['state'])
+os.fchmod(state, 0o700)
+os.close(state)
+for mount in config['mounts']:
+    upper = config['state'] + '/' + mount['key'] + '/upper'
+    work = config['state'] + '/' + mount['key'] + '/work'
+    for path in (upper, work):
+        fd = directory(path)
+        if path == upper:
+            os.fchown(fd, uid, gid)
+        os.close(fd)
+    target = directory(mount['target'], (uid, gid))
+    try:
+        options = 'lowerdir=' + config['base'] + '/' + mount['key'] + ',upperdir=' + upper + ',workdir=' + work
+        result = subprocess.run(['/usr/bin/mount', '--no-canonicalize', '-t', 'overlay', 'overlay', '-o', options, '/proc/self/fd/' + str(target)], pass_fds=(target,), capture_output=True, text=True)
+        if result.returncode:
+            raise RuntimeError('overlay mount failed: ' + result.stderr.strip())
+    finally:
+        os.close(target)
+`
+
+export async function prepareOverlayMounts(sandbox: Sandbox, mounts: readonly SandboxMount[]): Promise<void> {
+  const overlays = overlayMounts(mounts)
+  if (!overlays.length) return
+  const { runtime } = ConfigSchema.parse(await sandbox.config())
+  const config = { mounts: overlays, user: runtime.user ?? 'root', base: OVERLAY_BASE_ROOT, state: OVERLAY_STATE_ROOT }
+  const result = await sandbox.execWith('/usr/bin/python3', (exec) =>
+    exec
+      .user('root')
+      .args(['-I', '-c', MOUNT_SCRIPT, JSON.stringify(config)])
+      .timeout(30_000)
+  )
+  if (!result.success) throw new Error(`microsandbox overlay setup failed: ${result.stderr().trim()}`)
+}

--- a/packages/daemon/src/microsandbox/support.ts
+++ b/packages/daemon/src/microsandbox/support.ts
@@ -15,9 +15,9 @@ export function microsandboxSupportMounts(root: string, sessionGitConfigPath?: s
   }
   chmodSync(source, 0o755)
   return [
-    { source, target: gitcredShimPath(root), readOnly: true },
+    { source, target: gitcredShimPath(root), mode: 'readonly' },
     ...(sessionGitConfigPath && existsSync(sessionGitConfigPath)
-      ? [{ source: sessionGitConfigPath, target: sessionGitConfigPath, readOnly: true }]
+      ? [{ source: sessionGitConfigPath, target: sessionGitConfigPath, mode: 'readonly' as const }]
       : [])
   ]
 }

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -47,11 +47,16 @@ function existingRoot(path: string, env: NodeJS.ProcessEnv, label = 'trusted run
   return realpathSync(expanded)
 }
 
-function guestMountTarget(path: string): string {
-  if (!posix.isAbsolute(path) || path.includes('\0')) {
-    throw new Error(`sandbox.mounts target must be an absolute POSIX guest path: ${path}`)
+function guestMountTarget(path: string, home?: string): string {
+  const relativeHome = path === '~' || path.startsWith('~/')
+  const normalized = posix.normalize(path)
+  if (
+    path.includes('\0') ||
+    (relativeHome ? normalized !== '~' && !normalized.startsWith('~/') : !posix.isAbsolute(path))
+  ) {
+    throw new Error(`sandbox.mounts target must be an absolute POSIX guest path or stay within ~/: ${path}`)
   }
-  const target = posix.normalize(path).replace(/\/$/, '')
+  const target = (relativeHome && home ? posix.join(home, normalized.slice(2)) : normalized).replace(/\/$/, '')
   if (!target) throw new Error('sandbox.mounts target must not be the guest root')
   return target
 }
@@ -60,13 +65,19 @@ function guestMountTarget(path: string): string {
 export function normalizeSandboxMounts(
   mounts: readonly SandboxMount[],
   env: NodeJS.ProcessEnv = process.env,
-  backend: SandboxBackend = 'srt'
+  backend: SandboxBackend = 'srt',
+  guestHome?: string
 ): SandboxMount[] {
   const normalized = new Map<string, SandboxMount>()
   for (const mount of mounts) {
     const source = existingRoot(mount.source, env, 'sandbox.mounts source')
     const target =
-      backend === 'srt' ? existingRoot(mount.target, env, 'sandbox.mounts target') : guestMountTarget(mount.target)
+      backend === 'srt'
+        ? existingRoot(mount.target, env, 'sandbox.mounts target')
+        : guestMountTarget(mount.target, guestHome)
+    if (backend !== 'microsandbox' && mount.mode === 'overlay') {
+      throw new Error('sandbox.mounts mode=overlay requires microsandbox')
+    }
     if (backend === 'srt' && source !== target) {
       throw new Error('sandbox.mounts requires source and target to be the same path for srt')
     }
@@ -75,14 +86,33 @@ export function normalizeSandboxMounts(
       if (!stat.isFile() && !stat.isDirectory()) {
         throw new Error(`sandbox.mounts source must be a file or directory for microsandbox: ${source}`)
       }
+      if (mount.mode === 'overlay' && !stat.isDirectory()) {
+        throw new Error(`sandbox.mounts overlay source must be a directory: ${source}`)
+      }
     }
     const previous = normalized.get(target)
     if (previous && previous.source !== source) {
       throw new Error(`sandbox.mounts cannot map different sources to the same target: ${target}`)
     }
-    normalized.set(target, { source, target, readOnly: mount.readOnly && (previous?.readOnly ?? true) })
+    if (previous && previous.mode !== mount.mode && [previous.mode, mount.mode].includes('overlay')) {
+      throw new Error(`sandbox.mounts cannot combine overlay and bind modes at the same target: ${target}`)
+    }
+    const mode = previous?.mode === 'writable' ? previous.mode : mount.mode
+    normalized.set(target, { source, target, mode })
   }
-  return [...normalized.values()]
+  const result = [...normalized.values()]
+  for (const mount of result.filter((mount) => mount.mode === 'overlay')) {
+    if (
+      result.some(
+        (other) =>
+          other !== mount &&
+          (other.target.startsWith(`${mount.target}/`) || mount.target.startsWith(`${other.target}/`))
+      )
+    ) {
+      throw new Error(`sandbox.mounts overlay targets must not overlap other configured mounts: ${mount.target}`)
+    }
+  }
+  return result
 }
 
 /** Resolve the existing prefix too, so a missing socket/file below a symlink is

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -299,7 +299,7 @@ describe('runChat', () => {
     expect(hostFactory).not.toHaveBeenCalled()
   })
 
-  it.each([true, false])('rejects a missing mount before creating any host (readOnly=%s)', async (readOnly) => {
+  it.each(['readonly', 'writable'])('rejects a missing mount before creating any host (mode=%s)', async (mode) => {
     const files = scaffold()
     const source = join(files.root, 'no-such-mount')
     writeFileSync(
@@ -308,7 +308,7 @@ describe('runChat', () => {
         version: 1,
         controlPlane: { enabled: false },
         runtimes: { fake: { command: process.execPath, args: [fakeAgent], env: [] } },
-        sandbox: { mounts: [{ source, target: source, readOnly }] }
+        sandbox: { mounts: [{ source, target: source, mode }] }
       })
     )
     const hostFactory = vi.fn()

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -91,8 +91,14 @@ describe('loadConfig', () => {
     })
     expect(cfg.sandbox).toEqual({
       backend: 'srt',
-      mounts: [{ source: '/opt/toolchain', target: '/opt/toolchain', readOnly: true }]
+      mounts: [{ source: '/opt/toolchain', target: '/opt/toolchain', mode: 'readonly' }]
     })
+    expect(() =>
+      ConfigSchema.parse({
+        version: 1,
+        sandbox: { mounts: [{ source: '/opt/toolchain', target: '/opt/toolchain', readOnly: true }] }
+      })
+    ).toThrow()
   })
 
   it('rejects an unimplemented sandbox backend', () => {

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -59,7 +59,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     config.sandbox = {
       mounts: [
         { source: toolchain, target: toolchain },
-        { source: cache, target: cache, readOnly: false }
+        { source: cache, target: cache, mode: 'writable' }
       ]
     }
     writeFileSync(join(root, 'config.json'), JSON.stringify(config))
@@ -108,7 +108,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     ).rejects.toThrow(/daemon startup refused.*requireSandbox.*no supported Linux SRT\/bwrap/)
   })
 
-  it.each([true, false])('refuses daemon startup for a missing mount (readOnly=%s)', async (readOnly) => {
+  it.each(['readonly', 'writable'])('refuses daemon startup for a missing mount (mode=%s)', async (mode) => {
     const root = scaffold()
     const source = join(root, 'no-such-mount')
     writeFileSync(
@@ -116,7 +116,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       JSON.stringify({
         version: 1,
         controlPlane: { enabled: false },
-        sandbox: { mounts: [{ source, target: source, readOnly }] }
+        sandbox: { mounts: [{ source, target: source, mode }] }
       })
     )
 

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -5,9 +5,14 @@ import { runInNewContext } from 'node:vm'
 import { decode, encode } from 'cborg'
 import type { ExecEvent } from 'microsandbox'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { MicrosandboxManager, type MicrosandboxManagerOptions } from '../src/microsandbox/driver.js'
+import {
+  MicrosandboxManager,
+  type MicrosandboxEnvironment,
+  type MicrosandboxManagerOptions
+} from '../src/microsandbox/driver.js'
 import { MICROSANDBOX_NODE } from '../src/microsandbox/exec.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../src/shim/sandbox-paths.js'
+import { OVERLAY_BASE_ROOT } from '../src/microsandbox/overlay.js'
 
 class FakeExec {
   private readonly queue: Array<ExecEvent | Error | undefined> = []
@@ -78,19 +83,25 @@ function fakeSdk() {
       sandboxes.delete(this.name)
     })
     readonly detach = vi.fn(async () => {
-      if (this.dockerVolume && volumes.has(this.dockerVolume)) volumes.get(this.dockerVolume)!.attached = false
+      for (const name of this.volumeNames) {
+        if (volumes.has(name)) volumes.get(name)!.attached = false
+      }
     })
 
     constructor(
       readonly name: string,
-      readonly dockerVolume?: string
+      readonly volumeNames: string[] = [],
+      readonly mounts: Array<{ source: string; target: string; readonly: boolean }> = []
     ) {}
+    get dockerVolume() {
+      return this.volumeNames.find((name) => name.endsWith('-docker'))
+    }
     config() {
       return this.spec
     }
     async startDetached() {
-      if (this.dockerVolume) {
-        const volume = volumes.get(this.dockerVolume)!
+      for (const name of this.volumeNames) {
+        const volume = volumes.get(name)!
         if (volume.attached) throw new Error('disk is still attached')
         volume.attached = true
       }
@@ -101,6 +112,12 @@ function fakeSdk() {
       return this.startDetached()
     }
     async ping() {}
+    readonly execWith = vi.fn(async (_command: string, configure: (exec: any) => unknown) => {
+      const exec = { user: vi.fn(() => exec), args: vi.fn(() => exec), timeout: vi.fn(() => exec) }
+      configure(exec)
+      expect(exec.user).toHaveBeenCalledWith('root')
+      return { success: true, code: 0, stderr: (): string => '' }
+    })
     readonly exec = vi.fn(async (command: string, args: string[]) => {
       expect(command).toBe(MICROSANDBOX_NODE)
       expect(args[0]).toBe('-e')
@@ -187,7 +204,8 @@ function fakeSdk() {
         return sandbox
       },
       builder(name: string) {
-        let dockerVolume: string | undefined
+        const volumeNames: string[] = []
+        const mounts: FakeSandbox['mounts'] = []
         let image = 'test-image'
         const builder = {
           image(value: string) {
@@ -215,25 +233,37 @@ function fakeSdk() {
           quietLogs() {
             return builder
           },
-          volume(target: string, configure: (volume: { namedWith: (name: string) => unknown }) => unknown) {
-            if (target === '/var/lib/docker')
-              configure({
-                namedWith(name) {
-                  dockerVolume = name
-                  return this
-                }
-              })
+          volume(target: string, configure: (volume: any) => unknown) {
+            let source: string | undefined
+            let readonly = false
+            const volume = {
+              namedWith(name: string) {
+                volumeNames.push(name)
+                return volume
+              },
+              tmpfs: () => volume,
+              bind(path: string) {
+                source = path
+                return volume
+              },
+              readonly() {
+                readonly = true
+                return volume
+              }
+            }
+            configure(volume)
+            if (source) mounts.push({ source, target, readonly })
             return builder
           },
           vsock() {
             return builder
           },
           async create() {
-            if (dockerVolume) {
-              if (volumes.has(dockerVolume)) throw new Error('volume already exists')
-              volumes.set(dockerVolume, { attached: true })
+            for (const name of volumeNames) {
+              if (volumes.has(name)) throw new Error('volume already exists')
+              volumes.set(name, { attached: true })
             }
-            const sandbox = new FakeSandbox(name, dockerVolume)
+            const sandbox = new FakeSandbox(name, volumeNames, mounts)
             sandbox.spec.image = image
             created.push(sandbox)
             sandboxes.set(name, sandbox)
@@ -279,6 +309,56 @@ async function fixture() {
 }
 
 describe('microsandbox process and VM ownership', () => {
+  it('shares read-only bases while retaining and cleaning up each session overlay disk', async () => {
+    const { manager, options, environment, request, created, volumes, removeVolume } = await fixture()
+    const first: MicrosandboxEnvironment = {
+      ...environment,
+      mounts: [{ source: '/shared/store', target: '/session/home/store', mode: 'overlay' }]
+    }
+    const second = { ...first, id: 'agent/second-session' }
+    for (const env of [first, second]) await (await manager.driverFor(env).launch(request)).stop(0)
+    expect(volumes.size).toBe(4)
+    for (const vm of created) {
+      expect(vm.mounts).toEqual([
+        { source: '/shared/store', target: expect.stringMatching(OVERLAY_BASE_ROOT), readonly: true }
+      ])
+      expect(vm.execWith).toHaveBeenCalledOnce()
+    }
+    await manager.stopAll()
+    const resumed = new MicrosandboxManager(options)
+    await (await resumed.driverFor(first).launch(request)).stop(0)
+    expect(created).toHaveLength(2)
+    expect(created[0]!.execWith).toHaveBeenCalledTimes(2)
+    const overlay = created[0]!.volumeNames.find((name) => name.endsWith('-overlays'))!
+    const originalRemove = removeVolume.getMockImplementation()!
+    removeVolume.mockImplementationOnce(originalRemove).mockRejectedValueOnce(new Error('volume busy'))
+    await expect(resumed.discard(first.id)).rejects.toThrow('volume busy')
+    expect(volumes.has(overlay)).toBe(true)
+    await resumed.discard(first.id)
+    await resumed.discard(second.id)
+    expect(volumes.size).toBe(0)
+    expect(await resumed.environmentIds()).toEqual([])
+  })
+
+  it('preserves a retained overlay disk when remounting fails and retries on the next resume', async () => {
+    const { manager, options, environment, request, created, volumes } = await fixture()
+    const env: MicrosandboxEnvironment = {
+      ...environment,
+      mounts: [{ source: '/shared/store', target: '/cache/store', mode: 'overlay' }]
+    }
+    await (await manager.driverFor(env).launch(request)).stop(0)
+    await manager.stopAll()
+    const vm = created[0]!
+    vm.execWith.mockResolvedValueOnce({ success: false, code: 1, stderr: () => 'mount failed' })
+    const resumed = new MicrosandboxManager(options)
+    await expect(resumed.driverFor(env).launch(request)).rejects.toThrow('overlay setup failed')
+    expect(vm.status).toBe('stopped')
+    expect(volumes.size).toBe(2)
+    await (await resumed.driverFor(env).launch(request)).stop(0)
+    await resumed.discard(env.id)
+    expect(volumes.size).toBe(0)
+  })
+
   it('prepares only layered image artifacts without stopping an existing VM', async () => {
     const { manager, options, environment, request, created } = await fixture()
     const runtime = await manager.driverFor(environment).launch(request)
@@ -498,7 +578,7 @@ describe('microsandbox process and VM ownership', () => {
     const resumed = new MicrosandboxManager(upgraded)
     await expect(
       resumed
-        .driverFor({ ...environment, mounts: [{ source: '/extra', target: '/extra', readOnly: true }] })
+        .driverFor({ ...environment, mounts: [{ source: '/extra', target: '/extra', mode: 'readonly' }] })
         .launch(request)
     ).rejects.toThrow('changed persisted configuration')
     await (await resumed.driverFor(environment).launch(request)).stop(0)
@@ -523,9 +603,9 @@ describe('microsandbox process and VM ownership', () => {
     await mkdir(helpers, { recursive: true })
     const helper = join(helpers, 'guest.js')
     await writeFile(helper, 'export {}')
-    const legacy = {
+    const legacy: MicrosandboxEnvironment = {
       ...environment,
-      mounts: [{ source: await realpath(helper), target: '/opt/agentconnect-local/guest.js', readOnly: true }]
+      mounts: [{ source: await realpath(helper), target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }]
     }
     const runtime = await manager.driverFor(legacy).launch(request)
     await runtime.stop(0)
@@ -538,7 +618,7 @@ describe('microsandbox process and VM ownership', () => {
       resumed
         .driverFor({
           ...environment,
-          mounts: [{ source: '/workspace-other', target: '/workspace-other', readOnly: false }]
+          mounts: [{ source: '/workspace-other', target: '/workspace-other', mode: 'writable' }]
         })
         .launch(request)
     ).rejects.toThrow('changed persisted configuration')

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -103,17 +103,17 @@ describe('prepareMicrosandboxLaunch', () => {
         TESTCONTAINERS_HOST_OVERRIDE: 'host-docker.example.test'
       },
       trustedRuntimeReadRoots: [tool, missing],
-      mounts: [{ source: tool, target: '/tools/tool.js', readOnly: true }]
+      mounts: [{ source: tool, target: '/tools/tool.js', mode: 'readonly' }]
     })
     expect(launch.inheritProcessEnv).toBe(false)
     expect(launch.sandbox).toBeUndefined()
     expect(launch.microsandbox.workspaceRoot).toBe(opts.scopeDir)
     expect(launch.microsandbox.mounts).toEqual(
       expect.arrayContaining([
-        { source: opts.cwd, target: opts.cwd, readOnly: false },
-        { source: join(opts.scopeDir, 'home'), target: join(opts.scopeDir, 'home'), readOnly: false },
-        { source: tool, target: tool, readOnly: true },
-        { source: tool, target: '/tools/tool.js', readOnly: true }
+        { source: opts.cwd, target: opts.cwd, mode: 'writable' },
+        { source: join(opts.scopeDir, 'home'), target: join(opts.scopeDir, 'home'), mode: 'writable' },
+        { source: tool, target: tool, mode: 'readonly' },
+        { source: tool, target: '/tools/tool.js', mode: 'readonly' }
       ])
     )
     expect(launch.microsandbox.mounts.some((mount) => mount.source === opts.scopeDir)).toBe(false)
@@ -146,7 +146,7 @@ describe('prepareMicrosandboxLaunch', () => {
     expect(explicit.microsandbox.mounts).toContainEqual({
       source: join(opts.scopeDir, 'run', 'config-files'),
       target: join(opts.scopeDir, 'run', 'config-files'),
-      readOnly: true
+      mode: 'readonly'
     })
   })
 
@@ -175,7 +175,7 @@ describe('prepareMicrosandboxLaunch', () => {
     mkdirSync(other)
     const launch = prepareMicrosandboxLaunch({ ...opts, cwd, trustedSessionDir: sessionDir })
     expect(launch.runtimeHome).toBe(join(sessionDir, 'home'))
-    expect(launch.microsandbox.mounts).toContainEqual({ source: sessionDir, target: sessionDir, readOnly: false })
+    expect(launch.microsandbox.mounts).toContainEqual({ source: sessionDir, target: sessionDir, mode: 'writable' })
     expect(
       launch.microsandbox.mounts.some((mount) => other === mount.target || other.startsWith(mount.target + '/'))
     ).toBe(false)
@@ -198,7 +198,7 @@ describe('prepareMicrosandboxLaunch', () => {
     const launch = prepareMicrosandboxLaunch({ ...opts, cwd, hostKey })
     const home = join(opts.scopeDir, 'runtime-homes', hostKeyDirName(hostKey), 'home')
     expect(launch.runtimeHome).toBe(home)
-    expect(launch.microsandbox.mounts).toContainEqual({ source: home, target: home, readOnly: false })
+    expect(launch.microsandbox.mounts).toContainEqual({ source: home, target: home, mode: 'writable' })
     expect(launch.microsandbox.mounts.some((mount) => mount.source === dirname(home))).toBe(false)
     expect(existsSync(join(opts.scopeDir, 'sessions'))).toBe(false)
   })
@@ -209,7 +209,7 @@ describe('prepareMicrosandboxLaunch', () => {
     const second = prepareMicrosandboxLaunch({ ...opts, hostKey: sessionHostKey('agent', 'second') })
     expect(first.runtimeHome).not.toBe(second.runtimeHome)
     for (const launch of [first, second]) {
-      expect(launch.microsandbox.mounts).toContainEqual({ source: opts.cwd, target: opts.cwd, readOnly: false })
+      expect(launch.microsandbox.mounts).toContainEqual({ source: opts.cwd, target: opts.cwd, mode: 'writable' })
     }
     expect(first.microsandbox.mounts.some(({ target }) => target === second.runtimeHome)).toBe(false)
     expect(existsSync(join(opts.scopeDir, 'sessions'))).toBe(false)
@@ -234,7 +234,7 @@ describe('prepareMicrosandboxLaunch', () => {
           microsandbox: { mounts: [] }
         })
         const mounts = launch.microsandbox!.mounts
-        expect(mounts).toContainEqual({ source, target: memory.readRoot(launch.runtimeHome!), readOnly: false })
+        expect(mounts).toContainEqual({ source, target: memory.readRoot(launch.runtimeHome!), mode: 'writable' })
         expect(mounts.some((mount) => mount.source === agentHome)).toBe(false)
         expect(mounts.some((mount) => mount.source === join(agentHome, '.codex'))).toBe(false)
         writeFileSync(join(source, 'MEMORY.md'), session)
@@ -262,9 +262,9 @@ describe('prepareMicrosandboxLaunch', () => {
     const launch = prepareMicrosandboxLaunch({ ...opts, trustedMounts })
     expect(launch.microsandbox.mounts).toEqual(
       expect.arrayContaining([
-        { source: opts.cwd, target: opts.cwd, readOnly: false },
-        { source: gitConfig, target: gitConfig, readOnly: true },
-        { source: trustedMounts[0]!.source, target: helper, readOnly: true }
+        { source: opts.cwd, target: opts.cwd, mode: 'writable' },
+        { source: gitConfig, target: gitConfig, mode: 'readonly' },
+        { source: trustedMounts[0]!.source, target: helper, mode: 'readonly' }
       ])
     )
     for (const target of [helper, dirname(helper), gitConfig]) {
@@ -272,7 +272,7 @@ describe('prepareMicrosandboxLaunch', () => {
         prepareMicrosandboxLaunch({
           ...opts,
           trustedMounts,
-          mounts: [{ source: opts.hostHome, target, readOnly: false }]
+          mounts: [{ source: opts.hostHome, target, mode: 'writable' }]
         })
       ).toThrow('overlaps an automatic')
     }
@@ -282,7 +282,8 @@ describe('prepareMicrosandboxLaunch', () => {
     const opts = fixture()
     for (const target of [
       opts.scopeDir,
-      join(opts.scopeDir, 'home', 'replacement'),
+      join(opts.scopeDir, 'home'),
+      join(opts.scopeDir, 'home', '.run', 'replacement'),
       '/run',
       '/var/run',
       '/run/docker',
@@ -292,7 +293,7 @@ describe('prepareMicrosandboxLaunch', () => {
       '/tmp'
     ]) {
       expect(() =>
-        prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: opts.hostHome, target, readOnly: false }] })
+        prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: opts.hostHome, target, mode: 'writable' }] })
       ).toThrow('overlaps an automatic')
     }
     expect(() => prepareMicrosandboxLaunch({ ...opts, trustedRuntimeReadRoots: [opts.scopeDir] })).toThrow(
@@ -304,6 +305,35 @@ describe('prepareMicrosandboxLaunch', () => {
         runtime: { command: 'external', args: [], env: [], externalExecution: true }
       })
     ).toThrow('outside the microsandbox VM')
+  })
+
+  it('mounts a shared base inside each session HOME with private writes and protected runtime state', () => {
+    const opts = fixture()
+    opts.runtimeId = 'codex-acp'
+    const source = join(opts.root, 'shared-store')
+    mkdirSync(source)
+    for (const leaf of ['session-one', 'session-two']) {
+      const session = join(opts.scopeDir, 'sessions', leaf)
+      const cwd = join(session, 'workspace')
+      mkdirSync(cwd, { recursive: true })
+      const launch = prepareMicrosandboxLaunch({
+        ...opts,
+        cwd,
+        trustedSessionDir: session,
+        mounts: [{ source, target: '~/.local/share/pnpm/store', mode: 'overlay' }]
+      })
+      const target = join(session, 'home', '.local/share/pnpm/store')
+      expect(launch.microsandbox.mounts).toContainEqual({ source, target, mode: 'overlay' })
+      expect(launch.toolSandbox?.sharedWriteRoots).toContain(target)
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          cwd,
+          trustedSessionDir: session,
+          mounts: [{ source, target: '~/.codex', mode: 'overlay' }]
+        })
+      ).toThrow('protected runtime state')
+    }
   })
 
   it('reuses the native Codex auth-file link and exposes only the shared credential file', () => {
@@ -318,7 +348,7 @@ describe('prepareMicrosandboxLaunch', () => {
     )
     const launch = prepareMicrosandboxLaunch({ ...opts, runtimeId: 'codex-acp' })
     expect(readlinkSync(join(launch.runtimeHome!, '.codex', 'auth.json'))).toBe(auth)
-    expect(launch.microsandbox.mounts).toContainEqual({ source: auth, target: auth, readOnly: false })
+    expect(launch.microsandbox.mounts).toContainEqual({ source: auth, target: auth, mode: 'writable' })
     expect(
       launch.microsandbox.mounts.some((mount) => mount.source === hostCodex || mount.source === opts.hostHome)
     ).toBe(false)
@@ -353,11 +383,11 @@ describe('prepareMicrosandboxLaunch', () => {
       allowModelToolUnixSockets: true,
       explicitEnv: { CODEX_CONFIG: JSON.stringify({ 'permissions.untrusted': {}, model: 'test-model' }) },
       mounts: [
-        { source: cache, target: '/shared/cache', readOnly: false },
-        { source: opts.hostHome, target: '/credential-copy', readOnly: false },
-        { source: auth, target: '/credential-file', readOnly: true },
-        { source: hostCodex, target: '/credential-dir', readOnly: false },
-        { source: auth, target: '/credential-dir/auth.json', readOnly: false }
+        { source: cache, target: '/shared/cache', mode: 'writable' },
+        { source: opts.hostHome, target: '/credential-copy', mode: 'writable' },
+        { source: auth, target: '/credential-file', mode: 'readonly' },
+        { source: hostCodex, target: '/credential-dir', mode: 'writable' },
+        { source: auth, target: '/credential-dir/auth.json', mode: 'writable' }
       ]
     })
     expect(JSON.parse(launch.env.CODEX_CONFIG!)).toEqual({ model: 'test-model' })
@@ -395,7 +425,7 @@ describe('prepareMicrosandboxLaunch', () => {
       runtimeId: 'claude-acp',
       runtime: { command: 'claude-agent-acp', args: [], env: [] },
       explicitEnv: { ANTHROPIC_CONFIG_DIR: '/untrusted-profile', ANTHROPIC_PROFILE: 'untrusted' },
-      mounts: [{ source: config, target: '/credential-copy', readOnly: false }]
+      mounts: [{ source: config, target: '/credential-copy', mode: 'writable' }]
     })
     expect(launch.sandbox).toBeUndefined()
     const profileRoot = join(opts.scopeDir, '.agentconnect', 'runtime-policy', 'claude-profile-disabled')
@@ -409,11 +439,11 @@ describe('prepareMicrosandboxLaunch', () => {
       expect.arrayContaining([config, join(launch.runtimeHome!, '.claude'), '/credential-copy'])
     )
     expect(launch.toolSandbox?.sharedWriteRoots).toBeUndefined()
-    expect(launch.microsandbox.mounts).toContainEqual({ source: config, target: config, readOnly: false })
+    expect(launch.microsandbox.mounts).toContainEqual({ source: config, target: config, mode: 'writable' })
     expect(launch.microsandbox.mounts).toContainEqual({
       source: join(opts.scopeDir, '.agentconnect', 'runtime-policy'),
       target: join(opts.scopeDir, '.agentconnect', 'runtime-policy'),
-      readOnly: true
+      mode: 'readonly'
     })
   })
 

--- a/packages/daemon/test/read-roots.test.ts
+++ b/packages/daemon/test/read-roots.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import type { SandboxMount } from '../src/config/config-schema.js'
 import {
   resolveTrustedExecutable,
   normalizeSandboxMounts,
@@ -56,8 +57,8 @@ describe('trusted runtime read roots', () => {
 
     const mounts = normalizeSandboxMounts(
       [
-        { source: '~/.rustup/toolchains/stable/bin', target: toolchain, readOnly: true },
-        { source: nodeInstall, target: nodeInstall, readOnly: true }
+        { source: '~/.rustup/toolchains/stable/bin', target: toolchain, mode: 'readonly' },
+        { source: nodeInstall, target: nodeInstall, mode: 'readonly' }
       ],
       { HOME: home }
     )
@@ -91,14 +92,14 @@ describe('trusted runtime read roots', () => {
     mkdirSync(store, { recursive: true })
     symlinkSync(store, alias, 'junction')
 
-    const mounts = [
-      { source: '~/toolchain', target: toolchain, readOnly: true },
-      { source: alias, target: store, readOnly: true },
-      { source: store, target: alias, readOnly: false }
+    const mounts: SandboxMount[] = [
+      { source: '~/toolchain', target: toolchain, mode: 'readonly' },
+      { source: alias, target: store, mode: 'readonly' },
+      { source: store, target: alias, mode: 'writable' }
     ]
     const expected = [
-      { source: realpathSync(toolchain), target: realpathSync(toolchain), readOnly: true },
-      { source: realpathSync(store), target: realpathSync(store), readOnly: false }
+      { source: realpathSync(toolchain), target: realpathSync(toolchain), mode: 'readonly' },
+      { source: realpathSync(store), target: realpathSync(store), mode: 'writable' }
     ]
     for (const entries of [mounts, [...mounts].reverse()]) {
       const normalized = normalizeSandboxMounts(entries, { HOME: home })
@@ -112,9 +113,9 @@ describe('trusted runtime read roots', () => {
     temporaryRoots.push(root)
     const file = join(root, 'toolchain.conf')
     writeFileSync(file, 'test configuration')
-    const mount = { source: file, target: file, readOnly: true }
+    const mount: SandboxMount = { source: file, target: file, mode: 'readonly' }
     expect(normalizeSandboxMounts([mount])).toEqual([
-      { source: realpathSync(file), target: realpathSync(file), readOnly: true }
+      { source: realpathSync(file), target: realpathSync(file), mode: 'readonly' }
     ])
     expect(() => normalizeSandboxMounts([{ ...mount, source: join(root, 'missing') }])).toThrow(
       /sandbox\.mounts source does not exist/
@@ -136,16 +137,16 @@ describe('trusted runtime read roots', () => {
     const alias = join(root, 'store-link')
     mkdirSync(nested, { recursive: true })
     symlinkSync(store, alias, 'junction')
-    const mounts = [
-      { source: '~/store-link', target: '/cache/../cache/store/', readOnly: true },
-      { source: store, target: '/cache/store', readOnly: false },
-      { source: nested, target: '/cache/store/nested', readOnly: true },
-      { source: store, target: '/other-cache', readOnly: true }
+    const mounts: SandboxMount[] = [
+      { source: '~/store-link', target: '/cache/../cache/store/', mode: 'readonly' },
+      { source: store, target: '/cache/store', mode: 'writable' },
+      { source: nested, target: '/cache/store/nested', mode: 'readonly' },
+      { source: store, target: '/other-cache', mode: 'readonly' }
     ]
     const expected = [
-      { source: realpathSync(store), target: '/cache/store', readOnly: false },
-      { source: realpathSync(nested), target: '/cache/store/nested', readOnly: true },
-      { source: realpathSync(store), target: '/other-cache', readOnly: true }
+      { source: realpathSync(store), target: '/cache/store', mode: 'writable' },
+      { source: realpathSync(nested), target: '/cache/store/nested', mode: 'readonly' },
+      { source: realpathSync(store), target: '/other-cache', mode: 'readonly' }
     ]
     for (const entries of [mounts, [...mounts].reverse()]) {
       const normalized = normalizeSandboxMounts(entries, { HOME: root }, 'microsandbox')
@@ -154,7 +155,7 @@ describe('trusted runtime read roots', () => {
     }
     expect(() =>
       normalizeSandboxMounts(
-        [...mounts, { source: nested, target: '/cache/store/', readOnly: false }],
+        [...mounts, { source: nested, target: '/cache/store/', mode: 'writable' }],
         { HOME: root },
         'microsandbox'
       )
@@ -167,15 +168,37 @@ describe('trusted runtime read roots', () => {
     const file = join(root, 'config')
     writeFileSync(file, 'configuration')
     const normalize = (source: string, target = '/cache') =>
-      normalizeSandboxMounts([{ source, target, readOnly: true }], {}, 'microsandbox')
+      normalizeSandboxMounts([{ source, target, mode: 'readonly' }], {}, 'microsandbox')
     expect(() => normalize(join(root, 'missing'))).toThrow(/source does not exist/)
     expect(() => normalize('relative/source')).toThrow(/source must be absolute/)
-    expect(normalize(file)).toEqual([{ source: realpathSync(file), target: '/cache', readOnly: true }])
-    for (const target of ['relative/target', '~/cache', 'C:\\cache', '/cache\0invalid']) {
+    expect(normalize(file)).toEqual([{ source: realpathSync(file), target: '/cache', mode: 'readonly' }])
+    for (const target of ['relative/target', '~/../cache', 'C:\\cache', '/cache\0invalid']) {
       expect(() => normalize(root, target)).toThrow(/absolute POSIX guest path/)
     }
     for (const target of ['/', '//', '/cache/..']) {
       expect(() => normalize(root, target)).toThrow(/must not be the guest root/)
+    }
+  })
+
+  it('resolves guest HOME at launch and limits overlays to independent directory mounts in microsandbox', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-overlay-mounts-'))
+    temporaryRoots.push(root)
+    const mount: SandboxMount = { source: root, target: '~/.cache/store', mode: 'overlay' }
+    const normalized = normalizeSandboxMounts([mount], {}, 'microsandbox')
+    expect(normalized[0]!.target).toBe('~/.cache/store')
+    expect(normalizeSandboxMounts(normalized, {}, 'microsandbox', '/session/home')[0]!.target).toBe(
+      '/session/home/.cache/store'
+    )
+    expect(() => normalizeSandboxMounts([{ ...mount, target: root }])).toThrow('requires microsandbox')
+    const file = join(root, 'file')
+    writeFileSync(file, '')
+    expect(() => normalizeSandboxMounts([{ ...mount, source: file }], {}, 'microsandbox')).toThrow(
+      'overlay source must be a directory'
+    )
+    for (const target of [mount.target, `${mount.target}/child`, '~/.cache']) {
+      expect(() => normalizeSandboxMounts([mount, { ...mount, target, mode: 'writable' }], {}, 'microsandbox')).toThrow(
+        /cannot combine|must not overlap/
+      )
     }
   })
 

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -496,8 +496,8 @@ describe('prepareRuntimeLaunch', () => {
     const store = join(hostHome, '.local', 'share', 'pnpm', 'store')
     mkdirSync(store, { recursive: true })
     const mounts = normalizeSandboxMounts([
-      { source: dirname(store), target: dirname(store), readOnly: true },
-      { source: store, target: store, readOnly: false }
+      { source: dirname(store), target: dirname(store), mode: 'readonly' },
+      { source: store, target: store, mode: 'writable' }
     ])
 
     const launch = prepareRuntimeLaunch({
@@ -513,7 +513,7 @@ describe('prepareRuntimeLaunch', () => {
       // What the daemon hands a session host: the session directory alone (workspace-manager.ts).
       trustedWorkspaceWriteRoots: [sessionDir],
       trustedRuntimeReadRoots: mounts.map((mount) => mount.source),
-      trustedOperatorWriteRoots: mounts.filter((mount) => !mount.readOnly).map((mount) => mount.source),
+      trustedOperatorWriteRoots: mounts.filter((mount) => mount.mode !== 'readonly').map((mount) => mount.source),
       trustedPrimaryCheckout: join(scopeDir, 'workspace'),
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })


### PR DESCRIPTION
Sessions can now reuse one host package store while keeping cache misses, updates, and deletions on their own writable layer. The common mount configuration uses `mode: readonly | writable | overlay`; the former `readOnly` field is removed without a configuration compatibility path. Ordinary mounts retain their persisted VM identity.

For microsandbox, `overlay` combines a read-only host directory with a session-owned ext4 upper/work disk. Startup and resume mount it before session processes run, and session deletion cleans up the disk. Guest targets may use `~/` for the session HOME, with credential, socket, and internal mount paths protected. SRT rejects overlay mode.

Validation:
- 185 focused daemon tests, daemon typecheck, targeted ESLint, and self-contained daemon/shim build.
- Real Linux/KVM smoke through the new launch preparation and driver: two sessions of one agent and a third session of another agent used pnpm 11.19's default store path without a store setting. All reused four baseline packages offline; an additional two packages and filesystem changes remained isolated and survived resume. All 1,744 host base files were unchanged; symlink targets were rejected; disposable VMs and volumes were cleaned up.

The VM smoke exercises filesystem and lifecycle behavior, not ACP model turns. Live host-base mutation consistency and cache publication remain separate work. Existing configuration files must replace `readOnly` with `mode` when upgrading.

Refs #1973.

Created by Codex . GPT-6
