### PR TITLE
ci: publish the Helm chart beside the tag finalize instead of after it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -577,14 +577,16 @@ jobs:
 
   # The Helm chart rides the same release train as the images: chart version = the release
   # with the `v` stripped (OCI/SemVer form), appVersion = the release tag (the image-tag
-  # form its templates default to). Published after `finalize` so a chart version never
-  # exists without its images, and before the dispatch below so a consumer deploying on
-  # that signal can pull the chart at the version it names.
+  # form its templates default to). Gated on the built images but NOT on `finalize`: it reads
+  # nothing that job produces, so the two run side by side instead of costing every release a
+  # serial job. The trade is narrow — while `finalize` runs, a chart pulled straight from the
+  # registry names this release's tag on components whose alias has yet to land, and nothing
+  # consumes it that way: the dispatch below is this workflow's only signal and awaits both.
   publish-chart:
     name: Publish Helm chart
     needs:
       - prepare
-      - finalize
+      - build-images
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
`publish-chart` sat behind `finalize` on the release path, but it reads
nothing that job produces — its only input is the release version, which
comes from `prepare`. The edge between them was ordering alone, and it cost
every release a serial job plus a runner start.

Gating the chart on the built images instead makes it a sibling of
`finalize`:

```
prepare → build-images (matrix) → ┬→ finalize      ─┬→ notify-workflow
                                  └→ publish-chart ─┘
```

## What the ordering was protecting, and why this is safe

The chart's templates default every component's image tag to
`Chart.AppVersion`, which is the release tag. `finalize` is what makes that
tag resolve for components this release did not rebuild — it aliases them
onto their effective image. So publishing the chart before `finalize` opens
a window where a chart pulled straight from the registry names tags whose
aliases have yet to land.

Nothing consumes it that way. The `repository_dispatch` below is the only
signal this workflow emits, and it still waits for both jobs, so a consumer
acting on that signal sees no change at all. The window is the length of
`finalize` (~20s) and applies only to a client polling the OCI registry
directly, which is not how the chart is published or announced.

Publishing even earlier — off `prepare`, concurrent with the matrix — was
considered and rejected: `finalize` already runs at least as long as the
chart job, so hiding the chart under the matrix saves no additional
wall-clock while widening that window from seconds to the whole build.

## Verification

Job graph parsed and asserted with `yaml`; `prettier --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
