### PR TITLE
feat(web): an options card refuses from its head instead of beside its answers

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.elicit-transcript.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicit-transcript.test.tsx
@@ -184,6 +184,9 @@ async function render() {
 const text = () => container?.textContent ?? ''
 const buttonNamed = (label: string) =>
   [...(container?.querySelectorAll('button') ?? [])].find((b) => b.textContent === label)
+// An options card refuses from its head, where the control is an icon named by its label alone.
+const declineButton = () =>
+  container?.querySelector('button[aria-label="Decline without answering"]') as HTMLButtonElement | null
 
 beforeEach(() => {
   wire.messages = []
@@ -224,7 +227,7 @@ describe('a recorded elicitation card on the session page', () => {
     expect(text()).toContain('release/1.2')
     // A settled card collapses to its outcome, so there is nothing here to tap.
     expect(buttonNamed('main')).toBeUndefined()
-    expect(buttonNamed('Dismiss')).toBeUndefined()
+    expect(declineButton()).toBeNull()
     // And the conversation around it is still the conversation.
     expect(text()).toContain('cut a release')
     expect(text()).toContain('cut from develop')
@@ -237,7 +240,8 @@ describe('a recorded elicitation card on the session page', () => {
     expect(text()).toContain('Which branch should I cut from?')
     // The options are still visible — what was OFFERED is part of the record — but this reader
     // has no socket to answer over, so the card is read-only rather than missing its controls.
-    for (const label of ['main', 'develop', 'Dismiss']) expect(buttonNamed(label)?.disabled).toBe(true)
+    for (const label of ['main', 'develop']) expect(buttonNamed(label)?.disabled).toBe(true)
+    expect(declineButton()?.disabled).toBe(true)
   })
 
   it('keeps the card where it was asked, not above the turn that asked it', async () => {

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -184,6 +184,9 @@ const text = () => container?.textContent ?? ''
 const buttonsNamed = (label: string) =>
   [...(container?.querySelectorAll('button') ?? [])].filter((b) => b.textContent === label)
 const buttonNamed = (label: string) => buttonsNamed(label)[0]
+// An options card refuses from its head, where the control is an icon named by its label alone.
+const declineButtons = () => [...(container?.querySelectorAll('button[aria-label="Decline without answering"]') ?? [])]
+const declineButton = () => declineButtons()[0] as HTMLButtonElement | undefined
 
 beforeEach(() => {
   wire.messages = []
@@ -216,7 +219,8 @@ describe('the agent’s elicitation card on the session page', () => {
     await render()
 
     expect(text()).toContain('Which branch should I cut from?')
-    for (const label of ['main', 'develop', 'Dismiss']) expect(buttonNamed(label)?.disabled).toBe(false)
+    for (const label of ['main', 'develop']) expect(buttonNamed(label)?.disabled).toBe(false)
+    expect(declineButton()?.disabled).toBe(false)
 
     await act(async () => {
       buttonNamed('develop')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -225,9 +229,9 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', 'develop', 'conv-1']])
 
     await act(async () => {
-      buttonNamed('Dismiss')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      declineButton()?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    // Dismiss is an explicit null, never an absent value.
+    // The head's decline is an explicit null, never an absent value.
     expect(live.answered[1]).toEqual(['session-1', 'agent-1', 'elicit-1', null, 'conv-1'])
   })
 
@@ -858,7 +862,7 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(text()).toContain('Which branch should I cut from?')
     expect(text()).toContain('develop')
     expect(buttonNamed('main')).toBeUndefined()
-    expect(buttonNamed('Dismiss')).toBeUndefined()
+    expect(declineButton()).toBeUndefined()
     expect(live.answered).toEqual([])
   })
 
@@ -1041,7 +1045,7 @@ describe('a reload with a webchat card still pending', () => {
     await render()
 
     expect(buttonsNamed('main')).toHaveLength(1)
-    expect(buttonsNamed('Dismiss')).toHaveLength(1)
+    expect(declineButtons()).toHaveLength(1)
     expect(buttonNamed('main')?.disabled).toBe(false)
 
     await act(async () => {
@@ -1060,7 +1064,7 @@ describe('a reload with a webchat card still pending', () => {
 
     expect(text()).toContain('Which branch should I cut from?')
     expect(buttonsNamed('main')).toHaveLength(0)
-    expect(buttonsNamed('Dismiss')).toHaveLength(0)
+    expect(declineButtons()).toHaveLength(0)
     expect(live.answered).toEqual([])
   })
 })

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1114,6 +1114,8 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   // the preamble it is, above the questions rather than as a paragraph-long title.
   const headLine = step.text.split('\n', 1)[0] ?? step.text
   const preamble = step.text.slice(headLine.length).trim()
+  // A body that is nothing but answers reads a Dismiss beside them as one more answer, so an options card refuses from its head; other shapes have an action row where a refusal beside Submit reads right.
+  const cornerDismiss = !settled && !fields && !typed && !consentUrl
   const counter =
     rows && !settled
       ? `${rows.filter((f) => rowAnswered(f, companionOf(fields!, f), drafts, picks)).length}/${rows.length} answered`
@@ -1138,6 +1140,18 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
           <span className="mt-[3px] ml-auto flex-none font-mono text-[11.5px] font-normal leading-normal text-(--text-disabled)">
             {step.time}
           </span>
+        )}
+        {cornerDismiss && (
+          <button
+            type="button"
+            className={`iconbtn -my-[2px] -mr-[4px] h-[22px] w-[22px] flex-none ${step.time ? '' : 'ml-auto'}`}
+            disabled={!onAnswer}
+            aria-label="Decline without answering"
+            title="Decline without answering"
+            onClick={() => onAnswer?.(null)}
+          >
+            <Icon name="x" size={12} color="var(--text-tertiary)" />
+          </button>
         )}
       </div>
       <div className="min-w-0 border-t border-(--border-subtle) px-[14px] py-[11px]">
@@ -1436,8 +1450,9 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
               })}
             </div>
             {multi && <span className={ELICIT_HINT}>{selectionHint(min, max)}</span>}
-            <div className={ELICIT_ACTIONS}>
-              {multi && (
+            {/* Only a multi-select has anything to submit — a single-choice card answers on the tap. */}
+            {multi && (
+              <div className={ELICIT_ACTIONS}>
                 <button
                   type="button"
                   className="dsbtn dsbtn-primary xs"
@@ -1446,17 +1461,8 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                 >
                   Confirm
                 </button>
-              )}
-              <button
-                type="button"
-                className={ELICIT_CHIP}
-                disabled={!onAnswer}
-                onClick={() => onAnswer?.(null)}
-                title="Dismiss without answering"
-              >
-                Dismiss
-              </button>
-            </div>
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## What

A single-choice elicitation card's body is nothing but answers, so the `Dismiss` button sitting among them read as one more answer to pick. On the daemon's memory-write approval card — whose own options already end in `Deny` — it read as a second, duplicate refusal.

The refusal moves into the card head as an icon control, next to the timestamp, labelled **"Decline without answering"**. It is the same `onAnswer(null)` it always was (the spec's `decline`), only it no longer sits in the answer row. The action row it leaves behind on a single-choice card — a divider holding one button — goes with it; a multi-select keeps its row for the Confirm alone.

## What does not change

Only the options shapes (single-choice and multi-select) move. A typed field, a multi-field form and a URL consent card all answer through an action row, where a refusal beside Submit reads as the action it is — and on some of those it is the **only** refusal the card offers, so hiding it in a corner would be a regression. Those keep it in the body, untouched.

Web only. The Slack/Telegram/Discord cards are not touched; their refusal is still a button beside the options, because those surfaces have no head to put it in.

## Why not go further

The daemon flattens a single-field form to a plain options card (`elicit-record.ts`), so on the wire this approval card is byte-identical to any third-party MCP server's three-way question. The renderer cannot tell "this card already offers a refusal" from "this card's three options are all ways of saying yes". Distinguishing them would need a daemon-set flag on the reduced `ElicitCard` — deliberately daemon-set, never read from agent-supplied `_meta`, since letting a server suppress the user's refusal path is a worse problem than the duplication this fixes. That is a possible follow-up, not this PR.

## Verification

- `pnpm --filter @agentconnect.md/web test` — 221 files, 2531 tests, green
- `pnpm --filter @agentconnect.md/web typecheck`, eslint, prettier — clean
- The two elicitation suites' assertions were retargeted from the button's text to its `aria-label`; the behaviour they assert (an explicit `null` answer, no controls once settled, one card after a reload) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
