### PR TITLE
feat(daemon): protect DeepSeek keys with microsandbox secrets

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -316,7 +316,10 @@ diagnostic. Custom credential-reference names are outside this first implementat
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
 existing private logins are preserved. Without a DeepSeek key, normal seeding is
-unchanged. The daemon rejects mounts exposing protected host paths, sharing SRT's
+unchanged. On the currently supported Linux backend, projection holds directory
+and file descriptors without following symlinks and publishes by atomic rename,
+so a guest swapping a file or parent cannot redirect a daemon write. The daemon
+rejects mounts exposing protected host paths, sharing SRT's
 boundary and runtime-state inventory, and supplies the guest CA environment even
 when process-environment inheritance is disabled. Keys stay out
 of serialized launch metadata and environment bindings. The SDK persists its own

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -316,6 +316,8 @@ copies, rejects mounts exposing the host source files, and supplies the guest CA
 environment even when process-environment inheritance is disabled. Keys stay out
 of serialized launch metadata and environment bindings. The SDK persists its own
 secret configuration on the host; this protection is against guest access.
+All VM launches reject requested mounts of the host SDK state directory or its descendants,
+including launches for runtimes that do not use secret injection themselves.
 The proxy does not redact provider responses, so the allowed provider remains a
 trusted recipient of the key.
 

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -306,26 +306,41 @@ a shared discovery descriptor retain the runtime probe's authentication result.
 For DeepSeek Harness in microsandbox, the daemon resolves the standard
 `DEEPSEEK_API_KEY` reference using the existing credential-file descriptors and
 DSH parser (`.credentials.yaml`, including the legacy layout and version-1 refs,
-then `.env`). An explicit launch or inherited host key takes precedence. The guest
+then `.env`). An explicit launch or inherited host key takes precedence, so a
+malformed unused YAML seed cannot override it. The guest
 receives only a placeholder; microsandbox's built-in TLS proxy substitutes the key
-in request headers for `https://api.deepseek.com`. Custom provider endpoints and
-custom credential-reference names are outside this first implementation.
+in request headers for `https://api.deepseek.com`. A non-default base URL in the
+launch environment, host environment or DSH `.env` refuses the launch with a
+diagnostic. Custom credential-reference names are outside this first implementation.
 
-The daemon skips both credential seed files, removes their previous private-HOME
-copies, rejects mounts exposing the host source files, and supplies the guest CA
-environment even when process-environment inheritance is disabled. Keys stay out
+When a DeepSeek key is available, the daemon projects the credential seed files
+with that ref replaced by the placeholder; other provider refs, OAuth records and
+existing private logins are preserved. Without a DeepSeek key, normal seeding is
+unchanged. The daemon rejects mounts exposing protected host paths, sharing SRT's
+boundary and runtime-state inventory, and supplies the guest CA environment even
+when process-environment inheritance is disabled. Keys stay out
 of serialized launch metadata and environment bindings. The SDK persists its own
 secret configuration on the host; this protection is against guest access.
-All VM launches reject requested mounts of the host SDK state directory or its descendants,
-including launches for runtimes that do not use secret injection themselves.
+All VM launches reject requested mounts of the host SDK state directory, its
+ancestors or its descendants, including launches for runtimes that do not use
+secret injection themselves. Public support helpers live outside SDK state;
+retained VMs can keep their previous exact read-only helper mounts.
 The proxy does not redact provider responses, so the allowed provider remains a
 trusted recipient of the key.
+
+The pinned SDK installs the proxy CA into the guest system bundle before execution.
+Combining it with operator-provided trust bundles is deferred: protected DeepSeek
+launches explicitly refuse custom `TLS_TRUST_ENV`, `REQUESTS_CA_BUNDLE` or
+`CURL_CA_BUNDLE` settings instead of silently replacing them. Use SRT for those
+configurations until custom trust is supported.
 
 New VMs receive the proxy configuration at creation. Retained protected VMs reload
 the host key before starting again; already-running VMs keep their current key
 until stopped and resumed. Previously unprotected DeepSeek VMs fail configuration
 reuse and retain their data: start a new session instead of treating an old disk
-that may contain credentials as protected. SRT and Kubernetes authentication
+that may contain credentials as protected. If a protected VM's credential later
+disappears, restore that credential and retry or start a new session; no VM or
+session data is automatically discarded. SRT and Kubernetes authentication
 paths are unchanged. No separate daemon HTTP proxy or networking option is added.
 
 ## 2. Selecting the backend

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -249,7 +249,7 @@ sessions that share workspace files. Its private HOME lives under
 `runtime-homes/<session-leaf>/home` unless it already owns a confined session
 directory. For shared workspaces, native-memory directories mount the agent's
 existing memory store so Console reads and edits reach every session; runtime
-credentials stay in the session's HOME. Image changes apply to new sessions;
+state stays in the session's HOME. Image changes apply to new sessions;
 resume keeps the original image, runtime versions, HOME and disks until session
 retention removes them. Sessions created in a legacy shared agent VM continue
 using that VM until its last session retires. Resource and mount changes still
@@ -300,6 +300,31 @@ keys, Antigravity ACP file logins, Devin, and Copilot's stored token map. These
 descriptors also prepare the corresponding files in the private runtime HOME.
 Keyring-only logins are not detected by file discovery. Credential formats without
 a shared discovery descriptor retain the runtime probe's authentication result.
+
+### DeepSeek credential protection
+
+For DeepSeek Harness in microsandbox, the daemon resolves the standard
+`DEEPSEEK_API_KEY` reference using the existing credential-file descriptors and
+DSH parser (`.credentials.yaml`, including the legacy layout and version-1 refs,
+then `.env`). An explicit launch or inherited host key takes precedence. The guest
+receives only a placeholder; microsandbox's built-in TLS proxy substitutes the key
+in request headers for `https://api.deepseek.com`. Custom provider endpoints and
+custom credential-reference names are outside this first implementation.
+
+The daemon skips both credential seed files, removes their previous private-HOME
+copies, rejects mounts exposing the host source files, and supplies the guest CA
+environment even when process-environment inheritance is disabled. Keys stay out
+of serialized launch metadata and environment bindings. The SDK persists its own
+secret configuration on the host; this protection is against guest access.
+The proxy does not redact provider responses, so the allowed provider remains a
+trusted recipient of the key.
+
+New VMs receive the proxy configuration at creation. Retained protected VMs reload
+the host key before starting again; already-running VMs keep their current key
+until stopped and resumed. Previously unprotected DeepSeek VMs fail configuration
+reuse and retain their data: start a new session instead of treating an old disk
+that may contain credentials as protected. SRT and Kubernetes authentication
+paths are unchanged. No separate daemon HTTP proxy or networking option is added.
 
 ## 2. Selecting the backend
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3810,6 +3810,13 @@ export class Daemon {
     const launch = prepareMicrosandboxLaunch({
       runtimeId: runtimeEntry?.aliasOf ?? agent.runtime,
       runtime,
+      // Workspace preparation and ACP must select the same provider credentials.
+      explicitEnv: {
+        ...this.cfg.sandbox.env,
+        ...Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value])),
+        ...agentChildEnv(agent),
+        ...cpRuntimeEnv(agent)
+      },
       nativeMemory: memoryKindOf(agent) === 'native',
       scopeDir: agent.dir,
       cwd: placement.trustedSessionDir ?? (key && hostKeySessionKey(key) ? cwd : agent.workspace.path),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -61,7 +61,7 @@ import {
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { basename, dirname, join, relative, sep } from 'node:path'
 import { installMicrosandbox } from './microsandbox/install.js'
-import { prepareMicrosandboxLaunch } from './microsandbox/launch.js'
+import { microsandboxRuntimeHome, prepareMicrosandboxLaunch } from './microsandbox/launch.js'
 import type { MicrosandboxManager, MicrosandboxEnvironment } from './microsandbox/driver.js'
 import { microsandboxGitRunner } from './microsandbox/git.js'
 import { createMicrosandboxWorkspaceMutations } from './microsandbox/files.js'
@@ -3819,6 +3819,8 @@ export class Daemon {
       },
       nativeMemory: memoryKindOf(agent) === 'native',
       scopeDir: agent.dir,
+      daemonRoot: this.root,
+      agentsRoot: this.cfg.agentsDir,
       cwd: placement.trustedSessionDir ?? (key && hostKeySessionKey(key) ? cwd : agent.workspace.path),
       hostKey: key,
       ...placement,
@@ -4639,9 +4641,7 @@ export class Daemon {
     }
     const runtime = catalog?.runtimes[agent.runtime]
     if (!runtime) throw new Error(this.runtimeUnavailableMessage(agent.runtime))
-    const microContext = micro
-      ? this.microsandboxContext(agent, opts.cwd, opts.hostKey, opts.excludeAgentToolCredentials === true)
-      : undefined
+    const microPlacement = micro ? this.microsandboxPlacement(agent, opts.cwd, opts.hostKey) : undefined
     // A dream reads only its materialized inputs to produce a memory proposal, so
     // it never needs the agent's TOOL credentials (github-app git helper, gh
     // wrapper, or materialized `*_DATA` config-file secrets like KUBECONFIG /
@@ -4678,7 +4678,12 @@ export class Daemon {
     // Native memory is redirected under the HOME this host actually launches with — a confined session's own (§11).
     const memoryAgent =
       memoryKindOf(agent) === 'native' && runInSandbox
-        ? { ...agent, dir: microContext?.launch.runtimeHome ?? privateRuntimeHomeFor(agent.dir, opts.hostKey) }
+        ? {
+            ...agent,
+            dir: microPlacement
+              ? microsandboxRuntimeHome(agent.dir, opts.hostKey, microPlacement.trustedSessionDir)
+              : privateRuntimeHomeFor(agent.dir, opts.hostKey)
+          }
         : agent
     const runtimeEnv = {
       ...(runInSandbox ? cfg.sandbox.env : {}),
@@ -4775,12 +4780,12 @@ export class Daemon {
     let launchRuntime = runtime
     try {
       const assembled = assembleRuntimeLaunch({
-        ...(microContext
+        ...(microPlacement
           ? {
               microsandbox: {
                 mounts: this.cfg.sandbox.mounts,
                 trustedMounts: microsandboxSupportMounts(this.root, sessionGitInjection?.GIT_CONFIG_GLOBAL),
-                ...this.microsandboxPlacement(agent, opts.cwd, opts.hostKey)
+                ...microPlacement
               }
             }
           : {}),
@@ -4865,9 +4870,9 @@ export class Daemon {
     const constructed: { host?: AcpHost } = {}
     const podSubject = this.k8sPlane ? this.podSubjectFor(agent, opts.hostKey) : undefined
     const host = new AcpHost(launchRuntime, {
-      ...(microContext
+      ...(microPlacement && launch.microsandbox
         ? {
-            driver: this.microsandbox!.driverFor({ ...microContext.environment, ...launch.microsandbox }),
+            driver: this.microsandbox!.driverFor({ id: microPlacement.id, ...launch.microsandbox }),
             hostKey: opts.hostKey
           }
         : {}),

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -1,5 +1,4 @@
 import { chmodSync, existsSync, lstatSync, mkdirSync, realpathSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from '../acp/sandbox.js'
 import { prepareSandboxTempDir, SANDBOX_TEMP_DIR_ENV } from '../acp/sandbox-temp.js'
@@ -7,7 +6,7 @@ import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key
 import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
 import { prepareMicrosandboxLaunch } from '../microsandbox/launch.js'
 import type { MicrosandboxSecret } from '../microsandbox/secrets.js'
-import { compactReadRoots } from '../runtimes/read-roots.js'
+import { compactReadRoots, protectedSandboxRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
 import {
   hostPackageCacheEnv,
@@ -15,7 +14,6 @@ import {
   runtimeHomeEnvironment,
   runtimeHomePath
 } from '../runtimes/runtime-home.js'
-import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import { primaryCheckoutIn, secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
 import { confinedSessionDirIn, sessionGitDirsIn, sessionHomeIn } from '../workspace/session-layout.js'
 import {
@@ -289,30 +287,14 @@ export function prepareRuntimeLaunch(opts: {
       runtimeHome: sessionHome ?? runtimeHomePath(opts.scopeDir)
     })
     const daemonRoot = safeRoot(opts.daemonRoot!, 'AgentConnect daemon root')
-    const agentRoot = safeRoot(opts.scopeDir, 'agent root')
-    const hostHomeRoots = compactReadRoots(
-      [...new Set([stateSourceEnv.HOME, homedir()].filter((path): path is string => Boolean(path)))].map((path) =>
-        safeRoot(path, 'host HOME')
-      )
-    )
-    const sharedTempRoots = ['/tmp', '/var/tmp', stateSourceEnv.TMPDIR, stateSourceEnv.TMP, stateSourceEnv.TEMP]
-      .filter((path): path is string => Boolean(path))
-      .map((path) => safeRoot(path, 'shared temp root'))
-    // Linux service sockets conventionally live below /run; /var/run resolves
-    // there as well. The outer parent keeps AF_UNIX available for AgentConnect's
-    // exact carve-backs, so mount visibility is the host-socket boundary.
-    const hostSocketRoots = [safeRoot('/run', 'host socket root')]
-    protectedRuntimeStateRoots = Object.keys(RUNTIME_STATE_LOCATIONS).flatMap((id) =>
-      runtimeStateLocations(id, stateSourceEnv).map((location) => safeRoot(location.source, `${id} host state root`))
-    )
-    protectedBoundaryRoots = [
+    const protectedPaths = protectedSandboxRoots({
       daemonRoot,
-      agentRoot,
-      ...(opts.agentsRoot ? [safeRoot(opts.agentsRoot, 'agents root')] : []),
-      ...hostHomeRoots,
-      ...sharedTempRoots,
-      ...hostSocketRoots
-    ]
+      scopeDir: opts.scopeDir,
+      agentsRoot: opts.agentsRoot,
+      hostEnv: stateSourceEnv
+    })
+    protectedBoundaryRoots = protectedPaths.boundary.map((path) => safeRoot(path, 'protected sandbox boundary'))
+    protectedRuntimeStateRoots = protectedPaths.runtimeState.map((path) => safeRoot(path, 'host runtime state root'))
     protectedRoots = [...protectedBoundaryRoots, ...protectedRuntimeStateRoots]
     denyReadRoots = compactReadRoots(protectedRoots)
   }

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -6,6 +6,7 @@ import { prepareSandboxTempDir, SANDBOX_TEMP_DIR_ENV } from '../acp/sandbox-temp
 import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key.js'
 import type { RuntimeDef, SandboxMount } from '../config/config-schema.js'
 import { prepareMicrosandboxLaunch } from '../microsandbox/launch.js'
+import type { MicrosandboxSecret } from '../microsandbox/secrets.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
 import {
@@ -143,7 +144,7 @@ export interface PreparedRuntimeLaunch {
    *  was confined or nothing was found. Logged at spawn so a stale grant is visible after the fact. */
   gitMetadataWriteRoots: string[]
   runtimeHome?: string
-  microsandbox?: { mounts: SandboxMount[]; workspaceRoot: string }
+  microsandbox?: { mounts: SandboxMount[]; workspaceRoot: string; secrets?: MicrosandboxSecret[] }
   toolSandbox?: AcpToolSandbox
   sandbox?: {
     mechanism: SandboxMechanism

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -9,6 +9,7 @@ import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-dri
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
+import { canonicalPath, contains } from '../runtimes/read-roots.js'
 import { SinkRelPathSchema } from '../shim/file-sink.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../shim/sandbox-paths.js'
 import { MICROSANDBOX_SOCKET_BRIDGE_COMMAND, MICROSANDBOX_SOCKET_BRIDGE_ARGS } from './socket-bridge.js'
@@ -411,6 +412,12 @@ export class MicrosandboxManager {
   }
 
   private async open(environment: MicrosandboxEnvironment): Promise<Sandbox> {
+    const stateRoot = canonicalPath(join(this.options.root, 'microsandbox'), process.env)
+    for (const mount of environment.mounts) {
+      const source = canonicalPath(mount.source, process.env)
+      if (contains(source, stateRoot) || contains(stateRoot, source))
+        throw new Error('microsandbox mounts cannot expose host sandbox state')
+    }
     const name = this.name(environment.id)
     const binding = await this.readBinding(environment.id)
     // Image changes apply to new environments; retained disks keep their original image.

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -8,6 +8,7 @@ import { z } from 'zod'
 import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-driver.js'
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
+import { gitcredShimPath } from '../cp/gitcred-server.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import { canonicalPath, contains } from '../runtimes/read-roots.js'
 import { SinkRelPathSchema } from '../shim/file-sink.js'
@@ -427,6 +428,20 @@ export class MicrosandboxManager {
     if (binding || existing) {
       let matchingSpec = binding?.spec === spec
       if (binding && !matchingSpec) {
+        const helper = canonicalPath(
+          join(this.options.root, 'run', 'microsandbox-helpers', 'git-credential'),
+          process.env
+        )
+        const legacyMounts = environment.mounts.map((mount) =>
+          mount.source === helper && mount.target === gitcredShimPath(this.options.root) && mount.mode === 'readonly'
+            ? {
+                ...mount,
+                source: canonicalPath(join(this.options.root, 'microsandbox', 'helpers', 'git-credential'), process.env)
+              }
+            : mount
+        )
+        // Retained VMs may still own the old exact read-only helper mount; new mounts use the public support directory.
+        matchingSpec = binding.spec === this.spec({ ...environment, mounts: legacyMounts }, image)
         const source = await realpath(join(this.options.root, 'microsandbox', 'helpers', 'guest.js')).catch(
           (error: NodeJS.ErrnoException) => {
             if (error.code === 'ENOENT') return undefined
@@ -434,16 +449,13 @@ export class MicrosandboxManager {
           }
         )
         // Retain an older VM's disk when only the retired, read-only guest helper mount differs.
-        if (source) {
+        if (source && !matchingSpec) {
           matchingSpec =
             binding.spec ===
             this.spec(
               {
                 ...environment,
-                mounts: [
-                  ...environment.mounts,
-                  { source, target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }
-                ]
+                mounts: [...legacyMounts, { source, target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }]
               },
               image
             )
@@ -457,7 +469,7 @@ export class MicrosandboxManager {
         binding.configHash !== hash(stableJson(existing.config()))
       ) {
         throw new Error(
-          `microsandbox environment ${environment.id} has missing or changed persisted configuration; discard it before recreating`
+          `microsandbox environment ${environment.id} has missing or changed persisted configuration. Restore the previous configuration and DeepSeek credentials, or start a new session. Existing session data has been retained.`
         )
       }
       if (existing.status === 'running' || existing.status === 'starting' || existing.status === 'draining') {
@@ -468,9 +480,13 @@ export class MicrosandboxManager {
           secrets: Object.fromEntries(environment.secrets.map((secret) => [secret.env, { value: secret.readValue() }])),
           policy: 'next_start'
         })
-        if (!result.applied) throw new Error('microsandbox could not update its host-side credentials')
-        binding.configHash = hash(stableJson((await this.options.sdk.Sandbox.get(name)).config()))
-        await this.writeBinding(binding)
+        if (!result.applied && (result.changes.length || result.conflicts.length))
+          throw new Error('microsandbox could not update its host-side credentials')
+        const configHash = hash(stableJson((await this.options.sdk.Sandbox.get(name)).config()))
+        if (binding.configHash !== configHash) {
+          binding.configHash = configHash
+          await this.writeBinding(binding)
+        }
       }
       const sandbox = await this.retryDiskOperation(() => existing.connectOrStart({ detached: true }))
       try {

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -13,6 +13,7 @@ import { SinkRelPathSchema } from '../shim/file-sink.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../shim/sandbox-paths.js'
 import { MICROSANDBOX_SOCKET_BRIDGE_COMMAND, MICROSANDBOX_SOCKET_BRIDGE_ARGS } from './socket-bridge.js'
 import { overlayMounts, OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT, prepareOverlayMounts } from './overlay.js'
+import type { MicrosandboxSecret } from './secrets.js'
 import {
   MICROSANDBOX_NODE,
   openExecStream,
@@ -38,6 +39,7 @@ export interface MicrosandboxEnvironment {
   id: string
   mounts: SandboxMount[]
   workspaceRoot: string
+  secrets?: MicrosandboxSecret[]
 }
 
 export type MicrosandboxExecOptions = MicrosandboxExecuteOptions
@@ -229,6 +231,9 @@ export class MicrosandboxManager {
       config: { ...this.options.config, image },
       environment: {
         ...environment,
+        ...(environment.secrets
+          ? { secrets: environment.secrets.map(({ env, placeholder, host }) => ({ env, placeholder, host })) }
+          : {}),
         // Keep ordinary bind identities stable when the public configuration changes from readOnly to mode.
         mounts: environment.mounts
           .map(({ mode, ...mount }) =>
@@ -240,7 +245,7 @@ export class MicrosandboxManager {
     })
   }
 
-  private builder(name: string, mounts: SandboxMount[]) {
+  private builder(name: string, mounts: SandboxMount[], secrets: MicrosandboxSecret[] = []) {
     const builder = this.options.sdk.Sandbox.builder(name)
       .image(this.options.config.image)
       .rootDisk((disk) => disk.size(this.options.config.diskGiB * 1024))
@@ -254,6 +259,18 @@ export class MicrosandboxManager {
         volume.namedWith(`${name}-docker`, 'create', 'disk', this.options.config.diskGiB * 1024)
       )
       .quietLogs()
+    for (const secret of secrets) {
+      builder.secret((entry) =>
+        entry
+          .env(secret.env)
+          .value(secret.readValue())
+          .placeholder(secret.placeholder)
+          .allowHost(secret.host)
+          .injectBasicAuth(false)
+          .injectQuery(false)
+          .injectBody(false)
+      )
+    }
     const overlays = overlayMounts(mounts)
     if (overlays.length) {
       builder.volume(OVERLAY_STATE_ROOT, (volume) =>
@@ -439,6 +456,15 @@ export class MicrosandboxManager {
       if (existing.status === 'running' || existing.status === 'starting' || existing.status === 'draining') {
         await existing.stopWithTimeout(STOP_TIMEOUT_MS)
       }
+      if (environment.secrets?.length) {
+        const result = await existing.modify({
+          secrets: Object.fromEntries(environment.secrets.map((secret) => [secret.env, { value: secret.readValue() }])),
+          policy: 'next_start'
+        })
+        if (!result.applied) throw new Error('microsandbox could not update its host-side credentials')
+        binding.configHash = hash(stableJson((await this.options.sdk.Sandbox.get(name)).config()))
+        await this.writeBinding(binding)
+      }
       const sandbox = await this.retryDiskOperation(() => existing.connectOrStart({ detached: true }))
       try {
         await prepareOverlayMounts(sandbox, environment.mounts)
@@ -450,7 +476,7 @@ export class MicrosandboxManager {
         throw error
       }
     }
-    const sandbox = await this.builder(name, environment.mounts)
+    const sandbox = await this.builder(name, environment.mounts, environment.secrets)
       .vsock(this.options.sockets.mcp, 5000)
       .vsock(this.options.sockets.gitcred, 5001)
       .create()
@@ -465,15 +491,7 @@ export class MicrosandboxManager {
         dockerVolume: `${name}-docker`,
         ...(overlayMounts(environment.mounts).length ? { overlayVolume: `${name}-overlays` } : {})
       }
-      const path = this.bindingPath(environment.id)
-      await mkdir(dirname(path), { recursive: true, mode: 0o700 })
-      const temporary = `${path}.${randomUUID()}.tmp`
-      try {
-        await writeFile(temporary, JSON.stringify(binding), { mode: 0o600, flag: 'wx' })
-        await rename(temporary, path)
-      } finally {
-        await rm(temporary, { force: true })
-      }
+      await this.writeBinding(binding)
       await prepareOverlayMounts(sandbox, environment.mounts)
       await this.startBridge(environment.id, sandbox)
       return sandbox
@@ -484,6 +502,18 @@ export class MicrosandboxManager {
       if (overlayMounts(environment.mounts).length) await this.removeVolume(`${name}-overlays`)
       await rm(this.bindingPath(environment.id), { force: true })
       throw error
+    }
+  }
+
+  private async writeBinding(binding: Binding): Promise<void> {
+    const path = this.bindingPath(binding.environmentId)
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+    const temporary = `${path}.${randomUUID()}.tmp`
+    try {
+      await writeFile(temporary, JSON.stringify(binding), { mode: 0o600, flag: 'wx' })
+      await rename(temporary, path)
+    } finally {
+      await rm(temporary, { force: true })
     }
   }
 

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -13,12 +13,13 @@ import {
   prepareClaudeProtectedSettings
 } from '../runtime-defs/claude-runtime.js'
 import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
-import { compactReadRoots, normalizeSandboxMounts } from '../runtimes/read-roots.js'
+import { canonicalPath, compactReadRoots, normalizeSandboxMounts } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
-import { prepareRuntimeHome, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
+import { prepareRuntimeHome, removeRuntimeHomeSeedFiles, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
 import { SESSIONS_DIR } from '../workspace/session-layout.js'
 import { MICROSANDBOX_SOCKET_BRIDGES, MICROSANDBOX_TUNNEL_PATHS } from './socket-bridge.js'
 import { OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT } from './overlay.js'
+import { prepareDeepSeekSecret, type MicrosandboxSecret } from './secrets.js'
 
 const IMAGE_PATH = '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 const HOST_IPC_ENV = [
@@ -67,7 +68,7 @@ function contains(root: string, path: string): boolean {
 }
 
 export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions): PreparedRuntimeLaunch & {
-  microsandbox: { mounts: SandboxMount[]; workspaceRoot: string }
+  microsandbox: { mounts: SandboxMount[]; workspaceRoot: string; secrets?: MicrosandboxSecret[] }
 } {
   if (opts.runtime?.externalExecution) {
     throw new Error(`runtime "${opts.runtimeId}" executes outside the microsandbox VM`)
@@ -103,7 +104,12 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   for (const path of [...writable, ...configDirs]) mkdirSync(path, { recursive: true, mode: 0o700 })
 
   const credentials = prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
-  runtimeHome = prepareRuntimeHome(opts.runtimeId, scopeDir, hostEnv, runtimeHome, credentials?.seedExclusions)
+  const deepseek = prepareDeepSeekSecret(opts.runtimeId, opts.runtime, hostEnv, opts.explicitEnv)
+  runtimeHome = prepareRuntimeHome(opts.runtimeId, scopeDir, hostEnv, runtimeHome, [
+    ...(credentials?.seedExclusions ?? []),
+    ...(deepseek?.seedExclusions ?? [])
+  ])
+  if (deepseek) removeRuntimeHomeSeedFiles(runtimeHome, deepseek.seedExclusions)
   credentials?.preparePrivateHome(runtimeHome)
   writable.push(...(credentials?.writablePaths ?? []))
   const readRoots = (opts.trustedRuntimeReadRoots ?? []).filter((path) => {
@@ -164,6 +170,14 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   }
 
   const env = { ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, hostEnv), ...credentials?.env }
+  if (deepseek?.secret) {
+    const secret = deepseek.secret
+    for (const [name, value] of Object.entries(env))
+      env[name] = value.replaceAll(secret.readValue(), secret.placeholder)
+    env[secret.env] = secret.placeholder
+    env.NODE_EXTRA_CA_CERTS = '/.msb/tls/ca.pem'
+    env.SSL_CERT_FILE = env.REQUESTS_CA_BUNDLE = env.CURL_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+  }
   for (const name of HOST_IPC_ENV) delete env[name]
   // Drop ambient Docker client settings, but keep explicit guest config, including materialized registry config.
   for (const name of [
@@ -189,11 +203,16 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   mkdirSync(env.XDG_RUNTIME_DIR, { recursive: true, mode: 0o700 })
   env[GITCRED_SOCKET_ENV] = MICROSANDBOX_TUNNEL_PATHS.gitcred
   const mounts = [...automatic, ...configured]
+  const deepseekSources = deepseek?.sources.map((path) => canonicalPath(path, hostEnv)) ?? []
+  if (mounts.some(({ source }) => deepseekSources.some((path) => contains(source, path)))) {
+    throw new Error('sandbox.mounts would expose a host DeepSeek credential file')
+  }
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   const claudeSettings = claudeRuntime ? prepareClaudeProtectedSettings(scopeDir, env) : undefined
-  const privateStateTargets =
-    credentialProfile === 'codex'
+  const privateStateTargets = deepseek
+    ? deepseek.seedExclusions.map((path) => join(runtimeHome, path))
+    : credentialProfile === 'codex'
       ? [join(runtimeHome, '.codex')]
       : claudeRuntime
         ? [join(runtimeHome, '.claude'), join(runtimeHome, '.claude.json')]
@@ -254,6 +273,10 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
       ...(claudeSettings ? { claudeProtectedSettings: claudeSettings } : {}),
       ...(sharedWriteRoots.length > 0 ? { sharedWriteRoots } : {})
     },
-    microsandbox: { mounts, workspaceRoot: scopeDir }
+    microsandbox: {
+      mounts,
+      workspaceRoot: scopeDir,
+      ...(deepseek?.secret ? { secrets: [deepseek.secret] } : {})
+    }
   }
 }

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, mkdirSync, realpathSync, statSync } from 'node:fs'
-import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { join, relative, resolve, sep } from 'node:path'
 import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key.js'
 import { sandboxBoundary } from '../acp/sandbox.js'
 import { applyCodexPermissionProfile } from '../acp/codex-permission-profiles.js'
@@ -13,7 +13,7 @@ import {
   prepareClaudeProtectedSettings
 } from '../runtime-defs/claude-runtime.js'
 import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
-import { canonicalPath, compactReadRoots, normalizeSandboxMounts } from '../runtimes/read-roots.js'
+import { canonicalPath, compactReadRoots, contains, normalizeSandboxMounts } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
 import { prepareRuntimeHome, removeRuntimeHomeSeedFiles, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
 import { SESSIONS_DIR } from '../workspace/session-layout.js'
@@ -60,11 +60,6 @@ export interface PrepareMicrosandboxLaunchOptions {
   allowModelToolUnixSockets?: boolean
   trustedMounts?: SandboxMount[]
   mounts: SandboxMount[]
-}
-
-function contains(root: string, path: string): boolean {
-  const rel = relative(root, path)
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
 }
 
 export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions): PreparedRuntimeLaunch & {

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -13,9 +13,16 @@ import {
   prepareClaudeProtectedSettings
 } from '../runtime-defs/claude-runtime.js'
 import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
-import { canonicalPath, compactReadRoots, contains, normalizeSandboxMounts } from '../runtimes/read-roots.js'
+import {
+  canonicalPath,
+  compactReadRoots,
+  contains,
+  normalizeSandboxMounts,
+  protectedSandboxRoots
+} from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
-import { prepareRuntimeHome, removeRuntimeHomeSeedFiles, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
+import { prepareRuntimeHome, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
+import { TLS_TRUST_ENV } from '../config/tls-trust-env.js'
 import { SESSIONS_DIR } from '../workspace/session-layout.js'
 import { MICROSANDBOX_SOCKET_BRIDGES, MICROSANDBOX_TUNNEL_PATHS } from './socket-bridge.js'
 import { OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT } from './overlay.js'
@@ -48,6 +55,8 @@ export interface PrepareMicrosandboxLaunchOptions {
   runtimeId: string
   runtime?: RuntimeDef
   scopeDir: string
+  daemonRoot?: string
+  agentsRoot?: string
   cwd: string
   hostKey?: HostKey
   explicitEnv?: Record<string, string>
@@ -62,6 +71,14 @@ export interface PrepareMicrosandboxLaunchOptions {
   mounts: SandboxMount[]
 }
 
+export function microsandboxRuntimeHome(scopeDir: string, hostKey?: HostKey, sessionDir?: string): string {
+  if (sessionDir) return join(sessionDir, 'home')
+  const home = privateRuntimeHomeFor(scopeDir, hostKey)
+  return hostKey && hostKeySessionKey(hostKey) !== undefined && home === join(scopeDir, 'home')
+    ? join(scopeDir, 'runtime-homes', hostKeyDirName(hostKey), 'home')
+    : home
+}
+
 export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions): PreparedRuntimeLaunch & {
   microsandbox: { mounts: SandboxMount[]; workspaceRoot: string; secrets?: MicrosandboxSecret[] }
 } {
@@ -70,18 +87,14 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   }
   const scopeDir = realpathSync(resolve(opts.scopeDir))
   const hostEnv = opts.stateSourceEnv ?? process.env
-  let runtimeHome = privateRuntimeHomeFor(scopeDir, opts.hostKey)
-  if (opts.hostKey && hostKeySessionKey(opts.hostKey) !== undefined && runtimeHome === join(scopeDir, 'home')) {
-    runtimeHome = join(scopeDir, 'runtime-homes', hostKeyDirName(opts.hostKey), 'home')
-  }
   const sessionDir = opts.trustedSessionDir ? realpathSync(opts.trustedSessionDir) : undefined
   if (sessionDir) {
     const parts = relative(scopeDir, sessionDir).split(sep)
     if (parts.length !== 2 || parts[0] !== SESSIONS_DIR || !parts[1] || !statSync(sessionDir).isDirectory()) {
       throw new Error('microsandbox session directory must be one existing scopeDir/sessions/<leaf> directory')
     }
-    runtimeHome = join(sessionDir, 'home')
   }
+  let runtimeHome = microsandboxRuntimeHome(scopeDir, opts.hostKey, sessionDir)
   const boundary = sandboxBoundary({ agentDir: scopeDir, cwd: opts.cwd, runtimeHome })
   if (sessionDir && !contains(sessionDir, boundary.writable[0]!)) {
     throw new Error('microsandbox cwd is outside its session directory')
@@ -100,11 +113,21 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
 
   const credentials = prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
   const deepseek = prepareDeepSeekSecret(opts.runtimeId, opts.runtime, hostEnv, opts.explicitEnv)
+  if (
+    deepseek &&
+    [...TLS_TRUST_ENV, 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'].some((name) =>
+      (opts.explicitEnv?.[name] ?? hostEnv[name])?.trim()
+    )
+  ) {
+    throw new Error(
+      'DeepSeek launch refused: microsandbox credential protection does not yet support custom TLS trust bundles; use SRT for this configuration'
+    )
+  }
   runtimeHome = prepareRuntimeHome(opts.runtimeId, scopeDir, hostEnv, runtimeHome, [
     ...(credentials?.seedExclusions ?? []),
     ...(deepseek?.seedExclusions ?? [])
   ])
-  if (deepseek) removeRuntimeHomeSeedFiles(runtimeHome, deepseek.seedExclusions)
+  deepseek?.preparePrivateHome(runtimeHome)
   credentials?.preparePrivateHome(runtimeHome)
   writable.push(...(credentials?.writablePaths ?? []))
   const readRoots = (opts.trustedRuntimeReadRoots ?? []).filter((path) => {
@@ -141,6 +164,13 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
     )
   ]
   const configured = normalizeSandboxMounts(opts.mounts, hostEnv, 'microsandbox', runtimeHome)
+  const protectedPaths = protectedSandboxRoots({ ...opts, hostEnv })
+  const protectedSources = [...protectedPaths.boundary, ...protectedPaths.runtimeState].map((path) =>
+    canonicalPath(path, hostEnv)
+  )
+  if (configured.some(({ source }) => protectedSources.some((path) => contains(source, path)))) {
+    throw new Error('sandbox.mounts source would reopen a protected host path')
+  }
   const ownedTargets = [
     '/run',
     '/var/run',

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -1,8 +1,10 @@
 import { lstatSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { stringify as stringifyYaml } from 'yaml'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { isDeepSeekRuntime } from '../runtimes/model-provider-config.js'
 import { runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
 import { MAX_SEED_FILE_BYTES, parseDshCredentialDocument } from '../runtimes/runtime-seeded-credentials.js'
 
 export interface MicrosandboxSecret {
@@ -29,13 +31,16 @@ export function prepareDeepSeekSecret(
     }))
   )
   let key = explicitEnv[env] ?? hostEnv[env]
+  let baseUrl = explicitEnv.DEEPSEEK_BASE_URL ?? hostEnv.DEEPSEEK_BASE_URL
   for (const file of files) {
     if (file.format !== 'dsh' && file.format !== 'dsh-env') continue
+    if (key && (baseUrl || file.format !== 'dsh-env')) continue
     try {
       const stat = lstatSync(file.source)
       if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) continue
       const { refs } = parseDshCredentialDocument(readFileSync(file.source, 'utf8'), file.format)
       key ||= refs[env]
+      if (file.format === 'dsh-env') baseUrl ??= refs.DEEPSEEK_BASE_URL
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
       // YAML parser errors can quote a line containing the key.
@@ -43,11 +48,15 @@ export function prepareDeepSeekSecret(
     }
   }
   const value = key?.trim()
-  const secret: MicrosandboxSecret | undefined = value
-    ? { env, placeholder: 'msb-secret-DEEPSEEK_API_KEY', host: 'api.deepseek.com', readValue: () => value }
-    : undefined
-  if (secret) {
-    const endpoint = new URL(explicitEnv.DEEPSEEK_BASE_URL ?? hostEnv.DEEPSEEK_BASE_URL ?? 'https://api.deepseek.com')
+  if (!value) return undefined
+  const secret: MicrosandboxSecret = {
+    env,
+    placeholder: 'msb-secret-DEEPSEEK_API_KEY',
+    host: 'api.deepseek.com',
+    readValue: () => value
+  }
+  try {
+    const endpoint = new URL(baseUrl ?? 'https://api.deepseek.com')
     if (
       endpoint.protocol !== 'https:' ||
       endpoint.hostname !== secret.host ||
@@ -55,11 +64,36 @@ export function prepareDeepSeekSecret(
       endpoint.username ||
       endpoint.password
     )
-      throw new Error('DeepSeek credential protection requires https://api.deepseek.com')
+      throw new Error('unsupported endpoint')
+  } catch {
+    throw new Error('DeepSeek launch refused: credential protection requires https://api.deepseek.com')
   }
   return {
     secret,
     sources: files.map((file) => file.source),
-    seedExclusions: [...new Set(files.map((file) => file.destination))]
+    seedExclusions: [...new Set(files.map((file) => file.destination))],
+    preparePrivateHome(home: string) {
+      for (const file of files) {
+        const format = file.format
+        if (format !== 'dsh' && format !== 'dsh-env') continue
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text) => {
+          try {
+            const { data, refs } = parseDshCredentialDocument(text, format)
+            if (format === 'dsh') {
+              const target = data.version === 1 ? (data.refs as Record<string, unknown> | undefined) : data
+              if (target && Object.hasOwn(target, env)) target[env] = secret.placeholder
+              text = stringifyYaml(data)
+            } else if (refs[env]) {
+              if (!text.includes(refs[env])) return undefined
+              text = text.replaceAll(refs[env], secret.placeholder)
+            }
+            return text.replaceAll(value, secret.placeholder)
+          } catch {
+            // Invalid host seeds are skipped; invalid retained credentials fail closed without quoting their content.
+            return undefined
+          }
+        })
+      }
+    }
   }
 }

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -1,0 +1,65 @@
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { RuntimeDef } from '../config/config-schema.js'
+import { isDeepSeekRuntime } from '../runtimes/model-provider-config.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { MAX_SEED_FILE_BYTES, parseDshCredentialDocument } from '../runtimes/runtime-seeded-credentials.js'
+
+export interface MicrosandboxSecret {
+  env: string
+  placeholder: string
+  host: string
+  // The value stays host-side and cannot enter serialized launch metadata.
+  readValue: () => string
+}
+
+export function prepareDeepSeekSecret(
+  runtimeId: string,
+  runtime: RuntimeDef | undefined,
+  hostEnv: NodeJS.ProcessEnv,
+  explicitEnv: Record<string, string> = {}
+) {
+  if (!isDeepSeekRuntime(runtimeId, runtime)) return undefined
+  const env = 'DEEPSEEK_API_KEY'
+  const files = runtimeStateLocations('dsh-acp', hostEnv).flatMap((location) =>
+    (location.credentialFiles ?? []).map((file) => ({
+      source: join(location.source, file.path),
+      destination: join(location.destination, file.path),
+      format: file.format
+    }))
+  )
+  let key = explicitEnv[env] ?? hostEnv[env]
+  for (const file of files) {
+    if (file.format !== 'dsh' && file.format !== 'dsh-env') continue
+    try {
+      const stat = lstatSync(file.source)
+      if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) continue
+      const { refs } = parseDshCredentialDocument(readFileSync(file.source, 'utf8'), file.format)
+      key ||= refs[env]
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+      // YAML parser errors can quote a line containing the key.
+      throw new Error('Cannot read the host DeepSeek credential file')
+    }
+  }
+  const value = key?.trim()
+  const secret: MicrosandboxSecret | undefined = value
+    ? { env, placeholder: 'msb-secret-DEEPSEEK_API_KEY', host: 'api.deepseek.com', readValue: () => value }
+    : undefined
+  if (secret) {
+    const endpoint = new URL(explicitEnv.DEEPSEEK_BASE_URL ?? hostEnv.DEEPSEEK_BASE_URL ?? 'https://api.deepseek.com')
+    if (
+      endpoint.protocol !== 'https:' ||
+      endpoint.hostname !== secret.host ||
+      endpoint.port ||
+      endpoint.username ||
+      endpoint.password
+    )
+      throw new Error('DeepSeek credential protection requires https://api.deepseek.com')
+  }
+  return {
+    secret,
+    sources: files.map((file) => file.source),
+    seedExclusions: [...new Set(files.map((file) => file.destination))]
+  }
+}

--- a/packages/daemon/src/microsandbox/support.ts
+++ b/packages/daemon/src/microsandbox/support.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { SandboxMount } from '../config/config-schema.js'
 import { gitcredShimPath } from '../cp/gitcred-server.js'
@@ -6,7 +6,7 @@ import { gitcredShimPath } from '../cp/gitcred-server.js'
 const GIT_CREDENTIAL_HELPER = '#!/bin/sh\nexec /opt/agentconnect/bin/git-credential "$@"\n'
 
 export function microsandboxSupportMounts(root: string, sessionGitConfigPath?: string): SandboxMount[] {
-  const helpers = join(root, 'microsandbox', 'helpers')
+  const helpers = join(root, 'run', 'microsandbox-helpers')
   mkdirSync(helpers, { recursive: true, mode: 0o700 })
   chmodSync(helpers, 0o700)
   const source = join(helpers, 'git-credential')
@@ -15,7 +15,7 @@ export function microsandboxSupportMounts(root: string, sessionGitConfigPath?: s
   }
   chmodSync(source, 0o755)
   return [
-    { source, target: gitcredShimPath(root), mode: 'readonly' },
+    { source: realpathSync(source), target: gitcredShimPath(root), mode: 'readonly' },
     ...(sessionGitConfigPath && existsSync(sessionGitConfigPath)
       ? [{ source: sessionGitConfigPath, target: sessionGitConfigPath, mode: 'readonly' as const }]
       : [])

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -31,9 +31,12 @@ function isOpenCodeRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
 }
 
 // The bin, not the package: `dsh-acp` is the single bin of @openma/deepseek-harness-acp.
-function isDeepSeekRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
+export function isDeepSeekRuntime(runtimeId: string, runtime?: RuntimeDef): boolean {
   if (runtimeId === 'dsh-acp') return true
-  return [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])dsh-acp(?:@[^\/]*)?$/.test(part.toLowerCase()))
+  return (
+    !!runtime &&
+    [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])dsh-acp(?:@[^\/]*)?$/.test(part.toLowerCase()))
+  )
 }
 
 function applyCodexBaseUrl(env: Record<string, string>, baseUrl: string): void {

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -115,9 +115,8 @@ export function normalizeSandboxMounts(
   return result
 }
 
-/** Resolve the existing prefix too, so a missing socket/file below a symlink is
- * still expressed against the path the kernel will see later. */
-function canonicalPath(path: string, env: NodeJS.ProcessEnv): string {
+// Resolve existing prefixes so missing files below symlinks use their eventual kernel path.
+export function canonicalPath(path: string, env: NodeJS.ProcessEnv): string {
   const expanded = expandedAbsolute(path, env, 'trusted runtime read path')
   let current = expanded
   const missing: string[] = []

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -132,7 +132,7 @@ export function canonicalPath(path: string, env: NodeJS.ProcessEnv): string {
   }
 }
 
-function contains(root: string, path: string): boolean {
+export function contains(root: string, path: string): boolean {
   const rel = relative(root, path)
   return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
 }

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -3,7 +3,34 @@ import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, parse, posix, relative, resolve, sep } from 'node:path'
 import type { McpServerDef, RuntimeDef, SandboxBackend, SandboxMount } from '../config/config-schema.js'
-import { resolveCommandPath } from './probe.js'
+import { resolveCommandPath, RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from './probe.js'
+
+export function protectedSandboxRoots(opts: {
+  daemonRoot?: string
+  scopeDir: string
+  agentsRoot?: string
+  hostEnv: NodeJS.ProcessEnv
+}) {
+  const { hostEnv } = opts
+  return {
+    boundary: [
+      opts.daemonRoot,
+      opts.scopeDir,
+      opts.agentsRoot,
+      hostEnv.HOME,
+      homedir(),
+      '/tmp',
+      '/var/tmp',
+      hostEnv.TMPDIR,
+      hostEnv.TMP,
+      hostEnv.TEMP,
+      '/run'
+    ].filter((path): path is string => Boolean(path)),
+    runtimeState: Object.keys(RUNTIME_STATE_LOCATIONS).flatMap((id) =>
+      runtimeStateLocations(id, hostEnv).map((location) => location.source)
+    )
+  }
+}
 
 /**
  * Read-only code roots that must remain visible after the host HOME (and the

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -8,7 +8,6 @@ import {
   readFileSync,
   readdirSync,
   renameSync,
-  unlinkSync,
   writeFileSync
 } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
@@ -62,17 +61,31 @@ function assertNoDestinationSymlink(home: string, target: string): void {
   }
 }
 
-export function removeRuntimeHomeSeedFiles(home: string, destinations: readonly string[]): void {
-  for (const destination of destinations) {
-    const target = containedDestination(home, destination)
-    assertNoDestinationSymlink(home, target)
-    try {
-      if (!lstatSync(target).isFile()) throw new Error('runtime HOME credential destination is not a regular file')
-      unlinkSync(target)
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-    }
+export function projectRuntimeHomeSeedFile(
+  home: string,
+  destination: string,
+  source: string,
+  project: (text: string) => string | undefined
+): void {
+  const target = containedDestination(home, destination)
+  assertNoDestinationSymlink(home, target)
+  const retained = existsSync(target)
+  const path = retained ? target : source
+  if (!existsSync(path)) return
+  const stat = lstatSync(path)
+  if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) {
+    if (retained) throw new Error('runtime HOME credential destination must be a small regular file')
+    return
   }
+  const original = readFileSync(path, 'utf8')
+  const content = project(original)
+  if (content === undefined) {
+    if (retained) throw new Error('Cannot protect the existing private runtime credential file')
+    return
+  }
+  if (retained && content === original) return
+  ensurePrivateDir(dirname(target))
+  writeFileSync(target, content, { mode: 0o600 })
 }
 
 function projectedJson(source: string, keys: readonly string[]): string | undefined {

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -1,19 +1,26 @@
 import {
   chmodSync,
+  closeSync,
   constants,
   copyFileSync,
   existsSync,
+  fstatSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   readdirSync,
   renameSync,
+  unlinkSync,
   writeFileSync
 } from 'node:fs'
+import { randomUUID } from 'node:crypto'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { home as hostHomeDir, runtimeStateLocations } from './probe.js'
 import { extractOmpCredentials } from './omp-credentials.js'
 import { MAX_SEED_FILE_BYTES } from './runtime-seeded-credentials.js'
+import { withDescentSync } from '../shim/safe-descent.js'
 
 const LEGACY_RUNTIME_STATE: Record<string, string[]> = {
   'claude-acp': ['.claude'],
@@ -69,23 +76,63 @@ export function projectRuntimeHomeSeedFile(
 ): void {
   const target = containedDestination(home, destination)
   assertNoDestinationSymlink(home, target)
-  const retained = existsSync(target)
-  const path = retained ? target : source
-  if (!existsSync(path)) return
-  const stat = lstatSync(path)
-  if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) {
-    if (retained) throw new Error('runtime HOME credential destination must be a small regular file')
-    return
-  }
-  const original = readFileSync(path, 'utf8')
-  const content = project(original)
-  if (content === undefined) {
-    if (retained) throw new Error('Cannot protect the existing private runtime credential file')
-    return
-  }
-  if (retained && content === original) return
-  ensurePrivateDir(dirname(target))
-  writeFileSync(target, content, { mode: 0o600 })
+  if (!existsSync(target) && !existsSync(source)) return
+  const segments = relative(home, target).split(sep)
+  const leaf = segments.pop()!
+  withDescentSync(home, segments, (parent) => {
+    const destination = join(parent, leaf)
+    let retained = true
+    let input: number
+    const flags = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+    try {
+      input = openSync(destination, flags)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      retained = false
+      try {
+        input = openSync(source, flags)
+      } catch (error) {
+        if (['ENOENT', 'ELOOP'].includes((error as NodeJS.ErrnoException).code ?? '')) return
+        throw error
+      }
+    }
+    let original: string
+    try {
+      const stat = fstatSync(input)
+      if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) {
+        if (retained) throw new Error('runtime HOME credential source must be a small regular file')
+        return
+      }
+      const bytes = Buffer.alloc(stat.size + 1)
+      let length = 0
+      while (length < bytes.length) {
+        const count = readSync(input, bytes, length, bytes.length - length, length)
+        if (!count) break
+        length += count
+      }
+      if (length > stat.size) throw new Error('runtime HOME credential file changed during projection')
+      original = bytes.subarray(0, length).toString('utf8')
+    } finally {
+      closeSync(input)
+    }
+    const content = project(original)
+    if (content === undefined) {
+      if (retained) throw new Error('Cannot protect the existing private runtime credential file')
+      return
+    }
+    if (retained && content === original) return
+    const temporary = join(parent, `.credential-${randomUUID()}.tmp`)
+    try {
+      writeFileSync(temporary, content, { flag: 'wx', mode: 0o600 })
+      renameSync(temporary, destination)
+    } finally {
+      try {
+        unlinkSync(temporary)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+    }
+  })
 }
 
 function projectedJson(source: string, keys: readonly string[]): string | undefined {

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   readdirSync,
   renameSync,
+  unlinkSync,
   writeFileSync
 } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
@@ -57,6 +58,19 @@ function assertNoDestinationSymlink(home: string, target: string): void {
     if (!existsSync(current)) return
     if (lstatSync(current).isSymbolicLink()) {
       throw new Error(`runtime HOME destination contains a symlink: ${current}`)
+    }
+  }
+}
+
+export function removeRuntimeHomeSeedFiles(home: string, destinations: readonly string[]): void {
+  for (const destination of destinations) {
+    const target = containedDestination(home, destination)
+    assertNoDestinationSymlink(home, target)
+    try {
+      if (!lstatSync(target).isFile()) throw new Error('runtime HOME credential destination is not a regular file')
+      unlinkSync(target)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     }
   }
 }

--- a/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
@@ -98,7 +98,7 @@ export function parseDshCredentialDocument(text: string, format: 'dsh' | 'dsh-en
       (entry): entry is [string, string] => /^[A-Za-z_][A-Za-z0-9_]*$/.test(entry[0]) && nonempty(entry[1])
     )
   )
-  return { refs, records: record(data.records) ?? {} }
+  return { data, refs, records: record(data.records) ?? {} }
 }
 
 function hermesCredentialProviders(data: unknown): string[] {

--- a/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
@@ -91,6 +91,16 @@ const DSH_PROVIDER_REFS: Record<string, string> = {
   OPENROUTER_API_KEY: 'openrouter'
 }
 
+export function parseDshCredentialDocument(text: string, format: 'dsh' | 'dsh-env') {
+  const data = record(format === 'dsh' ? parseYaml(text) : parseEnv(text)) ?? {}
+  const refs = Object.fromEntries(
+    Object.entries(record(data.version === 1 ? data.refs : data) ?? {}).filter(
+      (entry): entry is [string, string] => /^[A-Za-z_][A-Za-z0-9_]*$/.test(entry[0]) && nonempty(entry[1])
+    )
+  )
+  return { refs, records: record(data.records) ?? {} }
+}
+
 function hermesCredentialProviders(data: unknown): string[] {
   const auth = record(data) ?? {}
   const hasToken = (raw: unknown): boolean => {
@@ -114,14 +124,9 @@ function credentialsInFile(text: string, file: SeededCredentialFile): { present:
     return { present, providers: present ? ['devin'] : [] }
   }
   if (file.format === 'dsh' || file.format === 'dsh-env') {
-    const data = record(file.format === 'dsh' ? parseYaml(text) : parseEnv(text))
-    if (!data) return { present: false, providers: [] }
-    const refs = record(data.version === 1 ? data.refs : data) ?? {}
-    const stored = Object.entries(refs).filter(
-      ([name, value]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) && nonempty(value)
-    )
-    const providers = stored.flatMap(([name]) => (DSH_PROVIDER_REFS[name] ? [DSH_PROVIDER_REFS[name]!] : []))
-    for (const [name, raw] of Object.entries(record(data.records) ?? {})) {
+    const { refs, records } = parseDshCredentialDocument(text, file.format)
+    const providers = Object.keys(refs).flatMap((name) => (DSH_PROVIDER_REFS[name] ? [DSH_PROVIDER_REFS[name]!] : []))
+    for (const [name, raw] of Object.entries(records)) {
       const value = record(raw)
       const env = record(value?.env)
       if (

--- a/packages/daemon/src/shim/safe-descent.ts
+++ b/packages/daemon/src/shim/safe-descent.ts
@@ -1,33 +1,5 @@
-/**
- * Path resolution that holds INODES instead of names, for the sandbox side of the workspace-file
- * channel.
- *
- * Everything else in this seam checks a path and then acts on that path, and on a volume the agent's
- * runtime owns those are two different resolutions of one name. Between them it can rename the
- * checkout aside, put a symlink at the same place, let the work follow it, and restore the original
- * before any closing check — which is how four rounds of progressively stricter path revalidation
- * each closed a window and exposed the next. The problem is not that the checks were too loose. It is
- * that a name is not a directory.
- *
- * A file descriptor is. Once `/agent/repo` is open, that handle refers to the inode: renaming the
- * path, replacing it with a symlink, even deleting it changes nothing about what the handle reaches.
- * So the rule here is that a path is resolved exactly ONCE, into a handle, and every step afterwards
- * is taken relative to a handle — never by naming the same place again.
- *
- * The kernel primitive for that is `openat(dirfd, name, …)`, which Node does not expose. On Linux
- * `/proc/self/fd/<n>/<name>` is the same thing: the kernel resolves the magic link straight to the
- * inode the descriptor holds rather than re-walking the path it came from. That is why this module is
- * Linux-only, and why it is here in `shim/` rather than in the shared placement layer — the daemon
- * serves self-hosted macOS and Windows installs, where its own workspace is not on a filesystem an
- * agent controls and this whole hazard is absent.
- *
- * `O_NOFOLLOW` covers only the LAST component of a path, so the descent takes one component at a
- * time: each step is a single name, opened from the previous handle, with symlinks refused. A
- * symlinked directory inside the workspace is therefore rejected rather than resolved — the one
- * behaviour that differs from the daemon-local path, which resolves it and then checks where it
- * landed. A leaf symlink was already refused on both.
- */
-import { constants, promises as fs, type Dirent, type Stats } from 'node:fs'
+// Linux descriptor-relative descent binds agent-writable paths to inodes and rejects symlinks at each step.
+import { closeSync, constants, mkdirSync, openSync, promises as fs, type Dirent, type Stats } from 'node:fs'
 import type { FileHandle } from 'node:fs/promises'
 import { isAbsolute, join } from 'node:path'
 
@@ -213,5 +185,29 @@ export async function withDescent<T>(
     // Reverse order is not required by the kernel; it just keeps the close sequence the mirror of the
     // open sequence, so a leak shows up as an unbalanced pair rather than as a puzzle.
     for (const handle of [...open].reverse()) await handle.close()
+  }
+}
+
+// Synchronous launch preparation uses the same descriptor-relative descent as guest filesystem operations.
+export function withDescentSync<T>(anchor: string, segments: string[], work: (parent: string) => T): T {
+  if (process.platform !== 'linux')
+    throw new UnsafePathError('fd-bound credential projection requires Linux', 'ENOTSUP')
+  if (!isAbsolute(anchor)) throw new UnsafePathError('anchor must be absolute', 'EINVAL')
+  const handles: number[] = []
+  try {
+    handles.push(openSync(anchor, DIR_FLAGS))
+    for (const segment of segments) {
+      assertComponent(segment)
+      const path = join(`/proc/self/fd/${handles.at(-1)!}`, segment)
+      try {
+        mkdirSync(path, { mode: 0o700 })
+      } catch (error) {
+        if (errno(error) !== 'EEXIST') throw error
+      }
+      handles.push(openSync(path, DIR_FLAGS))
+    }
+    return work(`/proc/self/fd/${handles.at(-1)!}`)
+  } finally {
+    for (const handle of handles.reverse()) closeSync(handle)
   }
 }

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -179,6 +179,46 @@ describe.each(['srt', 'microsandbox'])('sandbox.env (%s)', (backend) => {
   )
 })
 
+it.skipIf(process.platform === 'win32')(
+  'does not reintroduce excluded agent secrets through the VM proxy',
+  async () => {
+    const root = scaffold({ runtime: 'dsh-acp', workspace: { mode: 'from-scratch', path: 'workspace' } }, 'shared')
+    const path = join(root, 'config.json')
+    const config = JSON.parse(readFileSync(path, 'utf8'))
+    config.runtimes = { 'dsh-acp': { command: 'node', args: ['unused'] } }
+    writeFileSync(path, JSON.stringify(config))
+    vi.stubEnv('DSH_HOME', join(root, 'host-dsh'))
+    vi.stubEnv('DEEPSEEK_API_KEY', undefined)
+    const daemon = new Daemon({ root, sandboxMechanism: 'bwrap', probeRuntimes: async () => [] })
+    try {
+      await daemon.start()
+      const manager = useMicrosandbox(daemon)
+      const agent = (daemon as any).agents.get('bot-a')
+      agent.runtimeOverrides = { secrets: [{ name: 'DEEPSEEK_API_KEY', value: 'fixture-agent-secret' }] }
+      for (const excludeAgentToolCredentials of [false, true]) {
+        const host = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+          hostKey: sessionHostKey(agent.id, KEY(String(excludeAgentToolCredentials))),
+          runInSandbox: true,
+          cwd: agent.workspace.path,
+          excludeAgentToolCredentials
+        }).host
+        const environment = (manager.driverFor.mock.calls.at(-1) as any)[0]
+        if (excludeAgentToolCredentials) {
+          expect(environment.secrets).toBeUndefined()
+          expect(host.opts.env.DEEPSEEK_API_KEY).toBeUndefined()
+        } else {
+          expect(environment.secrets[0].readValue()).toBe('fixture-agent-secret')
+          expect(host.opts.env.DEEPSEEK_API_KEY).toBe(environment.secrets[0].placeholder)
+        }
+      }
+    } finally {
+      await daemon.stop()
+      vi.unstubAllEnvs()
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+)
+
 const dm = (ts: string, text: string, thread: string) => ({
   msgId: `slack:C1:${ts}`,
   traceId: ts,

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runInNewContext } from 'node:vm'
 import { decode, encode } from 'cborg'
-import type { ExecEvent } from 'microsandbox'
+import type { ExecEvent, ModifyOptions } from 'microsandbox'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   MicrosandboxManager,
@@ -72,6 +72,7 @@ function fakeSdk() {
     readonly spec = {
       image: 'test-image',
       env: [{ key: 'PATH', value: '/image/bin' }],
+      secrets: {} as Record<string, { value: string; placeholder: string; host: string }>,
       runtime: { workdir: '/image', user: 'agent' }
     }
     readonly stopWithTimeout = vi.fn(async () => {
@@ -99,6 +100,10 @@ function fakeSdk() {
     config() {
       return this.spec
     }
+    readonly modify = vi.fn(async (options: ModifyOptions) => {
+      for (const [name, spec] of Object.entries(options.secrets ?? {})) this.spec.secrets[name]!.value = spec.value!
+      return { applied: true }
+    })
     async startDetached() {
       for (const name of this.volumeNames) {
         const volume = volumes.get(name)!
@@ -206,6 +211,7 @@ function fakeSdk() {
       builder(name: string) {
         const volumeNames: string[] = []
         const mounts: FakeSandbox['mounts'] = []
+        const secrets: FakeSandbox['spec']['secrets'] = {}
         let image = 'test-image'
         const builder = {
           image(value: string) {
@@ -231,6 +237,43 @@ function fakeSdk() {
             return builder
           },
           quietLogs() {
+            return builder
+          },
+          secret(configure: (entry: any) => unknown) {
+            let name = ''
+            const data = { value: '', placeholder: '', host: '' }
+            const entry = {
+              env(value: string) {
+                name = value
+                return entry
+              },
+              value(value: string) {
+                data.value = value
+                return entry
+              },
+              placeholder(value: string) {
+                data.placeholder = value
+                return entry
+              },
+              allowHost(value: string) {
+                data.host = value
+                return entry
+              },
+              injectBasicAuth(value: boolean) {
+                expect(value).toBe(false)
+                return entry
+              },
+              injectQuery(value: boolean) {
+                expect(value).toBe(false)
+                return entry
+              },
+              injectBody(value: boolean) {
+                expect(value).toBe(false)
+                return entry
+              }
+            }
+            configure(entry)
+            secrets[name] = data
             return builder
           },
           volume(target: string, configure: (volume: any) => unknown) {
@@ -265,6 +308,7 @@ function fakeSdk() {
             }
             const sandbox = new FakeSandbox(name, volumeNames, mounts)
             sandbox.spec.image = image
+            sandbox.spec.secrets = secrets
             created.push(sandbox)
             sandboxes.set(name, sandbox)
             return sandbox
@@ -309,6 +353,63 @@ async function fixture() {
 }
 
 describe('microsandbox process and VM ownership', () => {
+  it('keeps secrets out of bindings and execs, and rotates them when the retained VM resumes', async () => {
+    const { manager, options, environment, request, created, processes } = await fixture()
+    let key = 'fixture-first-key'
+    const secret = {
+      env: 'DEEPSEEK_API_KEY',
+      placeholder: 'fixture-placeholder',
+      host: 'api.deepseek.com',
+      readValue: () => key
+    }
+    const env = { ...environment, secrets: [secret] }
+    const launch = {
+      ...request,
+      env: { DEEPSEEK_API_KEY: secret.placeholder, NODE_EXTRA_CA_CERTS: '/.msb/tls/ca.pem' },
+      inheritProcessEnv: false
+    }
+    await (await manager.driverFor(env).launch(launch)).stop(0)
+    expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
+    expect(JSON.stringify(processes[0]!.request)).not.toContain(key)
+    expect(JSON.stringify(processes[0]!.request)).toContain('NODE_EXTRA_CA_CERTS=/.msb/tls/ca.pem')
+    const directory = join(options.root, 'microsandbox', 'bindings')
+    const path = join(directory, (await readdir(directory))[0]!)
+    expect(await readFile(path, 'utf8')).not.toContain(key)
+    await manager.stopAll()
+    key = 'fixture-rotated-key'
+    const resumed = new MicrosandboxManager(options)
+    await (await resumed.driverFor(env).launch(launch)).stop(0)
+    expect(created).toHaveLength(1)
+    expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
+    expect(await readFile(path, 'utf8')).not.toContain(key)
+    await resumed.stopAll()
+    const restarted = new MicrosandboxManager(options)
+    await (await restarted.driverFor(env).launch(launch)).stop(0)
+    await restarted.discard(env.id)
+  })
+
+  it('retains an old unshielded VM without resuming it as a shielded environment', async () => {
+    const { manager, options, environment, request, created, volumes } = await fixture()
+    await (await manager.driverFor(environment).launch(request)).stop(0)
+    await manager.stopAll()
+    const resumed = new MicrosandboxManager(options)
+    const env = {
+      ...environment,
+      secrets: [
+        {
+          env: 'DEEPSEEK_API_KEY',
+          placeholder: 'fixture-placeholder',
+          host: 'api.deepseek.com',
+          readValue: () => 'fixture-key'
+        }
+      ]
+    }
+    await expect(resumed.driverFor(env).launch(request)).rejects.toThrow('changed persisted configuration')
+    expect(created[0]!.status).toBe('stopped')
+    expect(volumes.size).toBe(1)
+    await resumed.discard(environment.id)
+  })
+
   it('shares read-only bases while retaining and cleaning up each session overlay disk', async () => {
     const { manager, options, environment, request, created, volumes, removeVolume } = await fixture()
     const first: MicrosandboxEnvironment = {

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -13,6 +13,8 @@ import {
 import { MICROSANDBOX_NODE } from '../src/microsandbox/exec.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../src/shim/sandbox-paths.js'
 import { OVERLAY_BASE_ROOT } from '../src/microsandbox/overlay.js'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+import { microsandboxSupportMounts } from '../src/microsandbox/support.js'
 
 class FakeExec {
   private readonly queue: Array<ExecEvent | Error | undefined> = []
@@ -353,6 +355,31 @@ async function fixture() {
 }
 
 describe('microsandbox process and VM ownership', () => {
+  it.skipIf(process.platform === 'win32')('launches and resumes with the actual daemon support mounts', async () => {
+    const { manager, options, environment, request, created } = await fixture()
+    const scopeDir = join(options.root, 'agent')
+    const cwd = join(scopeDir, 'workspace')
+    const hostHome = join(options.root, 'host')
+    await mkdir(cwd, { recursive: true })
+    await mkdir(hostHome)
+    const launch = prepareMicrosandboxLaunch({
+      runtimeId: 'test',
+      scopeDir,
+      cwd,
+      daemonRoot: options.root,
+      stateSourceEnv: { HOME: hostHome },
+      mounts: [],
+      trustedMounts: microsandboxSupportMounts(options.root)
+    })
+    const env = { id: environment.id, ...launch.microsandbox }
+    await (await manager.driverFor(env).launch({ ...request, env: launch.env })).stop(0)
+    await manager.stopAll()
+    const resumed = new MicrosandboxManager(options)
+    await (await resumed.driverFor(env).launch({ ...request, env: launch.env })).stop(0)
+    expect(created).toHaveLength(1)
+    await resumed.discard(env.id)
+  })
+
   it('refuses host SDK state mounts even for a runtime without its own secrets', async () => {
     const { manager, options, environment, request, created } = await fixture()
     for (const path of ['', 'microsandbox', 'microsandbox/sandboxes']) {
@@ -395,32 +422,40 @@ describe('microsandbox process and VM ownership', () => {
     expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
     expect(await readFile(path, 'utf8')).not.toContain(key)
     await resumed.stopAll()
+    created[0]!.modify.mockResolvedValueOnce({ applied: false, changes: [], conflicts: [] } as never)
     const restarted = new MicrosandboxManager(options)
     await (await restarted.driverFor(env).launch(launch)).stop(0)
+    expect(created).toHaveLength(1)
+    expect(created[0]!.status).toBe('running')
     await restarted.discard(env.id)
   })
 
-  it('retains an old unshielded VM without resuming it as a shielded environment', async () => {
-    const { manager, options, environment, request, created, volumes } = await fixture()
-    await (await manager.driverFor(environment).launch(request)).stop(0)
-    await manager.stopAll()
-    const resumed = new MicrosandboxManager(options)
-    const env = {
-      ...environment,
-      secrets: [
-        {
-          env: 'DEEPSEEK_API_KEY',
-          placeholder: 'fixture-placeholder',
-          host: 'api.deepseek.com',
-          readValue: () => 'fixture-key'
-        }
-      ]
+  it.each([false, true])(
+    'retains VM data when its credential configuration changes (protected=%s)',
+    async (protectedVm) => {
+      const { manager, options, environment, request, created, volumes } = await fixture()
+      const env = {
+        ...environment,
+        secrets: [
+          {
+            env: 'DEEPSEEK_API_KEY',
+            placeholder: 'fixture-placeholder',
+            host: 'api.deepseek.com',
+            readValue: () => 'fixture-key'
+          }
+        ]
+      }
+      await (await manager.driverFor(protectedVm ? env : environment).launch(request)).stop(0)
+      await manager.stopAll()
+      const resumed = new MicrosandboxManager(options)
+      await expect(resumed.driverFor(protectedVm ? environment : env).launch(request)).rejects.toThrow(
+        'start a new session'
+      )
+      expect(created[0]!.status).toBe('stopped')
+      expect(volumes.size).toBe(1)
+      await resumed.discard(environment.id)
     }
-    await expect(resumed.driverFor(env).launch(request)).rejects.toThrow('changed persisted configuration')
-    expect(created[0]!.status).toBe('stopped')
-    expect(volumes.size).toBe(1)
-    await resumed.discard(environment.id)
-  })
+  )
 
   it('shares read-only bases while retaining and cleaning up each session overlay disk', async () => {
     const { manager, options, environment, request, created, volumes, removeVolume } = await fixture()
@@ -710,15 +745,23 @@ describe('microsandbox process and VM ownership', () => {
     expect(created).toHaveLength(2)
   })
 
-  it('resumes the retained VM after retiring only the known guest helper mount', async () => {
-    const { manager, options, environment, request, created } = await fixture()
+  it.each([false, true])('resumes with relocated support mounts (legacy guest helper=%s)', async (withGuestHelper) => {
+    const { manager, options, environment: original, request, created } = await fixture()
+    const environment = { ...original, mounts: microsandboxSupportMounts(options.root) }
     const helpers = join(options.root, 'microsandbox', 'helpers')
     await mkdir(helpers, { recursive: true })
+    const legacyGit = join(helpers, 'git-credential')
+    await writeFile(legacyGit, await readFile(environment.mounts[0]!.source))
     const helper = join(helpers, 'guest.js')
     await writeFile(helper, 'export {}')
     const legacy: MicrosandboxEnvironment = {
       ...environment,
-      mounts: [{ source: await realpath(helper), target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }]
+      mounts: [
+        { ...environment.mounts[0]!, source: await realpath(legacyGit) },
+        ...(withGuestHelper
+          ? [{ source: await realpath(helper), target: '/opt/agentconnect-local/guest.js', mode: 'readonly' as const }]
+          : [])
+      ]
     }
     const runtime = await manager.driverFor(environment).launch(request)
     await runtime.stop(0)

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -353,6 +353,19 @@ async function fixture() {
 }
 
 describe('microsandbox process and VM ownership', () => {
+  it('refuses host SDK state mounts even for a runtime without its own secrets', async () => {
+    const { manager, options, environment, request, created } = await fixture()
+    for (const path of ['', 'microsandbox', 'microsandbox/sandboxes']) {
+      const env = {
+        ...environment,
+        mounts: [{ source: join(options.root, path), target: '/config', mode: 'readonly' as const }]
+      }
+      await expect(manager.driverFor(env).launch(request)).rejects.toThrow('cannot expose host sandbox state')
+    }
+    expect(created).toHaveLength(0)
+    await manager.stopAll()
+  })
+
   it('keeps secrets out of bindings and execs, and rotates them when the retained VM resumes', async () => {
     const { manager, options, environment, request, created, processes } = await fixture()
     let key = 'fixture-first-key'
@@ -365,8 +378,7 @@ describe('microsandbox process and VM ownership', () => {
     const env = { ...environment, secrets: [secret] }
     const launch = {
       ...request,
-      env: { DEEPSEEK_API_KEY: secret.placeholder, NODE_EXTRA_CA_CERTS: '/.msb/tls/ca.pem' },
-      inheritProcessEnv: false
+      env: { DEEPSEEK_API_KEY: secret.placeholder, NODE_EXTRA_CA_CERTS: '/.msb/tls/ca.pem' }
     }
     await (await manager.driverFor(env).launch(launch)).stop(0)
     expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
@@ -708,9 +720,15 @@ describe('microsandbox process and VM ownership', () => {
       ...environment,
       mounts: [{ source: await realpath(helper), target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }]
     }
-    const runtime = await manager.driverFor(legacy).launch(request)
+    const runtime = await manager.driverFor(environment).launch(request)
     await runtime.stop(0)
     await manager.stopAll()
+    // Simulate a binding written before host SDK state mounts were forbidden.
+    const bindings = join(options.root, 'microsandbox', 'bindings')
+    const path = join(bindings, (await readdir(bindings))[0]!)
+    const binding = JSON.parse(await readFile(path, 'utf8'))
+    binding.spec = (manager as any).spec(legacy)
+    await writeFile(path, JSON.stringify(binding))
     const resumed = new MicrosandboxManager({
       ...options,
       config: { ...options.config, image: 'next-image' }

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 })
 
 describe('prepareMicrosandboxLaunch', () => {
-  it.each(['legacy', 'versioned', 'dotenv'])(
+  it.skipIf(process.platform !== 'linux').each(['legacy', 'versioned', 'dotenv'])(
     'protects %s DeepSeek keys while preserving other private provider credentials',
     (format) => {
       const opts = fixture()
@@ -88,7 +88,7 @@ describe('prepareMicrosandboxLaunch', () => {
     }
   )
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(process.platform !== 'linux')(
     'rejects host credential mounts and symlinked private copies instead of modifying the host',
     () => {
       const opts = fixture()
@@ -127,18 +127,21 @@ describe('prepareMicrosandboxLaunch', () => {
     expect(readFileSync(path, 'utf8')).toContain('fixture-guest-login')
   })
 
-  it('uses an explicit key despite malformed host YAML and rejects an unsupported dotenv endpoint', () => {
-    const opts = fixture()
-    const hostDsh = join(opts.hostHome, '.dsh')
-    mkdirSync(hostDsh)
-    writeFileSync(join(hostDsh, '.credentials.yaml'), 'DEEPSEEK_API_KEY: first\nDEEPSEEK_API_KEY: second\n')
-    const options = { ...opts, runtimeId: 'dsh-acp', explicitEnv: { DEEPSEEK_API_KEY: 'fixture-explicit-key' } }
-    const launch = prepareMicrosandboxLaunch(options)
-    expect(launch.microsandbox.secrets![0]!.readValue()).toBe('fixture-explicit-key')
-    expect(existsSync(join(launch.runtimeHome!, '.dsh', '.credentials.yaml'))).toBe(false)
-    writeFileSync(join(hostDsh, '.env'), 'DEEPSEEK_BASE_URL=https://gateway.example.test\n')
-    expect(() => prepareMicrosandboxLaunch(options)).toThrow('launch refused')
-  })
+  it.skipIf(process.platform !== 'linux')(
+    'uses an explicit key despite malformed host YAML and rejects an unsupported dotenv endpoint',
+    () => {
+      const opts = fixture()
+      const hostDsh = join(opts.hostHome, '.dsh')
+      mkdirSync(hostDsh)
+      writeFileSync(join(hostDsh, '.credentials.yaml'), 'DEEPSEEK_API_KEY: first\nDEEPSEEK_API_KEY: second\n')
+      const options = { ...opts, runtimeId: 'dsh-acp', explicitEnv: { DEEPSEEK_API_KEY: 'fixture-explicit-key' } }
+      const launch = prepareMicrosandboxLaunch(options)
+      expect(launch.microsandbox.secrets![0]!.readValue()).toBe('fixture-explicit-key')
+      expect(existsSync(join(launch.runtimeHome!, '.dsh', '.credentials.yaml'))).toBe(false)
+      writeFileSync(join(hostDsh, '.env'), 'DEEPSEEK_BASE_URL=https://gateway.example.test\n')
+      expect(() => prepareMicrosandboxLaunch(options)).toThrow('launch refused')
+    }
+  )
 
   it('refuses custom TLS trust instead of silently dropping the operator bundle', () => {
     const opts = fixture()
@@ -174,34 +177,37 @@ describe('prepareMicrosandboxLaunch', () => {
     }
   })
 
-  it('keeps SRT credential seeding and masks explicit DeepSeek keys only for microsandbox', () => {
-    const opts = fixture()
-    mkdirSync(join(opts.hostHome, '.dsh'))
-    const key = 'fixture-file-key'
-    writeFileSync(join(opts.hostHome, '.dsh', '.credentials.yaml'), `DEEPSEEK_API_KEY: ${key}\n`)
-    const srt = prepareRuntimeLaunch({
-      ...opts,
-      runtimeId: 'dsh-acp',
-      runInSandbox: true,
-      daemonRoot: opts.root,
-      sandboxMechanism: 'bwrap'
-    })
-    expect(readFileSync(join(srt.runtimeHome!, '.dsh', '.credentials.yaml'), 'utf8')).toContain(key)
-    const launch = prepareMicrosandboxLaunch({
-      ...opts,
-      runtimeId: 'dsh-acp',
-      explicitEnv: { DEEPSEEK_API_KEY: 'fixture-explicit-key' }
-    })
-    expect(launch.microsandbox.secrets![0]!.readValue()).toBe('fixture-explicit-key')
-    expect(JSON.stringify(launch)).not.toContain('fixture-explicit-key')
-    expect(() =>
-      prepareMicrosandboxLaunch({
+  it.skipIf(process.platform !== 'linux')(
+    'keeps SRT credential seeding and masks explicit DeepSeek keys only for microsandbox',
+    () => {
+      const opts = fixture()
+      mkdirSync(join(opts.hostHome, '.dsh'))
+      const key = 'fixture-file-key'
+      writeFileSync(join(opts.hostHome, '.dsh', '.credentials.yaml'), `DEEPSEEK_API_KEY: ${key}\n`)
+      const srt = prepareRuntimeLaunch({
         ...opts,
         runtimeId: 'dsh-acp',
-        explicitEnv: { DEEPSEEK_BASE_URL: 'https://proxy.example.test' }
+        runInSandbox: true,
+        daemonRoot: opts.root,
+        sandboxMechanism: 'bwrap'
       })
-    ).toThrow('requires https://api.deepseek.com')
-  })
+      expect(readFileSync(join(srt.runtimeHome!, '.dsh', '.credentials.yaml'), 'utf8')).toContain(key)
+      const launch = prepareMicrosandboxLaunch({
+        ...opts,
+        runtimeId: 'dsh-acp',
+        explicitEnv: { DEEPSEEK_API_KEY: 'fixture-explicit-key' }
+      })
+      expect(launch.microsandbox.secrets![0]!.readValue()).toBe('fixture-explicit-key')
+      expect(JSON.stringify(launch)).not.toContain('fixture-explicit-key')
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          runtimeId: 'dsh-acp',
+          explicitEnv: { DEEPSEEK_BASE_URL: 'https://proxy.example.test' }
+        })
+      ).toThrow('requires https://api.deepseek.com')
+    }
+  )
 
   it.each([
     ['claude-acp', false],

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -55,7 +55,7 @@ afterEach(() => {
 
 describe('prepareMicrosandboxLaunch', () => {
   it.each(['legacy', 'versioned', 'dotenv'])(
-    'keeps %s DeepSeek keys outside the VM and removes old seeded copies',
+    'protects %s DeepSeek keys while preserving other private provider credentials',
     (format) => {
       const opts = fixture()
       const hostDsh = join(opts.hostHome, '.dsh')
@@ -66,12 +66,12 @@ describe('prepareMicrosandboxLaunch', () => {
       const file = format === 'dotenv' ? '.env' : '.credentials.yaml'
       const content =
         format === 'dotenv'
-          ? `DEEPSEEK_API_KEY=${key}\n`
+          ? `DEEPSEEK_API_KEY=${key}\nOPENROUTER_API_KEY=fixture-other-provider\n`
           : format === 'versioned'
-            ? `version: 1\nrefs:\n  DEEPSEEK_API_KEY: ${key}\n`
-            : `DEEPSEEK_API_KEY: ${key}\n`
+            ? `version: 1\nrefs:\n  DEEPSEEK_API_KEY: ${key}\n  OPENROUTER_API_KEY: fixture-other-provider\nrecords:\n  login:\n    token: fixture-oauth-grant\n`
+            : `DEEPSEEK_API_KEY: ${key}\nOPENROUTER_API_KEY: fixture-other-provider\n`
       writeFileSync(join(hostDsh, file), content)
-      for (const name of ['.credentials.yaml', '.env']) writeFileSync(join(guestDsh, name), key)
+      writeFileSync(join(guestDsh, file), content.replace('fixture-other-provider', 'fixture-private-login'))
       const launch = prepareMicrosandboxLaunch({ ...opts, runtimeId: 'dsh-acp' })
       const secret = launch.microsandbox.secrets![0]!
       expect(secret.readValue()).toBe(key)
@@ -79,7 +79,11 @@ describe('prepareMicrosandboxLaunch', () => {
       expect(launch.env.NODE_EXTRA_CA_CERTS).toBe('/.msb/tls/ca.pem')
       expect(JSON.stringify(launch)).not.toContain(key)
       expect(secret.host).toBe('api.deepseek.com')
-      for (const name of ['.credentials.yaml', '.env']) expect(existsSync(join(guestDsh, name))).toBe(false)
+      const projected = readFileSync(join(guestDsh, file), 'utf8')
+      expect(projected).not.toContain(key)
+      expect(projected).toContain('fixture-private-login')
+      expect(projected).toContain(secret.placeholder)
+      if (format === 'versioned') expect(projected).toContain('fixture-oauth-grant')
       expect(readFileSync(join(hostDsh, file), 'utf8')).toBe(content)
     }
   )
@@ -96,17 +100,79 @@ describe('prepareMicrosandboxLaunch', () => {
       const deepseek = { ...opts, runtimeId: 'dsh-acp' }
       expect(() =>
         prepareMicrosandboxLaunch({ ...deepseek, mounts: [{ source: hostDsh, target: '/config', mode: 'readonly' }] })
-      ).toThrow('expose a host DeepSeek credential file')
+      ).toThrow('protected host path')
       rmSync(source)
       expect(() =>
         prepareMicrosandboxLaunch({ ...deepseek, mounts: [{ source: hostDsh, target: '/config', mode: 'readonly' }] })
-      ).toThrow('expose a host DeepSeek credential file')
+      ).toThrow('protected host path')
       writeFileSync(source, content)
+      rmSync(join(opts.scopeDir, 'home', '.dsh', '.credentials.yaml'), { force: true })
       symlinkSync(source, join(opts.scopeDir, 'home', '.dsh', '.credentials.yaml'))
       expect(() => prepareMicrosandboxLaunch(deepseek)).toThrow('symlink')
       expect(readFileSync(source, 'utf8')).toBe(content)
     }
   )
+
+  it('retains DSH file and guest login state when only another provider is configured', () => {
+    const opts = fixture()
+    const hostDsh = join(opts.hostHome, '.dsh')
+    mkdirSync(hostDsh)
+    writeFileSync(join(hostDsh, '.credentials.yaml'), 'OPENAI_API_KEY: fixture-openai-key\n')
+    const launch = prepareMicrosandboxLaunch({ ...opts, runtimeId: 'dsh-acp' })
+    expect(launch.microsandbox.secrets).toBeUndefined()
+    const path = join(launch.runtimeHome!, '.dsh', '.credentials.yaml')
+    expect(readFileSync(path, 'utf8')).toContain('fixture-openai-key')
+    writeFileSync(path, 'OPENAI_API_KEY: fixture-guest-login\n')
+    prepareMicrosandboxLaunch({ ...opts, runtimeId: 'dsh-acp' })
+    expect(readFileSync(path, 'utf8')).toContain('fixture-guest-login')
+  })
+
+  it('uses an explicit key despite malformed host YAML and rejects an unsupported dotenv endpoint', () => {
+    const opts = fixture()
+    const hostDsh = join(opts.hostHome, '.dsh')
+    mkdirSync(hostDsh)
+    writeFileSync(join(hostDsh, '.credentials.yaml'), 'DEEPSEEK_API_KEY: first\nDEEPSEEK_API_KEY: second\n')
+    const options = { ...opts, runtimeId: 'dsh-acp', explicitEnv: { DEEPSEEK_API_KEY: 'fixture-explicit-key' } }
+    const launch = prepareMicrosandboxLaunch(options)
+    expect(launch.microsandbox.secrets![0]!.readValue()).toBe('fixture-explicit-key')
+    expect(existsSync(join(launch.runtimeHome!, '.dsh', '.credentials.yaml'))).toBe(false)
+    writeFileSync(join(hostDsh, '.env'), 'DEEPSEEK_BASE_URL=https://gateway.example.test\n')
+    expect(() => prepareMicrosandboxLaunch(options)).toThrow('launch refused')
+  })
+
+  it('refuses custom TLS trust instead of silently dropping the operator bundle', () => {
+    const opts = fixture()
+    for (const name of [
+      'NODE_EXTRA_CA_CERTS',
+      'SSL_CERT_FILE',
+      'SSL_CERT_DIR',
+      'GIT_SSL_CAINFO',
+      'REQUESTS_CA_BUNDLE',
+      'CURL_CA_BUNDLE'
+    ]) {
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          runtimeId: 'dsh-acp',
+          explicitEnv: { DEEPSEEK_API_KEY: 'fixture-key', [name]: '/operator/ca.pem' }
+        })
+      ).toThrow('custom TLS trust bundles')
+    }
+  })
+
+  it('uses the same protected host roots as SRT for configured mounts', () => {
+    const opts = fixture()
+    for (const name of ['.codex', '.claude', '.dsh']) {
+      const source = join(opts.hostHome, name)
+      mkdirSync(source)
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          mounts: [{ source, target: '/config', mode: 'readonly' }]
+        })
+      ).toThrow('protected host path')
+    }
+  })
 
   it('keeps SRT credential seeding and masks explicit DeepSeek keys only for microsandbox', () => {
     const opts = fixture()
@@ -337,6 +403,8 @@ describe('prepareMicrosandboxLaunch', () => {
     writeFileSync(helper, 'original host helper')
     writeFileSync(gitConfig, '[core]\n hooksPath = /dev/null\n')
     const trustedMounts = microsandboxSupportMounts(opts.root, gitConfig)
+    const replacement = join(opts.root, 'replacement')
+    mkdirSync(replacement)
     expect(readFileSync(helper, 'utf8')).toBe('original host helper')
     expect(readFileSync(trustedMounts[0]!.source, 'utf8')).toBe(
       '#!/bin/sh\nexec /opt/agentconnect/bin/git-credential "$@"\n'
@@ -356,7 +424,7 @@ describe('prepareMicrosandboxLaunch', () => {
         prepareMicrosandboxLaunch({
           ...opts,
           trustedMounts,
-          mounts: [{ source: opts.hostHome, target, mode: 'writable' }]
+          mounts: [{ source: replacement, target, mode: 'writable' }]
         })
       ).toThrow('overlaps an automatic')
     }
@@ -364,6 +432,8 @@ describe('prepareMicrosandboxLaunch', () => {
 
   it('rejects operator mounts shadowing private data or socket bridges', () => {
     const opts = fixture()
+    const source = join(opts.root, 'replacement')
+    mkdirSync(source)
     for (const target of [
       opts.scopeDir,
       join(opts.scopeDir, 'home'),
@@ -376,9 +446,9 @@ describe('prepareMicrosandboxLaunch', () => {
       '/tmp/agentconnect',
       '/tmp'
     ]) {
-      expect(() =>
-        prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: opts.hostHome, target, mode: 'writable' }] })
-      ).toThrow('overlaps an automatic')
+      expect(() => prepareMicrosandboxLaunch({ ...opts, mounts: [{ source, target, mode: 'writable' }] })).toThrow(
+        'overlaps an automatic'
+      )
     }
     expect(() => prepareMicrosandboxLaunch({ ...opts, trustedRuntimeReadRoots: [opts.scopeDir] })).toThrow(
       'entire agent or host HOME'
@@ -468,9 +538,7 @@ describe('prepareMicrosandboxLaunch', () => {
       explicitEnv: { CODEX_CONFIG: JSON.stringify({ 'permissions.untrusted': {}, model: 'test-model' }) },
       mounts: [
         { source: cache, target: '/shared/cache', mode: 'writable' },
-        { source: opts.hostHome, target: '/credential-copy', mode: 'writable' },
         { source: auth, target: '/credential-file', mode: 'readonly' },
-        { source: hostCodex, target: '/credential-dir', mode: 'writable' },
         { source: auth, target: '/credential-dir/auth.json', mode: 'writable' }
       ]
     })
@@ -478,7 +546,7 @@ describe('prepareMicrosandboxLaunch', () => {
     const policy: CodexPermissionProfileConfig = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!)
     for (const profile of Object.values(policy.modeProfiles)) {
       const filesystem = policy.configOverrides.find((line) => line.startsWith(`permissions.${profile}.filesystem=`))!
-      for (const path of ['/credential-copy/.codex/auth.json', '/credential-file', '/credential-dir/auth.json']) {
+      for (const path of ['/credential-file', '/credential-dir/auth.json']) {
         expect(filesystem).toContain(`${JSON.stringify(path)} = "deny"`)
       }
     }
@@ -509,7 +577,7 @@ describe('prepareMicrosandboxLaunch', () => {
       runtimeId: 'claude-acp',
       runtime: { command: 'claude-agent-acp', args: [], env: [] },
       explicitEnv: { ANTHROPIC_CONFIG_DIR: '/untrusted-profile', ANTHROPIC_PROFILE: 'untrusted' },
-      mounts: [{ source: config, target: '/credential-copy', mode: 'writable' }]
+      mounts: [{ source: join(config, '.credentials.json'), target: '/credential-copy', mode: 'writable' }]
     })
     expect(launch.sandbox).toBeUndefined()
     const profileRoot = join(opts.scopeDir, '.agentconnect', 'runtime-policy', 'claude-profile-disabled')

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -8,6 +8,7 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { createServer } from 'node:net'
@@ -53,6 +54,89 @@ afterEach(() => {
 })
 
 describe('prepareMicrosandboxLaunch', () => {
+  it.each(['legacy', 'versioned', 'dotenv'])(
+    'keeps %s DeepSeek keys outside the VM and removes old seeded copies',
+    (format) => {
+      const opts = fixture()
+      const hostDsh = join(opts.hostHome, '.dsh')
+      const guestDsh = join(opts.scopeDir, 'home', '.dsh')
+      mkdirSync(hostDsh)
+      mkdirSync(guestDsh, { recursive: true })
+      const key = 'fixture-deepseek-host-key'
+      const file = format === 'dotenv' ? '.env' : '.credentials.yaml'
+      const content =
+        format === 'dotenv'
+          ? `DEEPSEEK_API_KEY=${key}\n`
+          : format === 'versioned'
+            ? `version: 1\nrefs:\n  DEEPSEEK_API_KEY: ${key}\n`
+            : `DEEPSEEK_API_KEY: ${key}\n`
+      writeFileSync(join(hostDsh, file), content)
+      for (const name of ['.credentials.yaml', '.env']) writeFileSync(join(guestDsh, name), key)
+      const launch = prepareMicrosandboxLaunch({ ...opts, runtimeId: 'dsh-acp' })
+      const secret = launch.microsandbox.secrets![0]!
+      expect(secret.readValue()).toBe(key)
+      expect(launch.env.DEEPSEEK_API_KEY).toBe(secret.placeholder)
+      expect(launch.env.NODE_EXTRA_CA_CERTS).toBe('/.msb/tls/ca.pem')
+      expect(JSON.stringify(launch)).not.toContain(key)
+      expect(secret.host).toBe('api.deepseek.com')
+      for (const name of ['.credentials.yaml', '.env']) expect(existsSync(join(guestDsh, name))).toBe(false)
+      expect(readFileSync(join(hostDsh, file), 'utf8')).toBe(content)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects host credential mounts and symlinked private copies instead of modifying the host',
+    () => {
+      const opts = fixture()
+      const hostDsh = join(opts.hostHome, '.dsh')
+      mkdirSync(hostDsh)
+      const source = join(hostDsh, '.credentials.yaml')
+      const content = 'DEEPSEEK_API_KEY: fixture-host-key\n'
+      writeFileSync(source, content)
+      const deepseek = { ...opts, runtimeId: 'dsh-acp' }
+      expect(() =>
+        prepareMicrosandboxLaunch({ ...deepseek, mounts: [{ source: hostDsh, target: '/config', mode: 'readonly' }] })
+      ).toThrow('expose a host DeepSeek credential file')
+      rmSync(source)
+      expect(() =>
+        prepareMicrosandboxLaunch({ ...deepseek, mounts: [{ source: hostDsh, target: '/config', mode: 'readonly' }] })
+      ).toThrow('expose a host DeepSeek credential file')
+      writeFileSync(source, content)
+      symlinkSync(source, join(opts.scopeDir, 'home', '.dsh', '.credentials.yaml'))
+      expect(() => prepareMicrosandboxLaunch(deepseek)).toThrow('symlink')
+      expect(readFileSync(source, 'utf8')).toBe(content)
+    }
+  )
+
+  it('keeps SRT credential seeding and masks explicit DeepSeek keys only for microsandbox', () => {
+    const opts = fixture()
+    mkdirSync(join(opts.hostHome, '.dsh'))
+    const key = 'fixture-file-key'
+    writeFileSync(join(opts.hostHome, '.dsh', '.credentials.yaml'), `DEEPSEEK_API_KEY: ${key}\n`)
+    const srt = prepareRuntimeLaunch({
+      ...opts,
+      runtimeId: 'dsh-acp',
+      runInSandbox: true,
+      daemonRoot: opts.root,
+      sandboxMechanism: 'bwrap'
+    })
+    expect(readFileSync(join(srt.runtimeHome!, '.dsh', '.credentials.yaml'), 'utf8')).toContain(key)
+    const launch = prepareMicrosandboxLaunch({
+      ...opts,
+      runtimeId: 'dsh-acp',
+      explicitEnv: { DEEPSEEK_API_KEY: 'fixture-explicit-key' }
+    })
+    expect(launch.microsandbox.secrets![0]!.readValue()).toBe('fixture-explicit-key')
+    expect(JSON.stringify(launch)).not.toContain('fixture-explicit-key')
+    expect(() =>
+      prepareMicrosandboxLaunch({
+        ...opts,
+        runtimeId: 'dsh-acp',
+        explicitEnv: { DEEPSEEK_BASE_URL: 'https://proxy.example.test' }
+      })
+    ).toThrow('requires https://api.deepseek.com')
+  })
+
   it.each([
     ['claude-acp', false],
     ['claude-acp', true],

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -1,10 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
-import { hostPackageCacheEnv, prepareRuntimeHome, runtimeHomeEnvironment } from '../src/runtimes/runtime-home.js'
+import {
+  hostPackageCacheEnv,
+  prepareRuntimeHome,
+  projectRuntimeHomeSeedFile,
+  runtimeHomeEnvironment
+} from '../src/runtimes/runtime-home.js'
 import { extractOmpCredentials } from '../src/runtimes/omp-credentials.js'
 import { discoverSeededRuntimeCredentials } from '../src/runtimes/runtime-seeded-credentials.js'
 
@@ -18,6 +34,38 @@ function fixture(): { root: string; hostHome: string; scopeDir: string } {
 }
 
 describe('private runtime HOME', () => {
+  it.skipIf(process.platform !== 'linux').each(['leaf', 'parent'])(
+    'does not follow a guest-swapped %s while projecting credentials',
+    (swap) => {
+      const { root, hostHome, scopeDir } = fixture()
+      const home = join(scopeDir, 'home')
+      const directory = join(home, '.dsh')
+      const destination = join(directory, '.env')
+      const outside = join(hostHome, '.env')
+      mkdirSync(directory, { recursive: true })
+      writeFileSync(destination, 'fixture-guest-content')
+      writeFileSync(outside, 'host-only-content')
+      try {
+        projectRuntimeHomeSeedFile(home, '.dsh/.env', outside, () => {
+          if (swap === 'leaf') {
+            unlinkSync(destination)
+            symlinkSync(outside, destination)
+          } else {
+            renameSync(directory, join(home, 'moved'))
+            symlinkSync(hostHome, directory)
+          }
+          return 'projected-content'
+        })
+        expect(readFileSync(outside, 'utf8')).toBe('host-only-content')
+        expect(readFileSync(swap === 'leaf' ? destination : join(home, 'moved', '.env'), 'utf8')).toBe(
+          'projected-content'
+        )
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('seeds only Claude model rollout cache and keeps other host state out', () => {
     const { hostHome, scopeDir } = fixture()
     writeFileSync(join(hostHome, '.claude', '.credentials.json'), '{"token":"host"}')


### PR DESCRIPTION
DeepSeek Harness currently receives copied credential files inside microsandbox. Resolve its standard API key on the host and give the guest a placeholder instead, using microsandbox's built-in TLS secret injection for `api.deepseek.com`.

Reuse the runtime credential-file descriptors and DSH parser. Replace the protected ref with a placeholder while retaining other provider credentials and private login state. Without a DeepSeek key, keep normal credential seeding. An environment key remains usable when an unused host YAML seed is malformed. On Linux, hold directory and file descriptors during projection and publish by atomic rename, so guest file or parent-directory swaps cannot redirect writes to the host. Derive the ACP driver's environment from the final launch after agent-secret exclusions, so background hosts cannot regain excluded secrets through the proxy.

Reject mounts exposing host credential sources or SDK state, using the same host-boundary and runtime-state inventory as SRT for configured mounts. Public Git helpers live outside SDK state; retained VMs can keep their previous exact read-only helper mappings. Secret values do not enter serialized launch metadata or daemon environment bindings. SRT and Kubernetes authentication retain their existing paths.

Protected VMs reload keys on stop/resume without rewriting unchanged bindings. Credential configuration changes retain the VM data and explain how to restore credentials or start a new session. Previously unprotected VMs require a new session for protection. This first implementation supports the standard `DEEPSEEK_API_KEY` reference and official HTTPS endpoint. A custom base URL, including one in DSH `.env`, explicitly refuses the launch. Combining operator CA bundles with the proxy CA is deferred: custom TLS trust settings also refuse the protected launch instead of being overwritten; use SRT for those configurations. The SDK stores secrets on the host, and the upstream provider remains trusted because responses are not redacted.

Validation:

- Focused microsandbox launch/driver, runtime HOME, shared policy, daemon session-host and descriptor-descent regression suites, including actual support-mount composition, retained legacy helpers, provider-state preservation, and excluded agent secrets.
- Daemon typecheck, build, and changed-file lint/format checks.
- Real Linux/KVM smoke with microsandbox 0.6.17 and the actual daemon support mounts: authenticated DeepSeek request, an ACP turn with a native shell tool, filtered guest credential files, no real key in inspected guest process state, blocked placeholder use at another domain, and ordinary public HTTPS.
- Retained VM restart and key replacement: valid key 200, invalid fixture key 401, restored key 200. Temporary VMs and files removed.
- Deterministic Linux leaf and parent-directory symlink swaps during credential projection: host files remain unchanged in both cases.

Created by Codex . GPT-6
