### PR TITLE
fix(daemon): a skill acquisition survives one transient GitHub failure

### DIFF
--- a/packages/daemon/src/skills/skill-git-source.ts
+++ b/packages/daemon/src/skills/skill-git-source.ts
@@ -346,6 +346,11 @@ async function discardResponse(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => undefined)
 }
 
+// A read repeats an unreachable host or a 5xx: immediately once, then after 300–600ms; an abort is final.
+const READ_RETRY_DELAYS_MS = [0, 300]
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
 async function fetchWithRedirectPolicy(
   fetchImpl: typeof globalThis.fetch,
   url: URL,
@@ -353,10 +358,20 @@ async function fetchWithRedirectPolicy(
   redirect: 'error' | 'manual',
   label: string
 ): Promise<Response> {
-  try {
-    return await fetchImpl(url, { ...init, redirect })
-  } catch {
-    throw new Error(`${label} request failed`)
+  for (let attempt = 0; ; attempt += 1) {
+    const delay = READ_RETRY_DELAYS_MS[attempt]
+    let response: Response
+    try {
+      response = await fetchImpl(url, { ...init, redirect })
+    } catch {
+      if (delay === undefined || init.signal?.aborted) throw new Error(`${label} request failed`)
+      await sleep(delay + Math.floor(Math.random() * delay))
+      continue
+    }
+    // Every caller here is a GET, so a 5xx is safe to repeat; the last answer stays the caller's to classify.
+    if (response.status < 500 || delay === undefined) return response
+    await discardResponse(response)
+    await sleep(delay + Math.floor(Math.random() * delay))
   }
 }
 

--- a/packages/daemon/test/skill-git-source.test.ts
+++ b/packages/daemon/test/skill-git-source.test.ts
@@ -537,6 +537,61 @@ describe('Git skill source policy boundary', () => {
     }
   })
 
+  it('repeats a commit lookup that met a 5xx and completes the acquisition', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-git-retry-'))
+    const offline = offlineGitHubFetch({ archive: tarGzip([{ path: `skills-${SHA}/SKILL.md`, body: 'safe' }]) })
+    let commitAnswers = 0
+    const flaky: typeof globalThis.fetch = async (input, init) => {
+      // One bad hop on the commit lookup; everything else answers as usual.
+      if (String(input).includes('/commits/') && commitAnswers++ === 0) {
+        offline.calls.push({ url: String(input), authorization: null, redirect: init?.redirect })
+        return new Response('', { status: 502 })
+      }
+      return offline.fetch(input, init)
+    }
+    try {
+      await acquireGitSkillSource(entry('acme/skills'), {
+        destination: join(root, 'acquired'),
+        agentId: 'agent-1',
+        useGitCredential: false,
+        fetch: flaky
+      })
+      expect(offline.calls.filter((call) => call.url.includes('/commits/'))).toHaveLength(2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('never repeats a definite 4xx, and stops after three 5xx answers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-git-no-retry-'))
+    const archive = tarGzip([{ path: `skills-${SHA}/SKILL.md`, body: 'safe' }])
+    const denied = offlineGitHubFetch({ archive, identities: [{ status: 404 }] })
+    const down = offlineGitHubFetch({ archive })
+    const persistent: typeof globalThis.fetch = async (input, init) => {
+      if (!String(input).includes('/commits/')) return down.fetch(input, init)
+      down.calls.push({ url: String(input), authorization: null, redirect: init?.redirect })
+      return new Response('', { status: 502 })
+    }
+    const options = { destination: join(root, 'acquired'), agentId: 'agent-1', useGitCredential: false }
+    try {
+      await expect(acquireGitSkillSource(entry('acme/skills'), { ...options, fetch: denied.fetch })).rejects.toThrow(
+        /identity lookup failed with status 404/
+      )
+      expect(denied.calls).toHaveLength(1)
+
+      await expect(
+        acquireGitSkillSource(entry('acme/skills'), {
+          ...options,
+          destination: join(root, 'acquired-again'),
+          fetch: persistent
+        })
+      ).rejects.toThrow(/commit resolution failed with status 502/)
+      expect(down.calls.filter((call) => call.url.includes('/commits/'))).toHaveLength(3)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('allows test seams to tighten but never widen daemon archive ceilings', async () => {
     const root = await mkdtemp(join(tmpdir(), 'ac-skill-git-limit-ceiling-'))
     const destination = join(root, 'acquired')


### PR DESCRIPTION
## Summary

Second follow-up to the GitHub retry survey (#1979–#1982, #1984). The skill acquisition path makes four GitHub calls — repository identity, commit resolution, archive lookup, and the codeload download — each with exactly one attempt, so a lone 502 or a reset connection failed the whole install and the daemon reported a skill it could not fetch.

All four are GETs, so the one fetch seam they share (`fetchWithRedirectPolicy`) now repeats an unreachable host or a 5xx: immediately once, then after 300–600 ms — three answers at most. The last answer is still the caller's to classify (the existing `… failed with status N` messages are unchanged), an abort is final, and a definite 4xx is never repeated. The credential retry in `githubApiRequest`, which keys on 401/403/404, never sees a 5xx and is untouched.

Same shape as the control plane's read retry in #1982; no new seam — the one test that exhausts the budget pays a single real 300–600 ms sleep.

## Test plan

- [x] A 502 on the commit lookup followed by a 200 completes the acquisition, with exactly two commit calls.
- [x] A 404 on the identity lookup stops after one call; a persistent 502 on the commit lookup stops after three and surfaces `commit resolution failed with status 502`.
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`; `test/skill-git-source.test.ts` (29/29); eslint; prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
