### PR TITLE
feat: show daemon upgrade preparation progress

### DIFF
--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -165,6 +165,15 @@ bundles without the entry keep their existing upgrade behavior. This preparation
 step requires an updated CLI; an older CLI still prepares the image on daemon
 startup.
 
+For tracked upgrades, the daemon reports `preparing` before installation and
+`restarting` before shutdown through the acknowledged `daemon/lifecycle/progress`
+request. Reports identify the durable operation and are fenced by daemon identity,
+connection epoch, deadline, and terminal status; preparation cannot overwrite a
+recorded restart. Preparation failures settle the operation while the old daemon
+continues serving. Bootstrap commands advertise progress support so recovery can
+report the same phases before registration. The console displays preparation
+alongside actual availability; only target-version READY completes an upgrade.
+
 Without `--restart`, the running daemon is unchanged. The selected version takes
 effect on its next launch.
 

--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -80,7 +80,7 @@ sequenceDiagram
 
 `CONNECTING → AUTHENTICATING → REGISTERING → READY → (DRAINING) → CLOSED`, plus the off-socket state `DEGRADED` (local autonomy, §7).
 
-- **READY** is the only state in which the CP issues ordinary orchestration control. Before READY, `auth`/`register` are valid, plus the narrowly scoped `daemon/bootstrap/result` while `REGISTERING`; anything else → `error PROTOCOL_STATE`.
+- **READY** is the only state in which the CP issues ordinary orchestration control. Before READY, `auth`/`register` are valid, plus operation-scoped `daemon/bootstrap/result` and `daemon/lifecycle/progress` while `REGISTERING`; anything else → `error PROTOCOL_STATE`.
 - **DRAINING** is entered on `daemon/drain` (§6) — daemon stops accepting new `route/assign`, finishes in-flight, then closes.
 
 ### 2.2 Heartbeat & watchdog
@@ -130,6 +130,7 @@ const AuthOk = z.object({
   lifecycle: z
     .object({
       operationId: z.string(),
+      reportProgress: z.boolean().optional(),
       action: z.literal('upgrade'),
       targetVersion: z.string()
     })
@@ -149,6 +150,13 @@ installs through its local CLI and reports
 `daemon/bootstrap/result {operationId,status:'installed'|'failed',reason?}`.
 `installed` is progress only. Success still requires a later authenticated
 connection to reach `READY` with `agentVersion == targetVersion`.
+
+When `lifecycle.reportProgress` is true, bootstrap recovery also sends
+`daemon/lifecycle/progress {operationId,phase:'preparing'|'restarting'|'failed',reason?}`
+and awaits `ack`. Online restart/upgrade commands carry an optional `operationId`
+for the same reports. The operation stores preparation separately from availability;
+only an authenticated report from its daemon can advance the phase, and a late
+preparation report cannot replace `restarting` or reopen a terminal operation.
 
 **`sessionEpoch` is the global fencing token.** Every C→D control frame that mutates routing or sessions carries the `epoch` it was issued under (see §4 envelope-ext). A daemon **rejects** any control frame whose `epoch < its current sessionEpoch` (a late frame from a pre-reconnect CP view) with `error STALE_EPOCH`.
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -46,12 +46,15 @@ instructions.
 
 ## Planned daemon lifecycle status
 
-A pending daemon upgrade or restart is a planned transition, not an unexpected outage.
-While that lifecycle operation is pending, the console shows the daemon and its active
-placed agents as `upgrading` or `restarting` with the paused-state color. An agent that
-an operator explicitly paused remains `paused`. Once the operation succeeds, fails, or
-expires, the console returns to the daemon's current connection status; a daemon that
-did not return then reads `offline`.
+A daemon reports `preparing` while it installs the target version and prepares its
+sandbox image before stopping. The console keeps the daemon's actual connection status
+and shows a separate `Preparing upgrade` badge; its agents remain online while it is
+serving. Preparation during offline recovery must never imply that agents are online.
+Once the daemon reports `restarting`, its active placed agents show `restarting` with
+the paused-state color through drain and relaunch. An explicitly paused agent remains
+`paused`. Operations without phase reports keep the generic `upgrading` or `restarting`
+presentation. On success, failure, or expiry, the current connection status applies;
+success still requires the new version to reach READY.
 
 ## An unavailable agent is reported by its actual cause
 

--- a/packages/control-plane/prisma/migrations/20260910130000_daemon_lifecycle_phase/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260910130000_daemon_lifecycle_phase/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "daemon_lifecycle_op" ADD COLUMN "phase" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -493,6 +493,7 @@ model DaemonLifecycleOp {
   targetVersion String? // the version to reach (upgrade only); null for restart
   initiator     String? // app_user.id that commanded it; null under devAuth / system
   status        DaemonLifecycleOpStatus @default(pending)
+  phase         String? // daemon-reported preparing or restarting; absent for unreported operations
   // The daemon `sessionEpoch` at command-send time. The op only settles on a READY
   // whose epoch is STRICTLY GREATER (the daemon re-authed after draining + relaunching),
   // so a coincidental reconnect at the same epoch can never close it.

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -9,6 +9,7 @@ import { Cron } from 'croner'
 import { RESERVED_AGENT_SLUGS } from '../../domain/reserved-agent-slugs.js'
 import {
   AgentMemoryBinding,
+  DaemonLifecyclePhase,
   AgentPermissionRequestRecord,
   ExternalMemoryBinding,
   ManagedMemoryBinding,
@@ -181,6 +182,7 @@ export const DaemonLifecycleOpDto = z.object({
   id: z.string(),
   op: z.enum(['restart', 'upgrade']),
   status: z.enum(['pending', 'succeeded', 'failed']),
+  phase: DaemonLifecyclePhase.nullable(),
   /** The version an `upgrade` drives toward; null for restart. */
   targetVersion: z.string().nullable(),
   /** Short closure detail (decline reason / timeout); null while pending / on success. */

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -145,6 +145,7 @@ function toDto(
           id: latestOp.id,
           op: latestOp.op,
           status: expired ? 'failed' : latestOp.status,
+          phase: latestOp.phase,
           targetVersion: latestOp.targetVersion,
           outcome: expired ? 'timed out — the daemon did not re-register before the deadline' : latestOp.outcome
         }
@@ -536,6 +537,7 @@ export function daemonRoutes(deps: HttpDeps) {
           id: opRow.id,
           op: opRow.op,
           status: opRow.status,
+          phase: opRow.phase,
           targetVersion: opRow.targetVersion,
           outcome: opRow.outcome
         })
@@ -556,8 +558,12 @@ export function daemonRoutes(deps: HttpDeps) {
 
       const result =
         op === 'upgrade' && targetVersion
-          ? await deps.control.daemonUpgrade(id, { targetVersion, drainFirst: true })
-          : await deps.control.daemonRestart(id, { reason: 'console-initiated restart', drainFirst: true })
+          ? await deps.control.daemonUpgrade(id, { operationId: opRow.id, targetVersion, drainFirst: true })
+          : await deps.control.daemonRestart(id, {
+              operationId: opRow.id,
+              reason: 'console-initiated restart',
+              drainFirst: true
+            })
 
       // Definitely unsent (pre-dispatch NoConnection) → fail the op + 503.
       if (result.kind === 'unsent') {
@@ -624,6 +630,7 @@ export function daemonRoutes(deps: HttpDeps) {
         id: latest.id,
         op: latest.op,
         status: latest.status,
+        phase: latest.phase,
         targetVersion: latest.targetVersion,
         outcome: latest.outcome
       })
@@ -709,6 +716,7 @@ export function daemonRoutes(deps: HttpDeps) {
           id: opRow.id,
           op: opRow.op,
           status: expired ? ('failed' as const) : opRow.status,
+          phase: opRow.phase,
           targetVersion: opRow.targetVersion,
           outcome: expired ? 'timed out — the daemon did not re-register before the deadline' : opRow.outcome
         }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -13,6 +13,8 @@ import type { MemoryTransactionReq, MemoryTransactionResult } from '@agentconnec
 import type { MemoryHomeUpdate } from '../agent-memory/home.js'
 import type {
   AuthReq,
+  DaemonLifecyclePhase,
+  DaemonLifecycleProgress,
   RegisterReq,
   Heartbeat,
   FactsRuntimeProfile,
@@ -334,6 +336,7 @@ export interface DaemonLifecycleOpRecord {
   targetVersion: string | null
   initiator: string | null
   status: DaemonLifecycleOpStatus
+  phase: DaemonLifecyclePhase | null
   commandEpoch: bigint
   /** Set once the daemon ACKs `accepted:true` — the op is "armed". A READY before this
    *  must not settle it (the command hadn't been accepted/executed yet). */
@@ -345,6 +348,7 @@ export interface DaemonLifecycleOpRecord {
 }
 
 export interface DaemonLifecycleOpRepo {
+  recordProgress(daemonId: DaemonId, epoch: bigint, progress: DaemonLifecycleProgress, at: Date): Promise<boolean>
   /** Open a `pending` op. Throws Prisma P2002 (the partial unique index) when the
    *  daemon already has one in flight — the route maps that to 409. */
   open(input: OpenLifecycleOpInput): Promise<DaemonLifecycleOpRecord>

--- a/packages/control-plane/src/persistence/repositories/daemon-lifecycle-op.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/daemon-lifecycle-op.repo.ts
@@ -7,6 +7,7 @@
  * route), and the row is closed out-of-band by the register→READY closure or a decline.
  */
 import type { DaemonLifecycleOp } from '../../generated/prisma/client.js'
+import type { DaemonLifecyclePhase, DaemonLifecycleProgress } from '@agentconnect.md/protocol'
 import type { PrismaLike } from '../prisma.js'
 import type {
   DaemonLifecycleOpRepo,
@@ -25,6 +26,7 @@ function toRecord(o: DaemonLifecycleOp): DaemonLifecycleOpRecord {
     targetVersion: o.targetVersion,
     initiator: o.initiator,
     status: o.status as DaemonLifecycleOpStatus,
+    phase: o.phase as DaemonLifecyclePhase | null,
     commandEpoch: o.commandEpoch,
     acceptedAt: o.acceptedAt,
     startedAt: o.startedAt,
@@ -36,6 +38,31 @@ function toRecord(o: DaemonLifecycleOp): DaemonLifecycleOpRecord {
 
 export class PgDaemonLifecycleOpRepo implements DaemonLifecycleOpRepo {
   constructor(private readonly db: PrismaLike) {}
+
+  async recordProgress(
+    daemonId: DaemonId,
+    epoch: bigint,
+    progress: DaemonLifecycleProgress,
+    at: Date
+  ): Promise<boolean> {
+    const result = await this.db.daemonLifecycleOp.updateMany({
+      where: {
+        id: progress.operationId,
+        daemonId,
+        status: 'pending',
+        commandEpoch: { lte: epoch },
+        deadline: { gt: at },
+        ...(progress.phase === 'preparing'
+          ? { op: 'upgrade' as const, OR: [{ phase: null }, { phase: 'preparing' }] }
+          : {})
+      },
+      data:
+        progress.phase === 'failed'
+          ? { status: 'failed', outcome: progress.reason ?? 'daemon upgrade preparation failed', settledAt: at }
+          : { phase: progress.phase }
+    })
+    return result.count > 0
+  }
 
   async open(input: OpenLifecycleOpInput): Promise<DaemonLifecycleOpRecord> {
     const row = await this.db.daemonLifecycleOp.create({

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -213,7 +213,7 @@ export class DaemonConnection implements ConnChannel {
       case 'AUTHENTICATING':
         return type === 'auth'
       case 'REGISTERING':
-        return type === 'register' || type === 'daemon/bootstrap/result'
+        return type === 'register' || type === 'daemon/bootstrap/result' || type === 'daemon/lifecycle/progress'
       case 'READY':
       case 'DRAINING':
         return true

--- a/packages/control-plane/src/ws/handlers/auth.ts
+++ b/packages/control-plane/src/ws/handlers/auth.ts
@@ -95,7 +95,7 @@ export const handleAuth: Handler = async (frame, conn, deps) => {
       await deps.lifecycleOps.markAccepted(op.id, new Date(deps.clock.now()), commandEpoch)
       okFrame = {
         ...okFrame,
-        lifecycle: { operationId: op.id, action: 'upgrade', targetVersion: op.targetVersion }
+        lifecycle: { operationId: op.id, action: 'upgrade', targetVersion: op.targetVersion, reportProgress: true }
       }
     }
   }

--- a/packages/control-plane/src/ws/handlers/daemon-lifecycle-progress.ts
+++ b/packages/control-plane/src/ws/handlers/daemon-lifecycle-progress.ts
@@ -1,0 +1,14 @@
+import { isFrame } from '@agentconnect.md/protocol'
+import { DaemonId } from '../../domain/ids.js'
+import type { Handler } from './index.js'
+
+export const handleDaemonLifecycleProgress: Handler = async (frame, conn, deps) => {
+  if (!isFrame('daemon/lifecycle/progress')(frame)) return
+  const ok = await deps.lifecycleOps.recordProgress(
+    DaemonId(conn.daemonId),
+    BigInt(conn.sessionEpoch),
+    frame.payload,
+    new Date(deps.clock.now())
+  )
+  conn.replyTo(frame, 'ack', { ok })
+}

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -24,6 +24,7 @@ import type { DaemonWsDeps } from '../deps.js'
 import type { DaemonConnection } from '../connection.js'
 import { handleAuth } from './auth.js'
 import { handleDaemonBootstrapResult } from './daemon-bootstrap-result.js'
+import { handleDaemonLifecycleProgress } from './daemon-lifecycle-progress.js'
 import { handleRegister } from './register.js'
 import { handleCapabilitiesUpdate } from './capabilities-update.js'
 import { handleHeartbeat } from './heartbeat.js'
@@ -79,6 +80,7 @@ export class FrameRouter {
     this.table = {
       auth: handleAuth,
       'daemon/bootstrap/result': handleDaemonBootstrapResult,
+      'daemon/lifecycle/progress': handleDaemonLifecycleProgress,
       register: handleRegister,
       'capabilities/update': handleCapabilitiesUpdate,
       heartbeat: handleHeartbeat,

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -777,17 +777,35 @@ describe('POST /daemons/:id/upgrade', () => {
       payload: { version: '0.5.0' }
     })
     expect(res.statusCode).toBe(202)
-    expect(calls).toEqual([{ method: 'upgrade', id: DAEMON, payload: { targetVersion: '0.5.0', drainFirst: true } }])
     // The 202 returns the opened op (with its id) so the console can track it.
     const opened = res.json() as { id: string; op: string; status: string; targetVersion: string | null }
     expect(opened).toMatchObject({ op: 'upgrade', status: 'pending', targetVersion: '0.5.0' })
     expect(opened.id).toBeTruthy()
+    expect(calls).toEqual([
+      { method: 'upgrade', id: DAEMON, payload: { operationId: opened.id, targetVersion: '0.5.0', drainFirst: true } }
+    ])
+
+    await new PgDaemonLifecycleOpRepo(prisma).recordProgress(
+      DaemonId(DAEMON),
+      1n,
+      { operationId: opened.id, phase: 'preparing' },
+      new Date()
+    )
 
     const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as (DaemonDto & {
       lifecycleOp: LifecycleOp | null
     })[]
     const row = rows.find((r) => r.daemonId === DAEMON)!
-    expect(row.lifecycleOp).toMatchObject({ id: opened.id, op: 'upgrade', status: 'pending', targetVersion: '0.5.0' })
+    expect(row.lifecycleOp).toMatchObject({
+      id: opened.id,
+      op: 'upgrade',
+      status: 'pending',
+      phase: 'preparing',
+      targetVersion: '0.5.0'
+    })
+    expect(row.status).toBe('ready')
+    const progress = await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${DAEMON}/lifecycle/${opened.id}` })
+    expect(progress.json()).toMatchObject({ status: 'pending', phase: 'preparing' })
   })
 
   it('503s when the daemon is not reachable (no op opened)', async () => {

--- a/packages/control-plane/test/protocol/auth.handler.test.ts
+++ b/packages/control-plane/test/protocol/auth.handler.test.ts
@@ -188,7 +188,12 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
 
     const ok = await stub.expectFrame('auth/ok')
     if (!isFrame('auth/ok')(ok)) throw new Error('expected auth/ok')
-    expect(ok.payload.lifecycle).toEqual({ operationId: op.id, action: 'upgrade', targetVersion: '2.0.0' })
+    expect(ok.payload.lifecycle).toEqual({
+      operationId: op.id,
+      action: 'upgrade',
+      targetVersion: '2.0.0',
+      reportProgress: true
+    })
     expect((await h.deps.lifecycleOps.getById(op.id))?.acceptedAt).not.toBeNull()
     expect((await h.deps.lifecycleOps.getById(op.id))?.commandEpoch).toBe(1n)
 
@@ -200,6 +205,55 @@ describe('auth handler — valid key mints next epoch; invalid key closes 4401',
     const ack = await stub.expectFrame('ack')
     if (!isFrame('ack')(ack)) throw new Error('expected ack')
     expect(ack.payload.ok).toBe(true)
+    expect((await h.deps.lifecycleOps.getById(op.id))?.status).toBe('failed')
+  })
+
+  it('persists authenticated progress before registration and refuses stale or foreign reports', async () => {
+    const h = buildWsHarness(prisma)
+    const token = await h.mintToken(DAEMON)
+    const op = await h.deps.lifecycleOps.open({
+      daemonId: DaemonId(DAEMON),
+      op: 'upgrade',
+      targetVersion: '2.0.0',
+      commandEpoch: 0n,
+      deadline: new Date(h.clock.now() + 60_000)
+    })
+    const { stub, conn } = h.connect()
+    stub.inject('auth', { ...authPayload(token), bootstrapProtocolVersion: 1 })
+    await stub.expectFrame('auth/ok')
+    expect(conn.state).toBe('REGISTERING')
+    const report = async (phase: 'preparing' | 'restarting' | 'failed', operationId = op.id) => {
+      const id = stub.inject('daemon/lifecycle/progress', { operationId, phase })
+      await stub.settled()
+      const ack = stub.sent.find((frame) => frame.corr === id)
+      if (!ack || !isFrame('ack')(ack)) throw new Error('expected correlated ack')
+      return ack.payload.ok
+    }
+
+    expect(await report('preparing')).toBe(true)
+    expect((await h.deps.lifecycleOps.getById(op.id))?.phase).toBe('preparing')
+    expect(
+      await h.deps.lifecycleOps.recordProgress(
+        DaemonId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'),
+        1n,
+        { operationId: op.id, phase: 'restarting' },
+        new Date(h.clock.now())
+      )
+    ).toBe(false)
+    expect(
+      await h.deps.lifecycleOps.recordProgress(
+        DaemonId(DAEMON),
+        0n,
+        { operationId: op.id, phase: 'restarting' },
+        new Date(h.clock.now())
+      )
+    ).toBe(false)
+    expect(await report('restarting', 'another-operation')).toBe(false)
+    expect(await report('restarting')).toBe(true)
+    expect(await report('preparing')).toBe(false)
+    expect((await h.deps.lifecycleOps.getById(op.id))?.phase).toBe('restarting')
+    expect(await report('failed')).toBe(true)
+    expect(await report('restarting')).toBe(false)
     expect((await h.deps.lifecycleOps.getById(op.id))?.status).toBe('failed')
   })
 })

--- a/packages/daemon/src/bootstrap-upgrade.ts
+++ b/packages/daemon/src/bootstrap-upgrade.ts
@@ -125,6 +125,20 @@ export async function runBootstrapUpgrade(
     const lifecycle = (reply.payload as AuthOk).lifecycle
     if (!lifecycle || lifecycle.action !== 'upgrade' || lifecycle.targetVersion === DAEMON_VERSION) return 'continue'
 
+    const progress = async (phase: 'preparing' | 'restarting'): Promise<void> => {
+      if (!lifecycle.reportProgress) return
+      try {
+        const reply = await correlator.request(
+          buildEnvelope('daemon/lifecycle/progress', { operationId: lifecycle.operationId, phase }),
+          (encoded) => transport!.send(encoded),
+          { maxTries: 1, ackTimeoutMs: BOOTSTRAP_TIMEOUT_MS }
+        )
+        if (reply.type !== 'ack' || !(reply.payload as { ok?: boolean }).ok) throw new Error('progress rejected')
+      } catch (err) {
+        deps.log.error(`cp: could not report bootstrap progress: ${(err as Error).message}`)
+      }
+    }
+    await progress('preparing')
     const installed = await deps.install(cliEntry, lifecycle.targetVersion, root, deps.log, opts.configPath)
     if (!installed) {
       await reportResult(transport, correlator, lifecycle, 'failed', `failed to install ${lifecycle.targetVersion}`)
@@ -133,6 +147,7 @@ export async function runBootstrapUpgrade(
     await reportResult(transport, correlator, lifecycle, 'installed').catch((err) => {
       deps.log.error(`cp: could not confirm bootstrap installation: ${(err as Error).message}`)
     })
+    await progress('restarting')
     return 'restart'
   } catch (err) {
     deps.log.info(`cp: bootstrap check skipped (${(err as Error).message})`)

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -77,6 +77,7 @@ import type {
   ManagedSkillReadReq,
   ManagedSkillChunk,
   BootstrapLifecycle,
+  DaemonLifecycleProgress,
   FrameOrgPeer,
   OrganizationMode
 } from '@agentconnect.md/protocol'
@@ -507,7 +508,9 @@ export class CpClient {
         outcome = { status: 'failed', reason: err instanceof Error ? err.message : String(err) }
       }
       if (outcome.status === 'failed') {
-        await this.reportBootstrapResult(expectedTransport, ok.lifecycle, 'failed', outcome.reason)
+        await this.reportBootstrapResult(expectedTransport, ok.lifecycle, 'failed', outcome.reason).catch((err) => {
+          this.deps.log.error(`cp: could not confirm bootstrap failure: ${(err as Error).message}`)
+        })
       } else if (outcome.status === 'installed') {
         await this.reportBootstrapResult(expectedTransport, ok.lifecycle, 'installed').catch((err) => {
           this.deps.log.error(`cp: could not confirm bootstrap installation: ${(err as Error).message}`)
@@ -610,6 +613,19 @@ export class CpClient {
     const reply = await this.correlator.request(result, (encoded) => transport.send(encoded))
     if (reply.type !== 'ack' || !(reply.payload as { ok?: boolean }).ok) {
       throw new Error('control plane rejected the bootstrap result')
+    }
+  }
+
+  async reportLifecycleProgress(progress: DaemonLifecycleProgress): Promise<void> {
+    const transport = this.transport
+    if (!transport) return
+    const reply = await this.correlator.request(
+      buildEnvelope('daemon/lifecycle/progress', progress),
+      (encoded) => transport.send(encoded),
+      { maxTries: 1, ackTimeoutMs: 5_000 }
+    )
+    if (reply.type !== 'ack' || !(reply.payload as { ok?: boolean }).ok) {
+      throw new Error('control plane rejected lifecycle progress')
     }
   }
 

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -165,7 +165,7 @@ export interface ConfigApplyControlHost {
   retractChannels(integrationId: string, channelIds: readonly string[]): Promise<void>
   runCronNow(cronId: string): Ack
   runDrain(drain: Drain, onProgress: (p: DrainProgress) => void): Promise<DrainDone>
-  scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string): DaemonControlAck
+  scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string, operationId?: string): DaemonControlAck
 }
 
 /** Everything the CP apply path touches on the `Daemon`. */
@@ -933,8 +933,10 @@ export function buildConfigApply(host: ConfigApplyHost): ConfigApply {
     applyAgentStop: (stop: AgentStop) => applyAgentStop(host, stop),
     applyDaemonDrain: (drain: Drain, onProgress: (p: DrainProgress) => void): Promise<DrainDone> =>
       host.runDrain(drain, onProgress),
-    applyDaemonRestart: (_req: DaemonRestart): DaemonControlAck => host.scheduleFleetExit('restart'),
-    applyDaemonUpgrade: (req: DaemonUpgrade): DaemonControlAck => host.scheduleFleetExit('upgrade', req.targetVersion),
+    applyDaemonRestart: (req: DaemonRestart): DaemonControlAck =>
+      host.scheduleFleetExit('restart', undefined, req.operationId),
+    applyDaemonUpgrade: (req: DaemonUpgrade): DaemonControlAck =>
+      host.scheduleFleetExit('upgrade', req.targetVersion, req.operationId),
     applySessionVisibility: (p: SessionVisibilityPush) => applySessionVisibility(host, p)
   }
 }

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -7,6 +7,7 @@ import { hostname } from 'node:os'
 import { join } from 'node:path'
 import type {
   FactsMcpServer,
+  BootstrapLifecycle,
   FactsRuntimeProfile,
   GitCommitIdentity,
   Heartbeat,
@@ -103,7 +104,7 @@ export interface CpClientRegistrationHost {
   hostCount(): number
   activeSessions(): number
   bootstrapUpgradeCapable(): boolean
-  runBootstrapFleetUpgrade(targetVersion: string): Promise<BootstrapUpgradeOutcome>
+  runBootstrapFleetUpgrade(targetVersion: string, operationId?: string): Promise<BootstrapUpgradeOutcome>
 }
 
 /** The replay batch that runs once this daemon reaches READY on each (re)connect. */
@@ -227,8 +228,11 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
     onAuthFatal: () => host.exitFatal(1),
     ...(host.bootstrapUpgradeCapable()
       ? {
-          onBootstrapUpgrade: (lifecycle: { targetVersion: string }) =>
-            host.runBootstrapFleetUpgrade(lifecycle.targetVersion)
+          onBootstrapUpgrade: (lifecycle: BootstrapLifecycle) =>
+            host.runBootstrapFleetUpgrade(
+              lifecycle.targetVersion,
+              lifecycle.reportProgress ? lifecycle.operationId : undefined
+            )
         }
       : {}),
     agentVersion: DAEMON_VERSION,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1486,6 +1486,9 @@ export class Daemon {
       root: () => this.opts.root,
       configPath: () => this.opts.configPath,
       upgradeInstaller: () => this.opts.upgradeInstaller,
+      reportProgress: async (progress) => {
+        await this.cpClient?.reportLifecycleProgress(progress)
+      },
       stop: () => this.stop(),
       requestExit: (code) => this.requestExit(code)
     })
@@ -17985,7 +17988,8 @@ export class Daemon {
         this.observedChannelsSync.retractChannels(integrationId, channelIds),
       runCronNow: (cronId) => this.runCronNow(cronId),
       runDrain: (drain, onProgress) => this.runDrain(drain, onProgress),
-      scheduleFleetExit: (kind, targetVersion) => this.fleetUpgrade.scheduleFleetExit(kind, targetVersion)
+      scheduleFleetExit: (kind, targetVersion, operationId) =>
+        this.fleetUpgrade.scheduleFleetExit(kind, targetVersion, operationId)
     }
   }
 
@@ -18035,7 +18039,8 @@ export class Daemon {
       hostCount: () => new Set([...this.hosts.keys()].map(hostKeyAgentId)).size,
       activeSessions: () => this.pending.size,
       bootstrapUpgradeCapable: () => this.bootstrapUpgradeCapable(),
-      runBootstrapFleetUpgrade: (targetVersion) => this.fleetUpgrade.runBootstrapFleetUpgrade(targetVersion),
+      runBootstrapFleetUpgrade: (targetVersion, operationId) =>
+        this.fleetUpgrade.runBootstrapFleetUpgrade(targetVersion, operationId),
       readiness: () => this.readiness,
       probeRuntimesAndEmit: () => this.runtimeFacts.probeAndEmit(),
       syncOrganizationSuggestions: () => this.syncOrganizationSuggestions(),

--- a/packages/daemon/src/lifecycle/fleet-upgrade.ts
+++ b/packages/daemon/src/lifecycle/fleet-upgrade.ts
@@ -1,4 +1,9 @@
-import { K8S_SUPERVISOR, RESERVED_RESTART_CODE, type DaemonControlAck } from '@agentconnect.md/protocol'
+import {
+  K8S_SUPERVISOR,
+  RESERVED_RESTART_CODE,
+  type DaemonControlAck,
+  type DaemonLifecycleProgress
+} from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import { cliEntryPointer, resolveRoot } from '../paths.js'
 import { readCliEntry, runCliUpgrade } from './cli-upgrade.js'
@@ -18,6 +23,7 @@ export interface FleetUpgradeHost {
   root: () => string | undefined
   configPath: () => string | undefined
   upgradeInstaller: () => typeof runCliUpgrade | undefined
+  reportProgress: (progress: DaemonLifecycleProgress) => Promise<void>
   stop: () => Promise<void>
   requestExit: (code: number) => void
 }
@@ -80,18 +86,43 @@ export class FleetUpgradeCoordinator {
     return { accepted: true, root, ...(cliEntry ? { cliEntry } : {}), ...(willDrainUntil ? { willDrainUntil } : {}) }
   }
 
-  private startFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
+  private async reportProgress(
+    operationId: string | undefined,
+    phase: DaemonLifecycleProgress['phase']
+  ): Promise<void> {
+    if (!operationId) return
+    try {
+      await this.host.reportProgress({ operationId, phase })
+    } catch (err) {
+      this.host.log().warn(`cp: could not report upgrade progress: ${formatErr(err)}`)
+    }
+  }
+
+  private startFleetUpgrade(
+    cliEntry: string,
+    targetVersion: string,
+    root: string,
+    operationId?: string
+  ): Promise<boolean> {
     const log = this.host.log()
     const installation = Promise.resolve()
-      .then(() =>
-        (this.host.upgradeInstaller() ?? runCliUpgrade)(cliEntry, targetVersion, root, log, this.host.configPath())
-      )
+      .then(async () => {
+        await this.reportProgress(operationId, 'preparing')
+        return (this.host.upgradeInstaller() ?? runCliUpgrade)(
+          cliEntry,
+          targetVersion,
+          root,
+          log,
+          this.host.configPath()
+        )
+      })
       .catch((err) => {
         log.error(`cp: could not install daemon ${targetVersion}: ${formatErr(err)}`)
         return false
       })
-      .then((ok) => {
+      .then(async (ok) => {
         if (!ok) {
+          await this.reportProgress(operationId, 'failed')
           log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
           this.lifecycleInFlight = false
           if (this.fleetUpgradeInFlight?.installation === installation) this.fleetUpgradeInFlight = undefined
@@ -102,11 +133,12 @@ export class FleetUpgradeCoordinator {
     return installation
   }
 
-  private finishFleetExit(kind: FleetExitKind): void {
+  private finishFleetExit(kind: FleetExitKind, operationId?: string): void {
     if (this.fleetExitStarted) return
     this.fleetExitStarted = true
     void (async () => {
       try {
+        await this.reportProgress(operationId, 'restarting')
         await this.host.stop()
       } catch (err) {
         this.host.log().error(`cp: ${kind} shutdown failed: ${formatErr(err)}`)
@@ -117,33 +149,38 @@ export class FleetUpgradeCoordinator {
   }
 
   /** Admit immediately, then install before the existing drain-and-relaunch path. */
-  scheduleFleetExit(kind: FleetExitKind, targetVersion?: string): DaemonControlAck {
+  scheduleFleetExit(kind: FleetExitKind, targetVersion?: string, operationId?: string): DaemonControlAck {
     const admission = this.admitFleetExit(kind, targetVersion)
     if (!admission.accepted) return admission
     void (async () => {
-      if (kind === 'upgrade' && !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))) {
+      if (
+        kind === 'upgrade' &&
+        !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root, operationId))
+      ) {
         return
       }
-      this.finishFleetExit(kind)
+      this.finishFleetExit(kind, operationId)
     })()
 
     return { accepted: true, ...(admission.willDrainUntil ? { willDrainUntil: admission.willDrainUntil } : {}) }
   }
 
-  async runBootstrapFleetUpgrade(targetVersion: string): Promise<BootstrapUpgradeOutcome> {
+  async runBootstrapFleetUpgrade(targetVersion: string, operationId?: string): Promise<BootstrapUpgradeOutcome> {
     if (targetVersion === DAEMON_VERSION) return { status: 'current' }
     const existing = this.fleetUpgradeInFlight
     if (existing?.targetVersion === targetVersion) {
       const installed = await existing.installation
+      if (installed) await this.reportProgress(operationId, 'restarting')
       return installed
         ? { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
         : { status: 'failed', reason: `failed to install ${targetVersion}` }
     }
     const admission = this.admitFleetExit('upgrade', targetVersion)
     if (!admission.accepted) return { status: 'failed', reason: admission.reason }
-    if (!(await this.startFleetUpgrade(admission.cliEntry!, targetVersion, admission.root))) {
+    if (!(await this.startFleetUpgrade(admission.cliEntry!, targetVersion, admission.root, operationId))) {
       return { status: 'failed', reason: `failed to install ${targetVersion}` }
     }
+    await this.reportProgress(operationId, 'restarting')
     return { status: 'installed', restart: () => this.finishFleetExit('upgrade') }
   }
 }

--- a/packages/daemon/test/bootstrap-upgrade.test.ts
+++ b/packages/daemon/test/bootstrap-upgrade.test.ts
@@ -93,15 +93,28 @@ describe('auth-only daemon bootstrap upgrade', () => {
             sessionEpoch: 2,
             heartbeatSec: 15,
             serverTime: SERVER_TIME,
-            lifecycle: { operationId: 'op-1', action: 'upgrade', targetVersion: '9.9.9' }
+            lifecycle: { operationId: 'op-1', action: 'upgrade', targetVersion: '9.9.9', reportProgress: true }
           },
           { corr: auth.id as string }
         )
       )
     )
+    const preparing = await waitForSent(transport, 'daemon/lifecycle/progress')
+    expect(preparing.payload).toEqual({ operationId: 'op-1', phase: 'preparing' })
+    expect(install).not.toHaveBeenCalled()
+    transport.pushInbound(encode(buildEnvelope('ack', { ok: true }, { corr: preparing.id as string })))
     const result = await waitForSent(transport, 'daemon/bootstrap/result')
     expect(result.payload).toEqual({ operationId: 'op-1', status: 'installed' })
     transport.pushInbound(encode(buildEnvelope('ack', { ok: true }, { corr: result.id as string })))
+    await vi.waitFor(() =>
+      expect(
+        transport.sent.map((text) => JSON.parse(text)).filter((frame) => frame.type === 'daemon/lifecycle/progress')
+      ).toHaveLength(2)
+    )
+    const restarting = transport.sent
+      .map((text) => JSON.parse(text))
+      .find((frame) => frame.payload?.phase === 'restarting')
+    transport.pushInbound(encode(buildEnvelope('ack', { ok: true }, { corr: restarting.id })))
 
     await expect(run).resolves.toBe('restart')
     expect(install).toHaveBeenCalledWith(

--- a/packages/daemon/test/cp/client-handshake.test.ts
+++ b/packages/daemon/test/cp/client-handshake.test.ts
@@ -671,6 +671,7 @@ describe('CpClient handshake', () => {
       makeDeps(t, {
         onBootstrapUpgrade: async (lifecycle) => {
           directives.push(lifecycle)
+          await client.reportLifecycleProgress({ operationId: lifecycle.operationId, phase: 'preparing' })
           return { status: 'installed', restart }
         }
       })
@@ -696,6 +697,14 @@ describe('CpClient handshake', () => {
     )
     await tick()
     expect(directives).toEqual([{ operationId: 'op-1', action: 'upgrade', targetVersion: '2.0.0' }])
+    const preparing = t.lastSent()
+    expect(preparing).toMatchObject({
+      type: 'daemon/lifecycle/progress',
+      payload: { operationId: 'op-1', phase: 'preparing' }
+    })
+    expect(t.sent.map((text) => JSON.parse(text).type)).not.toContain('register')
+    t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok: true }, { corr: preparing.id })))
+    await tick()
     const result = t.lastSent()
     expect(result).toMatchObject({
       type: 'daemon/bootstrap/result',
@@ -711,7 +720,7 @@ describe('CpClient handshake', () => {
     expect(t.sent.map((text) => JSON.parse(text).type)).not.toContain('register')
   })
 
-  it('reports installer failure and continues registration on the same connection', async () => {
+  it.each([true, false])('continues registration after installer failure with result ack=%s', async (ok) => {
     const t = new FakeTransport()
     const client = new CpClient(
       makeDeps(t, {
@@ -742,7 +751,7 @@ describe('CpClient handshake', () => {
       type: 'daemon/bootstrap/result',
       payload: { operationId: 'op-1', status: 'failed', reason: 'registry unavailable' }
     })
-    t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok: true }, { corr: result.id })))
+    t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok }, { corr: result.id })))
     await tick()
     expect(t.lastSent().type).toBe('register')
     expect(t.closed).toBeUndefined()

--- a/packages/daemon/test/daemon-fleet-upgrade.test.ts
+++ b/packages/daemon/test/daemon-fleet-upgrade.test.ts
@@ -35,11 +35,15 @@ describe('daemon fleet upgrade coordination', () => {
     const requestExit = vi.fn()
     const daemon = new Daemon({ root: scaffold(), supervisor: 'cli', upgradeInstaller, requestExit })
     ;(daemon as any).stop = vi.fn(async () => {})
+    const reportLifecycleProgress = vi.fn(async () => {})
+    ;(daemon as any).cpClient = { reportLifecycleProgress }
 
-    expect((daemon as any).fleetUpgrade.scheduleFleetExit('upgrade', '9.9.9')).toEqual({ accepted: true })
+    expect((daemon as any).fleetUpgrade.scheduleFleetExit('upgrade', '9.9.9', 'upgrade-1')).toEqual({ accepted: true })
     await vi.waitFor(() => expect(upgradeInstaller).toHaveBeenCalledTimes(1))
+    expect(reportLifecycleProgress).toHaveBeenCalledWith({ operationId: 'upgrade-1', phase: 'preparing' })
+    expect((daemon as any).stop).not.toHaveBeenCalled()
 
-    const reconnectOutcome = (daemon as any).fleetUpgrade.runBootstrapFleetUpgrade('9.9.9')
+    const reconnectOutcome = (daemon as any).fleetUpgrade.runBootstrapFleetUpgrade('9.9.9', 'upgrade-1')
     finishInstall(true)
 
     const outcome = await reconnectOutcome
@@ -47,5 +51,22 @@ describe('daemon fleet upgrade coordination', () => {
     expect(upgradeInstaller).toHaveBeenCalledTimes(1)
     outcome.restart()
     await vi.waitFor(() => expect(requestExit).toHaveBeenCalledTimes(1))
+    expect(reportLifecycleProgress).toHaveBeenCalledWith({ operationId: 'upgrade-1', phase: 'restarting' })
+  })
+
+  it('reports preparation failure without stopping the serving daemon', async () => {
+    const requestExit = vi.fn()
+    const daemon = new Daemon({ root: scaffold(), supervisor: 'cli', upgradeInstaller: async () => false, requestExit })
+    const stop = vi.fn(async () => {})
+    const reportLifecycleProgress = vi.fn(async () => {})
+    Object.assign(daemon, { stop, cpClient: { reportLifecycleProgress } })
+
+    expect((daemon as any).fleetUpgrade.scheduleFleetExit('upgrade', '9.9.9', 'upgrade-2')).toEqual({ accepted: true })
+
+    await vi.waitFor(() =>
+      expect(reportLifecycleProgress).toHaveBeenCalledWith({ operationId: 'upgrade-2', phase: 'failed' })
+    )
+    expect(stop).not.toHaveBeenCalled()
+    expect(requestExit).not.toHaveBeenCalled()
   })
 })

--- a/packages/protocol/src/frame-scope.ts
+++ b/packages/protocol/src/frame-scope.ts
@@ -10,6 +10,7 @@ export const INSTALL_WIDE_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameTyp
   'register',
   'register/ok',
   'daemon/bootstrap/result',
+  'daemon/lifecycle/progress',
   'capabilities/update',
   'heartbeat',
   'facts/runtime-profile',

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -197,6 +197,7 @@ import {
   DaemonRuntimes,
   ConfigPush,
   DaemonBootstrapResult,
+  DaemonLifecycleProgress,
   DaemonRestart,
   DaemonUpgrade,
   DaemonControlAck,
@@ -497,6 +498,7 @@ export const FRAME_SCHEMAS = {
   // ── fleet / config ──
   'config/push': ConfigPush,
   'daemon/bootstrap/result': DaemonBootstrapResult,
+  'daemon/lifecycle/progress': DaemonLifecycleProgress,
   'daemon/restart': DaemonRestart,
   'daemon/upgrade': DaemonUpgrade,
   // ── generic replies ──
@@ -769,6 +771,7 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('managed-skill/chunk', FRAME_SCHEMAS['managed-skill/chunk']),
   frame('config/push', FRAME_SCHEMAS['config/push']),
   frame('daemon/bootstrap/result', FRAME_SCHEMAS['daemon/bootstrap/result']),
+  frame('daemon/lifecycle/progress', FRAME_SCHEMAS['daemon/lifecycle/progress']),
   frame('daemon/restart', FRAME_SCHEMAS['daemon/restart']),
   frame('daemon/upgrade', FRAME_SCHEMAS['daemon/upgrade']),
   frame('daemon/control/ack', FRAME_SCHEMAS['daemon/control/ack']),

--- a/packages/protocol/src/frames/auth.ts
+++ b/packages/protocol/src/frames/auth.ts
@@ -34,6 +34,7 @@ export type AuthReq = z.infer<typeof AuthReq>
 
 export const BootstrapLifecycle = z.object({
   operationId: z.string(),
+  reportProgress: z.boolean().optional(),
   action: z.literal('upgrade'),
   targetVersion: z.string()
 })

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -389,8 +389,20 @@ export const DaemonBootstrapResult = z.object({
 })
 export type DaemonBootstrapResult = z.infer<typeof DaemonBootstrapResult>
 
+export const DaemonLifecyclePhase = z.enum(['preparing', 'restarting'])
+export type DaemonLifecyclePhase = z.infer<typeof DaemonLifecyclePhase>
+
+// Operation-scoped progress; completion still requires the target daemon to reach READY.
+export const DaemonLifecycleProgress = z.object({
+  operationId: z.string().min(1).max(200),
+  phase: z.enum(['preparing', 'restarting', 'failed']),
+  reason: z.string().max(500).optional()
+})
+export type DaemonLifecycleProgress = z.infer<typeof DaemonLifecycleProgress>
+
 /** Fleet: drain+exit, supervisor restarts — C→D REQ, protocol §8.3 / frame #27. */
 export const DaemonRestart = z.object({
+  operationId: z.string().optional(),
   reason: z.string(),
   drainFirst: z.boolean().default(true)
 })
@@ -398,6 +410,7 @@ export type DaemonRestart = z.infer<typeof DaemonRestart>
 
 /** Fleet: drain+exit for version bump — C→D REQ, protocol §8.3 / frame #28. */
 export const DaemonUpgrade = z.object({
+  operationId: z.string().optional(),
   targetVersion: z.string(),
   drainFirst: z.boolean().default(true)
 })

--- a/packages/web/src/components/console/DaemonLifecycleBadge.tsx
+++ b/packages/web/src/components/console/DaemonLifecycleBadge.tsx
@@ -1,10 +1,14 @@
 import { Spinner } from '@/components/marks'
 import type { DaemonLifecycleOp } from '@/lib/data'
 
-// Pending daemon lifecycle state. The list uses a compact action label so the
-// running version remains readable; detail views keep the full target version.
+// Lists show the action; detail views include the target version.
 export function daemonLifecycleLabel(op: DaemonLifecycleOp): string {
-  const action = op.op === 'upgrade' ? 'Upgrading' : 'Restarting'
+  const action =
+    op.phase === 'preparing'
+      ? 'Preparing upgrade'
+      : op.phase === 'restarting' || op.op === 'restart'
+        ? 'Restarting'
+        : 'Upgrading'
   return `${action}${op.targetVersion ? ` to ${op.targetVersion}` : ''}…`
 }
 
@@ -13,12 +17,12 @@ export function DaemonLifecycleBadge({ op, size = 'sm' }: { op: DaemonLifecycleO
 
   const fullLabel = daemonLifecycleLabel(op)
   const md = size === 'md'
-  const label = md ? fullLabel : `${op.op === 'upgrade' ? 'Upgrading' : 'Restarting'}…`
+  const label = md ? fullLabel : daemonLifecycleLabel({ ...op, targetVersion: null })
 
   return (
     <span
       title={fullLabel}
-      className={`inline-flex flex-none items-center rounded-full border border-(--brand) bg-(--surface-sunken) font-sans font-semibold leading-normal text-(--brand) ${
+      className={`inline-flex max-w-full flex-none items-center rounded-full border border-(--brand) bg-(--surface-sunken) font-sans font-semibold leading-normal text-(--brand) ${
         md ? 'gap-[5px] py-[2px] pr-[9px] pl-[6px] text-[11px]' : 'gap-1 py-[1px] pr-[7px] pl-[5px] text-[10.5px]'
       }`}
     >

--- a/packages/web/src/components/console/modals/DaemonLifecycleModal.tsx
+++ b/packages/web/src/components/console/modals/DaemonLifecycleModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useConsoleData } from '@/lib/data-context'
 import { getDaemonLifecycleOp, type DaemonLifecycleOpDto } from '@/lib/api'
+import { daemonLifecycleLabel } from '../DaemonLifecycleBadge'
 import type { DaemonRow } from '@/lib/data'
 import { registerCommandedLifecycleOpId } from '@/lib/daemon-notifications'
 import { Button, Icon } from '@/components/ui'
@@ -192,10 +193,14 @@ export default function DaemonLifecycleModal({
                 </span>
                 <div className="flex-1">
                   <div className="font-sans text-[13px] font-semibold leading-normal">
-                    {isUpgrade ? 'Installing and relaunching…' : 'Draining and relaunching…'}
+                    {tracked ? daemonLifecycleLabel(tracked) : isUpgrade ? 'Upgrading…' : 'Restarting…'}
                   </div>
                   <div className="mono text-[11px] text-(--text-tertiary)">
-                    {daemon.name} will re-register once its supervisor brings it back.
+                    {tracked?.phase === 'preparing'
+                      ? live?.status === 'online'
+                        ? 'Agents continue working while the new version is prepared.'
+                        : 'Preparing the new version. Agents will be available when the daemon is back online.'
+                      : 'Agents will be available when the restart completes.'}
                   </div>
                 </div>
               </>

--- a/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.pool.test.tsx
@@ -110,6 +110,27 @@ beforeEach(() => {
 })
 
 describe('DaemonsView pool', () => {
+  it('shows upgrade preparation alongside the live availability of an owned daemon', () => {
+    mocks.daemons = [
+      daemon({
+        lifecycleOp: {
+          id: 'upgrade-1',
+          op: 'upgrade',
+          status: 'pending',
+          phase: 'preparing',
+          targetVersion: '2.0.0',
+          outcome: null
+        }
+      })
+    ]
+
+    const html = render()
+
+    expect(html).toContain('Preparing upgrade')
+    expect(html).toContain('>online<')
+    expect(html).not.toContain('>upgrading<')
+  })
+
   it('shows one Cloud entry for the whole pool, however many Pods are in it', () => {
     mocks.daemons = [member('p1'), member('p2'), member('p3', { status: 'offline' })]
 

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -19,6 +19,7 @@ import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
 import { DaemonUpgradeBadge } from '@/components/console/DaemonUpgradeBadge'
+import { DaemonLifecycleBadge } from '@/components/console/DaemonLifecycleBadge'
 import { KubernetesMark, LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
@@ -604,7 +605,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
             />
           </div>
           {/* Mobile appends the host, desktop the agent count; the upgrade hint hides mid-op, where the status says so. */}
-          <div className="flex min-w-0 items-center gap-[7px]">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-[7px] gap-y-[3px]">
             <span className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:text-[11px] desktop:leading-[1.5] desktop:tabular-nums">
               {m.version}
               {m.host && m.host !== m.name && <span className="desktop:hidden">{` · ${m.host}`}</span>}
@@ -615,6 +616,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
               latest={m.latestVersion}
               onClick={canUpgrade ? () => openModal('upgradeDaemon', m) : undefined}
             />
+            {m.lifecycleOp?.phase === 'preparing' && <DaemonLifecycleBadge op={m.lifecycleOp} />}
           </div>
         </div>
         <span

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1148,6 +1148,7 @@ export interface DaemonLifecycleOpDto {
   id: string
   op: 'restart' | 'upgrade'
   status: 'pending' | 'succeeded' | 'failed'
+  phase?: import('@agentconnect.md/protocol').DaemonLifecyclePhase | null
   targetVersion: string | null
   outcome: string | null
 }

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -33,6 +33,19 @@ import {
 } from './data'
 
 describe('planned daemon lifecycle status', () => {
+  it('keeps availability during preparation and switches presentation only on reported restart', () => {
+    const op = { op: 'upgrade' as const, status: 'pending' as const, phase: 'preparing' as const }
+    const placed = { status: 'online' as const, daemon: 'daemon-1' }
+    for (const connection of ['online', 'offline'] as const) {
+      const daemon = { status: connection, lifecycleStatus: lifecycleStatus(op) ?? null }
+      expect(presentedDaemonStatus(daemon)).toBe(connection)
+      expect(effectiveAgentStatus(placed, daemon)).toBe(connection)
+      expect(effectiveAgentStatus({ ...placed, status: 'paused' }, daemon)).toBe('paused')
+    }
+    expect(lifecycleStatus({ ...op, phase: 'restarting' })).toBe('restarting')
+    expect(lifecycleStatus({ ...op, status: 'failed' })).toBeUndefined()
+  })
+
   it('keeps online agents in the explicit restart or upgrade transition', () => {
     expect(lifecycleStatus({ op: 'upgrade', status: 'pending' })).toBe('upgrading')
     expect(lifecycleStatus({ op: 'restart', status: 'pending' })).toBe('restarting')

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -4,6 +4,7 @@
 import type { AgentIcon } from '@/lib/agent-icon'
 import { gitRepoHostname, managedGitlabRepoPath } from './git-url-tile'
 import { isCodeHostHookKind, type HookKind } from '@agentconnect.md/protocol/code-host'
+import type { DaemonLifecyclePhase } from '@agentconnect.md/protocol'
 import type {
   DaemonSessionRetention,
   ManagedMemoryHome,
@@ -54,9 +55,11 @@ export function status(s: string): StatusInfo {
 }
 
 export function lifecycleStatus(
-  op: Pick<DaemonLifecycleOp, 'op' | 'status'> | null | undefined
+  op: Pick<DaemonLifecycleOp, 'op' | 'status' | 'phase'> | null | undefined
 ): LifecycleStatusKey | undefined {
   if (op?.status !== 'pending') return undefined
+  if (op.phase === 'preparing') return undefined
+  if (op.phase === 'restarting') return 'restarting'
   return op.op === 'upgrade' ? 'upgrading' : 'restarting'
 }
 
@@ -2191,6 +2194,7 @@ export interface DaemonLifecycleOp {
   id: string
   op: 'restart' | 'upgrade'
   status: 'pending' | 'succeeded' | 'failed'
+  phase?: DaemonLifecyclePhase | null
   targetVersion: string | null
   outcome: string | null
 }


### PR DESCRIPTION
An accepted upgrade currently marks a serving daemon and its agents as upgrading throughout installation and image preparation. The console now keeps actual availability and shows Preparing upgrade until the daemon begins shutdown, then switches to Restarting.

Persist acknowledged preparation and restart reports on the existing lifecycle operation, fenced by operation ID, daemon identity, connection epoch, and deadline. Preparation failures settle the operation while the current daemon keeps serving; success still requires the target version to reach READY. Offline bootstrap recovery reports the same phases without implying online availability, and older daemons retain the existing generic upgrade display.

Validation: protocol suite (522 tests), focused daemon tests (20), PostgreSQL lifecycle route/auth tests (66), web status/render tests (88), affected package typechecks, and desktop/mobile rendering at 1280, 390, and 320 pixels. Adds one nullable database column for the reported phase.

Created by Codex . GPT-6
