### PR TITLE
perf(daemon): retain unchanged skills across source updates

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -516,6 +516,12 @@ node <bundled skills@1.5.21 bin> add <absoluteSnapshot> \
   renamed receipt on a runtime switch, not a second installation over the first.
   The unchanged fast path re-hashes every owned live tree; existence alone is
   insufficient.
+- A changed plan replaces only bundles whose file manifests changed. A desired
+  bundle with the same manifest, verified live bytes, recorded directory identity,
+  and contained workspace path remains in place while its source record advances.
+  Untouched bundles stay in the journal's prior set for rollback and do not spawn
+  mutation helpers. A missing or modified bundle still follows the normal
+  installation or ownership-refusal path.
 - An external SQLite lease serializes every process that can mutate the same
   canonical workspace. `BEGIN IMMEDIATE` protects the workspace key,
   owner-PID/token, and optional detached-helper process-group ID. A live owner or

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -329,6 +329,12 @@ export async function recoverSkillLedger(
         )
       }
     }
+    const operationRoots = new Set(ledger.operations.map((operation) => operation.relativeRoot))
+    for (const prior of ledger.prior) {
+      if (!operationRoots.has(prior.relativeRoot) && !(await destinationOccupied(cwd, prior.relativeRoot))) {
+        vanished.add(prior.relativeRoot)
+      }
+    }
     const ready: ReadyLedger = {
       version: 3,
       phase: 'ready',

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -478,11 +478,19 @@ async function reconcileSkillBundlesLocked(
     const conflicts: string[] = []
     const candidates: CandidateSkillBundle[] = []
     const adopted: OwnedSkillBundle[] = []
+    const kept = new Map<string, OwnedSkillBundle>()
     for (const candidate of deduped) {
-      if (
-        priorByPath.has(candidate.relativeRoot) ||
-        !(await destinationOccupied(options.cwd, candidate.relativeRoot))
-      ) {
+      const priorEntry = priorByPath.get(candidate.relativeRoot)
+      if (priorEntry?.treeDigest === candidate.treeDigest) {
+        // Reuse requires both the live receipt and the recorded identity, under a contained path.
+        await canonicalSkillMutationRoot(options.cwd, candidate.relativeRoot)
+        const found = await bundleIdentity(join(options.cwd, ...candidate.relativeRoot.split('/')), candidate)
+        if (found && sameIdentity(found, priorEntry.identity)) {
+          kept.set(candidate.relativeRoot, { ...stripCandidate(candidate), identity: found })
+          continue
+        }
+      }
+      if (priorEntry || !(await destinationOccupied(options.cwd, candidate.relativeRoot))) {
         candidates.push(candidate)
         continue
       }
@@ -501,19 +509,16 @@ async function reconcileSkillBundlesLocked(
       options.warn?.(`skills: skipped unowned skill ${candidate.relativeRoot}: ${detail}`)
     }
 
-    // A preserved bundle is untouched: it is not a candidate to publish and not a
-    // removal to plan, so it never enters the journal. A candidate claiming the
-    // same root wins — rebuilding beats keeping.
+    // Desired candidates take precedence over retaining a source that could not be rebuilt.
     const candidateRoots = new Set(candidates.map((entry) => entry.relativeRoot))
-    const preserved = new Set<string>()
     for (const root of options.preserveOwned ?? []) {
       const canonical = await canonicalizeRelativeRoot(options.cwd, root)
-      if (!candidateRoots.has(canonical)) preserved.add(canonical)
+      const priorEntry = priorByPath.get(canonical)
+      if (priorEntry && !candidateRoots.has(canonical) && !kept.has(canonical)) kept.set(canonical, priorEntry)
     }
-    const kept = prior.filter((entry) => preserved.has(entry.relativeRoot))
     const paths = [
       ...new Set([
-        ...prior.filter((entry) => !preserved.has(entry.relativeRoot)).map((entry) => entry.relativeRoot),
+        ...prior.filter((entry) => !kept.has(entry.relativeRoot)).map((entry) => entry.relativeRoot),
         ...candidates.map((entry) => entry.relativeRoot)
       ])
     ].sort()
@@ -536,22 +541,18 @@ async function reconcileSkillBundlesLocked(
       // A pruned set is no longer what that fingerprint described, and recovery cannot see the prune: leaving it would let the next plan skip the reinstall.
       ...(ledger?.fingerprint && prior.length === recorded.length ? { priorFingerprint: ledger.fingerprint } : {}),
       priorGitResolutions: ledger?.gitResolutions ?? [],
-      // Preserved receipts stay in the durable recovery state — recovery rebuilds
-      // `owned` from here, and a crash mid-publication must not orphan the files
-      // this run deliberately left alone. Their paths carry no operation, which is
-      // what keeps them untouched.
+      // Recovery retains every prior receipt, including untouched bundles whose source records may change.
       prior,
       pending: candidates.map(stripCandidate),
       operations
     }
+    options.assertMutationAuthority?.()
     await writeSkillLedger(location.file, nextApplying, options.publicationKey)
-    // Recovery authority begins only after the journal is durable. If writing
-    // the applying ledger failed, no live mutation has occurred and pretending
-    // otherwise could operate from state that never became authoritative.
+    // Recovery gains mutation authority only after the applying journal is durable.
     recoveryLedger = nextApplying
 
     const candidatesByPath = new Map(candidates.map((entry) => [entry.relativeRoot, entry]))
-    const owned: OwnedSkillBundle[] = [...adopted, ...kept]
+    const owned: OwnedSkillBundle[] = [...adopted, ...kept.values()]
     for (const operation of operations) {
       const priorEntry = priorByPath.get(operation.relativeRoot)
       const candidate = candidatesByPath.get(operation.relativeRoot)
@@ -633,6 +634,7 @@ async function reconcileSkillBundlesLocked(
       gitResolutions,
       cleanup: { operations, prior }
     }
+    options.assertMutationAuthority?.()
     await writeSkillLedger(location.file, readyWithCleanup, options.publicationKey)
     recoveryLedger = readyWithCleanup
     await finishReadyCleanup(
@@ -651,9 +653,8 @@ async function reconcileSkillBundlesLocked(
     }
     return {
       installed: candidates.map((entry) => entry.relativeRoot),
-      // Everything previously owned that this run did not keep, the paths that had
-      // already vanished included: none of THAT is owned once this returns.
-      removed: recorded.filter((entry) => !preserved.has(entry.relativeRoot)).map((entry) => entry.relativeRoot),
+      // Replaced and vanished prior bundles count as removed; untouched bundles do not.
+      removed: recorded.filter((entry) => !kept.has(entry.relativeRoot)).map((entry) => entry.relativeRoot),
       skipped: null,
       conflicts,
       owned

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { lstat, mkdir, mkdtemp, readdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -356,6 +356,118 @@ describe.skipIf(process.platform === 'win32')('skill install ledger over a re-ch
     location: Awaited<ReturnType<typeof skillLedgerLocation>>,
     ledger: NonNullable<Awaited<ReturnType<typeof readSkillLedger>>>
   ) => withSkillWorkspaceLock(cwd, () => recoverSkillLedger(cwd, location, ledger), stateDir)
+
+  it('keeps identical bundles in place while advancing source and Git metadata', async () => {
+    await reconcile('v1')
+    const target = join(cwd, BUNDLE)
+    const directoryIdentity = await pathIdentity(target)
+    const fileIdentity = await pathIdentity(join(target, 'SKILL.md'))
+    const resolution = { definitionDigest: 'a'.repeat(64), resolvedCommit: 'b'.repeat(40) }
+    const options = {
+      cwd,
+      stateDir,
+      agentId: 'a1',
+      runtime: 'claude',
+      cliVersion: '1.5.21',
+      fingerprint: 'v2',
+      candidates: [{ ...oneFileReceipt(BUNDLE, 'fixture:v2'), sourceDir }],
+      gitResolutions: [resolution],
+      preserveOwned: [BUNDLE]
+    }
+
+    const updated = await reconcileSkillBundles(options)
+
+    expect(updated.installed).toEqual([])
+    expect(updated.removed).toEqual([])
+    expect(await pathIdentity(target)).toEqual(directoryIdentity)
+    expect(await pathIdentity(join(target, 'SKILL.md'))).toEqual(fileIdentity)
+    const ledger = await readSkillLedger(await skillLedgerLocation(cwd, stateDir))
+    expect(ledger).toMatchObject({
+      phase: 'ready',
+      fingerprint: 'v2',
+      gitResolutions: [resolution],
+      owned: [{ relativeRoot: BUNDLE, sourceKey: 'fixture:v2', identity: directoryIdentity }]
+    })
+    expect((await reconcileSkillBundles(options)).skipped).toBe('unchanged')
+  })
+
+  it('retains an unchanged sibling through interrupted replacement and retry', async () => {
+    const changingRoot = '.claude/skills/changing'
+    const target = join(cwd, changingRoot, 'SKILL.md')
+    const options = { cwd, stateDir, agentId: 'a1', runtime: 'claude', cliVersion: '1.5.21' }
+    await reconcileSkillBundles({
+      ...options,
+      fingerprint: 'v1',
+      candidates: [
+        { ...oneFileReceipt(BUNDLE, 'fixture:v1'), sourceDir },
+        { ...oneFileReceipt(changingRoot, 'changing:v1'), sourceDir }
+      ]
+    })
+    const location = await skillLedgerLocation(cwd, stateDir)
+    const prior = await readSkillLedger(location)
+    const unchangedIdentity = await pathIdentity(join(cwd, BUNDLE))
+    const nextSource = join(root, 'next-source')
+    const nextBody = `${BODY}Updated content\n`
+    await mkdir(nextSource)
+    await writeFile(join(nextSource, 'SKILL.md'), nextBody)
+    const files = [{ path: 'SKILL.md', mode: 0o600, size: Buffer.byteLength(nextBody), sha256: sha256(nextBody) }]
+    const next = {
+      ...options,
+      fingerprint: 'v2',
+      candidates: [
+        { ...oneFileReceipt(BUNDLE, 'fixture:v2'), sourceDir },
+        {
+          relativeRoot: changingRoot,
+          sourceKey: 'changing:v2',
+          sourceDir: nextSource,
+          files,
+          treeDigest: treeDigest(files)
+        }
+      ]
+    }
+
+    await expect(
+      reconcileSkillBundles({
+        ...next,
+        assertMutationAuthority: () => {
+          if (!existsSync(target) || readFileSync(target, 'utf8') !== nextBody) return
+          const journal = JSON.parse(readFileSync(location.file, 'utf8'))
+          expect(journal.phase).toBe('applying')
+          expect(journal.operations.map((entry: { relativeRoot: string }) => entry.relativeRoot)).toEqual([
+            changingRoot
+          ])
+          expect(journal.prior).toContainEqual(
+            expect.objectContaining({ relativeRoot: BUNDLE, sourceKey: 'fixture:v1' })
+          )
+          throw new Error('publication authority lost after replacement')
+        }
+      })
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'publication authority lost after replacement' })
+    })
+
+    expect(await readSkillLedger(location)).toEqual(prior)
+    expect(await readFile(target, 'utf8')).toBe(BODY)
+    expect(await pathIdentity(join(cwd, BUNDLE))).toEqual(unchangedIdentity)
+    const retried = await reconcileSkillBundles(next)
+    expect(retried.installed).toEqual([changingRoot])
+    expect(retried.removed).toEqual([changingRoot])
+    expect(await readFile(target, 'utf8')).toBe(nextBody)
+    expect(await pathIdentity(join(cwd, BUNDLE))).toEqual(unchangedIdentity)
+    expect(retried.owned.map((entry) => entry.sourceKey).sort()).toEqual(['changing:v2', 'fixture:v2'])
+  })
+
+  it('refuses to reuse a recorded bundle moved outside the workspace through a parent alias', async () => {
+    await reconcile('v1')
+    const outside = join(root, 'outside')
+    await rename(join(cwd, '.claude'), outside)
+    await symlink(outside, join(cwd, '.claude'))
+
+    await expect(reconcile('v2')).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: expect.stringMatching(/outside workspace/) })
+    })
+    expect(await readFile(join(outside, 'skills/fixture/SKILL.md'), 'utf8')).toBe(BODY)
+  })
 
   it('reinstalls a recorded bundle the checkout no longer holds', async () => {
     const first = await reconcile('v1')

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -626,6 +626,27 @@ describe.skipIf(process.platform === 'win32')('skill install ledger over a re-ch
     expect(installed.installed).toEqual([BUNDLE])
     expect(existsSync(join(cwd, ...BUNDLE.split('/'), 'SKILL.md'))).toBe(true)
   })
+
+  it('refuses modified retained bundles but recovers and reinstalls them after cleanup', async () => {
+    const installed = await reconcile('v1')
+    const location = await writeApplyingOver(installed.owned, [])
+    const applying = await readSkillLedger(location)
+    const target = join(cwd, BUNDLE, 'SKILL.md')
+    await writeFile(target, 'modified')
+
+    await expect(recover(location, applying!)).rejects.toThrow(/could not restore the prior receipt set/)
+    expect(await readFile(target, 'utf8')).toBe('modified')
+    expect(await readSkillLedger(location)).toEqual(applying)
+
+    await rm(join(cwd, '.claude'), { recursive: true, force: true })
+    const recovered = await recover(location, applying!)
+
+    expect(recovered.owned).toEqual([])
+    expect(recovered.fingerprint).toBeUndefined()
+    const retried = await reconcile('v1')
+    expect(retried.installed).toEqual([BUNDLE])
+    expect(await readFile(target, 'utf8')).toBe(BODY)
+  })
 })
 
 describe.skipIf(process.platform !== 'win32')('skill install ledger on Windows', () => {

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -167,7 +167,9 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
 
     // The switch must not read its own bundle as a foreign path, and both harnesses must agree on the real directory.
     expect(switched.errors).toEqual([])
-    expect(switched.installed).toEqual(['.claude/skills/aliased'])
+    expect(switched.installed).toEqual([])
+    expect(switched.removed).toEqual([])
+    expect(switched.owned).toEqual(['.claude/skills/aliased'])
     // Surviving bytes are the proof it was not installed under one root and then removed under the other.
     expect(await readFile(join(cwd, '.claude/skills/aliased/SKILL.md'), 'utf8')).toContain('# v1')
   }, 120_000)


### PR DESCRIPTION
A skill repository update currently republishes every selected bundle, even when its files are unchanged. Keep verified, already-owned bundles in place and advance their source records; replace only changed bundles and remove disabled ones.

Reuse checks the live file manifest, recorded directory identity, and workspace containment. Retained bundles stay in the rollback journal, and ledger-only updates still check publication authority.

Validation: focused ledger and shim regressions, daemon typecheck, lint, formatting, and self-contained build; real Linux SRT/bwrap verification of unchanged updates, partial updates, and rejection of modified workspace files. GitHub acquisition is excluded from the installation benchmark.

Created by Codex . GPT-6
