### PR TITLE
fix(daemon): protect credentials from native Claude file tools

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -427,6 +427,7 @@ export interface AcpToolSandbox {
 
 interface ClaudeSessionSettings {
   env?: ClaudeProtectedSettings['env']
+  plansDirectory?: string
   permissions?: { deny: string[] }
   modelOverrides?: unknown
   availableModels?: unknown
@@ -469,7 +470,8 @@ export function claudeSessionMeta(
   })
   const settings: ClaudeSessionSettings = {
     ...(protectedSettings ?? {}),
-    ...(deny.length > 0 ? { permissions: { deny } } : {}),
+    // Claude requires custom plans inside the workspace; its default HOME/.claude/plans is protected above.
+    ...(deny.length > 0 ? { permissions: { deny }, plansDirectory: './.claude/plans' } : {}),
     ...(ultracode ? { ultracode: true, enableWorkflows: true } : {})
   }
   return {

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -415,7 +415,7 @@ export const SDK_LIFECYCLE_FILTERS = [
 ] as const
 
 export interface AcpToolSandbox {
-  /** Credential paths available to the trusted runtime but denied to model-authored commands. */
+  /** Credential paths available to the trusted runtime but denied to model-authored tools. */
   protectedCredentialRoots: string[]
   /** Permit model-authored tools to use the daemon-provided Unix socket channels. */
   allowModelToolUnixSockets?: boolean
@@ -427,6 +427,7 @@ export interface AcpToolSandbox {
 
 interface ClaudeSessionSettings {
   env?: ClaudeProtectedSettings['env']
+  permissions?: { deny: string[] }
   modelOverrides?: unknown
   availableModels?: unknown
   ultracode?: true
@@ -458,27 +459,31 @@ export function claudeSessionMeta(
     }
   | undefined {
   if (!isClaudeRuntime) return undefined
-  // The seed and the memory index ride the SAME append (seed first, blank line, then
-  // memory). Either/both/neither — an empty result omits `systemPrompt` entirely.
+  // Append the system prompt and memory together, omitting an empty result.
   const append = [systemPrompt, memoryAppend].filter(Boolean).join('\n\n')
   const ultracode = reasoningEffort === ULTRACODE_EFFORT
+  const deny = [...new Set(protectedCredentialRoots)].flatMap((root) => {
+    // Claude uses gitignore patterns with // for absolute paths; cover the root and its descendants.
+    const pattern = `/${root.replace(/\/+$/, '').replace(/[\\*?[\] ]/g, (char) => `\\${char}`)}`
+    return ['Read', 'Edit'].flatMap((tool) => [`${tool}(${pattern})`, `${tool}(${pattern}/**)`])
+  })
   const settings: ClaudeSessionSettings = {
     ...(protectedSettings ?? {}),
+    ...(deny.length > 0 ? { permissions: { deny } } : {}),
     ...(ultracode ? { ultracode: true, enableWorkflows: true } : {})
   }
   return {
     claudeCode: {
       options: {
         thinking: { type: 'adaptive', display: 'summarized' },
-        // #998: the built-in agent-teams SendMessage is a live misdelivery channel;
-        // adapters spread this into SDK query() options (older ones ignore it).
+        // Suppress built-in cross-session messaging through the SDK options (#998).
         disallowedTools: [...CLAUDE_DISALLOWED_BUILTIN_TOOLS, ...extraDisallowedTools],
         ...(protectedCredentialRoots
           ? {
               sandbox: claudeInnerSandboxSettings(protectedCredentialRoots, allowModelToolUnixSockets, sharedWriteRoots)
             }
           : {}),
-        ...(protectedSettings || ultracode ? { settings } : {})
+        ...(protectedSettings || ultracode || deny.length > 0 ? { settings } : {})
       },
       emitRawSDKMessages: SDK_LIFECYCLE_FILTERS
     },

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -258,6 +258,14 @@ describe('claudeSessionMeta', () => {
 
   it('enables the native Claude sandbox only behind an outer AgentConnect sandbox', () => {
     const credentialRoot = '/host/.claude/agentconnect-auth'
+    const permissions = {
+      deny: [
+        'Read(//host/.claude/agentconnect-auth)',
+        'Read(//host/.claude/agentconnect-auth/**)',
+        'Edit(//host/.claude/agentconnect-auth)',
+        'Edit(//host/.claude/agentconnect-auth/**)'
+      ]
+    }
     const protectedSettings = {
       modelOverrides: { sonnet: 'bedrock/sonnet' },
       availableModels: ['sonnet'],
@@ -312,7 +320,7 @@ describe('claudeSessionMeta', () => {
     }
 
     expect(claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings)).toEqual(
-      cc({ thinking: THINKING, sandbox, settings: protectedSettings })
+      cc({ thinking: THINKING, sandbox, settings: { ...protectedSettings, permissions } })
     )
     expect(
       claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings, true)?.claudeCode
@@ -322,7 +330,7 @@ describe('claudeSessionMeta', () => {
       cc({
         thinking: THINKING,
         sandbox,
-        settings: { ...protectedSettings, ultracode: true, enableWorkflows: true }
+        settings: { ...protectedSettings, permissions, ultracode: true, enableWorkflows: true }
       })
     )
     // An empty array still means an outer sandbox is active; undefined means it
@@ -344,6 +352,25 @@ describe('claudeSessionMeta', () => {
       claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], undefined, false, [], ['/host/store'])
         ?.claudeCode.options.sandbox?.filesystem
     ).toEqual({ allowWrite: ['/host/store'], denyRead: [credentialRoot], denyWrite: [credentialRoot] })
+  })
+
+  it('denies literal credential paths even without profile settings', () => {
+    const roots = ['/credentials/[account]/auth.json', '/credentials/[account]/auth.json', '/credentials/shared/']
+    expect(claudeSessionMeta(undefined, true, undefined, undefined, roots)?.claudeCode.options.settings).toEqual({
+      permissions: {
+        deny: [
+          'Read(//credentials/\\[account\\]/auth.json)',
+          'Read(//credentials/\\[account\\]/auth.json/**)',
+          'Edit(//credentials/\\[account\\]/auth.json)',
+          'Edit(//credentials/\\[account\\]/auth.json/**)',
+          'Read(//credentials/shared)',
+          'Read(//credentials/shared/**)',
+          'Edit(//credentials/shared)',
+          'Edit(//credentials/shared/**)'
+        ]
+      }
+    })
+    expect(claudeSessionMeta(undefined, true, undefined, undefined, [])?.claudeCode.options.settings).toBeUndefined()
   })
 
   it('returns undefined off a Claude runtime (the _meta is claude-acp-specific)', () => {

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -320,7 +320,11 @@ describe('claudeSessionMeta', () => {
     }
 
     expect(claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings)).toEqual(
-      cc({ thinking: THINKING, sandbox, settings: { ...protectedSettings, permissions } })
+      cc({
+        thinking: THINKING,
+        sandbox,
+        settings: { ...protectedSettings, permissions, plansDirectory: './.claude/plans' }
+      })
     )
     expect(
       claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings, true)?.claudeCode
@@ -330,7 +334,13 @@ describe('claudeSessionMeta', () => {
       cc({
         thinking: THINKING,
         sandbox,
-        settings: { ...protectedSettings, permissions, ultracode: true, enableWorkflows: true }
+        settings: {
+          ...protectedSettings,
+          permissions,
+          plansDirectory: './.claude/plans',
+          ultracode: true,
+          enableWorkflows: true
+        }
       })
     )
     // An empty array still means an outer sandbox is active; undefined means it
@@ -357,6 +367,7 @@ describe('claudeSessionMeta', () => {
   it('denies literal credential paths even without profile settings', () => {
     const roots = ['/credentials/[account]/auth.json', '/credentials/[account]/auth.json', '/credentials/shared/']
     expect(claudeSessionMeta(undefined, true, undefined, undefined, roots)?.claudeCode.options.settings).toEqual({
+      plansDirectory: './.claude/plans',
       permissions: {
         deny: [
           'Read(//credentials/\\[account\\]/auth.json)',

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -37,6 +37,7 @@ describe('AcpHost (against a fake ACP agent)', () => {
     expect(expected?.claudeCode.options.settings?.permissions).toEqual({
       deny: ['Read(//credentials)', 'Read(//credentials/**)', 'Edit(//credentials)', 'Edit(//credentials/**)']
     })
+    expect(expected?.claudeCode.options.settings?.plansDirectory).toBe('./.claude/plans')
     const host = new AcpHost(
       { command: process.execPath, args: [fakeAgent, 'claude-acp'], env: [] },
       {

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -34,6 +34,9 @@ describe('AcpHost (against a fake ACP agent)', () => {
       [],
       toolSandbox.sharedWriteRoots
     )
+    expect(expected?.claudeCode.options.settings?.permissions).toEqual({
+      deny: ['Read(//credentials)', 'Read(//credentials/**)', 'Edit(//credentials)', 'Edit(//credentials/**)']
+    })
     const host = new AcpHost(
       { command: process.execPath, args: [fakeAgent, 'claude-acp'], env: [] },
       {


### PR DESCRIPTION
Sandboxed Claude sessions denied credential access through Bash, but the daemon did not inject the corresponding permissions for native file tools. Add Read/Edit deny rules from the existing protected credential roots through the shared session settings used by SRT and microsandbox, including session creation and restoration.

The rules cover exact paths and directory descendants, escape literal glob characters, and preserve existing model, profile, and ultracode settings. Plan files use the workspace's `.claude/plans` directory so normal planning remains available outside the protected credential tree. Native authentication continues to use the existing credential mounts.

Validation:
- 91 focused ACP configuration and session tests passed; daemon typecheck and changed-file lint/format checks passed.
- Native CLI smoke with the image adapter's pinned Claude SDK executable, fake credential files, and a local mock API: new and resumed full-access sessions each rejected six protected operations and allowed three ordinary operations. Covered direct and symlink reads, Write, Edit, and NotebookEdit.
- Native plan-mode smoke with the same executable and generated settings: new and resumed sessions both wrote and read the actual assigned plan file while rejecting credential reads.

Created by Codex . GPT-6
