### PR TITLE
feat(daemon): protect OpenCode API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -318,18 +318,32 @@ OpenCode uses the same proxy and lifecycle for `type: api` records in its native
 own placeholder and allowed HTTPS hosts; providers sharing a key share one
 placeholder with their combined authorized hosts. Routing comes from standard host OpenCode
 config and `OPENCODE_CONFIG_CONTENT`, then provider defaults or OpenCode's cached model
-catalog. Unknown destinations require an explicit host `provider.options.baseURL`;
+catalog. Unknown or unsupported destinations keep placeholders but receive no
+proxy key injection; other providers can still start and authenticate. Configure
+a supported HTTPS host `provider.options.baseURL` to enable that provider. There
+is no fallback to mounting its real API key. An absent or unusable catalog only
+affects providers that need that catalog, not providers with known defaults;
 guest workspace configuration cannot authorize a new destination. Standard
 providers do not require a warm model cache. Copies of the protected keys in
-seeded OpenCode config files are replaced too; the host files are unchanged.
+seeded OpenCode credential values, Bearer headers, and JSON environment config are
+replaced too, without replacing matching substrings in paths or unrelated text.
+The host files are unchanged.
 This path protects keys discovered in native `auth.json`; it does not discover
 additional keys stored only in other configuration sources.
+`OPENCODE_CONFIG` and `OPENCODE_CONFIG_DIR` paths are not imported or used for proxy
+routing; use the standard host config locations or `OPENCODE_CONFIG_CONTENT`.
+Symlinked host files are skipped, matching native HOME seeding. Credential import
+uses the registered `opencode` state profile, not command-name matching for custom
+runtime IDs.
 
-OpenCode OAuth records remain unchanged in the mounted private credential file
+OpenCode OAuth and `wellknown` records remain unchanged in the mounted private credential file
 and are readable by the guest. Guest-refreshed OAuth records survive subsequent
 preparation. OAuth-only launches retain the existing seeding path, without proxy
 secrets or additional credential shielding. This change does not add an OAuth
 proxy or refresh coordinator.
+API records for providers configured only inside the guest retain their native local login
+behavior on resume; they are not host-managed proxy credentials. Blank or malformed
+API keys are not selected for protection and do not prevent preparing other records.
 
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -315,7 +315,8 @@ diagnostic. Custom credential-reference names are outside this first implementat
 
 OpenCode uses the same proxy and lifecycle for `type: api` records in its native
 `auth.json` (including XDG data-directory overrides). Each provider receives its
-own placeholder and allowed HTTPS hosts. Routing comes from standard host OpenCode
+own placeholder and allowed HTTPS hosts; providers sharing a key share one
+placeholder with their combined authorized hosts. Routing comes from standard host OpenCode
 config and `OPENCODE_CONFIG_CONTENT`, then provider defaults or OpenCode's cached model
 catalog. Unknown destinations require an explicit host `provider.options.baseURL`;
 guest workspace configuration cannot authorize a new destination. Standard

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -301,7 +301,7 @@ descriptors also prepare the corresponding files in the private runtime HOME.
 Keyring-only logins are not detected by file discovery. Credential formats without
 a shared discovery descriptor retain the runtime probe's authentication result.
 
-### DeepSeek credential protection
+### API key protection
 
 For DeepSeek Harness in microsandbox, the daemon resolves the standard
 `DEEPSEEK_API_KEY` reference using the existing credential-file descriptors and
@@ -312,6 +312,23 @@ receives only a placeholder; microsandbox's built-in TLS proxy substitutes the k
 in request headers for `https://api.deepseek.com`. A non-default base URL in the
 launch environment, host environment or DSH `.env` refuses the launch with a
 diagnostic. Custom credential-reference names are outside this first implementation.
+
+OpenCode uses the same proxy and lifecycle for `type: api` records in its native
+`auth.json` (including XDG data-directory overrides). Each provider receives its
+own placeholder and allowed HTTPS hosts. Routing comes from standard host OpenCode
+config and `OPENCODE_CONFIG_CONTENT`, then provider defaults or OpenCode's cached model
+catalog. Unknown destinations require an explicit host `provider.options.baseURL`;
+guest workspace configuration cannot authorize a new destination. Standard
+providers do not require a warm model cache. Copies of the protected keys in
+seeded OpenCode config files are replaced too; the host files are unchanged.
+This path protects keys discovered in native `auth.json`; it does not discover
+additional keys stored only in other configuration sources.
+
+OpenCode OAuth records remain unchanged in the mounted private credential file
+and are readable by the guest. Guest-refreshed OAuth records survive subsequent
+preparation. OAuth-only launches retain the existing seeding path, without proxy
+secrets or additional credential shielding. This change does not add an OAuth
+proxy or refresh coordinator.
 
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
@@ -332,14 +349,14 @@ The proxy does not redact provider responses, so the allowed provider remains a
 trusted recipient of the key.
 
 The pinned SDK installs the proxy CA into the guest system bundle before execution.
-Combining it with operator-provided trust bundles is deferred: protected DeepSeek
+Combining it with operator-provided trust bundles is deferred: protected runtime
 launches explicitly refuse custom `TLS_TRUST_ENV`, `REQUESTS_CA_BUNDLE` or
 `CURL_CA_BUNDLE` settings instead of silently replacing them. Use SRT for those
 configurations until custom trust is supported.
 
 New VMs receive the proxy configuration at creation. Retained protected VMs reload
 the host key before starting again; already-running VMs keep their current key
-until stopped and resumed. Previously unprotected DeepSeek VMs fail configuration
+until stopped and resumed. Previously unprotected VMs fail configuration
 reuse and retain their data: start a new session instead of treating an old disk
 that may contain credentials as protected. If a protected VM's credential later
 disappears, restore that credential and retry or start a new session; no VM or

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -263,11 +263,12 @@ export class MicrosandboxManager {
       .quietLogs()
     for (const secret of secrets) {
       builder.secret((entry) =>
-        entry
-          .env(secret.env)
-          .value(secret.readValue())
-          .placeholder(secret.placeholder)
-          .allowHost(secret.host)
+        [secret.host]
+          .flat()
+          .reduce(
+            (entry, host) => entry.allowHost(host),
+            entry.env(secret.env).value(secret.readValue()).placeholder(secret.placeholder)
+          )
           .injectBasicAuth(false)
           .injectQuery(false)
           .injectBody(false)
@@ -469,7 +470,7 @@ export class MicrosandboxManager {
         binding.configHash !== hash(stableJson(existing.config()))
       ) {
         throw new Error(
-          `microsandbox environment ${environment.id} has missing or changed persisted configuration. Restore the previous configuration and DeepSeek credentials, or start a new session. Existing session data has been retained.`
+          `microsandbox environment ${environment.id} has missing or changed persisted configuration. Restore the previous configuration and runtime credentials, or start a new session. Existing session data has been retained.`
         )
       }
       if (existing.status === 'running' || existing.status === 'starting' || existing.status === 'draining') {

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -26,7 +26,7 @@ import { TLS_TRUST_ENV } from '../config/tls-trust-env.js'
 import { SESSIONS_DIR } from '../workspace/session-layout.js'
 import { MICROSANDBOX_SOCKET_BRIDGES, MICROSANDBOX_TUNNEL_PATHS } from './socket-bridge.js'
 import { OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT } from './overlay.js'
-import { prepareDeepSeekSecret, type MicrosandboxSecret } from './secrets.js'
+import { prepareMicrosandboxCredentials, type MicrosandboxSecret } from './secrets.js'
 
 const IMAGE_PATH = '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 const HOST_IPC_ENV = [
@@ -112,22 +112,22 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   for (const path of [...writable, ...configDirs]) mkdirSync(path, { recursive: true, mode: 0o700 })
 
   const credentials = prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
-  const deepseek = prepareDeepSeekSecret(opts.runtimeId, opts.runtime, hostEnv, opts.explicitEnv)
+  const protectedCredentials = prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, hostEnv, opts.explicitEnv)
   if (
-    deepseek &&
+    protectedCredentials &&
     [...TLS_TRUST_ENV, 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'].some((name) =>
       (opts.explicitEnv?.[name] ?? hostEnv[name])?.trim()
     )
   ) {
     throw new Error(
-      'DeepSeek launch refused: microsandbox credential protection does not yet support custom TLS trust bundles; use SRT for this configuration'
+      'Runtime launch refused: microsandbox credential protection does not yet support custom TLS trust bundles; use SRT for this configuration'
     )
   }
   runtimeHome = prepareRuntimeHome(opts.runtimeId, scopeDir, hostEnv, runtimeHome, [
     ...(credentials?.seedExclusions ?? []),
-    ...(deepseek?.seedExclusions ?? [])
+    ...(protectedCredentials?.seedExclusions ?? [])
   ])
-  deepseek?.preparePrivateHome(runtimeHome)
+  protectedCredentials?.preparePrivateHome(runtimeHome)
   credentials?.preparePrivateHome(runtimeHome)
   writable.push(...(credentials?.writablePaths ?? []))
   const readRoots = (opts.trustedRuntimeReadRoots ?? []).filter((path) => {
@@ -195,11 +195,14 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   }
 
   const env = { ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, hostEnv), ...credentials?.env }
-  if (deepseek?.secret) {
-    const secret = deepseek.secret
-    for (const [name, value] of Object.entries(env))
-      env[name] = value.replaceAll(secret.readValue(), secret.placeholder)
-    env[secret.env] = secret.placeholder
+  if (protectedCredentials) {
+    for (const secret of protectedCredentials.secrets) {
+      for (const [name, value] of Object.entries(env))
+        env[name] = value
+          .replaceAll(secret.readValue(), secret.placeholder)
+          .replaceAll(JSON.stringify(secret.readValue()).slice(1, -1), secret.placeholder)
+      env[secret.env] = secret.placeholder
+    }
     env.NODE_EXTRA_CA_CERTS = '/.msb/tls/ca.pem'
     env.SSL_CERT_FILE = env.REQUESTS_CA_BUNDLE = env.CURL_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
   }
@@ -228,15 +231,15 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   mkdirSync(env.XDG_RUNTIME_DIR, { recursive: true, mode: 0o700 })
   env[GITCRED_SOCKET_ENV] = MICROSANDBOX_TUNNEL_PATHS.gitcred
   const mounts = [...automatic, ...configured]
-  const deepseekSources = deepseek?.sources.map((path) => canonicalPath(path, hostEnv)) ?? []
-  if (mounts.some(({ source }) => deepseekSources.some((path) => contains(source, path)))) {
-    throw new Error('sandbox.mounts would expose a host DeepSeek credential file')
+  const protectedSourcesForLaunch = protectedCredentials?.sources.map((path) => canonicalPath(path, hostEnv)) ?? []
+  if (mounts.some(({ source }) => protectedSourcesForLaunch.some((path) => contains(source, path)))) {
+    throw new Error('sandbox.mounts would expose a protected host credential source')
   }
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   const claudeSettings = claudeRuntime ? prepareClaudeProtectedSettings(scopeDir, env) : undefined
-  const privateStateTargets = deepseek
-    ? deepseek.seedExclusions.map((path) => join(runtimeHome, path))
+  const privateStateTargets = protectedCredentials
+    ? protectedCredentials.seedExclusions.map((path) => join(runtimeHome, path))
     : credentialProfile === 'codex'
       ? [join(runtimeHome, '.codex')]
       : claudeRuntime
@@ -301,7 +304,7 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
     microsandbox: {
       mounts,
       workspaceRoot: scopeDir,
-      ...(deepseek?.secret ? { secrets: [deepseek.secret] } : {})
+      ...(protectedCredentials ? { secrets: protectedCredentials.secrets } : {})
     }
   }
 }

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -27,6 +27,7 @@ import { SESSIONS_DIR } from '../workspace/session-layout.js'
 import { MICROSANDBOX_SOCKET_BRIDGES, MICROSANDBOX_TUNNEL_PATHS } from './socket-bridge.js'
 import { OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT } from './overlay.js'
 import { prepareMicrosandboxCredentials, type MicrosandboxSecret } from './secrets.js'
+import { replaceEnvironmentSecrets } from './secret-values.js'
 
 const IMAGE_PATH = '/opt/agentconnect/pathbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 const HOST_IPC_ENV = [
@@ -114,7 +115,7 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   const credentials = prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
   const protectedCredentials = prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, hostEnv, opts.explicitEnv)
   if (
-    protectedCredentials &&
+    protectedCredentials?.secrets.length &&
     [...TLS_TRUST_ENV, 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'].some((name) =>
       (opts.explicitEnv?.[name] ?? hostEnv[name])?.trim()
     )
@@ -196,15 +197,14 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
 
   const env = { ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, hostEnv), ...credentials?.env }
   if (protectedCredentials) {
+    replaceEnvironmentSecrets(env, protectedCredentials.replacements)
     for (const secret of protectedCredentials.secrets) {
-      for (const [name, value] of Object.entries(env))
-        env[name] = value
-          .replaceAll(secret.readValue(), secret.placeholder)
-          .replaceAll(JSON.stringify(secret.readValue()).slice(1, -1), secret.placeholder)
       env[secret.env] = secret.placeholder
     }
-    env.NODE_EXTRA_CA_CERTS = '/.msb/tls/ca.pem'
-    env.SSL_CERT_FILE = env.REQUESTS_CA_BUNDLE = env.CURL_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+    if (protectedCredentials.secrets.length) {
+      env.NODE_EXTRA_CA_CERTS = '/.msb/tls/ca.pem'
+      env.SSL_CERT_FILE = env.REQUESTS_CA_BUNDLE = env.CURL_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+    }
   }
   for (const name of HOST_IPC_ENV) delete env[name]
   // Drop ambient Docker client settings, but keep explicit guest config, including materialized registry config.

--- a/packages/daemon/src/microsandbox/opencode-secrets.ts
+++ b/packages/daemon/src/microsandbox/opencode-secrets.ts
@@ -141,15 +141,24 @@ export function prepareOpenCodeSecrets(
     const name = `OPENCODE_API_${createHash('sha256').update(provider).digest('hex').slice(0, 16).toUpperCase()}`
     secrets.set(provider, { env: name, placeholder: `msb-secret-${name}`, host: hosts, readValue: () => key })
   }
+  const sharedKeys = new Map<string, MicrosandboxSecret>()
+  for (const [provider, secret] of secrets) {
+    const shared = sharedKeys.get(secret.readValue())
+    if (shared) {
+      shared.host = [...new Set([shared.host, secret.host].flat())].sort()
+      secrets.set(provider, shared)
+    } else sharedKeys.set(secret.readValue(), secret)
+  }
+  const bindings = [...sharedKeys.values()]
   const files = [{ source: authLocation.source, destination: authLocation.destination }, ...configFiles]
   const redact = (text: string): string => {
-    for (const secret of secrets.values()) text = text.replaceAll(secret.readValue(), secret.placeholder)
+    for (const secret of bindings) text = text.replaceAll(secret.readValue(), secret.placeholder)
     return text
   }
   const projectedConfig = (data: unknown): string =>
     JSON.stringify(data, (_key, value: unknown) => (typeof value === 'string' ? redact(value) : value))
   return {
-    secrets: [...secrets.values()],
+    secrets: bindings,
     sources: [...files.map(({ source }) => source), ...(needsCatalog ? [catalogPath] : [])],
     seedExclusions: files.map(({ destination }) => destination),
     preparePrivateHome(home) {

--- a/packages/daemon/src/microsandbox/opencode-secrets.ts
+++ b/packages/daemon/src/microsandbox/opencode-secrets.ts
@@ -2,13 +2,12 @@ import { createHash } from 'node:crypto'
 import { lstatSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import stripJsonComments from 'strip-json-comments'
-import type { RuntimeDef } from '../config/config-schema.js'
 import { objectFromJson } from '../runtimes/codex-config.js'
-import { isOpenCodeRuntime } from '../runtimes/model-provider-config.js'
 import { home as hostHome, runtimeStateLocations } from '../runtimes/probe.js'
 import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
 import { MAX_SEED_FILE_BYTES } from '../runtimes/runtime-seeded-credentials.js'
 import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+import { replaceSecretValue } from './secret-values.js'
 
 // Native SDK defaults can omit api from OpenCode's provider catalog; common defaults also work before cache warmup.
 const DEFAULT_ORIGINS: Record<string, string> = {
@@ -33,24 +32,39 @@ function document(text: string): Record<string, unknown> {
   return objectFromJson(stripJsonComments(text, { trailingCommas: true }), 'OpenCode credential/configuration file')
 }
 
-function readDocument(path: string, limit = MAX_SEED_FILE_BYTES): Record<string, unknown> {
+function readDocument(path: string, jsonc = false, limit = MAX_SEED_FILE_BYTES): Record<string, unknown> {
   try {
     const stat = lstatSync(path)
+    if (stat.isSymbolicLink()) return {}
     if (!stat.isFile() || stat.size > limit) throw new Error('invalid source')
-    return document(readFileSync(path, 'utf8'))
+    const text = readFileSync(path, 'utf8')
+    return jsonc ? document(text) : objectFromJson(text, 'OpenCode credential/catalog file')
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
     throw new Error('Cannot read the host OpenCode credential/configuration file')
   }
 }
 
+function apiKey(value: Record<string, unknown>): string | undefined {
+  return value.type === 'api' && typeof value.key === 'string' && value.key.trim() ? value.key : undefined
+}
+
+function allowedHost(endpoint: unknown, env: NodeJS.ProcessEnv): string | undefined {
+  if (typeof endpoint !== 'string') return undefined
+  try {
+    const url = new URL(endpoint.replace(/\{env:([^}]+)\}/g, (_, name: string) => env[name] ?? ''))
+    if (url.protocol === 'https:' && !url.port && !url.username && !url.password && /^[a-z0-9.-]+$/.test(url.hostname))
+      return url.hostname
+  } catch {
+    // Unresolved providers keep placeholders without authorizing the host-side key.
+  }
+  return undefined
+}
+
 export function prepareOpenCodeSecrets(
-  runtimeId: string,
-  runtime: RuntimeDef | undefined,
   hostEnv: NodeJS.ProcessEnv,
   explicitEnv: Record<string, string>
 ): MicrosandboxCredentials | undefined {
-  if (!isOpenCodeRuntime(runtimeId, runtime)) return undefined
   const locations = runtimeStateLocations('opencode', hostEnv)
   const authLocation = locations.find((location) =>
     location.credentialFiles?.some((file) => file.format === 'opencode')
@@ -59,10 +73,8 @@ export function prepareOpenCodeSecrets(
   const api = Object.entries(auth)
     .sort(([a], [b]) => a.localeCompare(b))
     .flatMap(([provider, raw]) => {
-      const value = object(raw)
-      return value.type === 'api' && typeof value.key === 'string' && value.key.trim()
-        ? [{ provider, key: value.key }]
-        : []
+      const key = apiKey(object(raw))
+      return key === undefined ? [] : [{ provider, key }]
     })
   if (!api.length) return undefined
   const configFiles = locations
@@ -80,8 +92,8 @@ export function prepareOpenCodeSecrets(
   const providers: Record<string, Record<string, unknown>> = {}
   const env = { ...hostEnv, ...explicitEnv }
   const configs = [
-    ...configFiles.map(({ source }) => readDocument(source)),
-    document(env.OPENCODE_CONFIG_CONTENT ?? '{}')
+    ...configFiles.map(({ source }) => readDocument(source, true)),
+    objectFromJson(env.OPENCODE_CONFIG_CONTENT, 'OPENCODE_CONFIG_CONTENT')
   ]
   for (const config of configs) {
     for (const [id, raw] of Object.entries(object(config.provider))) {
@@ -96,15 +108,21 @@ export function prepareOpenCodeSecrets(
     }
   }
   const catalogPath = join(hostEnv.XDG_CACHE_HOME || join(hostHome(hostEnv), '.cache'), 'opencode', 'models.json')
-  const needsCatalog = api.some(
-    ({ provider }) => !object(providers[provider]?.options).baseURL && !DEFAULT_ORIGINS[provider]
-  )
-  const catalog = needsCatalog ? readDocument(catalogPath, 16 * 1024 * 1024) : {}
+  const usesCatalog = (provider: string) => !object(providers[provider]?.options).baseURL && !DEFAULT_ORIGINS[provider]
+  const needsCatalog = api.some(({ provider }) => usesCatalog(provider))
+  let catalog: Record<string, unknown> = {}
+  if (needsCatalog) {
+    try {
+      catalog = readDocument(catalogPath, false, 16 * 1024 * 1024)
+    } catch {
+      // An unusable cache cannot prevent providers with configured or default origins from starting.
+    }
+  }
   const secrets = new Map<string, MicrosandboxSecret>()
   for (const { provider, key } of api) {
     const config = providers[provider] ?? {}
     const options = object(config.options)
-    const known = object(catalog[provider])
+    const known = usesCatalog(provider) ? object(catalog[provider]) : {}
     const endpoints = options.baseURL
       ? [options.baseURL]
       : [
@@ -113,30 +131,8 @@ export function prepareOpenCodeSecrets(
             .filter(Boolean),
           known.api ?? DEFAULT_ORIGINS[provider]
         ].filter(Boolean)
-    if (!endpoints.length) endpoints.push(undefined)
     const hosts = [
-      ...new Set(
-        endpoints.map((endpoint) => {
-          try {
-            if (typeof endpoint !== 'string') throw new Error('missing endpoint')
-            const expanded = endpoint.replace(/\{env:([^}]+)\}/g, (_, name: string) => env[name] ?? '')
-            const url = new URL(expanded)
-            if (
-              url.protocol !== 'https:' ||
-              url.port ||
-              url.username ||
-              url.password ||
-              !/^[a-z0-9.-]+$/.test(url.hostname)
-            )
-              throw new Error('unsupported endpoint')
-            return url.hostname
-          } catch {
-            throw new Error(
-              `OpenCode launch refused: configure a host provider.options.baseURL with a supported HTTPS endpoint for ${provider}`
-            )
-          }
-        })
-      )
+      ...new Set(endpoints.map((endpoint) => allowedHost(endpoint, env)).filter((host) => host !== undefined))
     ].sort()
     const name = `OPENCODE_API_${createHash('sha256').update(provider).digest('hex').slice(0, 16).toUpperCase()}`
     secrets.set(provider, { env: name, placeholder: `msb-secret-${name}`, host: hosts, readValue: () => key })
@@ -151,14 +147,14 @@ export function prepareOpenCodeSecrets(
   }
   const bindings = [...sharedKeys.values()]
   const files = [{ source: authLocation.source, destination: authLocation.destination }, ...configFiles]
-  const redact = (text: string): string => {
-    for (const secret of bindings) text = text.replaceAll(secret.readValue(), secret.placeholder)
-    return text
-  }
+  const replacements = new Map(bindings.map((secret) => [secret.readValue(), secret.placeholder]))
   const projectedConfig = (data: unknown): string =>
-    JSON.stringify(data, (_key, value: unknown) => (typeof value === 'string' ? redact(value) : value))
+    JSON.stringify(data, (_key, value: unknown) =>
+      typeof value === 'string' ? replaceSecretValue(value, replacements) : value
+    )
   return {
-    secrets: bindings,
+    secrets: bindings.filter((secret) => secret.host.length > 0),
+    replacements,
     sources: [...files.map(({ source }) => source), ...(needsCatalog ? [catalogPath] : [])],
     seedExclusions: files.map(({ destination }) => destination),
     preparePrivateHome(home) {
@@ -168,11 +164,9 @@ export function prepareOpenCodeSecrets(
           if (file.source === authLocation.source) {
             for (const [provider, raw] of Object.entries(data)) {
               const value = object(raw)
-              if (value.type !== 'api') continue
+              if (apiKey(value) === undefined) continue
               const secret = secrets.get(provider)
-              if (!secret)
-                throw new Error('OpenCode private API credentials changed; log in on the host and start a new session')
-              data[provider] = JSON.parse(projectedConfig({ ...value, key: secret.placeholder }))
+              data[provider] = JSON.parse(projectedConfig(secret ? { ...value, key: secret.placeholder } : value))
             }
             return `${JSON.stringify(data)}\n`
           }

--- a/packages/daemon/src/microsandbox/opencode-secrets.ts
+++ b/packages/daemon/src/microsandbox/opencode-secrets.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
+import type { RuntimeDef } from '../config/config-schema.js'
+import { objectFromJson } from '../runtimes/codex-config.js'
+import { isOpenCodeRuntime } from '../runtimes/model-provider-config.js'
+import { home as hostHome, runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { MAX_SEED_FILE_BYTES } from '../runtimes/runtime-seeded-credentials.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+// Native SDK defaults can omit api from OpenCode's provider catalog; common defaults also work before cache warmup.
+const DEFAULT_ORIGINS: Record<string, string> = {
+  opencode: 'https://opencode.ai',
+  'opencode-go': 'https://opencode.ai',
+  openai: 'https://api.openai.com',
+  anthropic: 'https://api.anthropic.com',
+  google: 'https://generativelanguage.googleapis.com',
+  deepseek: 'https://api.deepseek.com',
+  openrouter: 'https://openrouter.ai',
+  xai: 'https://api.x.ai',
+  groq: 'https://api.groq.com',
+  mistral: 'https://api.mistral.ai',
+  cohere: 'https://api.cohere.com'
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function document(text: string): Record<string, unknown> {
+  return objectFromJson(stripJsonComments(text, { trailingCommas: true }), 'OpenCode credential/configuration file')
+}
+
+function readDocument(path: string, limit = MAX_SEED_FILE_BYTES): Record<string, unknown> {
+  try {
+    const stat = lstatSync(path)
+    if (!stat.isFile() || stat.size > limit) throw new Error('invalid source')
+    return document(readFileSync(path, 'utf8'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Cannot read the host OpenCode credential/configuration file')
+  }
+}
+
+export function prepareOpenCodeSecrets(
+  runtimeId: string,
+  runtime: RuntimeDef | undefined,
+  hostEnv: NodeJS.ProcessEnv,
+  explicitEnv: Record<string, string>
+): MicrosandboxCredentials | undefined {
+  if (!isOpenCodeRuntime(runtimeId, runtime)) return undefined
+  const locations = runtimeStateLocations('opencode', hostEnv)
+  const authLocation = locations.find((location) =>
+    location.credentialFiles?.some((file) => file.format === 'opencode')
+  )!
+  const auth = readDocument(authLocation.source)
+  const api = Object.entries(auth)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .flatMap(([provider, raw]) => {
+      const value = object(raw)
+      return value.type === 'api' && typeof value.key === 'string' && value.key.trim()
+        ? [{ provider, key: value.key }]
+        : []
+    })
+  if (!api.length) return undefined
+  const configFiles = locations
+    .filter((location) => !location.credentialFiles?.length)
+    .flatMap((location) =>
+      [
+        ...(location.destination === join('.config', 'opencode') ? ['config.json'] : []),
+        'opencode.json',
+        'opencode.jsonc'
+      ].map((file) => ({
+        source: join(location.source, file),
+        destination: join(location.destination, file)
+      }))
+    )
+  const providers: Record<string, Record<string, unknown>> = {}
+  const env = { ...hostEnv, ...explicitEnv }
+  const configs = [
+    ...configFiles.map(({ source }) => readDocument(source)),
+    document(env.OPENCODE_CONFIG_CONTENT ?? '{}')
+  ]
+  for (const config of configs) {
+    for (const [id, raw] of Object.entries(object(config.provider))) {
+      const value = object(raw)
+      const previous = providers[id]
+      providers[id] = {
+        ...previous,
+        ...value,
+        options: { ...object(previous?.options), ...object(value.options) },
+        models: { ...object(previous?.models), ...object(value.models) }
+      }
+    }
+  }
+  const catalogPath = join(hostEnv.XDG_CACHE_HOME || join(hostHome(hostEnv), '.cache'), 'opencode', 'models.json')
+  const needsCatalog = api.some(
+    ({ provider }) => !object(providers[provider]?.options).baseURL && !DEFAULT_ORIGINS[provider]
+  )
+  const catalog = needsCatalog ? readDocument(catalogPath, 16 * 1024 * 1024) : {}
+  const secrets = new Map<string, MicrosandboxSecret>()
+  for (const { provider, key } of api) {
+    const config = providers[provider] ?? {}
+    const options = object(config.options)
+    const known = object(catalog[provider])
+    const endpoints = options.baseURL
+      ? [options.baseURL]
+      : [
+          ...Object.values({ ...object(known.models), ...object(config.models) })
+            .map((model) => object(object(model).provider).api)
+            .filter(Boolean),
+          known.api ?? DEFAULT_ORIGINS[provider]
+        ].filter(Boolean)
+    if (!endpoints.length) endpoints.push(undefined)
+    const hosts = [
+      ...new Set(
+        endpoints.map((endpoint) => {
+          try {
+            if (typeof endpoint !== 'string') throw new Error('missing endpoint')
+            const expanded = endpoint.replace(/\{env:([^}]+)\}/g, (_, name: string) => env[name] ?? '')
+            const url = new URL(expanded)
+            if (
+              url.protocol !== 'https:' ||
+              url.port ||
+              url.username ||
+              url.password ||
+              !/^[a-z0-9.-]+$/.test(url.hostname)
+            )
+              throw new Error('unsupported endpoint')
+            return url.hostname
+          } catch {
+            throw new Error(
+              `OpenCode launch refused: configure a host provider.options.baseURL with a supported HTTPS endpoint for ${provider}`
+            )
+          }
+        })
+      )
+    ].sort()
+    const name = `OPENCODE_API_${createHash('sha256').update(provider).digest('hex').slice(0, 16).toUpperCase()}`
+    secrets.set(provider, { env: name, placeholder: `msb-secret-${name}`, host: hosts, readValue: () => key })
+  }
+  const files = [{ source: authLocation.source, destination: authLocation.destination }, ...configFiles]
+  const redact = (text: string): string => {
+    for (const secret of secrets.values()) text = text.replaceAll(secret.readValue(), secret.placeholder)
+    return text
+  }
+  const projectedConfig = (data: unknown): string =>
+    JSON.stringify(data, (_key, value: unknown) => (typeof value === 'string' ? redact(value) : value))
+  return {
+    secrets: [...secrets.values()],
+    sources: [...files.map(({ source }) => source), ...(needsCatalog ? [catalogPath] : [])],
+    seedExclusions: files.map(({ destination }) => destination),
+    preparePrivateHome(home) {
+      for (const file of files) {
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text) => {
+          const data = document(text)
+          if (file.source === authLocation.source) {
+            for (const [provider, raw] of Object.entries(data)) {
+              const value = object(raw)
+              if (value.type !== 'api') continue
+              const secret = secrets.get(provider)
+              if (!secret)
+                throw new Error('OpenCode private API credentials changed; log in on the host and start a new session')
+              data[provider] = JSON.parse(projectedConfig({ ...value, key: secret.placeholder }))
+            }
+            return `${JSON.stringify(data)}\n`
+          }
+          return `${projectedConfig(data)}\n`
+        })
+      }
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secret-values.ts
+++ b/packages/daemon/src/microsandbox/secret-values.ts
@@ -1,0 +1,30 @@
+export function replaceSecretValue(value: string, replacements: ReadonlyMap<string, string>): string {
+  const replacement = replacements.get(value)
+  if (replacement !== undefined) return replacement
+  const bearer = /^(Bearer\s+)(.+)$/i.exec(value)
+  return bearer ? `${bearer[1]}${replacements.get(bearer[2]!) ?? bearer[2]}` : value
+}
+
+export function replaceEnvironmentSecrets(
+  env: Record<string, string>,
+  replacements: ReadonlyMap<string, string>
+): void {
+  for (const [name, value] of Object.entries(env)) {
+    const replacement = replaceSecretValue(value, replacements)
+    if (replacement !== value) {
+      env[name] = replacement
+      continue
+    }
+    try {
+      let changed = false
+      const projected = JSON.stringify(JSON.parse(value), (_key, entry: unknown) => {
+        const result = typeof entry === 'string' ? replaceSecretValue(entry, replacements) : entry
+        changed ||= result !== entry
+        return result
+      })
+      if (changed) env[name] = projected
+    } catch {
+      // Ordinary environment values are not JSON configuration.
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -18,10 +18,19 @@ export interface MicrosandboxSecret {
 
 export interface MicrosandboxCredentials {
   secrets: MicrosandboxSecret[]
+  replacements: ReadonlyMap<string, string>
   sources: string[]
   seedExclusions: string[]
   preparePrivateHome: (home: string) => void
 }
+
+const CREDENTIAL_PREPARERS = new Map<
+  string,
+  (hostEnv: NodeJS.ProcessEnv, explicitEnv: Record<string, string>) => MicrosandboxCredentials | undefined
+>([
+  ['dsh-acp', prepareDeepSeekSecret],
+  ['opencode', prepareOpenCodeSecrets]
+])
 
 export function prepareMicrosandboxCredentials(
   runtimeId: string,
@@ -29,19 +38,11 @@ export function prepareMicrosandboxCredentials(
   hostEnv: NodeJS.ProcessEnv,
   explicitEnv: Record<string, string> = {}
 ): MicrosandboxCredentials | undefined {
-  return (
-    prepareDeepSeekSecret(runtimeId, runtime, hostEnv, explicitEnv) ??
-    prepareOpenCodeSecrets(runtimeId, runtime, hostEnv, explicitEnv)
-  )
+  const id = isDeepSeekRuntime(runtimeId, runtime) ? 'dsh-acp' : runtimeId
+  return CREDENTIAL_PREPARERS.get(id)?.(hostEnv, explicitEnv)
 }
 
-export function prepareDeepSeekSecret(
-  runtimeId: string,
-  runtime: RuntimeDef | undefined,
-  hostEnv: NodeJS.ProcessEnv,
-  explicitEnv: Record<string, string> = {}
-) {
-  if (!isDeepSeekRuntime(runtimeId, runtime)) return undefined
+function prepareDeepSeekSecret(hostEnv: NodeJS.ProcessEnv, explicitEnv: Record<string, string> = {}) {
   const env = 'DEEPSEEK_API_KEY'
   const files = runtimeStateLocations('dsh-acp', hostEnv).flatMap((location) =>
     (location.credentialFiles ?? []).map((file) => ({
@@ -69,12 +70,12 @@ export function prepareDeepSeekSecret(
   }
   const value = key?.trim()
   if (!value) return undefined
-  const secret: MicrosandboxSecret = {
+  const secret = {
     env,
     placeholder: 'msb-secret-DEEPSEEK_API_KEY',
     host: 'api.deepseek.com',
     readValue: () => value
-  }
+  } satisfies MicrosandboxSecret
   try {
     const endpoint = new URL(baseUrl ?? 'https://api.deepseek.com')
     if (
@@ -90,6 +91,7 @@ export function prepareDeepSeekSecret(
   }
   return {
     secrets: [secret],
+    replacements: new Map([[value, secret.placeholder]]),
     sources: files.map((file) => file.source),
     seedExclusions: [...new Set(files.map((file) => file.destination))],
     preparePrivateHome(home: string) {

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -6,13 +6,33 @@ import { isDeepSeekRuntime } from '../runtimes/model-provider-config.js'
 import { runtimeStateLocations } from '../runtimes/probe.js'
 import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
 import { MAX_SEED_FILE_BYTES, parseDshCredentialDocument } from '../runtimes/runtime-seeded-credentials.js'
+import { prepareOpenCodeSecrets } from './opencode-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
   placeholder: string
-  host: string
+  host: string | string[]
   // The value stays host-side and cannot enter serialized launch metadata.
   readValue: () => string
+}
+
+export interface MicrosandboxCredentials {
+  secrets: MicrosandboxSecret[]
+  sources: string[]
+  seedExclusions: string[]
+  preparePrivateHome: (home: string) => void
+}
+
+export function prepareMicrosandboxCredentials(
+  runtimeId: string,
+  runtime: RuntimeDef | undefined,
+  hostEnv: NodeJS.ProcessEnv,
+  explicitEnv: Record<string, string> = {}
+): MicrosandboxCredentials | undefined {
+  return (
+    prepareDeepSeekSecret(runtimeId, runtime, hostEnv, explicitEnv) ??
+    prepareOpenCodeSecrets(runtimeId, runtime, hostEnv, explicitEnv)
+  )
 }
 
 export function prepareDeepSeekSecret(
@@ -69,7 +89,7 @@ export function prepareDeepSeekSecret(
     throw new Error('DeepSeek launch refused: credential protection requires https://api.deepseek.com')
   }
   return {
-    secret,
+    secrets: [secret],
     sources: files.map((file) => file.source),
     seedExclusions: [...new Set(files.map((file) => file.destination))],
     preparePrivateHome(home: string) {

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -25,9 +25,12 @@ export interface ModelProviderTarget {
   opencodeProvider?: string
 }
 
-function isOpenCodeRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
+export function isOpenCodeRuntime(runtimeId: string, runtime?: RuntimeDef): boolean {
   if (runtimeId === 'opencode') return true
-  return [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])opencode(?:@[^\/]*)?$/.test(part.toLowerCase()))
+  return (
+    !!runtime &&
+    [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])opencode(?:@[^\/]*)?$/.test(part.toLowerCase()))
+  )
 }
 
 // The bin, not the package: `dsh-acp` is the single bin of @openma/deepseek-harness-acp.

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -25,12 +25,9 @@ export interface ModelProviderTarget {
   opencodeProvider?: string
 }
 
-export function isOpenCodeRuntime(runtimeId: string, runtime?: RuntimeDef): boolean {
+function isOpenCodeRuntime(runtimeId: string, runtime: RuntimeDef): boolean {
   if (runtimeId === 'opencode') return true
-  return (
-    !!runtime &&
-    [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])opencode(?:@[^\/]*)?$/.test(part.toLowerCase()))
-  )
+  return [runtime.command, ...runtime.args].some((part) => /(?:^|[\/@])opencode(?:@[^\/]*)?$/.test(part.toLowerCase()))
 }
 
 // The bin, not the package: `dsh-acp` is the single bin of @openma/deepseek-harness-acp.

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -74,7 +74,7 @@ function fakeSdk() {
     readonly spec = {
       image: 'test-image',
       env: [{ key: 'PATH', value: '/image/bin' }],
-      secrets: {} as Record<string, { value: string; placeholder: string; host: string }>,
+      secrets: {} as Record<string, { value: string; placeholder: string; host: string[] }>,
       runtime: { workdir: '/image', user: 'agent' }
     }
     readonly stopWithTimeout = vi.fn(async () => {
@@ -243,7 +243,7 @@ function fakeSdk() {
           },
           secret(configure: (entry: any) => unknown) {
             let name = ''
-            const data = { value: '', placeholder: '', host: '' }
+            const data = { value: '', placeholder: '', host: [] as string[] }
             const entry = {
               env(value: string) {
                 name = value
@@ -258,7 +258,7 @@ function fakeSdk() {
                 return entry
               },
               allowHost(value: string) {
-                data.host = value
+                data.host.push(value)
                 return entry
               },
               injectBasicAuth(value: boolean) {
@@ -393,42 +393,46 @@ describe('microsandbox process and VM ownership', () => {
     await manager.stopAll()
   })
 
-  it('keeps secrets out of bindings and execs, and rotates them when the retained VM resumes', async () => {
-    const { manager, options, environment, request, created, processes } = await fixture()
-    let key = 'fixture-first-key'
-    const secret = {
-      env: 'DEEPSEEK_API_KEY',
-      placeholder: 'fixture-placeholder',
-      host: 'api.deepseek.com',
-      readValue: () => key
+  it.each(['api.deepseek.com', ['api.example.test', 'alternate.example.test']])(
+    'keeps secrets scoped to %j and rotates them when the retained VM resumes',
+    async (host) => {
+      const { manager, options, environment, request, created, processes } = await fixture()
+      let key = 'fixture-first-key'
+      const secret = {
+        env: 'DEEPSEEK_API_KEY',
+        placeholder: 'fixture-placeholder',
+        host,
+        readValue: () => key
+      }
+      const env = { ...environment, secrets: [secret] }
+      const launch = {
+        ...request,
+        env: { DEEPSEEK_API_KEY: secret.placeholder, NODE_EXTRA_CA_CERTS: '/.msb/tls/ca.pem' }
+      }
+      await (await manager.driverFor(env).launch(launch)).stop(0)
+      expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
+      expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.host).toEqual([host].flat())
+      expect(JSON.stringify(processes[0]!.request)).not.toContain(key)
+      expect(JSON.stringify(processes[0]!.request)).toContain('NODE_EXTRA_CA_CERTS=/.msb/tls/ca.pem')
+      const directory = join(options.root, 'microsandbox', 'bindings')
+      const path = join(directory, (await readdir(directory))[0]!)
+      expect(await readFile(path, 'utf8')).not.toContain(key)
+      await manager.stopAll()
+      key = 'fixture-rotated-key'
+      const resumed = new MicrosandboxManager(options)
+      await (await resumed.driverFor(env).launch(launch)).stop(0)
+      expect(created).toHaveLength(1)
+      expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
+      expect(await readFile(path, 'utf8')).not.toContain(key)
+      await resumed.stopAll()
+      created[0]!.modify.mockResolvedValueOnce({ applied: false, changes: [], conflicts: [] } as never)
+      const restarted = new MicrosandboxManager(options)
+      await (await restarted.driverFor(env).launch(launch)).stop(0)
+      expect(created).toHaveLength(1)
+      expect(created[0]!.status).toBe('running')
+      await restarted.discard(env.id)
     }
-    const env = { ...environment, secrets: [secret] }
-    const launch = {
-      ...request,
-      env: { DEEPSEEK_API_KEY: secret.placeholder, NODE_EXTRA_CA_CERTS: '/.msb/tls/ca.pem' }
-    }
-    await (await manager.driverFor(env).launch(launch)).stop(0)
-    expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
-    expect(JSON.stringify(processes[0]!.request)).not.toContain(key)
-    expect(JSON.stringify(processes[0]!.request)).toContain('NODE_EXTRA_CA_CERTS=/.msb/tls/ca.pem')
-    const directory = join(options.root, 'microsandbox', 'bindings')
-    const path = join(directory, (await readdir(directory))[0]!)
-    expect(await readFile(path, 'utf8')).not.toContain(key)
-    await manager.stopAll()
-    key = 'fixture-rotated-key'
-    const resumed = new MicrosandboxManager(options)
-    await (await resumed.driverFor(env).launch(launch)).stop(0)
-    expect(created).toHaveLength(1)
-    expect(created[0]!.spec.secrets.DEEPSEEK_API_KEY!.value).toBe(key)
-    expect(await readFile(path, 'utf8')).not.toContain(key)
-    await resumed.stopAll()
-    created[0]!.modify.mockResolvedValueOnce({ applied: false, changes: [], conflicts: [] } as never)
-    const restarted = new MicrosandboxManager(options)
-    await (await restarted.driverFor(env).launch(launch)).stop(0)
-    expect(created).toHaveLength(1)
-    expect(created[0]!.status).toBe('running')
-    await restarted.discard(env.id)
-  })
+  )
 
   it.each([false, true])(
     'retains VM data when its credential configuration changes (protected=%s)',

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -112,6 +112,40 @@ describe('prepareMicrosandboxLaunch', () => {
     )
   })
 
+  it.skipIf(process.platform !== 'linux')('preserves every authorized host when OpenCode providers share a key', () => {
+    const key = 'fixture-shared-"key\\value'
+    const { opts } = openCodeFixture({ east: { type: 'api', key }, west: { type: 'api', key } })
+    const config = {
+      provider: {
+        east: { options: { baseURL: 'https://east.example.test/v1', apiKey: key } },
+        west: { options: { baseURL: 'https://west.example.test/v1', apiKey: key } }
+      }
+    }
+    const source = join(opts.hostHome, '.config', 'opencode', 'opencode.json')
+    mkdirSync(dirname(source), { recursive: true })
+    writeFileSync(source, JSON.stringify(config))
+    const launch = prepareMicrosandboxLaunch({
+      ...opts,
+      explicitEnv: { OPENCODE_CONFIG_CONTENT: JSON.stringify(config), MODEL_TOKEN: key }
+    })
+    expect(launch.microsandbox.secrets).toHaveLength(1)
+    const secret = launch.microsandbox.secrets![0]!
+    expect(secret.host).toEqual(['east.example.test', 'west.example.test'])
+    const auth = JSON.parse(readFileSync(join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'), 'utf8'))
+    const privateConfig = JSON.parse(
+      readFileSync(join(launch.runtimeHome!, '.config', 'opencode', 'opencode.json'), 'utf8')
+    )
+    const envConfig = JSON.parse(launch.env.OPENCODE_CONFIG_CONTENT!)
+    for (const provider of ['east', 'west']) {
+      expect(auth[provider].key).toBe(secret.placeholder)
+      expect(privateConfig.provider[provider].options.apiKey).toBe(secret.placeholder)
+      expect(envConfig.provider[provider].options.apiKey).toBe(secret.placeholder)
+    }
+    expect(launch.env.MODEL_TOKEN).toBe(secret.placeholder)
+    expect(secret.readValue()).toBe(key)
+    expect(JSON.parse(readFileSync(source, 'utf8'))).toEqual(config)
+  })
+
   it.skipIf(process.platform !== 'linux')(
     'uses trusted OpenCode JSONC routing and projects duplicate keys in config',
     () => {

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -54,6 +54,134 @@ afterEach(() => {
 })
 
 describe('prepareMicrosandboxLaunch', () => {
+  function openCodeFixture(auth: Record<string, unknown>) {
+    const opts = { ...fixture(), runtimeId: 'opencode' }
+    const source = join(opts.hostHome, '.local', 'share', 'opencode', 'auth.json')
+    mkdirSync(dirname(source), { recursive: true })
+    writeFileSync(source, JSON.stringify(auth))
+    return { opts, source }
+  }
+
+  it.skipIf(process.platform !== 'linux')(
+    'projects OpenCode API keys and preserves OAuth records across refresh and key rotation',
+    () => {
+      const oauth = {
+        type: 'oauth',
+        access: 'fixture-oauth-access',
+        refresh: 'fixture-refresh',
+        expires: 1,
+        accountId: 'fixture-account'
+      }
+      const auth = {
+        opencode: { type: 'api', key: 'fixture-zen-key', metadata: { duplicate: 'fixture-zen-key' } },
+        deepseek: { type: 'api', key: 'fixture-deepseek-key' },
+        openai: oauth
+      }
+      const { opts, source } = openCodeFixture(auth)
+      const launch = prepareMicrosandboxLaunch(opts)
+      const path = join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json')
+      const privateAuth = JSON.parse(readFileSync(path, 'utf8'))
+      expect(privateAuth.openai).toEqual(oauth)
+      expect(privateAuth.opencode.key).toMatch(/^msb-secret-OPENCODE_API_/)
+      expect(privateAuth.deepseek.key).not.toBe(privateAuth.opencode.key)
+      expect(launch.microsandbox.secrets!.map(({ host }) => host)).toEqual([['api.deepseek.com'], ['opencode.ai']])
+      for (const key of [auth.opencode.key, auth.deepseek.key]) {
+        expect(readFileSync(path, 'utf8')).not.toContain(key)
+        expect(JSON.stringify(launch)).not.toContain(key)
+      }
+      expect(JSON.parse(readFileSync(source, 'utf8'))).toEqual(auth)
+      privateAuth.openai.access = 'fixture-refreshed-access'
+      writeFileSync(path, JSON.stringify(privateAuth))
+      writeFileSync(source, JSON.stringify({ ...auth, opencode: { type: 'api', key: 'fixture-rotated-key' } }))
+      const resumed = prepareMicrosandboxLaunch(opts)
+      expect(resumed.microsandbox.secrets!.find(({ host }) => host.includes('opencode.ai'))!.readValue()).toBe(
+        'fixture-rotated-key'
+      )
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(privateAuth)
+    }
+  )
+
+  it('keeps OAuth-only OpenCode launches on the existing unprotected credential path', () => {
+    const oauth = { type: 'oauth', access: 'fixture-access', refresh: 'fixture-refresh', expires: 1 }
+    const { opts, source } = openCodeFixture({ openai: oauth })
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toBeUndefined()
+    expect(launch.env.NODE_EXTRA_CA_CERTS).toBeUndefined()
+    expect(readFileSync(join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'), 'utf8')).toBe(
+      readFileSync(source, 'utf8')
+    )
+  })
+
+  it.skipIf(process.platform !== 'linux')(
+    'uses trusted OpenCode JSONC routing and projects duplicate keys in config',
+    () => {
+      const key = 'fixture-custom-provider-key'
+      const { opts, source } = openCodeFixture({ custom: { type: 'api', key } })
+      const config = join(opts.hostHome, '.config', 'opencode', 'opencode.jsonc')
+      mkdirSync(dirname(config), { recursive: true })
+      writeFileSync(
+        config,
+        `// host config\n${JSON.stringify({ provider: { custom: { options: { baseURL: 'https://gateway.example.test/v1', apiKey: key } } } })}`
+      )
+      const launch = prepareMicrosandboxLaunch(opts)
+      expect(launch.microsandbox.secrets![0]!.host).toEqual(['gateway.example.test'])
+      const guestConfig = readFileSync(join(launch.runtimeHome!, '.config', 'opencode', 'opencode.jsonc'), 'utf8')
+      expect(guestConfig).not.toContain(key)
+      expect(guestConfig).toContain(launch.microsandbox.secrets![0]!.placeholder)
+      for (const file of [source, config]) {
+        expect(() =>
+          prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: file, target: '/config-copy', mode: 'readonly' }] })
+        ).toThrow(/protected host (path|credential source)/)
+      }
+      expect(readFileSync(config, 'utf8')).toContain(key)
+    }
+  )
+
+  it.skipIf(process.platform !== 'linux')(
+    'uses the OpenCode catalog for additional providers and preserves SRT seeding',
+    () => {
+      const key = 'fixture-catalog-provider-key'
+      const { opts } = openCodeFixture({ catalog: { type: 'api', key } })
+      const catalog = join(opts.hostHome, '.cache', 'opencode', 'models.json')
+      mkdirSync(dirname(catalog), { recursive: true })
+      writeFileSync(
+        catalog,
+        JSON.stringify({
+          catalog: {
+            api: 'https://api.example.test/v1',
+            models: { alternate: { provider: { api: 'https://alternate.example.test/v1' } } }
+          }
+        })
+      )
+      const launch = prepareMicrosandboxLaunch(opts)
+      expect(launch.microsandbox.secrets![0]!.host).toEqual(['alternate.example.test', 'api.example.test'])
+      const srtScope = join(opts.root, 'srt')
+      const srtCwd = join(srtScope, 'workspace')
+      mkdirSync(srtCwd, { recursive: true })
+      const srt = prepareRuntimeLaunch({
+        ...opts,
+        scopeDir: srtScope,
+        cwd: srtCwd,
+        runInSandbox: true,
+        daemonRoot: opts.root,
+        sandboxMechanism: 'bwrap'
+      })
+      expect(readFileSync(join(srt.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'), 'utf8')).toContain(key)
+    }
+  )
+
+  it('refuses unresolved or non-HTTPS OpenCode endpoints without including API keys in errors', () => {
+    const { opts } = openCodeFixture({ custom: { type: 'api', key: 'fixture-secret-not-in-error' } })
+    for (const baseURL of [undefined, 'http://gateway.example.test/v1']) {
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          explicitEnv: { OPENCODE_CONFIG_CONTENT: JSON.stringify({ provider: { custom: { options: { baseURL } } } }) }
+        })
+      ).toThrow('OpenCode launch refused')
+    }
+  })
+
   it.skipIf(process.platform !== 'linux').each(['legacy', 'versioned', 'dotenv'])(
     'protects %s DeepSeek keys while preserving other private provider credentials',
     (format) => {

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -75,13 +75,19 @@ describe('prepareMicrosandboxLaunch', () => {
       const auth = {
         opencode: { type: 'api', key: 'fixture-zen-key', metadata: { duplicate: 'fixture-zen-key' } },
         deepseek: { type: 'api', key: 'fixture-deepseek-key' },
-        openai: oauth
+        openai: oauth,
+        blank: { type: 'api', key: '' },
+        malformed: { type: 'api', key: null },
+        wellknown: { type: 'wellknown', key: 'fixture-key-name', token: 'fixture-token' }
       }
       const { opts, source } = openCodeFixture(auth)
       const launch = prepareMicrosandboxLaunch(opts)
       const path = join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json')
       const privateAuth = JSON.parse(readFileSync(path, 'utf8'))
       expect(privateAuth.openai).toEqual(oauth)
+      expect(privateAuth.blank).toEqual(auth.blank)
+      expect(privateAuth.malformed).toEqual(auth.malformed)
+      expect(privateAuth.wellknown).toEqual(auth.wellknown)
       expect(privateAuth.opencode.key).toMatch(/^msb-secret-OPENCODE_API_/)
       expect(privateAuth.deepseek.key).not.toBe(privateAuth.opencode.key)
       expect(launch.microsandbox.secrets!.map(({ host }) => host)).toEqual([['api.deepseek.com'], ['opencode.ai']])
@@ -91,6 +97,7 @@ describe('prepareMicrosandboxLaunch', () => {
       }
       expect(JSON.parse(readFileSync(source, 'utf8'))).toEqual(auth)
       privateAuth.openai.access = 'fixture-refreshed-access'
+      privateAuth.guest = { type: 'api', key: 'fixture-guest-login' }
       writeFileSync(path, JSON.stringify(privateAuth))
       writeFileSync(source, JSON.stringify({ ...auth, opencode: { type: 'api', key: 'fixture-rotated-key' } }))
       const resumed = prepareMicrosandboxLaunch(opts)
@@ -112,38 +119,80 @@ describe('prepareMicrosandboxLaunch', () => {
     )
   })
 
-  it.skipIf(process.platform !== 'linux')('preserves every authorized host when OpenCode providers share a key', () => {
-    const key = 'fixture-shared-"key\\value'
-    const { opts } = openCodeFixture({ east: { type: 'api', key }, west: { type: 'api', key } })
-    const config = {
-      provider: {
-        east: { options: { baseURL: 'https://east.example.test/v1', apiKey: key } },
-        west: { options: { baseURL: 'https://west.example.test/v1', apiKey: key } }
-      }
-    }
-    const source = join(opts.hostHome, '.config', 'opencode', 'opencode.json')
-    mkdirSync(dirname(source), { recursive: true })
-    writeFileSync(source, JSON.stringify(config))
+  it('does not import host OpenCode credentials for a custom runtime id', () => {
+    const { opts } = openCodeFixture({
+      opencode: { type: 'api', key: 'fixture-key' },
+      openai: { type: 'oauth', access: 'fixture-access', refresh: 'fixture-refresh', expires: 1 }
+    })
     const launch = prepareMicrosandboxLaunch({
       ...opts,
-      explicitEnv: { OPENCODE_CONFIG_CONTENT: JSON.stringify(config), MODEL_TOKEN: key }
+      runtimeId: 'custom-opencode',
+      runtime: { command: 'opencode', args: ['acp'], env: [] }
     })
-    expect(launch.microsandbox.secrets).toHaveLength(1)
-    const secret = launch.microsandbox.secrets![0]!
-    expect(secret.host).toEqual(['east.example.test', 'west.example.test'])
-    const auth = JSON.parse(readFileSync(join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'), 'utf8'))
-    const privateConfig = JSON.parse(
-      readFileSync(join(launch.runtimeHome!, '.config', 'opencode', 'opencode.json'), 'utf8')
-    )
-    const envConfig = JSON.parse(launch.env.OPENCODE_CONFIG_CONTENT!)
-    for (const provider of ['east', 'west']) {
-      expect(auth[provider].key).toBe(secret.placeholder)
-      expect(privateConfig.provider[provider].options.apiKey).toBe(secret.placeholder)
-      expect(envConfig.provider[provider].options.apiKey).toBe(secret.placeholder)
+    expect(launch.microsandbox.secrets).toBeUndefined()
+    expect(existsSync(join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'))).toBe(false)
+  })
+
+  it.skipIf(process.platform !== 'linux').each(['fixture-shared-"key\\value', 'local'])(
+    'preserves shared-key routing and unrelated text for %j',
+    (key) => {
+      const { opts } = openCodeFixture({ east: { type: 'api', key }, west: { type: 'api', key } })
+      const config = {
+        instructions: ['./local-rules.md'],
+        provider: {
+          east: { options: { baseURL: 'https://east.example.test/v1', apiKey: key } },
+          west: { options: { baseURL: 'https://west.example.test/v1', apiKey: key } }
+        }
+      }
+      const source = join(opts.hostHome, '.config', 'opencode', 'opencode.json')
+      mkdirSync(dirname(source), { recursive: true })
+      writeFileSync(source, JSON.stringify(config))
+      const launch = prepareMicrosandboxLaunch({
+        ...opts,
+        explicitEnv: {
+          OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+          MODEL_TOKEN: key,
+          AUTH_HEADER: `Bearer ${key}`,
+          INSTRUCTIONS: 'keep local files'
+        }
+      })
+      expect(launch.microsandbox.secrets).toHaveLength(1)
+      const secret = launch.microsandbox.secrets![0]!
+      expect(secret.host).toEqual(['east.example.test', 'west.example.test'])
+      const auth = JSON.parse(
+        readFileSync(join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'), 'utf8')
+      )
+      const privateConfig = JSON.parse(
+        readFileSync(join(launch.runtimeHome!, '.config', 'opencode', 'opencode.json'), 'utf8')
+      )
+      const envConfig = JSON.parse(launch.env.OPENCODE_CONFIG_CONTENT!)
+      for (const provider of ['east', 'west']) {
+        expect(auth[provider].key).toBe(secret.placeholder)
+        expect(privateConfig.provider[provider].options.apiKey).toBe(secret.placeholder)
+        expect(envConfig.provider[provider].options.apiKey).toBe(secret.placeholder)
+      }
+      expect(launch.env.MODEL_TOKEN).toBe(secret.placeholder)
+      expect(launch.env.AUTH_HEADER).toBe(`Bearer ${secret.placeholder}`)
+      expect(launch.env.INSTRUCTIONS).toBe('keep local files')
+      expect(launch.env.XDG_DATA_HOME).toBe(join(launch.runtimeHome!, '.local', 'share'))
+      expect(privateConfig.instructions).toEqual(config.instructions)
+      expect(envConfig.instructions).toEqual(config.instructions)
+      expect(secret.readValue()).toBe(key)
+      expect(JSON.parse(readFileSync(source, 'utf8'))).toEqual(config)
     }
-    expect(launch.env.MODEL_TOKEN).toBe(secret.placeholder)
-    expect(secret.readValue()).toBe(key)
-    expect(JSON.parse(readFileSync(source, 'utf8'))).toEqual(config)
+  )
+
+  it.skipIf(process.platform !== 'linux')('skips symlinked host OpenCode configuration like native seeding', () => {
+    const { opts } = openCodeFixture({ opencode: { type: 'api', key: 'fixture-key' } })
+    const target = join(opts.hostHome, 'managed-config.json')
+    writeFileSync(target, 'invalid unused configuration')
+    const config = join(opts.hostHome, '.config', 'opencode', 'opencode.json')
+    mkdirSync(dirname(config), { recursive: true })
+    symlinkSync(target, config)
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets![0]!.host).toEqual(['opencode.ai'])
+    expect(existsSync(join(launch.runtimeHome!, '.config', 'opencode', 'opencode.json'))).toBe(false)
+    expect(readFileSync(target, 'utf8')).toBe('invalid unused configuration')
   })
 
   it.skipIf(process.platform !== 'linux')(
@@ -175,12 +224,16 @@ describe('prepareMicrosandboxLaunch', () => {
     'uses the OpenCode catalog for additional providers and preserves SRT seeding',
     () => {
       const key = 'fixture-catalog-provider-key'
-      const { opts } = openCodeFixture({ catalog: { type: 'api', key } })
+      const { opts } = openCodeFixture({
+        catalog: { type: 'api', key },
+        deepseek: { type: 'api', key: 'fixture-independent-key' }
+      })
       const catalog = join(opts.hostHome, '.cache', 'opencode', 'models.json')
       mkdirSync(dirname(catalog), { recursive: true })
       writeFileSync(
         catalog,
         JSON.stringify({
+          deepseek: { api: 'https://different.example.test/v1' },
           catalog: {
             api: 'https://api.example.test/v1',
             models: { alternate: { provider: { api: 'https://alternate.example.test/v1' } } }
@@ -189,6 +242,7 @@ describe('prepareMicrosandboxLaunch', () => {
       )
       const launch = prepareMicrosandboxLaunch(opts)
       expect(launch.microsandbox.secrets![0]!.host).toEqual(['alternate.example.test', 'api.example.test'])
+      expect(launch.microsandbox.secrets![1]!.host).toEqual(['api.deepseek.com'])
       const srtScope = join(opts.root, 'srt')
       const srtCwd = join(srtScope, 'workspace')
       mkdirSync(srtCwd, { recursive: true })
@@ -204,17 +258,38 @@ describe('prepareMicrosandboxLaunch', () => {
     }
   )
 
-  it('refuses unresolved or non-HTTPS OpenCode endpoints without including API keys in errors', () => {
-    const { opts } = openCodeFixture({ custom: { type: 'api', key: 'fixture-secret-not-in-error' } })
-    for (const baseURL of [undefined, 'http://gateway.example.test/v1']) {
-      expect(() =>
-        prepareMicrosandboxLaunch({
-          ...opts,
-          explicitEnv: { OPENCODE_CONFIG_CONTENT: JSON.stringify({ provider: { custom: { options: { baseURL } } } }) }
+  it.skipIf(process.platform !== 'linux').each([undefined, 'http://localhost:11434/v1'])(
+    'keeps an unroutable OpenCode key hidden without blocking other providers: %j',
+    (baseURL) => {
+      const key = 'fixture-unroutable-key'
+      for (const withSupported of [true, false]) {
+        const { opts } = openCodeFixture({
+          custom: { type: 'api', key },
+          ...(withSupported ? { opencode: { type: 'api', key: 'fixture-supported-key' } } : {})
         })
-      ).toThrow('OpenCode launch refused')
+        const cache = join(opts.hostHome, '.cache', 'opencode', 'models.json')
+        mkdirSync(dirname(cache), { recursive: true })
+        writeFileSync(cache, 'broken cache')
+        const launch = prepareMicrosandboxLaunch({
+          ...opts,
+          explicitEnv: {
+            MODEL_TOKEN: key,
+            OPENCODE_CONFIG_CONTENT: JSON.stringify({ provider: { custom: { options: { baseURL, apiKey: key } } } })
+          }
+        })
+        expect(launch.microsandbox.secrets).toHaveLength(withSupported ? 1 : 0)
+        if (withSupported) expect(launch.microsandbox.secrets![0]!.host).toEqual(['opencode.ai'])
+        else expect(launch.env.NODE_EXTRA_CA_CERTS).toBeUndefined()
+        const auth = JSON.parse(
+          readFileSync(join(launch.runtimeHome!, '.local', 'share', 'opencode', 'auth.json'), 'utf8')
+        )
+        expect(auth.custom.key).toMatch(/^msb-secret-OPENCODE_API_/)
+        expect(launch.env.MODEL_TOKEN).toBe(auth.custom.key)
+        expect(JSON.parse(launch.env.OPENCODE_CONFIG_CONTENT!).provider.custom.options.apiKey).toBe(auth.custom.key)
+        expect(JSON.stringify(launch)).not.toContain(key)
+      }
     }
-  })
+  )
 
   it.skipIf(process.platform !== 'linux').each(['legacy', 'versioned', 'dotenv'])(
     'protects %s DeepSeek keys while preserving other private provider credentials',


### PR DESCRIPTION
OpenCode sessions in microsandbox currently seed API keys into the guest's native `auth.json`. Replace each host API record's key with a placeholder and let microsandbox's existing TLS proxy inject the real key only for its allowed HTTPS hosts. Providers sharing a key share one placeholder with their combined authorized hosts. An unresolved or unsupported endpoint keeps its key hidden and receives no proxy injection; it does not prevent other providers from starting.

- Reuse the DeepSeek proxy lifecycle, descriptor-based file projection, mount guards, and guest CA setup. Protected keys stay out of guest files and serialized launch metadata.
- Resolve allowed hosts from standard host OpenCode config, `OPENCODE_CONFIG_CONTENT`, provider defaults, or the cached model catalog. An unusable optional catalog does not block providers with known origins. Replace exact credential values, Bearer headers, and JSON environment values without corrupting paths containing short dummy keys.
- Preserve native OAuth and `wellknown` records, guest-refreshed OAuth state, and credentials for providers configured only inside the guest. Blank API records do not block startup. Custom runtime IDs do not implicitly import the registered OpenCode credentials.
- Keep SRT and Kubernetes authentication unchanged. Protection covers API records in native `auth.json`, not keys stored only in other configuration sources. `OPENCODE_CONFIG` and `OPENCODE_CONFIG_DIR` paths are outside the import/routing scope. Previously unprotected VMs retain their data and require a new session to enable protection.

Validation: 142 focused daemon tests passed locally, with 16 Linux-only cases skipped; typecheck, ESLint, formatting, and the self-contained build passed. Isolated Linux/KVM verification covered the partial-provider policy, blank keys, short keys, symlinked config, guest login persistence, custom runtime IDs, mixed API/OAuth projection, per-secret host restrictions, actual provider requests, VM resume, key rotation, and cleanup. The initial feature validation also completed an OpenCode native-tool conversation. Host credential files were unchanged.

Created by Codex . GPT-6
