### PR TITLE
perf(runtime): separate system bases from application layers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -347,10 +347,7 @@ jobs:
           bash scripts/runtime-image-effective.sh "$IMAGE" "$VERSION" "$PREVIOUS_TAG" "$SHIM" "$RECIPE"
           | tee -a "$GITHUB_OUTPUT"
 
-      # What only the image CONFIG can answer — a non-root USER, tini as the ENTRYPOINT and the browser path ENV — read
-      # from the digest-pinned base the Dockerfile names, once the script has checked that the release stage writes no
-      # config of its own: it adds one COPY, so the base's config IS the image's. Independent of the build and cheap, so
-      # it runs first and a Dockerfile mistake fails here before a base is pulled.
+      # Check inherited system-base config and the final application USER before pulling any image layers.
       - name: Verify the runtime sandbox image configuration
         if: startsWith(matrix.verify, 'runtime-sandbox') && steps.decision.outputs.unchanged != 'true'
         env:
@@ -364,12 +361,7 @@ jobs:
           done <<< "$BUILD_ARGS"
           node scripts/verify-runtime-image.mjs "$@"
 
-      # The Dockerfile's verify target, built with `--output type=cacheonly`: the runtime-table probe (cached by the base
-      # pin and the roster), the shim smoke test (the image's own entrypoint started the way the pod starts it, the daemon
-      # side dialling it over loopback, the real ACP runtime answering `initialize` and `session/new`) and the static
-      # in-image assertions, each inside the built image as its own user. No image is loaded and no toolchain is installed
-      # on the runner. The probe stages are not in the image's graph, and a `mode=max` export replaces the whole cache
-      # manifest, so the Build step below would drop them from the shared ref; they live under their own `-verify` ref.
+      # Verify applications, runtime tables and real shim sessions inside the build, retaining a separate verification cache.
       - name: Verify the runtime sandbox image inside the build
         if: startsWith(matrix.verify, 'runtime-sandbox') && steps.decision.outputs.unchanged != 'true'
         uses: docker/build-push-action@v7

--- a/.github/workflows/runtime-base.yaml
+++ b/.github/workflows/runtime-base.yaml
@@ -1,9 +1,6 @@
 name: Build runtime bases
 
 on:
-  push:
-    branches: [codex/runtime-image-layers]
-    paths: [.github/workflows/runtime-base.yaml]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/runtime-base.yaml
+++ b/.github/workflows/runtime-base.yaml
@@ -1,0 +1,126 @@
+name: Build runtime bases
+
+on:
+  push:
+    branches: [codex/runtime-image-layers]
+    paths: [.github/workflows/runtime-base.yaml]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Optional tag (default: base-YYYYMMDD-HHMMSS in UTC)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-base-publication
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Select a dated tag
+        id: tag
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          tag="${REQUESTED_TAG:-base-$(date -u +%Y%m%d-%H%M%S)}"
+          if ! [[ "$tag" =~ ^base-[0-9]{8}([.-][a-zA-Z0-9_.-]+)?$ ]] || [ "${#tag}" -gt 128 ]; then
+            echo 'Use a tag such as base-20260911-120000.' >&2
+            exit 1
+          fi
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: runtime-sandbox
+            base_arg: RUNTIME_SANDBOX_BASE
+          - variant: runtime-sandbox-full
+            base_arg: RUNTIME_SANDBOX_FULL_BASE
+    concurrency:
+      group: image-build-${{ matrix.variant }}
+      cancel-in-progress: false
+    env:
+      IMAGE: ghcr.io/agentconnect-md/${{ matrix.variant }}
+      BASE_TAG: ${{ needs.prepare.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Verify native runtime architecture
+        run: |
+          test "$(uname -m)" = x86_64
+          grep -qw avx /proc/cpuinfo
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v4
+      - name: Refuse to replace an existing base
+        run: |
+          if docker buildx imagetools inspect "$IMAGE:$BASE_TAG" > /dev/null 2> "$RUNNER_TEMP/base-inspect.log"; then
+            echo 'The tag already exists; choose a new dated tag.' >&2
+            exit 1
+          fi
+          if ! grep -Eiq 'not found|manifest unknown' "$RUNNER_TEMP/base-inspect.log"; then
+            cat "$RUNNER_TEMP/base-inspect.log" >&2
+            exit 1
+          fi
+      - name: Publish candidate system base
+        id: base
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/runtime-sandbox-base.Dockerfile
+          target: ${{ matrix.variant }}-base
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE }}:${{ env.BASE_TAG }}
+          push: true
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache-base
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-base,mode=max
+      - name: Verify application configuration
+        env:
+          VARIANT: ${{ matrix.variant }}
+          BASE_ARG: ${{ matrix.base_arg }}
+          DIGEST: ${{ steps.base.outputs.digest }}
+        run: node scripts/verify-runtime-image.mjs "$VARIANT" --build-arg "$BASE_ARG=$IMAGE@$DIGEST"
+      - name: Verify applications, runtime table and real shim session
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/runtime-sandbox.Dockerfile
+          target: ${{ matrix.variant }}-verify
+          platforms: linux/amd64
+          build-args: ${{ matrix.base_arg }}=${{ env.IMAGE }}@${{ steps.base.outputs.digest }}
+          outputs: type=cacheonly
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE }}:buildcache
+            type=registry,ref=${{ env.IMAGE }}:buildcache-verify
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-verify,mode=max
+      - name: Record the verified base pin
+        env:
+          BASE_ARG: ${{ matrix.base_arg }}
+          DIGEST: ${{ steps.base.outputs.digest }}
+        run: |
+          printf '%s=%s:%s@%s\n' "$BASE_ARG" "$IMAGE" "$BASE_TAG" "$DIGEST" > base-pin.txt
+          printf '### Verified base: %s\n\n```dockerfile\nARG %s\n```\n' "$BASE_TAG" "$(cat base-pin.txt)" >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: verified-base-pin-${{ matrix.variant }}
+          path: base-pin.txt
+          if-no-files-found: error

--- a/docker/runtime-sandbox-base.Dockerfile
+++ b/docker/runtime-sandbox-base.Dockerfile
@@ -43,40 +43,6 @@ RUN set -eu; \
   test -x /out/chrome; \
   chmod -R a-w /out
 
-# Standalone runtimes for the full image; their downloads never enter the pool image.
-FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS full-native-runtimes
-ARG OMP_VERSION=17.0.5
-ARG OMP_SHA256_AMD64=319d08ab8e5fb80c73f734907d5f47aa8bbd4ea31f7a19bacf8611c5aba26c31
-ARG ANTIGRAVITY_VERSION=1.1.1
-ARG ANTIGRAVITY_SHA256_AMD64=38f62d01b32deb0907b3d39a71ec301fd36369f6ffd1cf262d4af385177f79df
-ARG DEVIN_VERSION=3000.6.14
-ARG DEVIN_SHA256_AMD64=28cf64c1df9f58ccd063fb7e6fd6e9391073c585b733449371485e1ef8a3e6db
-ARG TARGETARCH
-RUN test "${TARGETARCH:-amd64}" = amd64 \
-  && apt-get update \
-  && apt-get install --no-install-recommends -y ca-certificates curl unzip \
-  && rm -rf /var/lib/apt/lists/* \
-  && mkdir -p /out/bin /out/antigravity
-RUN curl --retry 5 -fsSL -o /tmp/omp \
-  "https://github.com/can1357/oh-my-pi/releases/download/v${OMP_VERSION}/omp-linux-x64" \
-  && printf '%s  /tmp/omp\n' "$OMP_SHA256_AMD64" | sha256sum -c - \
-  && install -m 0555 /tmp/omp /out/bin/omp \
-  && rm /tmp/omp
-RUN curl --retry 5 -fsSL -o /tmp/antigravity.zip \
-  "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_${ANTIGRAVITY_VERSION}-linux-x86_64.zip" \
-  && printf '%s  /tmp/antigravity.zip\n' "$ANTIGRAVITY_SHA256_AMD64" | sha256sum -c - \
-  && unzip -q /tmp/antigravity.zip -d /out/antigravity \
-  && test -x /out/antigravity/agy_acp_server.par \
-  && test -x /out/antigravity/localharness_external \
-  && chmod -R a-w /out/antigravity \
-  && rm /tmp/antigravity.zip
-RUN curl --retry 5 -fsSL -o /tmp/devin.tar.gz \
-  "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-x86_64-unknown-linux.tar.gz" \
-  && printf '%s  /tmp/devin.tar.gz\n' "$DEVIN_SHA256_AMD64" | sha256sum -c - \
-  && tar -xzf /tmp/devin.tar.gz -C /tmp bin/devin \
-  && install -m 0555 /tmp/bin/devin /out/bin/devin \
-  && rm -rf /tmp/devin.tar.gz /tmp/bin
-
 # ─────────────────────────────── runtime ────────────────────────────────────
 FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS runtime-base
 
@@ -97,33 +63,6 @@ RUN apt-get update \
     libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 \
   && rm -rf /var/lib/apt/lists/*
 
-# Exact pins keep the published runtime table truthful.
-ARG CLAUDE_ACP_VERSION=0.76.0
-ARG CODEX_ACP_VERSION=1.11.0-agentconnect.1
-ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.30
-ARG AGENT_BROWSER_VERSION=0.37.1
-
-# Global installs give `--k8s` fixed PATH binaries without registry egress at spawn time.
-RUN npm install --global --no-fund --no-audit \
-  "@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_VERSION}" \
-  "@agentconnect.md/codex-acp@${CODEX_ACP_VERSION}" \
-  "@openma/deepseek-harness-acp@${DEEPSEEK_HARNESS_ACP_VERSION}" \
-  && npm cache clean --force
-
-# Install agent-browser and retain only its current platform's native binary.
-RUN npm install --global --no-fund --no-audit "agent-browser@${AGENT_BROWSER_VERSION}" \
-  && keep="$(readlink -f /usr/local/bin/agent-browser)" \
-  && case "$keep" in */agent-browser-*) ;; *) echo "agent-browser bin link resolved to $keep" >&2; exit 1 ;; esac \
-  && find /usr/local/lib/node_modules/agent-browser/bin -type f -name 'agent-browser-*' ! -path "$keep" -delete \
-  && npm cache clean --force \
-  && agent-browser --version
-
-# Generate the pinned DSH preset with web search disabled; see src/shim/dsh-preset.ts.
-RUN --mount=type=bind,source=docker/runtime-sandbox/bake-dsh-preset.mjs,target=/tmp/bake-dsh-preset.mjs \
-  node /tmp/bake-dsh-preset.mjs /opt/agentconnect/dsh/agent-presets/standard-no-search \
-  && chown -R root:root /opt/agentconnect/dsh \
-  && chmod -R a-w /opt/agentconnect/dsh
-
 # Git invokes this immutable wrapper to run the credential bundle from the final image.
 RUN mkdir -p /opt/agentconnect/bin \
   && printf '#!/bin/sh\n# agentconnect git credential helper — see src/shim/git-credential.ts.\nexec node /opt/agentconnect/shim/git-credential.js "$@"\n' \
@@ -141,28 +80,6 @@ RUN mkdir -p /opt/agentconnect/pathbin \
 # Preserve the downloader's immutable Chrome modes; chmod here would duplicate the browser layer.
 COPY --from=chrome --chown=0:0 /out /opt/agentconnect/browser
 
-# A bare agent-browser install uses baked Chrome; other arguments reach the real CLI.
-RUN printf '%s\n' \
-  '#!/bin/sh' \
-  '# agentconnect: this sandbox bakes Chrome, so a bare `install` has nothing to fetch. See runtime-sandbox.Dockerfile.' \
-  '# Defaulted here too, not only in ENV: an ACP child is spawned from an allowlist, so the image env may not reach it.' \
-  ': "${AGENT_BROWSER_EXECUTABLE_PATH:=/opt/agentconnect/browser/chrome}"' \
-  'export AGENT_BROWSER_EXECUTABLE_PATH' \
-  'if [ "$1" = install ]; then' \
-  '  shift' \
-  '  case "$*" in' \
-  '  ""|-d|--with-deps)' \
-  '    echo "agent-browser install: Chrome is already installed in this sandbox at $AGENT_BROWSER_EXECUTABLE_PATH"' \
-  '    exit 0' \
-  '    ;;' \
-  '  esac' \
-  '  exec /usr/local/bin/agent-browser install "$@"' \
-  'fi' \
-  'exec /usr/local/bin/agent-browser "$@"' \
-  > /opt/agentconnect/pathbin/agent-browser \
-  && chown root:root /opt/agentconnect/pathbin/agent-browser \
-  && chmod 0555 /opt/agentconnect/pathbin/agent-browser
-
 # Fixed uid/gid keep workspace volumes readable across image upgrades.
 RUN groupadd --gid 10001 agent \
   && useradd --uid 10001 --gid 10001 --home-dir /agent --shell /usr/sbin/nologin --create-home agent \
@@ -173,20 +90,6 @@ RUN mkdir -p /run/agentconnect \
   && chown 10001:10001 /run/agentconnect \
   && chmod 0700 /run/agentconnect
 
-# Probe the installed runtimes to bake their declared capabilities into the base image.
-COPY docker/runtime-sandbox/generate-runtime-table.mjs /opt/agentconnect/bin/generate-runtime-table.mjs
-COPY docker/runtime-sandbox/installed-runtimes.json /opt/agentconnect/runtime/installed-runtimes.json
-# Probe as the runtime user in a disposable HOME and cwd, leaving /agent clean.
-USER 10001:10001
-RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
-  && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
-    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/k8s-runtimes.json
-USER root
-RUN mkdir -p /opt/agentconnect/runtime \
-  && mv /tmp/ac-probe/k8s-runtimes.json /opt/agentconnect/runtime/k8s-runtimes.json \
-  && rm -rf /tmp/ac-probe \
-  && chown -R root:root /opt/agentconnect/runtime \
-  && chmod -R a-w /opt/agentconnect/runtime
 # The shim forwards this browser path and provider configuration through its runtime environment allowlist.
 ENV HOME=/agent \
   AGENT_BROWSER_EXECUTABLE_PATH=/opt/agentconnect/browser/chrome \
@@ -216,18 +119,9 @@ RUN apt-get update \
   && meson compile -C /build \
   && DESTDIR=/out meson install -C /build
 
-# Self-hosted daemon VMs add the broader runtime catalog, native shields and Docker.
+# The full system base adds native sandbox tools and Docker.
 FROM runtime-base AS runtime-sandbox-full-base
 USER root
-ARG CLINE_VERSION=3.0.61
-ARG PI_ACP_VERSION=0.0.33
-ARG PI_VERSION=0.80.6
-ARG OPENCODE_VERSION=1.17.18
-ARG QWEN_CODE_VERSION=0.23.1
-ARG COPILOT_VERSION=1.0.83
-ARG GROK_VERSION=1.0.24
-ARG QODER_VERSION=1.1.14
-ARG QODER_CN_VERSION=1.1.2
 ARG DOCKER_VERSION=5:29.8.0-1~debian.12~bookworm
 ARG CONTAINERD_VERSION=2.3.5-1~debian.12~bookworm
 ARG DOCKER_BUILDX_VERSION=0.37.0-1~debian.12~bookworm
@@ -237,24 +131,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=bubblewrap-builder --chown=0:0 /out/usr/local/bin/bwrap /usr/local/bin/bwrap
 RUN bwrap --help | rg -- '--argv0'
-
-# pi-acp delegates to the separately installed pi CLI; all launches use local executables.
-RUN export HOME=/root \
-  && npm install --global --no-fund --no-audit \
-    "cline@${CLINE_VERSION}" \
-    "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_VERSION}" \
-    "opencode-ai@${OPENCODE_VERSION}" \
-    "@qwen-code/qwen-code@${QWEN_CODE_VERSION}" \
-    "@github/copilot@${COPILOT_VERSION}" \
-    "@xai-official/grok@${GROK_VERSION}" \
-    "@qoder-ai/qodercli@${QODER_VERSION}" "@qodercn-ai/qoderclicn@${QODER_CN_VERSION}" \
-  && npm cache clean --force
-COPY --from=full-native-runtimes --chown=0:0 /out/bin/ /usr/local/bin/
-# Antigravity resolves its local harness relative to the ACP executable.
-COPY --from=full-native-runtimes --chown=0:0 /out/antigravity/ /opt/agentconnect/runtimes/antigravity/
-RUN printf '%s\n' '#!/bin/sh' \
-  'exec /opt/agentconnect/runtimes/antigravity/agy_acp_server.par "$@"' > /usr/local/bin/antigravity-acp \
-  && chmod 0555 /usr/local/bin/antigravity-acp
 
 # Docker's signed Debian repository supplies exact versions; the image never starts dockerd automatically.
 RUN install -m 0755 -d /etc/apt/keyrings \
@@ -276,17 +152,6 @@ RUN usermod --append --groups docker agent \
   && chmod 0440 /etc/sudoers.d/agent-dockerd \
   && visudo --check --file /etc/sudoers.d/agent-dockerd
 
-# Rebuild the declared table from the full image's explicitly installed runtime catalog.
-COPY docker/runtime-sandbox/installed-runtimes-full.json /opt/agentconnect/runtime/installed-runtimes.json
-USER 10001:10001
-RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
-  && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
-    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/k8s-runtimes.json
-USER root
-RUN mv /tmp/ac-probe/k8s-runtimes.json /opt/agentconnect/runtime/k8s-runtimes.json \
-  && rm -rf /tmp/ac-probe \
-  && chown -R root:root /opt/agentconnect/runtime \
-  && chmod -R a-w /opt/agentconnect/runtime
 USER 10001:10001
 
 # Keep the pool dependency image as the default build target.

--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
-ARG RUNTIME_SANDBOX_BASE=ghcr.io/agentconnect-md/runtime-sandbox:base-20260910.1@sha256:3da638f4707c4cb28522b3c82e3b5448c40a24d3b9723690a5cc62538dfc2296
-ARG RUNTIME_SANDBOX_FULL_BASE=ghcr.io/agentconnect-md/runtime-sandbox-full:base-20260910.1@sha256:425a1558338bd2c68dc69da846ee88ca5e1bbf2d212a3bc1a65d75c4761e59c0
+ARG RUNTIME_SANDBOX_BASE=ghcr.io/agentconnect-md/runtime-sandbox:base-20260911-021456@sha256:bc7614a2d7de40b77e03ac8cfdd09b738efbf93391122cb54ca4d1233c68f5cb
+ARG RUNTIME_SANDBOX_FULL_BASE=ghcr.io/agentconnect-md/runtime-sandbox-full:base-20260911-021456@sha256:669063d1594c8610267bbcd5d9503ea5932e712774346a1b1920e6aeb18891ae
 
 ARG AGENT_BROWSER_VERSION=0.37.1
 ARG CLAUDE_ACP_VERSION=0.76.0

--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -3,7 +3,12 @@
 ARG RUNTIME_SANDBOX_BASE=ghcr.io/agentconnect-md/runtime-sandbox:base-20260910.1@sha256:3da638f4707c4cb28522b3c82e3b5448c40a24d3b9723690a5cc62538dfc2296
 ARG RUNTIME_SANDBOX_FULL_BASE=ghcr.io/agentconnect-md/runtime-sandbox-full:base-20260910.1@sha256:425a1558338bd2c68dc69da846ee88ca5e1bbf2d212a3bc1a65d75c4761e59c0
 
-# Release images add daemon-versioned helpers to manually published dependency bases.
+ARG AGENT_BROWSER_VERSION=0.37.1
+ARG CLAUDE_ACP_VERSION=0.76.0
+ARG CODEX_ACP_VERSION=1.11.0-agentconnect.1
+ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.30
+
+# Release builds install applications over stable system bases, then add daemon-versioned helpers.
 
 # ───────────────────────────── shim builder ─────────────────────────────────
 # The shim build inlines its dependencies so runtime images need no daemon node_modules.
@@ -53,19 +58,142 @@ RUN node /build/scripts/tree-digest.mjs /out > /payload-digest
 FROM scratch AS runtime-payload-digest-export
 COPY --from=runtime-payload-digest /payload-digest /
 
+# Antigravity is the first, independently cached application layer in the full image.
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS antigravity
+ARG ANTIGRAVITY_VERSION=1.1.1
+ARG ANTIGRAVITY_SHA256_AMD64=38f62d01b32deb0907b3d39a71ec301fd36369f6ffd1cf262d4af385177f79df
+ARG TARGETARCH
+RUN test "${TARGETARCH:-amd64}" = amd64 \
+  && apt-get update \
+  && apt-get install --no-install-recommends -y ca-certificates curl unzip \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /out/antigravity
+RUN curl --retry 5 -fsSL -o /tmp/antigravity.zip \
+  "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_${ANTIGRAVITY_VERSION}-linux-x86_64.zip" \
+  && printf '%s  /tmp/antigravity.zip\n' "$ANTIGRAVITY_SHA256_AMD64" | sha256sum -c - \
+  && unzip -q /tmp/antigravity.zip -d /out/antigravity \
+  && test -x /out/antigravity/agy_acp_server.par \
+  && test -x /out/antigravity/localharness_external \
+  && chmod -R a-w /out/antigravity \
+  && rm /tmp/antigravity.zip
+
+# Other native harness downloads are independent of Antigravity and agent-browser.
+FROM node:24.21.0-bookworm-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553 AS full-native-runtimes
+ARG OMP_VERSION=17.0.5
+ARG OMP_SHA256_AMD64=319d08ab8e5fb80c73f734907d5f47aa8bbd4ea31f7a19bacf8611c5aba26c31
+ARG DEVIN_VERSION=3000.6.14
+ARG DEVIN_SHA256_AMD64=28cf64c1df9f58ccd063fb7e6fd6e9391073c585b733449371485e1ef8a3e6db
+ARG TARGETARCH
+RUN test "${TARGETARCH:-amd64}" = amd64 \
+  && apt-get update \
+  && apt-get install --no-install-recommends -y ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /out/bin
+RUN curl --retry 5 -fsSL -o /tmp/omp \
+  "https://github.com/can1357/oh-my-pi/releases/download/v${OMP_VERSION}/omp-linux-x64" \
+  && printf '%s  /tmp/omp\n' "$OMP_SHA256_AMD64" | sha256sum -c - \
+  && install -m 0555 /tmp/omp /out/bin/omp \
+  && rm /tmp/omp
+RUN curl --retry 5 -fsSL -o /tmp/devin.tar.gz \
+  "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-x86_64-unknown-linux.tar.gz" \
+  && printf '%s  /tmp/devin.tar.gz\n' "$DEVIN_SHA256_AMD64" | sha256sum -c - \
+  && tar -xzf /tmp/devin.tar.gz -C /tmp bin/devin \
+  && install -m 0555 /tmp/bin/devin /out/bin/devin \
+  && rm -rf /tmp/devin.tar.gz /tmp/bin
+
+FROM ${RUNTIME_SANDBOX_FULL_BASE} AS runtime-sandbox-full-apps
+USER root
+# Antigravity resolves its local harness relative to the ACP executable.
+COPY --link --from=antigravity --chown=0:0 /out/antigravity/ /opt/agentconnect/runtimes/antigravity/
+RUN printf '%s\n' '#!/bin/sh' \
+  'exec /opt/agentconnect/runtimes/antigravity/agy_acp_server.par "$@"' > /usr/local/bin/antigravity-acp \
+  && chmod 0555 /usr/local/bin/antigravity-acp
+
+ARG AGENT_BROWSER_VERSION
+RUN --mount=type=bind,source=docker/runtime-sandbox/install-agent-browser.sh,target=/tmp/install-agent-browser.sh \
+  HOME=/root sh /tmp/install-agent-browser.sh
+
+ARG CLAUDE_ACP_VERSION
+ARG CODEX_ACP_VERSION
+ARG DEEPSEEK_HARNESS_ACP_VERSION
+RUN --mount=type=bind,source=docker/runtime-sandbox/install-core-harnesses.sh,target=/tmp/install-core-harnesses.sh \
+  --mount=type=bind,source=docker/runtime-sandbox/bake-dsh-preset.mjs,target=/tmp/bake-dsh-preset.mjs \
+  HOME=/root sh /tmp/install-core-harnesses.sh
+
+ARG CLINE_VERSION=3.0.61
+ARG PI_ACP_VERSION=0.0.33
+ARG PI_VERSION=0.80.6
+ARG OPENCODE_VERSION=1.17.18
+ARG QWEN_CODE_VERSION=0.23.1
+ARG COPILOT_VERSION=1.0.83
+ARG GROK_VERSION=1.0.24
+ARG QODER_VERSION=1.1.14
+ARG QODER_CN_VERSION=1.1.2
+# pi-acp delegates to the separately installed pi CLI; all launches use local executables.
+RUN export HOME=/root \
+  && npm install --global --no-fund --no-audit \
+    "cline@${CLINE_VERSION}" \
+    "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    "opencode-ai@${OPENCODE_VERSION}" \
+    "@qwen-code/qwen-code@${QWEN_CODE_VERSION}" \
+    "@github/copilot@${COPILOT_VERSION}" \
+    "@xai-official/grok@${GROK_VERSION}" \
+    "@qoder-ai/qodercli@${QODER_VERSION}" "@qodercn-ai/qoderclicn@${QODER_CN_VERSION}" \
+  && npm cache clean --force
+COPY --from=full-native-runtimes --chown=0:0 /out/bin/ /usr/local/bin/
+# Bake the runtime table after all applications are installed, using a disposable non-root HOME.
+COPY docker/runtime-sandbox/generate-runtime-table.mjs /opt/agentconnect/bin/generate-runtime-table.mjs
+COPY docker/runtime-sandbox/installed-runtimes-full.json /opt/agentconnect/runtime/installed-runtimes.json
+USER 10001:10001
+RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
+  && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
+    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/k8s-runtimes.json
+USER root
+RUN mv /tmp/ac-probe/k8s-runtimes.json /opt/agentconnect/runtime/k8s-runtimes.json \
+  && rm -rf /tmp/ac-probe \
+  && chown -R root:root /opt/agentconnect/runtime \
+  && chmod -R a-w /opt/agentconnect/runtime
+USER 10001:10001
+
+FROM ${RUNTIME_SANDBOX_BASE} AS runtime-sandbox-apps
+USER root
+ARG AGENT_BROWSER_VERSION
+RUN --mount=type=bind,source=docker/runtime-sandbox/install-agent-browser.sh,target=/tmp/install-agent-browser.sh \
+  HOME=/root sh /tmp/install-agent-browser.sh
+
+ARG CLAUDE_ACP_VERSION
+ARG CODEX_ACP_VERSION
+ARG DEEPSEEK_HARNESS_ACP_VERSION
+RUN --mount=type=bind,source=docker/runtime-sandbox/install-core-harnesses.sh,target=/tmp/install-core-harnesses.sh \
+  --mount=type=bind,source=docker/runtime-sandbox/bake-dsh-preset.mjs,target=/tmp/bake-dsh-preset.mjs \
+  HOME=/root sh /tmp/install-core-harnesses.sh
+
+# Bake the runtime table after all applications are installed, using a disposable non-root HOME.
+COPY docker/runtime-sandbox/generate-runtime-table.mjs /opt/agentconnect/bin/generate-runtime-table.mjs
+COPY docker/runtime-sandbox/installed-runtimes.json /opt/agentconnect/runtime/installed-runtimes.json
+USER 10001:10001
+RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
+  && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
+    node /opt/agentconnect/bin/generate-runtime-table.mjs /tmp/ac-probe/k8s-runtimes.json
+USER root
+RUN mv /tmp/ac-probe/k8s-runtimes.json /opt/agentconnect/runtime/k8s-runtimes.json \
+  && rm -rf /tmp/ac-probe \
+  && chown -R root:root /opt/agentconnect/runtime \
+  && chmod -R a-w /opt/agentconnect/runtime
+USER 10001:10001
+
 # ────────────────────────── runtime table check ─────────────────────────────
-# Re-probes every installed runtime and compares with the table the base ships. Its inputs are the base pin, the
-# declared roster and the two scripts — never the shim — so a cached build re-runs it only when one of those moves.
-FROM ${RUNTIME_SANDBOX_FULL_BASE} AS runtime-sandbox-full-table-check
+# Re-probe the application table independently of the shim so shim-only changes reuse this check.
+FROM runtime-sandbox-full-apps AS runtime-sandbox-full-table-check
 COPY scripts/runtime-table-diff.mjs scripts/verify-runtime-table.mjs /tmp/ac-check/
 COPY docker/runtime-sandbox/installed-runtimes-full.json /tmp/ac-check/installed-runtimes.json
-# As the runtime user in a disposable HOME and cwd, the way the base built the table it ships.
+# Use the same disposable non-root environment that generated the application table.
 RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
   && HOME=/tmp/ac-probe/home AC_PROBE_CWD=/tmp/ac-probe/cwd \
     node /tmp/ac-check/verify-runtime-table.mjs runtime-sandbox-full /tmp/ac-check/installed-runtimes.json \
   && touch /tmp/ac-table-check.ok
 
-FROM ${RUNTIME_SANDBOX_BASE} AS runtime-sandbox-table-check
+FROM runtime-sandbox-apps AS runtime-sandbox-table-check
 COPY scripts/runtime-table-diff.mjs scripts/verify-runtime-table.mjs /tmp/ac-check/
 COPY docker/runtime-sandbox/installed-runtimes.json /tmp/ac-check/installed-runtimes.json
 RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
@@ -74,11 +202,11 @@ RUN mkdir -p /tmp/ac-probe/home /tmp/ac-probe/cwd \
   && touch /tmp/ac-table-check.ok
 
 # ───────────────────────────── release images ───────────────────────────────
-# The bases carry the installed catalog, runtime table, system tools and non-root entrypoint.
-FROM ${RUNTIME_SANDBOX_FULL_BASE} AS runtime-sandbox-full
+# Add the independently compiled shim after all application layers.
+FROM runtime-sandbox-full-apps AS runtime-sandbox-full
 COPY --link --from=runtime-helpers --chown=0:0 /out/ /opt/agentconnect/
 
-FROM ${RUNTIME_SANDBOX_BASE} AS runtime-sandbox
+FROM runtime-sandbox-apps AS runtime-sandbox
 COPY --link --from=runtime-helpers --chown=0:0 /out/ /opt/agentconnect/
 
 # ───────────────────────────── shim smoke test ──────────────────────────────
@@ -113,10 +241,7 @@ RUN --mount=type=bind,from=shim-builder,source=/build,target=/build \
   status=$?; kill "$shim" 2>/dev/null; wait "$shim" 2>/dev/null; [ "$status" -eq 0 ] && touch /tmp/ac-smoke.ok
 
 # ─────────────────────────── in-image verification ──────────────────────────
-# Static assertions against the built image as its own user; the marker COPYs make one target cover the table check,
-# the smoke test and these. Built with `--output type=cacheonly`: nothing here is published. The image's USER and ENV
-# reach this stage as its own uid and environment; the ENTRYPOINT does not, so scripts/verify-runtime-image.mjs reads
-# the pinned base's config on the host and asserts the release stage above writes no config of its own.
+# Verify the table, real shim session and filesystem as the final user; the host check resolves inherited image config.
 FROM runtime-sandbox-full AS runtime-sandbox-full-verify
 COPY --from=runtime-sandbox-full-table-check /tmp/ac-table-check.ok /tmp/ac-check/table.ok
 COPY --from=runtime-sandbox-full-smoke /tmp/ac-smoke.ok /tmp/ac-check/smoke.ok

--- a/docker/runtime-sandbox/install-agent-browser.sh
+++ b/docker/runtime-sandbox/install-agent-browser.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Install the CLI against the Chrome already supplied by the system base.
+set -eu
+
+npm install --global --no-fund --no-audit "agent-browser@${AGENT_BROWSER_VERSION}"
+keep="$(readlink -f /usr/local/bin/agent-browser)"
+case "$keep" in
+  */agent-browser-*) ;;
+  *)
+    echo "agent-browser bin link resolved to $keep" >&2
+    exit 1
+    ;;
+esac
+find /usr/local/lib/node_modules/agent-browser/bin -type f -name 'agent-browser-*' ! -path "$keep" -delete
+npm cache clean --force
+agent-browser --version
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  '# agentconnect: this sandbox bakes Chrome, so a bare `install` has nothing to fetch. See runtime-sandbox.Dockerfile.' \
+  '# Defaulted here too, not only in ENV: an ACP child is spawned from an allowlist, so the image env may not reach it.' \
+  ': "${AGENT_BROWSER_EXECUTABLE_PATH:=/opt/agentconnect/browser/chrome}"' \
+  'export AGENT_BROWSER_EXECUTABLE_PATH' \
+  'if [ "$1" = install ]; then' \
+  '  shift' \
+  '  case "$*" in' \
+  '  ""|-d|--with-deps)' \
+  '    echo "agent-browser install: Chrome is already installed in this sandbox at $AGENT_BROWSER_EXECUTABLE_PATH"' \
+  '    exit 0' \
+  '    ;;' \
+  '  esac' \
+  '  exec /usr/local/bin/agent-browser install "$@"' \
+  'fi' \
+  'exec /usr/local/bin/agent-browser "$@"' \
+  > /opt/agentconnect/pathbin/agent-browser
+chown root:root /opt/agentconnect/pathbin/agent-browser
+chmod 0555 /opt/agentconnect/pathbin/agent-browser

--- a/docker/runtime-sandbox/install-core-harnesses.sh
+++ b/docker/runtime-sandbox/install-core-harnesses.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Install the shared ACP runtimes and derive the preset from the pinned DeepSeek package.
+set -eu
+
+npm install --global --no-fund --no-audit \
+  "@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_VERSION}" \
+  "@agentconnect.md/codex-acp@${CODEX_ACP_VERSION}" \
+  "@openma/deepseek-harness-acp@${DEEPSEEK_HARNESS_ACP_VERSION}"
+npm cache clean --force
+node /tmp/bake-dsh-preset.mjs /opt/agentconnect/dsh/agent-presets/standard-no-search
+chown -R root:root /opt/agentconnect/dsh
+chmod -R a-w /opt/agentconnect/dsh

--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -475,19 +475,29 @@ boot and stop/start, reusing the prepared image cache.
 
 ### Release image selection and Docker
 
-Runtime dependencies live in manually published `base-<version>` tags of the two
-runtime image packages, built from `docker/runtime-sandbox-base.Dockerfile`.
-The release Dockerfile pins their digests and adds only the daemon-versioned helper
-payload. Release builds never rebuild the dependency images, even with an empty
-build cache. Updating Node, the toolchain, Chrome, Docker, or an installed runtime
-requires a manual base build and an explicit digest update.
+Stable system dependencies live in manually published `base-<version>` tags of
+the two runtime image packages, built from `docker/runtime-sandbox-base.Dockerfile`.
+Both bases provide Node, Git, the build toolchain and Chrome with its system
+libraries. Only the full base adds Docker, bubblewrap and socat. Neither base
+installs agent-browser or an ACP harness. Updating system dependencies requires a
+base build and an explicit digest update; release builds reuse these pinned bases
+even with an empty build cache.
+
+`docker/runtime-sandbox.Dockerfile` owns the application versions and installation.
+The full image first adds Antigravity in an independent, fixed-version layer,
+then agent-browser, then the other harnesses. The pool image starts with
+agent-browser and then installs its harnesses. Routine application upgrades change
+these exact version pins and use the normal release image build, without publishing
+another base. Standalone downloads also pin SHA-256. The shim remains an independent
+compilation stage whose small helper payload is copied last into both final images;
+it does not need a separately published image.
 
 The release build bundles `dist/release.json` with a `runtimeSandboxImage` OCI
 reference. It names the current release's `runtime-sandbox-full:v<version>` alias.
 The image workflow creates this alias even when it reuses an older component
 image. The pool continues to use the separate `runtime-sandbox` image. Both targets
-share the same helper payload over their respective dependency bases. Additional
-self-hosted runtimes belong in the full base. The pool provides Claude Code,
+share the same helper payload over their respective application layers. Additional
+self-hosted runtimes belong in the full application stage. The pool provides Claude Code,
 Codex, and DeepSeek Harness. The full image additionally installs Antigravity,
 Cline, Devin, GitHub Copilot, Grok Build, Oh My Pi, OpenCode, pi, Qwen Code,
 Qoder CLI, and Qoder CN CLI. The `qoder` compatibility ID resolves to `qoder-cli`
@@ -497,8 +507,8 @@ one entry while existing agent configurations retain either ID. Explicit runtime
 overrides remain independent. pi includes both its ACP adapter and the underlying
 CLI. Packages are version-pinned; standalone downloads also pin their SHA-256.
 
-Each dependency base bakes an explicit runtime roster and generates its own runtime table
-by probing the installed executables as the ordinary runtime user, without
+Each application stage bakes an explicit runtime roster and generates its own runtime table
+after installation by probing the executables as the ordinary runtime user, without
 provider credentials. Missing executables fail the build instead of silently
 reducing the roster. Installed runtimes remain discoverable without a saved login;
 saved logins also keep runtimes visible when their executable is missing.
@@ -512,15 +522,21 @@ The release images are currently Linux amd64; an arm64 daemon must configure
 a compatible image explicitly. The full image's Antigravity binary requires
 AVX in the guest CPU; amd64 emulation without AVX cannot run that runtime.
 
-To update dependencies, edit the pins in `docker/runtime-sandbox-base.Dockerfile`
-and build both targets on an amd64 host with AVX, using a new tag for each manual
-publication. Push the candidate bases before checking them: nothing references a new
-tag until the release Dockerfile pins it, and the checks read the pushed base the way
-release CI does. Run these commands from the repository root:
+To update system dependencies, edit `docker/runtime-sandbox-base.Dockerfile` and run
+the **Build runtime bases** workflow manually in GitHub Actions. Its default tag is
+`base-YYYYMMDD-HHMMSS` in UTC; an optional explicit tag must also include the date.
+The workflow refuses to overwrite an existing tag, publishes both bases and verifies
+each with the application layers, runtime table and real shim session. Successful jobs
+report digest-pinned references in the run summary and upload them as artifacts.
+Update the two base ARGs in the release Dockerfile to those verified references.
+
+For a local build, use a new tag and an amd64 host with AVX for full application
+verification. Push candidates before checking them: nothing references a new tag
+until the release Dockerfile pins it. Run these commands from the repository root:
 
 ```bash
 set -eu
-BASE_VERSION=20260910.1
+BASE_VERSION=20260911.2
 for variant in runtime-sandbox runtime-sandbox-full; do
   docker buildx build --builder "$(docker context show)" --platform linux/amd64 \
     -f docker/runtime-sandbox-base.Dockerfile --target "$variant-base" \
@@ -544,9 +560,11 @@ The `-verify` target runs the runtime-table probe, the static in-image checks an
 shim smoke test — the image's own entrypoint started as the pod starts it, the daemon
 side dialling it over loopback, the real ACP runtime answering `initialize` and
 `session/new` — as build stages, so the host needs no toolchain. The host script
-checks what only the image configuration says (the non-root user, the tini entrypoint
-and the browser path) against the base the build was given, after asserting that the
-release stage writes no configuration of its own. To try a built image by hand, build
+checks the tini entrypoint and browser path inherited from the pinned system base,
+follows application-stage inheritance and checks the final non-root user. Other
+configuration overrides are rejected. The release fingerprint includes application
+assets and installation scripts as well as Dockerfile pins and shim content.
+To try a built image by hand, build
 the `$variant` target with `--load -t "$variant:local"` and, after `pnpm install` and
 `pnpm --filter '@agentconnect.md/daemon^...' build`, run
 `pnpm --filter @agentconnect.md/daemon exec tsx scripts/smoke-runtime-image.mts "$variant:local"`,

--- a/scripts/runtime-image-fingerprint.sh
+++ b/scripts/runtime-image-fingerprint.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-# Fingerprint of a runtime image's inputs for build.yaml: the shim payload digest its build exported (tree-digest.mjs
-# over the helper stage's /out) plus a recipe digest over the Dockerfile and the build inputs the leg passes it. The
-# recipe covers what the payload cannot — the bases' digest pins and the final stages' instructions — so any Dockerfile
-# edit rebuilds, which is the safe side.
+# Fingerprint the shim payload separately from the Dockerfile, application assets and explicit build inputs.
 #
 # Usage: runtime-image-fingerprint.sh <payload digest file> <dockerfile> <target> <platforms> <build args> <build contexts>
 # Stdout (GITHUB_OUTPUT-ready): shim=<digest>, recipe=<digest>, and a multi-line `labels` carrying both as OCI labels.
@@ -24,8 +21,10 @@ if ! [[ "$shim" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   echo "::error::${DIGEST_FILE} holds no payload digest: '${shim}'" >&2
   exit 1
 fi
+assets="$(node "$(dirname "$0")/tree-digest.mjs" "$(dirname "$DOCKERFILE")/runtime-sandbox")"
 recipe="sha256:$({
   cat "$DOCKERFILE"
+  printf '\n%s\n' "$assets"
   printf '\n%s\n%s\n%s\n%s\n' "$TARGET" "$PLATFORMS" "$BUILD_ARGS" "$BUILD_CONTEXTS"
 } | sha256)"
 

--- a/scripts/runtime-image-fingerprint.test.mjs
+++ b/scripts/runtime-image-fingerprint.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -14,6 +14,9 @@ const DOCKERFILE =
 function harness(t) {
   const root = mkdtempSync(join(tmpdir(), 'ac-runtime-fingerprint-'))
   t.after(() => rmSync(root, { recursive: true, force: true }))
+  const assets = join(root, 'runtime-sandbox')
+  mkdirSync(assets)
+  writeFileSync(join(assets, 'install.sh'), 'npm install --global example-runtime@1.0.0\n')
   const fingerprint = ({
     digest = `${DIGEST}\n`,
     dockerfile = DOCKERFILE,
@@ -38,7 +41,7 @@ function harness(t) {
     const start = lines.indexOf('labels<<EOF')
     return { shim: value('shim'), recipe: value('recipe'), labels: lines.slice(start + 1, lines.indexOf('EOF', start)) }
   }
-  return { fingerprint, outputs }
+  return { fingerprint, outputs, assets }
 }
 
 test('the payload digest is read as is and both digests become labels', { skip: process.platform === 'win32' }, (t) => {
@@ -56,7 +59,7 @@ test(
   'the recipe follows the Dockerfile and the build inputs, never the payload',
   { skip: process.platform === 'win32' },
   (t) => {
-    const { fingerprint, outputs } = harness(t)
+    const { fingerprint, outputs, assets } = harness(t)
     const base = outputs(fingerprint())
     assert.equal(outputs(fingerprint()).recipe, base.recipe)
     assert.equal(outputs(fingerprint({ digest: `sha256:${'c'.repeat(64)}\n` })).recipe, base.recipe)
@@ -66,6 +69,8 @@ test(
     assert.notEqual(outputs(fingerprint({ args: 'RUNTIME_SANDBOX_BASE=other' })).recipe, base.recipe)
     assert.notEqual(outputs(fingerprint({ contexts: 'base=docker-image://other' })).recipe, base.recipe)
     assert.notEqual(outputs(fingerprint({ target: 'runtime-sandbox-full' })).recipe, base.recipe)
+    writeFileSync(join(assets, 'install.sh'), 'npm install --global example-runtime@1.0.1\n')
+    assert.notEqual(outputs(fingerprint()).recipe, base.recipe)
   }
 )
 

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
-// Asserts what the runtime-sandbox image's CONFIG says — a non-root USER, tini as the ENTRYPOINT and the browser path
-// ENV — without loading the image. The release stage adds one COPY on top of a digest-pinned base, so the base's config
-// IS the image's; this reads the base's config from the registry and, first, checks that the stage writes no config of
-// its own. Everything the image's filesystem can answer runs inside the build (docker/runtime-sandbox/verify-image.mjs).
+// Resolve inherited image configuration and the final USER without loading the runtime image.
 //
 //   node scripts/verify-runtime-image.mjs <runtime-sandbox|runtime-sandbox-full> [--build-arg KEY=VALUE]... \
 //     [--dockerfile <path>] [--platform <os/arch>]
@@ -19,7 +16,7 @@ export const DEFAULT_PLATFORM = 'linux/amd64'
 // Must match SANDBOX_BROWSER_EXECUTABLE_ENV in packages/daemon/src/shim/sandbox-paths.ts.
 export const BROWSER_ENV = 'AGENT_BROWSER_EXECUTABLE_PATH'
 
-// Every instruction that writes the image config a pod inherits; one of these in the release stage voids the reasoning.
+// USER may change during installation; other image configuration must remain inherited from the system base.
 export const CONFIG_INSTRUCTIONS = new Set([
   'USER',
   'ENTRYPOINT',
@@ -74,16 +71,20 @@ export function stagesOf(instructions) {
   return { globalArgs, stages }
 }
 
-/** The base ref the variant's release stage builds on, once that stage is shown to leave the base's config alone. */
+// Follow application stages back to the pinned system base and resolve their final USER.
 export function releaseBase(dockerfile, variant, buildArgs = {}) {
   const { globalArgs, stages } = stagesOf(parseDockerfile(dockerfile))
   const stage = stages.find((candidate) => candidate.name === variant)
   if (!stage) throw new Error(`the Dockerfile has no stage named ${variant}`)
-  const reference = /^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/.exec(stage.from)
+  const chain = []
+  for (let current = stage; current; current = stages.find((candidate) => candidate.name === current.from)) {
+    if (chain.includes(current)) throw new Error(`cyclic stage inheritance in ${variant}`)
+    chain.unshift(current)
+  }
+  const root = chain[0]
+  const reference = /^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/.exec(root.from)
   if (!reference) {
-    throw new Error(
-      `${variant} builds FROM ${stage.from} rather than directly from a build-arg base, so the base config need not be the image config`
-    )
+    throw new Error(`${variant} has no build-arg system base: ${root.from}`)
   }
   const arg = reference[1]
   const override = buildArgs[arg]
@@ -94,12 +95,19 @@ export function releaseBase(dockerfile, variant, buildArgs = {}) {
       `${arg} defaults to ${base}, which is not digest-pinned, so the base inspected need not be the base built`
     )
   }
-  const writes = stage.instructions.filter((entry) => CONFIG_INSTRUCTIONS.has(entry.instruction))
+  const instructions = chain.flatMap((ancestor) => ancestor.instructions)
+  const writes = instructions.filter(
+    (entry) => entry.instruction !== 'USER' && CONFIG_INSTRUCTIONS.has(entry.instruction)
+  )
   if (writes.length > 0) {
     const names = [...new Set(writes.map((entry) => entry.instruction))].join(', ')
     throw new Error(`${variant} writes image config of its own (${names}), so the base config is not the image config`)
   }
-  return { arg, base, stage }
+  const user = instructions.findLast((entry) => entry.instruction === 'USER')?.argument
+  if (user !== undefined && !/^[a-z0-9_-]+(?::[a-z0-9_-]+)?$/i.test(user)) {
+    throw new Error(`${variant} has an unresolved USER: ${user}`)
+  }
+  return { arg, base, stage, user }
 }
 
 /** `.Image` as imagetools prints it: one image, or one per platform when the base is a multi-platform index. */
@@ -172,13 +180,11 @@ export function main(argv, { stdout = process.stdout, stderr = process.stderr, i
   const { variant, buildArgs, dockerfile, platform } = options
   const notes = []
   try {
-    const { arg, base, stage } = releaseBase(readFileSync(dockerfile, 'utf8'), variant, buildArgs)
-    const instructions = stage.instructions.map((entry) => entry.instruction).join(', ') || 'nothing'
-    notes.push(
-      `the ${variant} stage builds directly on \${${arg}} and runs only ${instructions}, so the base config is the image config`
-    )
+    const { arg, base, user } = releaseBase(readFileSync(dockerfile, 'utf8'), variant, buildArgs)
+    notes.push(`the ${variant} stages inherit image config from \${${arg}}${user ? ` with final USER ${user}` : ''}`)
     notes.push(`base ${base}`)
-    notes.push(...checkImageConfig(selectImage(inspect(base), platform).config))
+    const config = selectImage(inspect(base), platform).config
+    notes.push(...checkImageConfig(user === undefined ? config : { ...config, User: user }))
   } catch (err) {
     stdout.write(`${variant} image configuration (${dockerfile})\n${notes.map((note) => `  ✓ ${note}`).join('\n')}\n`)
     stderr.write(`  ✗ ${err.message}\n`)

--- a/scripts/verify-runtime-image.test.mjs
+++ b/scripts/verify-runtime-image.test.mjs
@@ -29,16 +29,26 @@ RUN corepack enable
 FROM shim-builder AS runtime-helpers
 RUN mkdir -p /out/shim
 
-FROM \${RUNTIME_SANDBOX_FULL_BASE} AS runtime-sandbox-full-table-check
+FROM \${RUNTIME_SANDBOX_FULL_BASE} AS runtime-sandbox-full-apps
+USER root
+RUN npm install --global example-runtime@1.0.0
+USER 10001:10001
+
+FROM \${RUNTIME_SANDBOX_BASE} AS runtime-sandbox-apps
+USER root
+RUN npm install --global example-runtime@1.0.0
+USER 10001:10001
+
+FROM runtime-sandbox-full-apps AS runtime-sandbox-full-table-check
 RUN node /tmp/check.mjs
 
 # The release images.
-FROM \${RUNTIME_SANDBOX_FULL_BASE} AS runtime-sandbox-full
+FROM runtime-sandbox-full-apps AS runtime-sandbox-full
 COPY --link --from=runtime-helpers --chown=0:0 \\
   # a comment inside the continuation
   /out/ /opt/agentconnect/
 ${releaseExtra}
-FROM \${RUNTIME_SANDBOX_BASE} AS runtime-sandbox
+FROM runtime-sandbox-apps AS runtime-sandbox
 COPY --link --from=runtime-helpers --chown=0:0 /out/ /opt/agentconnect/
 
 FROM runtime-sandbox AS runtime-sandbox-verify
@@ -97,7 +107,7 @@ test('continuation lines are joined, comments and blank lines dropped, instructi
   const env = parsed.find((entry) => entry.instruction === 'ENV')
   assert.equal(env.argument, 'PNPM_HOME=/pnpm PATH=/pnpm:$PATH')
   assert.equal(parsed.filter((entry) => entry.instruction.startsWith('#')).length, 0)
-  assert.equal(parsed.filter((entry) => entry.instruction === 'FROM').length, 7)
+  assert.equal(parsed.filter((entry) => entry.instruction === 'FROM').length, 9)
 })
 
 test('stages carry their name, FROM reference and instructions; global ARG defaults are collected', () => {
@@ -110,7 +120,7 @@ test('stages carry their name, FROM reference and instructions; global ARG defau
     ]
   )
   const release = stages.find((stage) => stage.name === 'runtime-sandbox')
-  assert.equal(release.from, '${RUNTIME_SANDBOX_BASE}')
+  assert.equal(release.from, 'runtime-sandbox-apps')
   assert.deepEqual(
     release.instructions.map((entry) => entry.instruction),
     ['COPY']
@@ -136,10 +146,10 @@ test('a --build-arg override replaces the default and may name a tag, while the 
   )
 })
 
-test('a release stage that writes image config, or builds on another stage, is refused', () => {
+test('stage inheritance permits USER changes but rejects other config writes throughout the chain', () => {
   assert.throws(
     () => releaseBase(fixture({ releaseExtra: 'ENV HOME=/elsewhere\nUSER root\n' }), 'runtime-sandbox-full'),
-    /runtime-sandbox-full writes image config of its own \(ENV, USER\)/
+    /runtime-sandbox-full writes image config of its own \(ENV\)/
   )
   assert.throws(
     () => releaseBase(fixture({ releaseExtra: 'WORKDIR /tmp\n' }), 'runtime-sandbox-full'),
@@ -149,9 +159,14 @@ test('a release stage that writes image config, or builds on another stage, is r
   assert.doesNotThrow(() =>
     releaseBase(fixture({ releaseExtra: 'RUN chmod 0555 /opt/agentconnect\nLABEL a=b\n' }), 'runtime-sandbox-full')
   )
+  assert.equal(releaseBase(fixture(), 'runtime-sandbox-verify').user, 'root')
   assert.throws(
-    () => releaseBase(fixture(), 'runtime-sandbox-verify'),
-    /builds FROM runtime-sandbox rather than directly/
+    () => releaseBase(fixture().replace('USER root', 'ENV HOME=/elsewhere'), 'runtime-sandbox-full'),
+    /\(ENV\)/
+  )
+  assert.throws(
+    () => releaseBase(fixture({ releaseExtra: 'USER $RUNTIME_USER\n' }), 'runtime-sandbox-full'),
+    /unresolved USER/
   )
   assert.throws(() => releaseBase(fixture(), 'runtime-sandbox-smoke'), /no stage named runtime-sandbox-smoke/)
 })
@@ -159,8 +174,9 @@ test('a release stage that writes image config, or builds on another stage, is r
 test('the repository Dockerfile passes the stage assertions for both variants', () => {
   const text = readFileSync(realDockerfile, 'utf8')
   for (const variant of ['runtime-sandbox', 'runtime-sandbox-full']) {
-    const { base, stage } = releaseBase(text, variant)
+    const { base, stage, user } = releaseBase(text, variant)
     assert.match(base, /^ghcr\.io\/[^@]+@sha256:[0-9a-f]{64}$/)
+    assert.equal(user, '10001:10001')
     assert.deepEqual(
       stage.instructions.map((entry) => entry.instruction),
       ['COPY']
@@ -202,7 +218,7 @@ test('main inspects exactly the pinned base of the variant and reports every che
   assert.deepEqual(good.calls, [FULL_BASE])
   assert.match(
     good.stdout,
-    /runtime-sandbox-full stage builds directly on \$\{RUNTIME_SANDBOX_FULL_BASE\} and runs only COPY/
+    /runtime-sandbox-full stages inherit image config from \$\{RUNTIME_SANDBOX_FULL_BASE\} with final USER 10001:10001/
   )
   assert.match(good.stdout, /✓ base registry.example.test\/full:base-1@sha256:b+\n/)
   assert.match(good.stdout, /✓ a non-root USER is configured/)
@@ -214,12 +230,12 @@ test('main inspects exactly the pinned base of the variant and reports every che
 test('main honours --build-arg and --platform, and fails on a bad config without hiding what passed', (t) => {
   const { path } = withDockerfile(t, fixture())
   const tag = 'registry.example.test/pool:base-candidate'
-  const multi = { 'linux/amd64': inspected({ ...goodConfig(), User: 'root' }), 'linux/arm64': inspected() }
+  const multi = { 'linux/amd64': inspected({ ...goodConfig(), Entrypoint: ['node'] }), 'linux/arm64': inspected() }
   const bad = run(['runtime-sandbox', '--dockerfile', path, '--build-arg', `RUNTIME_SANDBOX_BASE=${tag}`], () => multi)
   assert.equal(bad.code, 1)
   assert.deepEqual(bad.calls, [tag])
-  assert.match(bad.stdout, /✓ the runtime-sandbox stage builds directly on/)
-  assert.match(bad.stderr, /✗ USER is root/)
+  assert.match(bad.stdout, /✓ the runtime-sandbox stages inherit image config/)
+  assert.match(bad.stderr, /✗ entrypoint is not tini/)
   const arm = run(
     [
       'runtime-sandbox',
@@ -233,6 +249,10 @@ test('main honours --build-arg and --platform, and fails on a bad config without
     () => multi
   )
   assert.equal(arm.code, 0, arm.stderr)
+  const rootStage = withDockerfile(t, fixture({ releaseExtra: 'USER root\n' }))
+  const root = run(['runtime-sandbox-full', '--dockerfile', rootStage.path], () => inspected())
+  assert.equal(root.code, 1)
+  assert.match(root.stderr, /✗ USER is root/)
 })
 
 test('main refuses a Dockerfile whose release stage writes config before touching the registry', (t) => {


### PR DESCRIPTION
Updating a harness currently requires manually rebuilding the sandbox dependency bases. Move application installation into the release build while retaining two stable system bases: the pool base excludes Docker and native sandbox tools, and the full base includes them.

The full application layers install Antigravity first, then agent-browser, then the other harnesses. Both variants add the independently compiled shim last. Runtime tables are generated after application installation, configuration checks follow the application stages, and image fingerprints include installation scripts and runtime assets.

Add a manually triggered **Build runtime bases** workflow with UTC date-based tags, overwrite protection, verification of both complete runtime images, and digest-pin artifacts. Release builds use the newly verified system-base digests.

Validation: 38 focused script tests, formatting and lint passed. Both bases were published as `base-20260911-021456` and passed native amd64 application installation, runtime-table probes, image assertions and real shim/ACP session smoke checks in [the successful build run](https://github.com/agentconnect-md/agentconnect/actions/runs/34553869261). The committed base digests match that run's verified-pin artifacts.

Created by Codex . GPT-6
