### PR TITLE
fix(control-plane): a secondary rate limit no longer blocks a Check forever, and GitHub's wait is honoured

### DIFF
--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -52,7 +52,8 @@ export function githubRetryAfterMs(err: unknown, nowMs: number): number | undefi
 /** `retry-after` is delta-seconds and `x-ratelimit-reset` epoch-seconds; anything unparseable is no hint. */
 function retryHintFrom(headers: Headers): GithubRetryHint {
   const retryAfter = headers.get('retry-after')
-  const reset = headers.get('x-ratelimit-reset')
+  // The reset names the primary window; while that budget still has requests it is not a wait at all.
+  const reset = headers.get('x-ratelimit-remaining') === '0' ? headers.get('x-ratelimit-reset') : null
   const retryAfterSec = retryAfter === null ? NaN : Number(retryAfter)
   const resetSec = reset === null ? NaN : Number(reset)
   return {

--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -13,16 +13,51 @@ export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>
 
 export type GithubErrorCode = 'LEASE_DENIED' | 'RATE_LIMITED' | 'INTERNAL'
 
+/** When GitHub said to come back: `retry-after` as a delay, `x-ratelimit-reset` as an instant (epoch ms). */
+export interface GithubRetryHint {
+  retryAfterMs?: number
+  rateLimitResetAt?: number
+}
+
 /** GitHub call failure, pre-mapped onto the wire ErrorCode vocabulary. */
 export class GithubApiError extends Error {
+  readonly retryAfterMs?: number
+  readonly rateLimitResetAt?: number
+
   constructor(
     message: string,
     readonly status: number,
     readonly code: GithubErrorCode,
-    readonly retryable: boolean
+    readonly retryable: boolean,
+    hint: GithubRetryHint = {}
   ) {
     super(message)
     this.name = 'GithubApiError'
+    if (hint.retryAfterMs !== undefined) this.retryAfterMs = hint.retryAfterMs
+    if (hint.rateLimitResetAt !== undefined) this.rateLimitResetAt = hint.rateLimitResetAt
+  }
+}
+
+/** A secondary limit that names no wait asks for "at least one minute" (GitHub's own guidance). */
+const RATE_LIMIT_DEFAULT_WAIT_MS = 60_000
+
+/** How long GitHub asked the caller to wait before retrying `err`, measured from the caller's clock. */
+export function githubRetryAfterMs(err: unknown, nowMs: number): number | undefined {
+  if (!(err instanceof GithubApiError)) return undefined
+  if (err.retryAfterMs !== undefined) return err.retryAfterMs
+  if (err.rateLimitResetAt !== undefined) return Math.max(0, err.rateLimitResetAt - nowMs)
+  return err.code === 'RATE_LIMITED' ? RATE_LIMIT_DEFAULT_WAIT_MS : undefined
+}
+
+/** `retry-after` is delta-seconds and `x-ratelimit-reset` epoch-seconds; anything unparseable is no hint. */
+function retryHintFrom(headers: Headers): GithubRetryHint {
+  const retryAfter = headers.get('retry-after')
+  const reset = headers.get('x-ratelimit-reset')
+  const retryAfterSec = retryAfter === null ? NaN : Number(retryAfter)
+  const resetSec = reset === null ? NaN : Number(reset)
+  return {
+    ...(Number.isFinite(retryAfterSec) && retryAfterSec >= 0 ? { retryAfterMs: retryAfterSec * 1000 } : {}),
+    ...(Number.isFinite(resetSec) && resetSec > 0 ? { rateLimitResetAt: resetSec * 1000 } : {})
   }
 }
 
@@ -124,8 +159,16 @@ export async function githubRequestPage<T>(path: string, opts: GithubRequestOpts
     // non-JSON error body — status alone will do
   }
 
-  if (res.status === 429 || (res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0')) {
-    throw new GithubApiError(`github rate limited: ${detail}`, res.status, 'RATE_LIMITED', true)
+  // A primary limit is 403/429 with remaining 0; a secondary limit is 403/429 with `retry-after` and remaining still positive.
+  const hint = retryHintFrom(res.headers)
+  const rateLimited =
+    res.status === 429 ||
+    (res.status === 403 &&
+      (hint.retryAfterMs !== undefined ||
+        res.headers.get('x-ratelimit-remaining') === '0' ||
+        /rate limit/i.test(detail)))
+  if (rateLimited) {
+    throw new GithubApiError(`github rate limited: ${detail}`, res.status, 'RATE_LIMITED', true, hint)
   }
   // 404 (installation gone / repo out of the grant set) and 422 (narrowing to a
   // repo the installation can't reach) are operator-recoverable denials.
@@ -133,7 +176,7 @@ export async function githubRequestPage<T>(path: string, opts: GithubRequestOpts
     throw new GithubApiError(`github denied (${res.status}): ${detail}`, res.status, 'LEASE_DENIED', false)
   }
   // 401 = our own JWT/key is wrong (misconfig) — internal, not retryable-by-daemon.
-  throw new GithubApiError(`github error (${res.status}): ${detail}`, res.status, 'INTERNAL', res.status >= 500)
+  throw new GithubApiError(`github error (${res.status}): ${detail}`, res.status, 'INTERNAL', res.status >= 500, hint)
 }
 
 // One GraphQL query/mutation → its `data` — for facts with no REST equivalent (thread resolution

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -11,7 +11,7 @@ import { FakeClock } from '../../test/fakes/fake-clock.js'
 import type { AgentRepoAuthorizationRecord, GithubInstallationRecord } from '../persistence/ports.js'
 import { OrgId } from '../domain/ids.js'
 import { githubAppBotIdentity, resolveGithubAppConfig, type GithubAppConfig } from './config.js'
-import { GithubApiError, githubRequest, mintAppJwt, type FetchLike } from './api.js'
+import { GithubApiError, githubRequest, githubRetryAfterMs, mintAppJwt, type FetchLike } from './api.js'
 import { InstallationTokenInvalidatedError, InstallationTokenService } from './installation-token.service.js'
 import { deriveInstallStateKey, mintInstallState, verifyInstallState, INSTALL_STATE_TTL_MS } from './install-state.js'
 import { GithubService } from './service.js'
@@ -731,6 +731,50 @@ describe('InstallationTokenService', () => {
         })
     )
     await expect(svc.mint(IID, 'acme/infra', 'write')).rejects.toMatchObject({ code: 'RATE_LIMITED', retryable: true })
+  })
+
+  it('maps a secondary-rate-limit 403 (retry-after, remaining still positive) to RATE_LIMITED with the wait', async () => {
+    const clock = new FakeClock(1_700_000_000_000)
+    const { svc } = service(
+      clock,
+      () =>
+        new Response(JSON.stringify({ message: 'You have exceeded a secondary rate limit.' }), {
+          status: 403,
+          headers: { 'retry-after': '45', 'x-ratelimit-remaining': '4990' }
+        })
+    )
+    await expect(svc.mint(IID, 'acme/infra', 'write')).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      retryable: true,
+      retryAfterMs: 45_000
+    })
+  })
+
+  it('carries x-ratelimit-reset so the caller can wait for the primary window from its own clock', async () => {
+    const clock = new FakeClock(1_700_000_000_000)
+    const resetSec = 1_700_000_900
+    const { svc } = service(
+      clock,
+      () =>
+        new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+          status: 403,
+          headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(resetSec) }
+        })
+    )
+    const err = await svc.mint(IID, 'acme/infra', 'write').catch((e: unknown) => e)
+    expect(err).toMatchObject({ code: 'RATE_LIMITED', rateLimitResetAt: resetSec * 1000 })
+    expect(githubRetryAfterMs(err, clock.now())).toBe(900_000)
+  })
+
+  it('keeps a plain 403 without rate-limit signals as a non-retryable denial with no wait', async () => {
+    const clock = new FakeClock(1_700_000_000_000)
+    const { svc } = service(
+      clock,
+      () => new Response(JSON.stringify({ message: 'Resource not accessible by integration' }), { status: 403 })
+    )
+    const err = await svc.mint(IID, 'acme/infra', 'write').catch((e: unknown) => e)
+    expect(err).toMatchObject({ code: 'LEASE_DENIED', retryable: false })
+    expect(githubRetryAfterMs(err, clock.now())).toBeUndefined()
   })
 })
 

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -766,6 +766,23 @@ describe('InstallationTokenService', () => {
     expect(githubRetryAfterMs(err, clock.now())).toBe(900_000)
   })
 
+  it('ignores x-ratelimit-reset while primary quota remains — a secondary limit waits its own minute', async () => {
+    const clock = new FakeClock(1_700_000_000_000)
+    const { svc } = service(
+      clock,
+      () =>
+        new Response(JSON.stringify({ message: 'You have exceeded a secondary rate limit.' }), {
+          status: 429,
+          // The primary window resets 50 minutes out; that is not this limit's wait.
+          headers: { 'x-ratelimit-remaining': '4990', 'x-ratelimit-reset': String(1_700_000_000 + 3_000) }
+        })
+    )
+    const err = await svc.mint(IID, 'acme/infra', 'write').catch((e: unknown) => e)
+    expect(err).toMatchObject({ code: 'RATE_LIMITED', retryable: true })
+    expect((err as GithubApiError).rateLimitResetAt).toBeUndefined()
+    expect(githubRetryAfterMs(err, clock.now())).toBe(60_000)
+  })
+
   it('keeps a plain 403 without rate-limit signals as a non-retryable denial with no wait', async () => {
     const clock = new FakeClock(1_700_000_000_000)
     const { svc } = service(

--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -1775,7 +1775,7 @@ describe('GithubRunReporter', () => {
     )
   })
 
-  it('clears a definite 429 marker and retries with exponential backoff', async () => {
+  it("clears a definite 429 marker and waits GitHub's minimum minute when the answer names no wait", async () => {
     const p = projection({ attempts: 2 })
     const { reporter, hooks } = worker(
       p,
@@ -1784,11 +1784,77 @@ describe('GithubRunReporter', () => {
 
     await reporter.tick()
 
+    // The 8s backoff for attempt 2 would only buy another refusal and a longer penalty.
     expect(hooks.retryProjectionWrite).toHaveBeenCalledWith(
       p.id,
       p.generation,
       'worker-1',
-      new Date(NOW + 8_000),
+      new Date(NOW + 60_000),
+      'rate_limited',
+      false
+    )
+  })
+
+  it("keeps the exponential backoff once it already exceeds GitHub's wait", async () => {
+    const p = projection({ attempts: 6 })
+    const { reporter, hooks } = worker(
+      p,
+      vi.fn(async () => Response.json({ message: 'slow down' }, { status: 429, headers: { 'retry-after': '10' } }))
+    )
+
+    await reporter.tick()
+
+    expect(hooks.retryProjectionWrite).toHaveBeenCalledWith(
+      p.id,
+      p.generation,
+      'worker-1',
+      new Date(NOW + 128_000),
+      'rate_limited',
+      false
+    )
+  })
+
+  it('waits out the retry-after GitHub sent instead of its own shorter backoff', async () => {
+    const p = projection({ attempts: 2 })
+    const { reporter, hooks } = worker(
+      p,
+      vi.fn(async () => Response.json({ message: 'slow down' }, { status: 429, headers: { 'retry-after': '120' } }))
+    )
+
+    await reporter.tick()
+
+    expect(hooks.retryProjectionWrite).toHaveBeenCalledWith(
+      p.id,
+      p.generation,
+      'worker-1',
+      new Date(NOW + 120_000),
+      'rate_limited',
+      false
+    )
+  })
+
+  it('treats a secondary rate limit 403 as a definite non-effect, not a permanent denial', async () => {
+    const p = projection({ checkRunId: '90071992547409931' })
+    const { reporter, hooks, github } = worker(
+      p,
+      vi.fn(async () =>
+        // Secondary limits leave the primary budget untouched, so remaining stays positive.
+        Response.json(
+          { message: 'You have exceeded a secondary rate limit. Please wait a few minutes before you try again.' },
+          { status: 403, headers: { 'retry-after': '60', 'x-ratelimit-remaining': '4990' } }
+        )
+      )
+    )
+
+    await reporter.tick()
+
+    expect(hooks.blockProjection).not.toHaveBeenCalled()
+    expect(github.refreshInstallationFacts).not.toHaveBeenCalled()
+    expect(hooks.retryProjectionWrite).toHaveBeenCalledWith(
+      p.id,
+      p.generation,
+      'worker-1',
+      new Date(NOW + 60_000),
       'rate_limited',
       false
     )

--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -1833,6 +1833,31 @@ describe('GithubRunReporter', () => {
     )
   })
 
+  it('does not wait for the primary reset on a secondary 429 that still has primary quota', async () => {
+    const p = projection({ attempts: 0 })
+    const { reporter, hooks } = worker(
+      p,
+      vi.fn(async () =>
+        Response.json(
+          { message: 'You have exceeded a secondary rate limit.' },
+          // Primary quota remains and its window resets 50 minutes out; only the secondary minute applies.
+          { status: 429, headers: { 'x-ratelimit-remaining': '4990', 'x-ratelimit-reset': String(NOW / 1000 + 3_000) } }
+        )
+      )
+    )
+
+    await reporter.tick()
+
+    expect(hooks.retryProjectionWrite).toHaveBeenCalledWith(
+      p.id,
+      p.generation,
+      'worker-1',
+      new Date(NOW + 60_000),
+      'rate_limited',
+      false
+    )
+  })
+
   it('treats a secondary rate limit 403 as a definite non-effect, not a permanent denial', async () => {
     const p = projection({ checkRunId: '90071992547409931' })
     const { reporter, hooks, github } = worker(

--- a/packages/control-plane/src/github/run-reporter.ts
+++ b/packages/control-plane/src/github/run-reporter.ts
@@ -23,7 +23,7 @@ import type {
   HookRunRecord,
   OrgRepo
 } from '../persistence/ports.js'
-import { githubRequest, GithubApiError, type FetchLike } from './api.js'
+import { githubRequest, githubRetryAfterMs, GithubApiError, type FetchLike } from './api.js'
 import {
   authoritativeHookProjectionState,
   hookRuntimeProjectionState,
@@ -43,6 +43,8 @@ const MAX_ASSOCIATION_PAGES = 10
 const ASSOCIATION_PAGE_SIZE = 100
 const RETRY_BASE_MS = 2_000
 const RETRY_MAX_MS = 5 * 60_000
+// A primary rate-limit window is at most an hour; no GitHub wait is honoured past that.
+const RETRY_HINT_MAX_MS = 60 * 60_000
 // How long a marker-bearing write may stay unobserved before its absence counts as proof it never landed.
 const AMBIGUOUS_WRITE_GRACE_MS = 10 * 60_000
 
@@ -981,7 +983,12 @@ export class GithubRunReporter {
       return
     }
     if (isRetryable(err)) {
-      await this.retry(projection, errorLabel(err, 'github_unavailable'), false)
+      await this.retry(
+        projection,
+        errorLabel(err, 'github_unavailable'),
+        false,
+        githubRetryAfterMs(err, this.deps.clock.now())
+      )
       return
     }
     await this.deps.hooks.blockProjection(projection.id, projection.generation, errorLabel(err, 'repo_authorization'))
@@ -993,9 +1000,8 @@ export class GithubRunReporter {
     installationId: bigint
   ): Promise<void> {
     if (err instanceof GithubApiError && err.code === 'RATE_LIMITED') {
-      // A received rate-limit response is a definite non-effect: clear the
-      // marker and retry the mutation after backoff.
-      await this.retry(projection, 'rate_limited', false)
+      // A received rate-limit response is a definite non-effect: clear the marker and retry once GitHub's wait is over.
+      await this.retry(projection, 'rate_limited', false, githubRetryAfterMs(err, this.deps.clock.now()))
       return
     }
     if (err instanceof GithubApiError && (err.status === 401 || err.status === 403 || err.status === 422)) {
@@ -1035,9 +1041,18 @@ export class GithubRunReporter {
     await this.deps.hooks.blockProjection(projection.id, projection.generation, code)
   }
 
-  private async retry(projection: HookReviewProjectionRecord, code: string, keepWriteMutex: boolean): Promise<void> {
+  private async retry(
+    projection: HookReviewProjectionRecord,
+    code: string,
+    keepWriteMutex: boolean,
+    waitAtLeastMs = 0
+  ): Promise<void> {
     const attempt = Math.max(0, projection.attempts)
-    const delay = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.min(attempt, 8))
+    // GitHub's own wait wins over the backoff: retrying inside it only buys another refusal and a longer penalty.
+    const delay = Math.max(
+      Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.min(attempt, 8)),
+      Math.min(RETRY_HINT_MAX_MS, waitAtLeastMs)
+    )
     await this.deps.hooks.retryProjectionWrite(
       projection.id,
       projection.generation,


### PR DESCRIPTION
## Summary

Two defects in how the control plane reads a GitHub rate-limit answer, found while surveying retry behaviour on the GitHub paths.

**1. A secondary rate limit was classified as a permanent denial.** `githubRequest` recognised a rate limit only as `429`, or `403` + `x-ratelimit-remaining: 0`. GitHub's *secondary* rate limit answers `403` with a `retry-after` header while the primary budget — and so that `remaining` header — is still positive. That fell through to the generic 403 branch (`LEASE_DENIED`, `retryable: false`), and the Check reporter treats a non-retryable write error as proof the write was denied: `blockProjection`. The Check then sat there until an operator noticed, over a limit that clears itself in a minute.

**2. No GitHub path ever read `retry-after` / `x-ratelimit-reset`.** The reporter retried on its own `2s × 2ⁿ` schedule, which inside GitHub's window only buys another refusal and — for secondary limits — a longer penalty. (The Linear module already honours `Retry-After`; GitHub was the outlier.)

What changes:

| | before | after |
| --- | --- | --- |
| `403` + `retry-after`, remaining > 0 | `LEASE_DENIED` → Check blocked | `RATE_LIMITED`, retried after the named wait |
| `403` "…exceeded a secondary rate limit…" with no headers | `LEASE_DENIED` | `RATE_LIMITED`, retried after 60 s (GitHub's "at least one minute") |
| `429` / `403` + remaining 0 | `RATE_LIMITED`, retried after own backoff | same class; waits `retry-after` / until `x-ratelimit-reset` when longer than the backoff |
| plain `403` (no signals) | `LEASE_DENIED` | unchanged |

`GithubApiError` carries the two headers as `retryAfterMs` / `rateLimitResetAt`; `githubRetryAfterMs(err, now)` turns them into a wait from the caller's own clock (no `Date.now()` in the wrapper). The reporter's `retry()` takes that as a floor over its backoff, capped at one hour — the longest primary window. Both retry paths that can see a rate limit (`handleWriteError` and `handlePreWriteError`) pass it.

Out of scope, deliberately: GraphQL rate limits ride inside a `200` and the wrapper does not surface headers for those, so they keep the reporter's backoff; the transport itself still never retries — that is a separate change for provably idempotent reads only.

## Test plan

- [x] `api.ts` via `github.test.ts`: secondary `403` + `retry-after` → `RATE_LIMITED` with `retryAfterMs`; primary `403` + `x-ratelimit-reset` → `rateLimitResetAt`, and `githubRetryAfterMs` computes the wait from the clock; a plain `403` stays `LEASE_DENIED` with no wait.
- [x] `run-reporter.test.ts`: secondary-limit `403` → `rate_limited` retry at `now + retry-after`, `blockProjection` and `refreshInstallationFacts` never called; `429` + `retry-after: 120` → retry at `now + 120 s`; headerless `429` → 60 s floor; backoff kept when it already exceeds GitHub's wait.
- [x] `pnpm --filter @agentconnect.md/control-plane typecheck`; the whole `test:unit` project; eslint; prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
