### PR TITLE
feat(daemon): add sandbox environment defaults

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -610,6 +610,7 @@ Workspace preparation is implemented by `packages/daemon/src/workspace/workspace
 Ordinary environment variables and write-only secrets can be configured through Console / CP `AgentSpec.env` and `AgentSpec.secrets`. The daemon keeps CP values in memory and `agentChildEnv()` merges/injects them when starting an ACP child; it never writes those values to `agent.json`.
 
 - Secret wins over ordinary env with the same name; daemon security/runtime injection remains higher priority.
+- Sandboxed launches also inherit daemon-local [`sandbox.env`](daemon-sandbox-backends.md#sandbox-environment-defaults) defaults, below runtime-definition and agent env/secrets.
 - Env/secrets changes affect host spawn. Reconcile evicts the old host so the next start uses the new values.
 - Daemon **does not read** a sibling `.env` and does not interpolate `${VAR}` in `agent.json`; configuration, descriptions, and cron-trigger strings remain literal.
 - Secret values are never logged. The model receives only secret names and confidentiality constraints; values exist only in child environment, with unified secret masking as a leak backstop.

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -18,7 +18,7 @@ Control Plane does not carry ACP or provider request traffic.
 ## 1. Configuration and ownership
 
 The daemon-owned `sandbox` object in `~/.agentconnect/config.json` defaults to
-`{ "backend": "srt", "mounts": [] }`. The minimal configuration is:
+`{ "backend": "srt", "env": {}, "mounts": [] }`. The minimal configuration is:
 
 ```json
 {
@@ -38,6 +38,9 @@ that default:
   },
   "sandbox": {
     "backend": "microsandbox",
+    "env": {
+      "PNPM_CONFIG_STORE_DIR": "/cache/pnpm"
+    },
     "mounts": [
       {
         "source": "/srv/agent-cache/pnpm",
@@ -66,6 +69,7 @@ settings.
 | Setting                        | Meaning and delivery status                                                                                                                                                                                                                                                                                                                 |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sandbox.backend`              | Implemented: `srt` is the default; `microsandbox` selects the Linux VM implementation for sandboxed launches.                                                                                                                                                                                                                               |
+| `sandbox.env`                  | Environment defaults for sandboxed session runtimes, default `{}`; shared by SRT and microsandbox. Runtime and agent variables override them; daemon-enforced private paths and security settings remain authoritative.                                                                                                                     |
 | `security.requireSandbox`      | Existing behavior: require sandboxed execution for every agent, using the selected backend.                                                                                                                                                                                                                                                 |
 | Agent **Run in sandbox**       | Keeps its current role when the daemon does not require sandboxing. Selecting a backend does not change the trust choice for unsandboxed agents.                                                                                                                                                                                            |
 | `sandbox.microsandbox.image`   | Implemented: optional, non-empty OCI override. Release builds default to their bundled shared-image reference; development builds require an explicit image. No Kubernetes image lookup is used.                                                                                                                                            |
@@ -119,6 +123,9 @@ For example, SRT uses the same common configuration shape:
 {
   "sandbox": {
     "backend": "srt",
+    "env": {
+      "PNPM_CONFIG_STORE_DIR": "/srv/agent-cache/pnpm"
+    },
     "mounts": [
       {
         "source": "/srv/agent-cache/pnpm",
@@ -137,6 +144,26 @@ settings: point the package manager at the effective target path. Do not mount
 an entire host HOME to make an isolated runtime work. Session retirement detaches
 operator-owned mounts without deleting their host contents.
 
+### Sandbox environment defaults
+
+Use `sandbox.env` for machine-local settings that accompany mounts. Values are
+strings passed literally: the daemon does not expand `~`, `${HOME}`, or shell
+commands. The child tool may implement its own expansion, as pnpm does for
+`${HOME}` in the example below. Environment variable names must be valid process
+variable names; values may be empty, must not contain NUL, and are limited to
+16,384 characters each.
+
+The merge order is inherited environment, `sandbox.env`, runtime-definition env,
+agent env/secrets, then daemon-owned runtime and security settings. Private
+`HOME` and XDG directories remain session-owned. Config-file variables such as
+`KUBECONFIG_DATA` follow the existing materialization rules. Unsandboxed agents,
+daemon subprocesses, and runtime compatibility probes do not consume these
+defaults. The local `chat` command uses them when running with SRT.
+
+Restart the daemon after editing `config.json`. A retained microsandbox session
+uses the updated environment when its runtime restarts; changing only
+`sandbox.env` does not require discarding its VM or disks.
+
 ### Shared bases with session-local writes
 
 microsandbox also accepts `mode: "overlay"` for directory sources. Multiple
@@ -145,13 +172,23 @@ host base while keeping additions, changes, and deletions on their own writable
 layer. `readonly` rejects guest writes; `writable` writes directly to the host;
 `overlay` never writes back to its host source. SRT rejects overlay mode.
 
-For example, when pnpm's default store is under the session's XDG data directory:
+For example, mount a shared pnpm store under the session's XDG data directory:
 
 ```json
 {
-  "source": "/srv/agent-cache/pnpm",
-  "target": "~/.local/share/pnpm/store",
-  "mode": "overlay"
+  "sandbox": {
+    "backend": "microsandbox",
+    "env": {
+      "PNPM_CONFIG_STORE_DIR": "${HOME}/.local/share/pnpm/store"
+    },
+    "mounts": [
+      {
+        "source": "/srv/agent-cache/pnpm",
+        "target": "~/.local/share/pnpm/store",
+        "mode": "overlay"
+      }
+    ]
+  }
 }
 ```
 
@@ -159,8 +196,12 @@ The source must be an existing, populated host store directory. `~` in `source`
 uses the daemon's HOME; `~` in a microsandbox `target` uses the session HOME.
 Verify the effective target with `pnpm store path` in the actual session and
 project, since package-manager versions, environment, and filesystem layout
-affect the default. Mounting at that default avoids a separate store setting.
-This shares store contents only; each session still has its own `node_modules`.
+affect the default.
+An explicit store setting keeps pnpm from choosing a project-local store when
+the workspace and mounted store are on different filesystems. This shares store
+contents only; each session still has its own `node_modules`. Registry metadata
+is a separate cache, so a populated store alone does not guarantee a fresh
+session can install fully offline.
 
 The daemon mounts each base read-only at an internal path and allocates one
 session-owned ext4 disk for all its overlay upper/work directories. Before

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -135,7 +135,10 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
 
   const agentEnv = agentChildEnv(agent)
-  const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+  const runtimeEnv = {
+    ...(runInSandbox ? cfg.sandbox.env : {}),
+    ...Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+  }
   const memoryAgent =
     memoryKindOf(agent) === 'native' && runInSandbox ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
   // Memory backend env joins the agent env BEFORE materialization, as the daemon does, so

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -189,11 +189,12 @@ export const ConfigSchema = z.object({
   sandbox: z
     .object({
       backend: SandboxBackendSchema.default('srt'),
+      env: z.record(EnvironmentName, ProcessValue).default({}),
       mounts: z.array(SandboxMountSchema).default([]),
       microsandbox: MicrosandboxConfigSchema.optional()
     })
     .strict()
-    .default({ backend: 'srt', mounts: [] }),
+    .default({ backend: 'srt', env: {}, mounts: [] }),
   security: z
     .object({
       // Prevent ACP runtimes from implicitly inheriting apps/connectors attached

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3124,10 +3124,11 @@ export class Daemon {
       // The session integration's own bot identity (auth.test-resolved on both
       // socket and send-only connections) for the `# Agent` Slack-identity line.
       slackBotUserIdFor: (integrationId) => this.connByIntegration.get(integrationId)?.botUserId || undefined,
-      // Same runtime-def env base the spawn path merges under the agent env, so
-      // the standing-context config-file description matches what materialized.
-      runtimeEnvFor: (runtimeId) =>
-        Object.fromEntries((this.runtimes[runtimeId]?.env ?? []).map((entry) => [entry.name, entry.value])),
+      // Match the spawn defaults so standing context describes the files actually materialized.
+      runtimeEnvFor: (agent) => ({
+        ...(this.agentRunsInSandbox(agent) ? this.cfg.sandbox.env : {}),
+        ...Object.fromEntries((this.runtimes[agent.runtime]?.env ?? []).map((entry) => [entry.name, entry.value]))
+      }),
       // Inject the agent's tool set. Memory/collaboration tools are universal, so a
       // session is registered even with no platform integration. The token binds this
       // ACP session to its exact channel/thread/delivery integration.
@@ -4672,7 +4673,10 @@ export class Daemon {
       memoryKindOf(agent) === 'native' && runInSandbox
         ? { ...agent, dir: microContext?.launch.runtimeHome ?? privateRuntimeHomeFor(agent.dir, opts.hostKey) }
         : agent
-    const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+    const runtimeEnv = {
+      ...(runInSandbox ? cfg.sandbox.env : {}),
+      ...Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+    }
     // On --k8s the runtime runs in the agent's pod, so the session gitconfig has to be COMPUTED in
     // pod coordinates and WRITTEN there: the file travels with the launch (SpawnRequest.files) and
     // is re-materialized on every spawn, because a resumed Sandbox is a new pod with an empty tmpfs.
@@ -4749,7 +4753,7 @@ export class Daemon {
       shimDirs.add(this.glabBinDir)
     }
     if (shimDirs.size > 0) {
-      env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? microContext?.launch.env.PATH ?? process.env.PATH ?? ''}`
+      env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? runtimeEnv.PATH ?? process.env.PATH ?? ''}`
     }
     const target = opts.modelCredential?.target ?? modelProviderTarget(agent, runtime)
     // OS sandbox decision (issue #312). security.requireSandbox forces every agent

--- a/packages/daemon/src/evaluation/runner.ts
+++ b/packages/daemon/src/evaluation/runner.ts
@@ -781,7 +781,10 @@ export class RawAcpEvaluationRunner {
       if (!mechanism) throw new Error('raw ACP evaluation requires a supported Linux SRT/bwrap sandbox')
       const runInSandbox = effectiveRunInSandbox(true, agent.runInSandbox, mechanism)
       const baseEnv = agentChildEnv(agent)
-      const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+      const runtimeEnv = {
+        ...cfg.sandbox.env,
+        ...Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
+      }
       const memoryOffEnv = memoryProviderFor(
         { ...agent, memory: { provider: 'none' } },
         runtime,

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -231,12 +231,8 @@ export class SessionManager {
        *  cannot tell that a multi-mention message addresses it — the
        *  response-choice rule then misfires into AC_NO_RESPONSE. */
       slackBotUserIdFor?: (integrationId: string) => string | undefined
-      /** The runtime-definition env (daemon config `runtimes[].env`) for an agent's
-       *  runtime. The spawn path detects config-file pointer-var conflicts over
-       *  `{...runtimeEnv, ...agentEnv}` — supply the same base here so the
-       *  standing-context description agrees with what actually materialized.
-       *  Omitted (e.g. tests) ⇒ agent-level env only. */
-      runtimeEnvFor?: (runtimeId: string) => Record<string, string>
+      /** Sandbox/runtime defaults used to detect config-file pointer conflicts, as at spawn. */
+      runtimeEnvFor?: (agent: Agent) => Record<string, string>
       /**
        * Build the default MCP servers to inject for a brand-new ACP session,
        * given its platform binding. Omitted (or returning []) means no tools —
@@ -568,11 +564,9 @@ export class SessionManager {
     // `@name` for a DM (same value the console labels with), surfaced as-is.
     const channelName = await (await this.deps.store.getDisplayNames([msg.channel])).get(msg.channel)
     const secretNames = (agent.runtimeOverrides?.secrets ?? []).map((s) => s.name)
-    // planConfigFiles over the same `{...runtimeEnv, ...agentEnv}` merge the spawn path uses
-    // keeps the two in agreement: a pointer var set explicitly ANYWHERE (agent env or the
-    // runtime definition) wins there too, leaving the secret a plain env var.
+    // Match the spawn merge so an explicit pointer in any layer suppresses file materialization here too.
     const fileSecrets = planConfigFiles({
-      ...this.deps.runtimeEnvFor?.(agent.runtime),
+      ...this.deps.runtimeEnvFor?.(agent),
       ...agentChildEnv(agent)
     }).materialize.filter((m) => secretNames.includes(m.sourceVar))
     const fileSecretNames = new Set(fileSecrets.map((m) => m.sourceVar))

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -77,7 +77,7 @@ describe('loadConfig', () => {
     expect(cfg.runtimes!.claude!.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
     expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['*'])
-    expect(cfg.sandbox).toEqual({ backend: 'srt', mounts: [] })
+    expect(cfg.sandbox).toEqual({ backend: 'srt', env: {}, mounts: [] })
     expect(cfg.features.turnFinalContextRefresh).toBe(true)
     expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')
@@ -91,6 +91,7 @@ describe('loadConfig', () => {
     })
     expect(cfg.sandbox).toEqual({
       backend: 'srt',
+      env: {},
       mounts: [{ source: '/opt/toolchain', target: '/opt/toolchain', mode: 'readonly' }]
     })
     expect(() =>
@@ -105,9 +106,22 @@ describe('loadConfig', () => {
     expect(() => ConfigSchema.parse({ version: 1, sandbox: { backend: 'docker' } })).toThrow()
   })
 
+  it('loads sandbox environment values literally, including empty values', () => {
+    const env = { PNPM_CONFIG_STORE_DIR: '${HOME}/.local/share/pnpm/store', EMPTY: '' }
+    expect(loadConfig({ root: tmpRoot({ version: 1, sandbox: { env } }) }).sandbox.env).toEqual(env)
+  })
+
+  it.each([{ 'BAD=NAME': 'value' }, { TOKEN: 'value\0' }, { PORT: 8080 }])(
+    'rejects invalid sandbox environment entries: %j',
+    (env) => {
+      expect(() => ConfigSchema.parse({ version: 1, sandbox: { env } })).toThrow()
+    }
+  )
+
   it('allows the release image default without adding Docker lifecycle configuration', () => {
     expect(ConfigSchema.parse({ version: 1, sandbox: { backend: 'microsandbox' } }).sandbox).toEqual({
       backend: 'microsandbox',
+      env: {},
       mounts: []
     })
     expect(
@@ -125,6 +139,7 @@ describe('loadConfig', () => {
       }).sandbox
     ).toEqual({
       backend: 'microsandbox',
+      env: {},
       mounts: [],
       microsandbox: {
         image: 'registry.example.test/runtime:test',

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -107,6 +107,7 @@ function makeRoutable(daemon: Daemon): void {
 
 function useMicrosandbox(daemon: Daemon, environments: string[] = []) {
   const manager = {
+    driverFor: vi.fn(() => ({})),
     environmentIds: vi.fn(async () => environments),
     suspend: vi.fn(async () => {}),
     suspendIdle: vi.fn(async () => {}),
@@ -119,6 +120,59 @@ function useMicrosandbox(daemon: Daemon, environments: string[] = []) {
   ;(daemon as any).microsandboxTable = { mcpBridge: { command: 'node', args: ['/image/mcp-bridge.js'] } }
   return manager
 }
+
+it.each(['srt', 'microsandbox'])('applies sandbox.env to %s sessions below runtime and agent env', async (backend) => {
+  const root = scaffold({ workspace: { mode: 'from-scratch', path: 'workspace' } }, 'shared')
+  const path = join(root, 'config.json')
+  const config = JSON.parse(readFileSync(path, 'utf8'))
+  const defaults = {
+    PNPM_CONFIG_STORE_DIR: '${HOME}/.local/share/pnpm/store',
+    RUNTIME_VALUE: 'sandbox',
+    AGENT_VALUE: 'sandbox',
+    HOME: '/ignored-home',
+    XDG_DATA_HOME: '/ignored-data',
+    KUBECONFIG_DATA: 'apiVersion: v1\nclusters: []\n'
+  }
+  config.sandbox = { env: defaults }
+  config.runtimes.claude.env = [
+    { name: 'RUNTIME_VALUE', value: 'runtime' },
+    { name: 'AGENT_VALUE', value: 'runtime' }
+  ]
+  writeFileSync(path, JSON.stringify(config))
+  const daemon = new Daemon({
+    root,
+    slackAppFactory: fakeSlackAppFactory(),
+    sandboxMechanism: 'bwrap',
+    probeRuntimes: async () => []
+  })
+  try {
+    await daemon.start()
+    if (backend === 'microsandbox') useMicrosandbox(daemon)
+    const agent = (daemon as any).agents.get('bot-a')
+    agent.runtimeOverrides = { env: [{ name: 'AGENT_VALUE', value: 'agent' }] }
+    const build = (runInSandbox: boolean) =>
+      (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        hostKey: sessionHostKey(agent.id, KEY('env')),
+        runInSandbox,
+        cwd: agent.workspace.path
+      }).host.opts
+    const launch = build(true)
+    expect(launch.env).toMatchObject({
+      PNPM_CONFIG_STORE_DIR: defaults.PNPM_CONFIG_STORE_DIR,
+      RUNTIME_VALUE: 'runtime',
+      AGENT_VALUE: 'agent'
+    })
+    expect(launch.env.HOME).not.toBe(defaults.HOME)
+    expect(launch.env.XDG_DATA_HOME).toBe(join(launch.env.HOME, '.local', 'share'))
+    expect(launch.env.KUBECONFIG_DATA).toBeUndefined()
+    expect(readFileSync(launch.env.KUBECONFIG, 'utf8')).toBe(defaults.KUBECONFIG_DATA)
+    expect((daemon as any).cfg.sandbox.env).toEqual(defaults)
+    expect(build(false).env.PNPM_CONFIG_STORE_DIR).toBeUndefined()
+  } finally {
+    await daemon.stop()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
 
 const dm = (ts: string, text: string, thread: string) => ({
   msgId: `slack:C1:${ts}`,

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -121,57 +121,62 @@ function useMicrosandbox(daemon: Daemon, environments: string[] = []) {
   return manager
 }
 
-it.each(['srt', 'microsandbox'])('applies sandbox.env to %s sessions below runtime and agent env', async (backend) => {
-  const root = scaffold({ workspace: { mode: 'from-scratch', path: 'workspace' } }, 'shared')
-  const path = join(root, 'config.json')
-  const config = JSON.parse(readFileSync(path, 'utf8'))
-  const defaults = {
-    PNPM_CONFIG_STORE_DIR: '${HOME}/.local/share/pnpm/store',
-    RUNTIME_VALUE: 'sandbox',
-    AGENT_VALUE: 'sandbox',
-    HOME: '/ignored-home',
-    XDG_DATA_HOME: '/ignored-data',
-    KUBECONFIG_DATA: 'apiVersion: v1\nclusters: []\n'
-  }
-  config.sandbox = { env: defaults }
-  config.runtimes.claude.env = [
-    { name: 'RUNTIME_VALUE', value: 'runtime' },
-    { name: 'AGENT_VALUE', value: 'runtime' }
-  ]
-  writeFileSync(path, JSON.stringify(config))
-  const daemon = new Daemon({
-    root,
-    slackAppFactory: fakeSlackAppFactory(),
-    sandboxMechanism: 'bwrap',
-    probeRuntimes: async () => []
-  })
-  try {
-    await daemon.start()
-    if (backend === 'microsandbox') useMicrosandbox(daemon)
-    const agent = (daemon as any).agents.get('bot-a')
-    agent.runtimeOverrides = { env: [{ name: 'AGENT_VALUE', value: 'agent' }] }
-    const build = (runInSandbox: boolean) =>
-      (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
-        hostKey: sessionHostKey(agent.id, KEY('env')),
-        runInSandbox,
-        cwd: agent.workspace.path
-      }).host.opts
-    const launch = build(true)
-    expect(launch.env).toMatchObject({
-      PNPM_CONFIG_STORE_DIR: defaults.PNPM_CONFIG_STORE_DIR,
-      RUNTIME_VALUE: 'runtime',
-      AGENT_VALUE: 'agent'
-    })
-    expect(launch.env.HOME).not.toBe(defaults.HOME)
-    expect(launch.env.XDG_DATA_HOME).toBe(join(launch.env.HOME, '.local', 'share'))
-    expect(launch.env.KUBECONFIG_DATA).toBeUndefined()
-    expect(readFileSync(launch.env.KUBECONFIG, 'utf8')).toBe(defaults.KUBECONFIG_DATA)
-    expect((daemon as any).cfg.sandbox.env).toEqual(defaults)
-    expect(build(false).env.PNPM_CONFIG_STORE_DIR).toBeUndefined()
-  } finally {
-    await daemon.stop()
-    rmSync(root, { recursive: true, force: true })
-  }
+describe.each(['srt', 'microsandbox'])('sandbox.env (%s)', (backend) => {
+  it.skipIf(process.platform === 'win32' && backend === 'microsandbox')(
+    'applies defaults below runtime and agent env',
+    async () => {
+      const root = scaffold({ workspace: { mode: 'from-scratch', path: 'workspace' } }, 'shared')
+      const path = join(root, 'config.json')
+      const config = JSON.parse(readFileSync(path, 'utf8'))
+      const defaults = {
+        PNPM_CONFIG_STORE_DIR: '${HOME}/.local/share/pnpm/store',
+        RUNTIME_VALUE: 'sandbox',
+        AGENT_VALUE: 'sandbox',
+        HOME: '/ignored-home',
+        XDG_DATA_HOME: '/ignored-data',
+        KUBECONFIG_DATA: 'apiVersion: v1\nclusters: []\n'
+      }
+      config.sandbox = { env: defaults }
+      config.runtimes.claude.env = [
+        { name: 'RUNTIME_VALUE', value: 'runtime' },
+        { name: 'AGENT_VALUE', value: 'runtime' }
+      ]
+      writeFileSync(path, JSON.stringify(config))
+      const daemon = new Daemon({
+        root,
+        slackAppFactory: fakeSlackAppFactory(),
+        sandboxMechanism: 'bwrap',
+        probeRuntimes: async () => []
+      })
+      try {
+        await daemon.start()
+        if (backend === 'microsandbox') useMicrosandbox(daemon)
+        const agent = (daemon as any).agents.get('bot-a')
+        agent.runtimeOverrides = { env: [{ name: 'AGENT_VALUE', value: 'agent' }] }
+        const build = (runInSandbox: boolean) =>
+          (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+            hostKey: sessionHostKey(agent.id, KEY('env')),
+            runInSandbox,
+            cwd: agent.workspace.path
+          }).host.opts
+        const launch = build(true)
+        expect(launch.env).toMatchObject({
+          PNPM_CONFIG_STORE_DIR: defaults.PNPM_CONFIG_STORE_DIR,
+          RUNTIME_VALUE: 'runtime',
+          AGENT_VALUE: 'agent'
+        })
+        expect(launch.env.HOME).not.toBe(defaults.HOME)
+        expect(launch.env.XDG_DATA_HOME).toBe(join(launch.env.HOME, '.local', 'share'))
+        expect(launch.env.KUBECONFIG_DATA).toBeUndefined()
+        expect(readFileSync(launch.env.KUBECONFIG, 'utf8')).toBe(defaults.KUBECONFIG_DATA)
+        expect((daemon as any).cfg.sandbox.env).toEqual(defaults)
+        expect(build(false).env.PNPM_CONFIG_STORE_DIR).toBeUndefined()
+      } finally {
+        await daemon.stop()
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 const dm = (ts: string, text: string, thread: string) => ({


### PR DESCRIPTION
Add `sandbox.env` to daemon configuration so operators can pair shared cache mounts with package-manager settings without editing the service environment or every agent. SRT and microsandbox sessions apply these defaults below runtime and agent variables while preserving private HOME, security settings, and config-file materialization.

Values remain literal. Document the pnpm overlay store configuration and its filesystem-dependent store selection. Local sandboxed chat and raw ACP evaluation use the same defaults; unsandboxed launches and compatibility probes retain their current environment behavior.

Validation: 188 focused tests across configuration, daemon session hosts, chat, and session management; daemon typecheck and build; targeted ESLint, Prettier, and publication scans.

Live Linux/microsandbox verification: resumed a retained session after moving the pnpm setting from the service environment to `sandbox.env`. The VM, image, and writable disks were preserved; an offline reinstall reused the cached package with zero downloads and passed a runtime import check.

Created by Codex . GPT-6
