### PR TITLE
feat(control-plane): a GitHub read survives one transient failure instead of surfacing it

### DIFF
--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -1,8 +1,9 @@
 /**
  * Thin GitHub REST wrapper — the only spot the CP talks to github.com (the
  * pattern set by `http/slack-identity.ts` for Slack). `fetch` is injectable so
- * integration tests stub the API without network; timeouts are short and every
- * error is typed for the WS handler's ErrorCode mapping.
+ * integration tests stub the API without network; timeouts are short, a read
+ * repeats a transient failure twice, and every error is typed for the WS
+ * handler's ErrorCode mapping.
  *
  * NEVER log request headers or token-bearing response bodies.
  */
@@ -60,6 +61,21 @@ export interface GithubRequestOpts {
    *  and a follow-up redeliver call 404s on a nonexistent id. The caller's type
    *  must declare those ids as `string`. */
   bigIdsAsStrings?: boolean
+  /** Between read retries; injectable so tests do not wait out real delays. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+// A GET is the one verb safe to repeat blind; every write's retry belongs to its caller's fenced, marker-first loop.
+// The first retry is immediate (a 502 or a reset is usually one bad hop); the second waits 300–600ms.
+const READ_RETRY_DELAYS_MS = [0, 300]
+
+const realSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/** Unreachable or 5xx on a read; a timeout already spent its 10s and would only spend it again. */
+function isTransientRead(err: unknown): boolean {
+  if (!(err instanceof GithubApiError)) return false
+  if (err.status >= 500) return true
+  return err.status === 0 && (err.cause as { name?: string } | undefined)?.name !== 'TimeoutError'
 }
 
 /** One page of a paginated GitHub list: the body plus the `rel="next"` cursor. */
@@ -88,6 +104,20 @@ export async function githubRequest<T>(path: string, opts: GithubRequestOpts): P
 /** {@link githubRequest} keeping the pagination cursor — for the list endpoints
  *  whose first page is not the whole answer. */
 export async function githubRequestPage<T>(path: string, opts: GithubRequestOpts): Promise<GithubPage<T>> {
+  const retries = (opts.method ?? 'GET') === 'GET' ? READ_RETRY_DELAYS_MS : []
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await githubRequestOnce<T>(path, opts)
+    } catch (err) {
+      // A rate limit names its own wait and stays the caller's; only the transient read class repeats here.
+      const delay = retries[attempt]
+      if (delay === undefined || !isTransientRead(err)) throw err
+      await (opts.sleep ?? realSleep)(delay + Math.floor(Math.random() * delay))
+    }
+  }
+}
+
+async function githubRequestOnce<T>(path: string, opts: GithubRequestOpts): Promise<GithubPage<T>> {
   const fetchImpl = opts.fetchImpl ?? (fetch as FetchLike)
   let res: Response
   try {
@@ -103,7 +133,9 @@ export async function githubRequestPage<T>(path: string, opts: GithubRequestOpts
       signal: AbortSignal.timeout(TIMEOUT_MS)
     })
   } catch (e) {
-    throw new GithubApiError(`github unreachable: ${(e as Error).message}`, 0, 'INTERNAL', true)
+    const unreachable = new GithubApiError(`github unreachable: ${(e as Error).message}`, 0, 'INTERNAL', true)
+    unreachable.cause = e // the read-retry loop tells a timeout from a reset by it
+    throw unreachable
   }
   if (res.ok) {
     const text = await res.text()

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -734,6 +734,81 @@ describe('InstallationTokenService', () => {
   })
 })
 
+describe('githubRequest — read retries', () => {
+  /** A fetch stub that answers from `script` in order and records how often it was asked. */
+  function scripted(script: Array<() => Response>) {
+    let calls = 0
+    const fetchImpl: FetchLike = async () => {
+      const next = script[Math.min(calls, script.length - 1)]!
+      calls += 1
+      return next()
+    }
+    return { fetchImpl, calls: () => calls }
+  }
+  const ok = () => Response.json({ id: 1 })
+  const bad = (status: number) => () => Response.json({ message: 'upstream' }, { status })
+  const sleeps: number[] = []
+  const sleep = async (ms: number) => void sleeps.push(ms)
+  const get = (fetchImpl: FetchLike) =>
+    githubRequest<{ id: number }>('/repos/acme/infra', { auth: 't', fetchImpl, sleep })
+
+  it('repeats a GET that met a 5xx, immediately first and after a short wait second', async () => {
+    sleeps.length = 0
+    const { fetchImpl, calls } = scripted([bad(502), bad(503), ok])
+    expect(await get(fetchImpl)).toEqual({ id: 1 })
+    expect(calls()).toBe(3)
+    expect(sleeps).toHaveLength(2)
+    expect(sleeps[0]).toBe(0)
+    expect(sleeps[1]).toBeGreaterThanOrEqual(300)
+    expect(sleeps[1]).toBeLessThan(600)
+  })
+
+  it('repeats a GET whose connection dropped, then gives up with the retryable error', async () => {
+    const reset = () => {
+      throw new Error('fetch failed: ECONNRESET')
+    }
+    const recovered = scripted([reset, ok])
+    expect(await get(recovered.fetchImpl)).toEqual({ id: 1 })
+    expect(recovered.calls()).toBe(2)
+
+    const dead = scripted([reset])
+    await expect(get(dead.fetchImpl)).rejects.toMatchObject({ status: 0, code: 'INTERNAL', retryable: true })
+    expect(dead.calls()).toBe(3)
+  })
+
+  it('does not repeat a timed-out GET — the 10s budget was already spent once', async () => {
+    const { fetchImpl, calls } = scripted([
+      () => {
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+      }
+    ])
+    await expect(get(fetchImpl)).rejects.toMatchObject({ status: 0, retryable: true })
+    expect(calls()).toBe(1)
+  })
+
+  it('never repeats a write, a rate limit, or a denial', async () => {
+    const post = scripted([bad(502)])
+    await expect(
+      githubRequest('/repos/acme/infra/issues', {
+        auth: 't',
+        method: 'POST',
+        body: {},
+        fetchImpl: post.fetchImpl,
+        sleep
+      })
+    ).rejects.toMatchObject({ status: 502 })
+    expect(post.calls()).toBe(1)
+
+    const limited = scripted([bad(429)])
+    await expect(get(limited.fetchImpl)).rejects.toMatchObject({ code: 'RATE_LIMITED' })
+    expect(limited.calls()).toBe(1)
+
+    const denied = scripted([bad(404)])
+    await expect(get(denied.fetchImpl)).rejects.toMatchObject({ code: 'LEASE_DENIED' })
+    expect(denied.calls()).toBe(1)
+  })
+})
+
 describe('InstallationTokenService.mintLevels — per-capability levels (issue #457)', () => {
   const IID = 42n
 

--- a/packages/control-plane/src/github/session-pull-request-link.service.test.ts
+++ b/packages/control-plane/src/github/session-pull-request-link.service.test.ts
@@ -182,10 +182,11 @@ describe('SessionPullRequestLinkService', () => {
   })
 
   it('keeps transient capture failures retryable and ignores a panel miss cache', async () => {
+    // The transport repeats a read twice on its own, so an outage the queue must see spans three answers.
     let calls = 0
     const fetch = vi.fn(async () => {
       calls += 1
-      if (calls <= 2) return new Response(JSON.stringify({ message: 'try later' }), { status: 503 })
+      if (calls <= 6) return new Response(JSON.stringify({ message: 'try later' }), { status: 503 })
       return new Response(JSON.stringify([pull(7, 'open')]), { status: 200 })
     })
     const service = new SessionPullRequestLinkService({
@@ -196,11 +197,23 @@ describe('SessionPullRequestLinkService', () => {
       latestSessionIdOfAgent: async () => SESSION.id,
       fetchImpl: fetch as unknown as FetchLike
     })
-
-    expect(await service.resolve(AGENT, SESSION)).toBeNull()
-    expect(await service.capture(AGENT, SESSION)).toEqual({ status: 'retry' })
-    expect(await service.capture(AGENT, SESSION)).toMatchObject({ status: 'resolved', link: { pullNumber: 7 } })
-    expect(fetch).toHaveBeenCalledTimes(3)
+    // The second transport retry sleeps on a real timer; run it forward rather than waiting it out.
+    vi.useFakeTimers()
+    const settled = async <T>(pending: Promise<T>): Promise<T> => {
+      await vi.runAllTimersAsync()
+      return pending
+    }
+    try {
+      expect(await settled(service.resolve(AGENT, SESSION))).toBeNull()
+      expect(await settled(service.capture(AGENT, SESSION))).toEqual({ status: 'retry' })
+      expect(await settled(service.capture(AGENT, SESSION))).toMatchObject({
+        status: 'resolved',
+        link: { pullNumber: 7 }
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(fetch).toHaveBeenCalledTimes(7)
   })
 
   it('classifies an empty head lookup as a definitive capture absence', async () => {


### PR DESCRIPTION
## Summary

Third piece of the GitHub retry survey (after #1979/#1980 on the review turn and #1981 on rate-limit classification). `githubRequest` made exactly one attempt, so a single 502 or a reset connection on a read the console was waiting on — the repository picker, a branch/tag/tree list, a permission check, the installation doorbell's re-pull — surfaced to the user as an error. Every *write* already had a durable, fenced retry loop; the reads had nothing.

The transport now repeats a **GET, and only a GET**, when it met a 5xx or an unreachable host:

| attempt | when |
| --- | --- |
| 1st retry | immediately — a 502 or a reset is usually one bad hop |
| 2nd retry | after 300–600 ms (jittered) |
| then | the same retryable `GithubApiError` as before |

Deliberately **not** repeated:

- a **timeout** — it already spent its 10 s once; three of them would triple a BFF read's worst case;
- a **rate limit** — it names its own wait, which is the caller's durable loop to honour (#1981);
- any **write** (POST/PATCH/DELETE) — their retry is the write-marker / attempt-ledger machinery, never a blind repeat;
- **GraphQL** — it rides on POST; a query could opt in later, but that needs the call site to say it is one, and the three current call sites are one PR-view read and two mutations.

`sleep` is injectable on `GithubRequestOpts` the same way `fetchImpl` is, so the direct tests do not wait out real delays. Callers that build their own opts are unchanged.

One existing test changed meaning rather than breaking: `session-pull-request-link`'s "transient capture failures stay retryable" scripted a 503 that cleared on the third answer — the transport now absorbs that on its own, so the test scripts an outage that outlasts the transport's budget and drives the one real sleep with fake timers. The integration file that scripts `[200, 503]` outages repeats its last status forever, so those scenarios keep their 502 mapping (with one extra short sleep each).

## Test plan

- [x] Direct `githubRequest` tests: 502 → 503 → 200 succeeds on the third call with sleeps `[0, 300–600)`; a reset connection recovers, and a persistent one gives up after three calls with the retryable error; a `TimeoutError` is not repeated; a POST 502, a 429, and a 404 each get exactly one call.
- [x] `pnpm --filter @agentconnect.md/control-plane typecheck`; the whole `test:unit` project; `test/integration/hooks.route.test.ts` (real Postgres); eslint; prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
