### PR TITLE
fix(daemon): a failed live upgrade reports itself so the CP stops reading `upgrading`

### DIFF
--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -419,9 +419,13 @@ agentconnect upgrade --to <version> --root <root>
 
 This installs and activates the target without asking the service controller to
 restart the process that is currently issuing the command. If the CLI step
-fails, the daemon stays running and clears its in-flight lifecycle guard. If it
-succeeds, the daemon drains and exits with `RESERVED_RESTART_CODE`; its
-supervisor then launches the new `current` version.
+fails, the daemon stays running and clears its in-flight lifecycle guard, and
+reports `daemon/bootstrap/result{status:"failed"}` for the operation id the
+`daemon/upgrade` command carried — the daemon never re-registers after a failed
+install, so without that report the operation would stay pending (and read as
+in-flight) until its deadline. If it succeeds, the daemon drains and exits with
+`RESERVED_RESTART_CODE`; its supervisor then launches the new `current`
+version.
 
 Remote completion is determined by the later `READY` registration. Unlike a
 local `upgrade --restart`, the remote flow does not perform process-level

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -556,7 +556,7 @@ export function daemonRoutes(deps: HttpDeps) {
 
       const result =
         op === 'upgrade' && targetVersion
-          ? await deps.control.daemonUpgrade(id, { targetVersion, drainFirst: true })
+          ? await deps.control.daemonUpgrade(id, { targetVersion, drainFirst: true, operationId: opRow.id })
           : await deps.control.daemonRestart(id, { reason: 'console-initiated restart', drainFirst: true })
 
       // Definitely unsent (pre-dispatch NoConnection) → fail the op + 503.

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -777,11 +777,14 @@ describe('POST /daemons/:id/upgrade', () => {
       payload: { version: '0.5.0' }
     })
     expect(res.statusCode).toBe(202)
-    expect(calls).toEqual([{ method: 'upgrade', id: DAEMON, payload: { targetVersion: '0.5.0', drainFirst: true } }])
     // The 202 returns the opened op (with its id) so the console can track it.
     const opened = res.json() as { id: string; op: string; status: string; targetVersion: string | null }
     expect(opened).toMatchObject({ op: 'upgrade', status: 'pending', targetVersion: '0.5.0' })
     expect(opened.id).toBeTruthy()
+    // The op id rides along so a failed install can settle the op instead of stranding it pending.
+    expect(calls).toEqual([
+      { method: 'upgrade', id: DAEMON, payload: { targetVersion: '0.5.0', drainFirst: true, operationId: opened.id } }
+    ])
 
     const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as (DaemonDto & {
       lifecycleOp: LifecycleOp | null

--- a/packages/control-plane/test/protocol/lifecycle-upgrade-failure.handler.test.ts
+++ b/packages/control-plane/test/protocol/lifecycle-upgrade-failure.handler.test.ts
@@ -1,0 +1,63 @@
+/**
+ * `daemon/bootstrap/result{failed}` on a READY connection (cli-daemon-split.md §6.2).
+ *
+ * A live-delivered `daemon/upgrade` is acked before the install runs, so an install that
+ * fails leaves the daemon running the current version and never re-registering. The daemon
+ * reports the failure on the same connection, which must settle the pending op — otherwise
+ * the console reads `upgrading` until the op's deadline lapses.
+ */
+import { describe, it, expect } from 'vitest'
+import { isFrame } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { buildWsHarness } from '../fakes/build-ws.js'
+import { DaemonId } from '../../src/domain/ids.js'
+
+const DAEMON = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const AUTH_ID = '66666666-6666-4666-8666-666666666666'
+const REG_ID = '77777777-7777-4777-8777-777777777777'
+
+async function connectReady(h: ReturnType<typeof buildWsHarness>) {
+  const token = await h.mintToken(DAEMON)
+  const { stub } = h.connect()
+  stub.inject('auth', { apiKey: token, daemonId: DAEMON, agentVersion: '1.4.0' }, { id: AUTH_ID })
+  await stub.expectFrame('auth/ok')
+  stub.inject(
+    'register',
+    {
+      host: 'host-1',
+      capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true },
+      maxAgents: 4,
+      localState: { assignments: [], crons: [], leases: [] }
+    },
+    { id: REG_ID }
+  )
+  await stub.expectFrame('register/ok')
+  return { stub }
+}
+
+describe('daemon/bootstrap/result on a live connection settles a failed live upgrade', () => {
+  it('fails the pending op with the daemon-reported reason', async () => {
+    const h = buildWsHarness(prisma)
+    const { stub } = await connectReady(h)
+    const op = await h.deps.lifecycleOps.open({
+      daemonId: DaemonId(DAEMON),
+      op: 'upgrade',
+      targetVersion: '2.0.0',
+      commandEpoch: 1n,
+      deadline: new Date(h.clock.now() + 15 * 60_000)
+    })
+
+    stub.inject('daemon/bootstrap/result', {
+      operationId: op.id,
+      status: 'failed',
+      reason: 'failed to install 2.0.0'
+    })
+
+    const ack = await stub.expectFrame('ack')
+    if (!isFrame('ack')(ack)) throw new Error('expected ack')
+    expect(ack.payload.ok).toBe(true)
+    const settled = await h.deps.lifecycleOps.getById(op.id)
+    expect(settled?.status).toBe('failed')
+    expect(settled?.outcome).toBe('failed to install 2.0.0')
+  })
+})

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -613,6 +613,17 @@ export class CpClient {
     }
   }
 
+  /** Report a live-delivered upgrade whose install failed (D→C `daemon/bootstrap/result`,
+   *  fire-and-forget). The daemon keeps running the current version, so nothing else would
+   *  settle the CP's lifecycle op and the console would read `upgrading` until its deadline.
+   *  No-op unless READY/DRAINING — an older CP answers `error{UNKNOWN_FRAME}`, ignored. */
+  emitUpgradeFailed(operationId: string, reason: string): void {
+    if (this.state !== 'READY' && this.state !== 'DRAINING') return
+    this.transport?.send(
+      encode(buildEnvelope('daemon/bootstrap/result', { operationId, status: 'failed', reason: reason.slice(0, 500) }))
+    )
+  }
+
   /**
    * Re-announce `RegisterReq.capabilities` when the daemon's computed set has
    * changed since this connection's register (D→C `capabilities/update` EVT,

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -165,7 +165,7 @@ export interface ConfigApplyControlHost {
   retractChannels(integrationId: string, channelIds: readonly string[]): Promise<void>
   runCronNow(cronId: string): Ack
   runDrain(drain: Drain, onProgress: (p: DrainProgress) => void): Promise<DrainDone>
-  scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string): DaemonControlAck
+  scheduleFleetExit(kind: 'restart' | 'upgrade', targetVersion?: string, operationId?: string): DaemonControlAck
 }
 
 /** Everything the CP apply path touches on the `Daemon`. */
@@ -934,7 +934,8 @@ export function buildConfigApply(host: ConfigApplyHost): ConfigApply {
     applyDaemonDrain: (drain: Drain, onProgress: (p: DrainProgress) => void): Promise<DrainDone> =>
       host.runDrain(drain, onProgress),
     applyDaemonRestart: (_req: DaemonRestart): DaemonControlAck => host.scheduleFleetExit('restart'),
-    applyDaemonUpgrade: (req: DaemonUpgrade): DaemonControlAck => host.scheduleFleetExit('upgrade', req.targetVersion),
+    applyDaemonUpgrade: (req: DaemonUpgrade): DaemonControlAck =>
+      host.scheduleFleetExit('upgrade', req.targetVersion, req.operationId),
     applySessionVisibility: (p: SessionVisibilityPush) => applySessionVisibility(host, p)
   }
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1480,7 +1480,8 @@ export class Daemon {
       configPath: () => this.opts.configPath,
       upgradeInstaller: () => this.opts.upgradeInstaller,
       stop: () => this.stop(),
-      requestExit: (code) => this.requestExit(code)
+      requestExit: (code) => this.requestExit(code),
+      reportUpgradeFailed: (operationId, reason) => this.cpClient?.emitUpgradeFailed(operationId, reason)
     })
   }
 
@@ -17951,7 +17952,8 @@ export class Daemon {
         this.observedChannelsSync.retractChannels(integrationId, channelIds),
       runCronNow: (cronId) => this.runCronNow(cronId),
       runDrain: (drain, onProgress) => this.runDrain(drain, onProgress),
-      scheduleFleetExit: (kind, targetVersion) => this.fleetUpgrade.scheduleFleetExit(kind, targetVersion)
+      scheduleFleetExit: (kind, targetVersion, operationId) =>
+        this.fleetUpgrade.scheduleFleetExit(kind, targetVersion, operationId)
     }
   }
 

--- a/packages/daemon/src/lifecycle/fleet-upgrade.ts
+++ b/packages/daemon/src/lifecycle/fleet-upgrade.ts
@@ -20,6 +20,8 @@ export interface FleetUpgradeHost {
   upgradeInstaller: () => typeof runCliUpgrade | undefined
   stop: () => Promise<void>
   requestExit: (code: number) => void
+  /** Tell the CP a live-delivered upgrade failed to install, so it settles its lifecycle op now. */
+  reportUpgradeFailed?: (operationId: string, reason: string) => void
 }
 
 type FleetExitKind = 'restart' | 'upgrade'
@@ -80,7 +82,12 @@ export class FleetUpgradeCoordinator {
     return { accepted: true, root, ...(cliEntry ? { cliEntry } : {}), ...(willDrainUntil ? { willDrainUntil } : {}) }
   }
 
-  private startFleetUpgrade(cliEntry: string, targetVersion: string, root: string): Promise<boolean> {
+  private startFleetUpgrade(
+    cliEntry: string,
+    targetVersion: string,
+    root: string,
+    operationId?: string
+  ): Promise<boolean> {
     const log = this.host.log()
     const installation = Promise.resolve()
       .then(() =>
@@ -95,6 +102,9 @@ export class FleetUpgradeCoordinator {
           log.error(`cp: upgrade to ${targetVersion} aborted — daemon continues on the current version`)
           this.lifecycleInFlight = false
           if (this.fleetUpgradeInFlight?.installation === installation) this.fleetUpgradeInFlight = undefined
+          // The daemon never re-registers after a failed install, so nothing else would settle
+          // the CP's op — it would read `upgrading` until its deadline expired.
+          if (operationId) this.host.reportUpgradeFailed?.(operationId, `failed to install ${targetVersion}`)
         }
         return ok
       })
@@ -117,11 +127,14 @@ export class FleetUpgradeCoordinator {
   }
 
   /** Admit immediately, then install before the existing drain-and-relaunch path. */
-  scheduleFleetExit(kind: FleetExitKind, targetVersion?: string): DaemonControlAck {
+  scheduleFleetExit(kind: FleetExitKind, targetVersion?: string, operationId?: string): DaemonControlAck {
     const admission = this.admitFleetExit(kind, targetVersion)
     if (!admission.accepted) return admission
     void (async () => {
-      if (kind === 'upgrade' && !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root))) {
+      if (
+        kind === 'upgrade' &&
+        !(await this.startFleetUpgrade(admission.cliEntry!, targetVersion!, admission.root, operationId))
+      ) {
         return
       }
       this.finishFleetExit(kind)

--- a/packages/daemon/test/daemon-fleet-upgrade.test.ts
+++ b/packages/daemon/test/daemon-fleet-upgrade.test.ts
@@ -48,4 +48,22 @@ describe('daemon fleet upgrade coordination', () => {
     outcome.restart()
     await vi.waitFor(() => expect(requestExit).toHaveBeenCalledTimes(1))
   })
+
+  it('reports a failed live install to the CP so its lifecycle op does not stay pending', async () => {
+    const upgradeInstaller = vi.fn(async () => false)
+    const daemon = new Daemon({ root: scaffold(), supervisor: 'cli', upgradeInstaller, requestExit: vi.fn() })
+    const emitUpgradeFailed = vi.fn()
+    ;(daemon as any).cpClient = { emitUpgradeFailed }
+    ;(daemon as any).stop = vi.fn(async () => {})
+
+    const ack = (daemon as any).cpConfigApply().applyDaemonUpgrade({
+      targetVersion: '9.9.9',
+      drainFirst: true,
+      operationId: 'op-1'
+    })
+    expect(ack).toEqual({ accepted: true })
+    await vi.waitFor(() => expect(emitUpgradeFailed).toHaveBeenCalledWith('op-1', 'failed to install 9.9.9'))
+    // The daemon keeps running the current version — no exit was requested.
+    expect((daemon as any).stop).not.toHaveBeenCalled()
+  })
 })

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -399,7 +399,10 @@ export type DaemonRestart = z.infer<typeof DaemonRestart>
 /** Fleet: drain+exit for version bump — C→D REQ, protocol §8.3 / frame #28. */
 export const DaemonUpgrade = z.object({
   targetVersion: z.string(),
-  drainFirst: z.boolean().default(true)
+  drainFirst: z.boolean().default(true),
+  // The CP lifecycle op this command opened, so a failed install can be reported as
+  // `daemon/bootstrap/result{failed}` instead of leaving the op pending to its deadline.
+  operationId: z.string().optional()
 })
 export type DaemonUpgrade = z.infer<typeof DaemonUpgrade>
 


### PR DESCRIPTION
## The bug

```
[agentconnect] INFO  cp: upgrade → 1.56.0-rc.53 accepted
agentconnect upgrade: fetch failed
[agentconnect] ERROR cp: CLI upgrade exited 1
[agentconnect] ERROR cp: upgrade to 1.56.0-rc.53 aborted — daemon continues on the current version
```

…and the console keeps showing the daemon as **upgrading**.

A live-delivered `daemon/upgrade` is acked *before* the install runs: `scheduleFleetExit`
returns `{accepted:true}` and installs in the background. When the install fails the daemon
logs it, clears its in-flight guard, and keeps running the current version — so it never
re-registers, and the CP's `pending` lifecycle op had nothing to settle it. The console
renders `lifecycleOp.status === 'pending'` as `upgrading`, so the badge stayed up until the
15-minute deadline lapsed (read-time expiry projection).

The offline bootstrap-upgrade path already reported failures via
`daemon/bootstrap/result{status:"failed"}`. Only the live path was missing it.

## The fix

- `protocol` — `DaemonUpgrade` carries an optional `operationId` (the CP's lifecycle op).
- `control-plane` — the upgrade command sends `operationId: opRow.id`.
- `daemon` — a failed install reports `daemon/bootstrap/result{failed}` for that id on the
  same connection; the CP's existing handler settles the op as `failed` with the reason.

No new CP handler is needed, and the console's existing failure notification now fires
immediately instead of after the deadline.

## Tests

- `daemon`: a failed live install reports `(opId, 'failed to install 9.9.9')` and does not exit.
- `control-plane`: a new `daemon/bootstrap/result{failed}` handler test on a READY connection;
  the route test now asserts the op id rides along in the command payload.
- Full CP integration suite green (127 files / 2007 tests); both packages typecheck.

## Known limits

A daemon older than this change sends no `operationId`, so its failed upgrade still waits for
the deadline (displayed as `failed` by the read-time projection, never stuck permanently).
An upgrade that installs but fails to relaunch is likewise deadline-bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)