### PR TITLE
fix(daemon): a dropped control-plane socket no longer consumes the turn's formal review

### DIFF
--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -9,6 +9,7 @@
  * stays where it is.
  */
 import { randomUUID } from 'node:crypto'
+import { WireError } from '@agentconnect.md/connection'
 import {
   GITLAB_DEFAULT_BASE_URL,
   normalizeGitCloneUrl,
@@ -871,8 +872,13 @@ export class GithubReviewOrchestrator {
         ? await cp.authorizeGithubReview(authorization, orgId)
         : await cp.authorizeGithubReview(authorization)
     } catch (err) {
-      active.reviewState = 'done'
-      throw err
+      // A retryable wire failure wrote nothing at GitHub and the same attempt re-authorizes idempotently: keep the retry.
+      if (!(err instanceof WireError && err.retryable)) {
+        active.reviewState = 'done'
+        throw err
+      }
+      active.reviewState = 'idle'
+      throw new Error(`formal review not submitted: control plane unreachable (${err.message}); call the tool again`)
     }
     if (!authorizedReviewTargetMatches(active, attemptId, authorized)) {
       active.reviewState = 'done'

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -39,7 +39,7 @@ import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
 import { openTestStore } from './store-support.js'
 import { statePath } from '../src/paths.js'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
-import { FakeClock } from '@agentconnect.md/connection'
+import { FakeClock, WireError } from '@agentconnect.md/connection'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { WAIT } from './wait-support.js'
 
@@ -1959,6 +1959,8 @@ describe('Daemon rd/msg hook fires', () => {
         body: 'Approved.'
       })
     ).rejects.toThrow('simulated crash window')
+    // A non-retryable authorization failure still consumes the turn's one attempt.
+    expect((daemon as any).activeGithubTurnMeta.get(key).reviewState).toBe('done')
 
     const row = (await (daemon as any).store.listInboxBySessionKeyFifo()).find(
       ({ id }: { id: string }) => id === inboxId
@@ -1973,6 +1975,118 @@ describe('Daemon rd/msg hook fires', () => {
     expect(persisted).not.toHaveProperty('reviewResult')
     expect(persisted).not.toHaveProperty('reviewReportAttemptId')
     expect(persisted).not.toHaveProperty('reviewReportResult')
+    await daemon.stop()
+  })
+
+  it('keeps the formal-review retry when the control-plane socket drops before authorization', async () => {
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: streamingHost().factory
+    })
+    await daemon.start()
+
+    const headSha = 'a'.repeat(40)
+    const baseSha = 'b'.repeat(40)
+    const hook: Record<string, unknown> = {
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'drop',
+      firedAt: new Date().toISOString()
+    }
+    const inboxId = `${HOOK_ID}:drop`
+    const key = `hook:acme/infra:42:${AGENT_ID}`
+    expect(
+      await (daemon as any).store.appendInbox({
+        id: inboxId,
+        sessionKey: key,
+        agentId: AGENT_ID,
+        msg: '{}',
+        hookContext: JSON.stringify(hook),
+        loopGuardCounted: 1,
+        enqueuedAt: '1'
+      })
+    ).toBe(true)
+    ;(daemon as any).activeGithubTurnMeta.set(key, {
+      entry: { inboxId, hookContext: hook },
+      hook,
+      snapshot: {
+        configRevision: '1',
+        dispatchRevision: '1',
+        dispatchDaemonId: '44444444-4444-4444-8444-444444444444',
+        reviewPolicy: 'full',
+        reportingMode: 'check',
+        gateMode: 'informational'
+      },
+      repoId: '123',
+      repoFullName: 'acme/infra',
+      pullNumber: 42,
+      expectedHeadSha: headSha,
+      expectedBaseSha: baseSha,
+      reportSha: headSha,
+      sessionId: 'acp-drop',
+      reviewState: 'idle'
+    })
+    // The correlator rejects every in-flight request this way when the daemon↔CP socket closes.
+    const authorizeGithubReview = vi
+      .fn()
+      .mockRejectedValueOnce(new WireError('INTERNAL', 'connection closed', true))
+      .mockImplementation(async ({ attemptId }: { attemptId: string }) => ({
+        attemptId,
+        token: 'ghs_review',
+        ttlSec: 60,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        repoId: '123',
+        repoFullName: 'acme/infra',
+        pullNumber: 42,
+        expectedHeadSha: headSha,
+        expectedBaseSha: baseSha
+      }))
+    ;(daemon as any).cpClient = {
+      stop: vi.fn(async () => {}),
+      authorizeGithubReview,
+      reportGithubReviewResult: vi.fn(async () => ({ accepted: true }))
+    }
+    const submit = vi.spyOn((daemon as any).githubReviews.githubReviewClient, 'submit').mockResolvedValue({
+      state: 'submitted',
+      reviewId: '9001',
+      event: 'APPROVE',
+      verdict: 'pass',
+      commitId: headSha
+    })
+    vi.spyOn((daemon as any).githubReviews, 'githubCommentAttribution').mockResolvedValue(undefined)
+    const req = {
+      agentId: AGENT_ID,
+      platform: 'hook',
+      channel: 'acme/infra',
+      thread: '42',
+      event: 'APPROVE',
+      verdict: 'pass',
+      body: 'Approved.'
+    }
+
+    await expect((daemon as any).githubReviews.submitGithubReview(req)).rejects.toThrow(
+      'formal review not submitted: control plane unreachable (connection closed)'
+    )
+    // Nothing reached GitHub, so the turn keeps its attempt instead of dying on the wire failure.
+    expect(submit).not.toHaveBeenCalled()
+    expect((daemon as any).activeGithubTurnMeta.get(key).reviewState).toBe('idle')
+    const attemptId = hook.reviewAttemptId
+    expect(attemptId).toEqual(expect.any(String))
+
+    await expect((daemon as any).githubReviews.submitGithubReview(req)).resolves.toMatchObject({
+      state: 'submitted',
+      reviewId: '9001'
+    })
+    // The retry re-authorizes the SAME attempt and goes marker-first, never a blind second POST.
+    expect(authorizeGithubReview).toHaveBeenCalledTimes(2)
+    expect(authorizeGithubReview.mock.calls.map((call) => call[0].attemptId)).toEqual([attemptId, attemptId])
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({ attemptId, recovering: true }),
+      expect.objectContaining({ event: 'APPROVE', verdict: 'pass' }),
+      undefined
+    )
+    expect((daemon as any).activeGithubTurnMeta.get(key).reviewState).toBe('done')
     await daemon.stop()
   })
 


### PR DESCRIPTION
## Summary

`submitCodeReview` authorizes each attempt with the control plane before it writes anything at GitHub. When the daemon↔control-plane socket closed mid-request, the correlator rejected the in-flight call with a retryable `connection closed` (`cp/client.ts` `onClose` → `rejectAll`), and `submitGithubReview` handled it like every other authorization failure: `reviewState = 'done'`. The agent saw a bare `connection closed`, the review was lost for the rest of the turn, and a second tool call answered `this PR hook turn already has a formal review attempt` — even though GitHub had never seen the request. Only a daemon restart replays the durable attempt; a socket blip does not restart the daemon.

A retryable wire failure at authorization is a proven no-effect, so this change:

- keeps the same attempt id and returns the turn to `idle` instead of `done`;
- throws `formal review not submitted: control plane unreachable (<reason>); call the tool again`, so the model knows nothing was published and a retry is the right move;
- leaves every non-retryable failure consuming the attempt exactly as before.

The retry is safe by construction: it re-authorizes the **same** attempt id (the lease treats a repeated attempt id as its own renewal, never a second fence), and `submit(recovering: true)` reads for the hidden marker before it will POST, so it cannot double-submit.

## Test plan

- [x] New: `keeps the formal-review retry when the control-plane socket drops before authorization` — first call rejects with the new message and `submit` is never reached; the turn is `idle`; the second call re-authorizes the same attempt id, submits marker-first (`recovering: true`), and lands `submitted`.
- [x] Existing crash-window test now also asserts a non-retryable authorization failure still leaves the turn `done`.
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`, `test/daemon-hook.test.ts` (109/109), eslint, prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
