### PR TITLE
fix(control-plane): a GraphQL query repeats a transient failure like the GET it is

### DIFF
--- a/packages/control-plane/src/github/api.ts
+++ b/packages/control-plane/src/github/api.ts
@@ -99,6 +99,8 @@ export interface GithubRequestOpts {
   bigIdsAsStrings?: boolean
   /** Between read retries; injectable so tests do not wait out real delays. */
   sleep?: (ms: number) => Promise<void>
+  /** The caller vouches this POST has no effect (a GraphQL query), so it repeats like a GET. */
+  idempotent?: boolean
 }
 
 // A GET is the one verb safe to repeat blind; every write's retry belongs to its caller's fenced, marker-first loop.
@@ -140,7 +142,7 @@ export async function githubRequest<T>(path: string, opts: GithubRequestOpts): P
 /** {@link githubRequest} keeping the pagination cursor — for the list endpoints
  *  whose first page is not the whole answer. */
 export async function githubRequestPage<T>(path: string, opts: GithubRequestOpts): Promise<GithubPage<T>> {
-  const retries = (opts.method ?? 'GET') === 'GET' ? READ_RETRY_DELAYS_MS : []
+  const retries = (opts.method ?? 'GET') === 'GET' || opts.idempotent === true ? READ_RETRY_DELAYS_MS : []
   for (let attempt = 0; ; attempt += 1) {
     try {
       return await githubRequestOnce<T>(path, opts)

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -868,6 +868,14 @@ describe('githubRequest — read retries', () => {
     await expect(get(denied.fetchImpl)).rejects.toMatchObject({ code: 'LEASE_DENIED' })
     expect(denied.calls()).toBe(1)
   })
+
+  it('repeats a POST only when the caller vouches it is idempotent — a GraphQL query', async () => {
+    const { fetchImpl, calls } = scripted([bad(502), ok])
+    expect(
+      await githubRequest('/graphql', { auth: 't', method: 'POST', body: {}, idempotent: true, fetchImpl, sleep })
+    ).toEqual({ id: 1 })
+    expect(calls()).toBe(2)
+  })
 })
 
 describe('InstallationTokenService.mintLevels — per-capability levels (issue #457)', () => {

--- a/packages/control-plane/src/github/pull-request-view.service.test.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.test.ts
@@ -350,12 +350,24 @@ describe('degraded shapes', () => {
 
   it('maps a GitHub 5xx to unreachable, not to denied', async () => {
     // 'denied' points the operator at a nonexistent installation problem for the length of an outage;
-    // a server error is GitHub being down, which is the 'unreachable' story.
-    const { service } = build([() => new Response('Server Error', { status: 502 })])
+    // a server error is GitHub being down, which is the 'unreachable' story. The query is repeated
+    // twice before the panel degrades, so the outage has to outlast three answers.
+    const bad = () => new Response('Server Error', { status: 502 })
+    const { service, calls } = build([bad, bad, bad])
 
     const view = await service.view(IDENTITY)
 
     expect(view).toMatchObject({ degraded: true, degradedReason: 'unreachable' })
+    expect(calls).toHaveLength(3)
+  })
+
+  it('reads through one bad hop: a 502 followed by a full answer is a full panel', async () => {
+    const { service, calls } = build([() => new Response('Server Error', { status: 502 }), ok(fullAnswer())])
+
+    const view = await service.view(IDENTITY)
+
+    expect(view).toMatchObject({ degraded: false, title: 'Ship the panel' })
+    expect(calls).toHaveLength(2)
   })
 
   it('maps a REST-level rate limit (403 + x-ratelimit-remaining: 0) to rate_limited', async () => {
@@ -384,15 +396,16 @@ describe('degraded shapes', () => {
   })
 
   it('maps a network failure to unreachable', async () => {
-    const { service } = build([
-      () => {
-        throw new TypeError('fetch failed')
-      }
-    ])
+    const down = () => {
+      throw new TypeError('fetch failed')
+    }
+    // Two repeats before the panel degrades, so the failure has to outlast three attempts.
+    const { service, calls } = build([down, down, down])
 
     const view = await service.view(IDENTITY)
 
     expect(view).toMatchObject({ degraded: true, degradedReason: 'unreachable' })
+    expect(calls).toHaveLength(3)
   })
 })
 

--- a/packages/control-plane/src/github/pull-request-view.service.ts
+++ b/packages/control-plane/src/github/pull-request-view.service.ts
@@ -348,6 +348,8 @@ export class PullRequestViewService {
         },
         {
           auth: cred.token,
+          // A query: the transport may repeat it through one bad hop instead of degrading the panel.
+          idempotent: true,
           ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
           ...(this.baseUrl ? { baseUrl: this.baseUrl } : {})
         }
@@ -441,7 +443,7 @@ export class PullRequestViewService {
     const node = await githubGraphql<MergeNodeAnswer>(
       'query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id state merged}}}',
       { owner, name, number: target.pullNumber },
-      opts
+      { ...opts, idempotent: true }
     )
     const pr = node.repository?.pullRequest
     if (!pr) throw new GithubApiError('pull request not visible to the installation', 200, 'LEASE_DENIED', false)


### PR DESCRIPTION
## Summary

Third follow-up to the GitHub retry survey (#1979–#1982, #1984, #1985). #1982 keyed the read retry on the HTTP verb, so GraphQL — which rides on POST — stayed at one attempt. The pull-request panel is the one user-facing read that goes that way, and a lone 502 or a reset connection degraded it to `unreachable` while every REST read already read through one bad hop.

`GithubRequestOpts` gains `idempotent?: boolean`: the caller's vouch that a POST has no effect, on which the transport repeats it exactly as it does a GET (immediately once, then after 300–600 ms; never a timeout, never a rate limit). `githubGraphql` already spreads its options through, so the two queries in `PullRequestViewService` (the panel read and the merge-node read) say `idempotent: true` at the call site; the merge mutation says nothing and keeps its one attempt, as does every request that does not vouch. GraphQL rate limits ride inside a `200` and are classified after the request succeeded, so they are unaffected.

The panel service's "unreachable" tests now script the three answers the transport actually makes (they used to rely on the scripted fetch running dry, which happened to read as unreachable too).

## Test plan

- [x] Transport: a POST with `idempotent: true` that met a 502 is repeated and succeeds on the second call; a POST without it still gets exactly one call (existing case).
- [x] Panel service: a 502 followed by a full answer is a full, non-degraded panel in two calls; three 502s, or three network failures, still degrade to `unreachable` in exactly three calls.
- [x] `pnpm --filter @agentconnect.md/control-plane typecheck`; the whole `test:unit` project (2317/2317); eslint; prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
