### PR TITLE
fix(web): rebuild a webchat dial that dies before the turn is sent

### DIFF
--- a/packages/relay/src/relay-browser-server.test.ts
+++ b/packages/relay/src/relay-browser-server.test.ts
@@ -57,6 +57,7 @@ async function start(
     verify?: (kind: 'webchat-token', token: string) => Promise<RcVerifyResult>
     daemon?: RelayDaemonConnection | undefined
     ack?: RdAck
+    log?: Logger
   } = {}
 ): Promise<Harness> {
   http = createServer()
@@ -77,7 +78,7 @@ async function start(
     verify,
     daemons,
     router,
-    log: silentLog
+    log: opts.log ?? silentLog
   })
   const port = (http.address() as AddressInfo).port
   return { base: `ws://127.0.0.1:${port}`, router, sendMsg, sent }
@@ -139,6 +140,19 @@ describe('createRelayBrowserServer (browser webchat edge)', () => {
       verify: async () => ({ ok: true, agentId: AGENT, conversationId: RESUME })
     }) // no daemonId
     await expect(dial(base, '?token=t')).rejects.toThrow('status:401')
+  })
+
+  // A refused dial is invisible on both sides otherwise: the browser is told only that its socket
+  // failed, and every reason worth acting on ("agent unplaced", "daemon offline") lives in the CP's
+  // verdict. Without this line an operator cannot tell a refusal from a dial that never arrived.
+  it('logs the CP verdict behind a refusal', async () => {
+    const warnings: string[] = []
+    const { base } = await start({
+      verify: async () => ({ ok: false, reason: 'agent unplaced' }),
+      log: { debug: () => {}, info: () => {}, warn: (m) => warnings.push(m), error: () => {} }
+    })
+    await expect(dial(base, '?token=t')).rejects.toThrow('status:401')
+    expect(warnings.some((w) => w.includes('agent unplaced') && w.includes('401'))).toBe(true)
   })
 
   it('uses the token-bound conversation id when the compatibility query is omitted', async () => {

--- a/packages/relay/src/relay-browser-server.ts
+++ b/packages/relay/src/relay-browser-server.ts
@@ -40,7 +40,18 @@ export interface RelayBrowserServerDeps {
   keepaliveMs?: number
 }
 
-function refuse(socket: Duplex, status: number, msg: string): void {
+/** Refuse the upgrade. The wire answer stays coarse — the `reason` is for the operator, and this line is the ONLY record a refused dial leaves: the browser learns its socket failed and nothing more, so without it a console reporting "could not reach the agent" is indistinguishable from one whose dial never arrived. */
+function refuse(
+  socket: Duplex,
+  status: number,
+  msg: string,
+  log: Logger,
+  reason: string,
+  conversationId?: string
+): void {
+  log.warn(
+    `webchat: refused browser dial ${status} — ${reason}${conversationId ? ` (conversation ${conversationId})` : ''}`
+  )
   socket.write(`HTTP/1.1 ${status} ${msg}\r\nConnection: close\r\n\r\n`)
   socket.destroy()
 }
@@ -60,7 +71,7 @@ export function createRelayBrowserServer(app: FastifyInstance, deps: RelayBrowse
     if (url.pathname !== RELAY_WEBCHAT_WS_PATH) return // not ours
 
     const token = url.searchParams.get('token')
-    if (!token) return refuse(socket, 401, 'Unauthorized')
+    if (!token) return refuse(socket, 401, 'Unauthorized', deps.log, 'missing token')
     const rawConv = url.searchParams.get('conversation_id')
     const requestedConversationId = rawConv && UUID_RE.test(rawConv) ? rawConv.toLowerCase() : undefined
 
@@ -71,10 +82,13 @@ export function createRelayBrowserServer(app: FastifyInstance, deps: RelayBrowse
       try {
         result = await deps.verify('webchat-token', token)
       } catch {
-        return refuse(socket, 503, 'Verify Unavailable') // relay↔CP link down → retryable
+        // relay↔CP link down → retryable
+        return refuse(socket, 503, 'Verify Unavailable', deps.log, 'cp verify unavailable', requestedConversationId)
       }
       if (!result.ok || !result.agentId || !result.daemonId || !result.conversationId) {
-        return refuse(socket, 401, 'Unauthorized')
+        // The CP's reason is the whole diagnosis — `agent unplaced` and `daemon offline` are the two a healthy-looking agent hits, and both read as a dead socket in the browser.
+        const reason = result.reason ?? (result.ok ? 'incomplete verification' : 'unverified')
+        return refuse(socket, 401, 'Unauthorized', deps.log, reason, requestedConversationId)
       }
       const { agentId, daemonId } = result
       const conversationId = result.conversationId.toLowerCase()
@@ -82,7 +96,7 @@ export function createRelayBrowserServer(app: FastifyInstance, deps: RelayBrowse
       // authoritative; rejecting a mismatch prevents a valid token for one
       // conversation from being replayed against another session key.
       if (!UUID_RE.test(conversationId) || (rawConv !== null && requestedConversationId !== conversationId)) {
-        return refuse(socket, 401, 'Unauthorized')
+        return refuse(socket, 401, 'Unauthorized', deps.log, 'conversation mismatch', requestedConversationId)
       }
       const user = result.user ?? 'webchat'
       // The verified roster (webchat-multi-agents.md §6.2). A pre-roster CP omits

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -1739,51 +1739,70 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // setups (leaving the getting-started "first conversation" tick to the 60s poll) —
       // so nudge the session lists shortly after the send lands.
       const isNewConversation = !conversationId && !conversationIds.current.get(id)
-      const conn = connect(id, agentForId, conversationId)
-      conn.ready
-        .then((ws) => {
-          const frame = JSON.stringify({
-            text,
-            turnId: requestedTurnId,
-            ...(roster.length > 1 ? { mentions: sentMentions, targets } : {}),
-            ...(image ? { attachments: [image] } : {}),
-            // Runtime staging is a single-agent affordance — multi-agent
-            // conversations expose no runtime controls (§9.1/§9.3).
-            ...(roster.length <= 1 && stagedRuntime.current.get(id) ? { runtime: stagedRuntime.current.get(id) } : {}),
-            ...(roster.length <= 1 && stagedWorktree.current.has(id)
-              ? { worktree: stagedWorktree.current.get(id) }
-              : {})
-          })
-          // Kept until the agent acks: a reconnect that finds it unacked re-sends it. Single-agent only — the relay mints the canonical post identity per received frame, so a re-sent multi-agent turn partially admitted the first time would land under a second postId on the rest of the roster (duplicate user messages in the merged transcript).
-          if (roster.length <= 1) pendingTurnFrames.current.set(id, { turnId: requestedTurnId, frame })
-          else pendingTurnFrames.current.delete(id)
-          ws.send(frame)
-          if (isNewConversation) setTimeout(refreshSessions, 2500)
+      const putOnWire = (ws: WebSocket): void => {
+        const frame = JSON.stringify({
+          text,
+          turnId: requestedTurnId,
+          ...(roster.length > 1 ? { mentions: sentMentions, targets } : {}),
+          ...(image ? { attachments: [image] } : {}),
+          // Runtime staging is a single-agent affordance — multi-agent conversations expose no runtime controls (§9.1/§9.3).
+          ...(roster.length <= 1 && stagedRuntime.current.get(id) ? { runtime: stagedRuntime.current.get(id) } : {}),
+          ...(roster.length <= 1 && stagedWorktree.current.has(id) ? { worktree: stagedWorktree.current.get(id) } : {})
         })
-        .catch((err) => {
-          // A 503 from the token mint means the CP has no relay pool configured — the
-          // agent may be perfectly healthy, so name the real cause instead of "unreachable".
-          const noRelay = err instanceof ApiError && err.status === 503
-          // A 409 from the conversation mint names the exact blocker (an agent's
-          // daemon lacking multi-agent webchat support) — surface it verbatim.
-          const conflict = err instanceof ApiError && err.status === 409 ? err.message : undefined
-          // A 404 on a RESUME is the CP refusing this account the conversation (private to its owner, or a roster member out of view) — not an unreachable agent.
-          const notYours = Boolean(conversationId) && err instanceof ApiError && err.status === 404
-          pushStep(id, {
-            kind: 'done',
-            turnId: requestedTurnId,
-            text: noRelay
-              ? '⚠️ Webchat relay not configured — set PUBLIC_RELAY_URL on the control plane.'
-              : conflict
-                ? `⚠️ ${conflict}`
-                : notYours
-                  ? '⚠️ You can’t continue this conversation — it is private to the person who started it, or includes an agent you can’t view.'
-                  : '⚠️ Could not reach the agent.'
-          })
-          pendingTurnFrames.current.delete(id)
-          dropLanes(id)
-          setBusy(id, false)
+        // Kept until the agent acks: a reconnect that finds it unacked re-sends it. Single-agent only — the relay mints the canonical post identity per received frame, so a re-sent multi-agent turn partially admitted the first time would land under a second postId on the rest of the roster (duplicate user messages in the merged transcript).
+        if (roster.length <= 1) pendingTurnFrames.current.set(id, { turnId: requestedTurnId, frame })
+        else pendingTurnFrames.current.delete(id)
+        ws.send(frame)
+        if (isNewConversation) setTimeout(refreshSessions, 2500)
+      }
+      const reportUnsent = (err: unknown): void => {
+        // A 503 from the token mint means the CP has no relay pool configured — the agent may be perfectly healthy, so name the real cause instead of "unreachable".
+        const noRelay = err instanceof ApiError && err.status === 503
+        // A 409 from the conversation mint names the exact blocker (an agent's daemon lacking multi-agent webchat support) — surface it verbatim.
+        const conflict = err instanceof ApiError && err.status === 409 ? err.message : undefined
+        // A 404 on a RESUME is the CP refusing this account the conversation (private to its owner, or a roster member out of view) — not an unreachable agent.
+        const notYours = Boolean(conversationId) && err instanceof ApiError && err.status === 404
+        pushStep(id, {
+          kind: 'done',
+          turnId: requestedTurnId,
+          text: noRelay
+            ? '⚠️ Webchat relay not configured — set PUBLIC_RELAY_URL on the control plane.'
+            : conflict
+              ? `⚠️ ${conflict}`
+              : notYours
+                ? '⚠️ You can’t continue this conversation — it is private to the person who started it, or includes an agent you can’t view.'
+                : '⚠️ Could not reach the agent.'
         })
+        pendingTurnFrames.current.delete(id)
+        dropLanes(id)
+        setBusy(id, false)
+      }
+      // Drop a connection whose dial died under this turn. Its handlers go first: the close would otherwise clear the composer's busy flag out from under the rebuild that replaces it.
+      const abandon = (conn: Conn): void => {
+        conn.closing = true
+        if (conn.reconnectTimer) window.clearTimeout(conn.reconnectTimer)
+        if (conn.ws) {
+          conn.ws.onclose = null
+          conn.ws.onerror = null
+          conn.ws.close()
+        }
+        if (conns.current.get(id) === conn) conns.current.delete(id)
+      }
+      // ONE rebuild before a turn is declared unsent. The first send of a fresh playground rides the socket `openPlayground` warmed seconds earlier (connect() reuses a CONNECTING one), so a dial that died in the browser took the message that opens the conversation down with it — and the retry the reader typed by hand started a SECOND conversation, blind to the first. Only a transport failure is rebuilt: a CP verdict (no relay pool, an incapable daemon, a conversation that is not theirs) is an answer, not a blip. A failure AFTER the frame reached the socket is the reconnect's resend to recover, never a fresh dial's.
+      const putThrough = (conn: Conn, mayRebuild: boolean): void => {
+        let onWire = false
+        conn.ready
+          .then((ws) => {
+            onWire = true
+            putOnWire(ws)
+          })
+          .catch((err) => {
+            if (!mayRebuild || onWire || err instanceof ApiError) return reportUnsent(err)
+            abandon(conn)
+            putThrough(connect(id, agentForId, conversationId), false)
+          })
+      }
+      putThrough(connect(id, agentForId, conversationId), true)
     },
     [pgSessions, connect, pushStep, setBusy, refreshSessions]
   )

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -1434,3 +1434,76 @@ describe('mid-turn steering', () => {
     expect(frames(socket).some((f) => f.steer === true)).toBe(false)
   })
 })
+
+// The first send of a fresh playground rides the socket `openPlayground` warmed seconds earlier —
+// connect() hands a still-CONNECTING one straight to the turn — so a dial that dies in the browser
+// (one that never reaches the relay at all) used to lose exactly the message that opens a
+// conversation, and the retry the reader typed by hand started a SECOND conversation blind to it.
+describe('a dial that dies before the turn reaches the socket', () => {
+  class DyingSocket extends StubSocket {
+    static instances: DyingSocket[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onerror?: (e: unknown) => void
+    onclose?: (() => void) | null
+    constructor() {
+      super()
+      DyingSocket.instances.push(this)
+    }
+  }
+  /** Let a rebuild settle: its socket is two promises deep (mint, then dial). */
+  const settle = () => act(async () => {})
+
+  beforeEach(async () => {
+    DyingSocket.instances = []
+    Reflect.set(globalThis, 'WebSocket', DyingSocket)
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockResolvedValue('wss://relay.test/ws')
+  })
+
+  it('rebuilds once and puts the SAME turn on the fresh socket', async () => {
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello')
+    })
+    await act(async () => {
+      DyingSocket.instances[0]!.onerror?.({})
+    })
+    await settle()
+    expect(DyingSocket.instances).toHaveLength(2)
+    const live = DyingSocket.instances[1]!
+    await act(async () => {
+      live.readyState = 1
+      live.onopen?.()
+    })
+    const turnId = getLiveSteps('s1').find((s) => s.text === 'hello')?.turnId
+    expect(JSON.parse(String(live.send.mock.calls[0]?.[0]))).toMatchObject({ text: 'hello', turnId })
+    expect(getLiveSteps('s1').some((s) => String(s.text).includes('Could not reach the agent'))).toBe(false)
+  })
+
+  it('reports the turn unsent when the rebuilt dial dies too', async () => {
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello')
+    })
+    await act(async () => {
+      DyingSocket.instances[0]!.onerror?.({})
+    })
+    await settle()
+    await act(async () => {
+      DyingSocket.instances[1]!.onerror?.({})
+    })
+    await settle()
+    expect(DyingSocket.instances).toHaveLength(2)
+    expect(getLiveSteps('s1').some((s) => String(s.text).includes('Could not reach the agent'))).toBe(true)
+  })
+
+  it('does not rebuild on a CP verdict — a refusal is an answer, not a blip', async () => {
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockRejectedValue(new api.ApiError('webchat relay pool not configured', 503))
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello')
+    })
+    await settle()
+    expect(vi.mocked(api.webchatWsUrl)).toHaveBeenCalledTimes(1)
+    expect(getLiveSteps('s1').some((s) => String(s.text).includes('Webchat relay not configured'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## What happened

A reader opened a playground on a freshly created agent, sent a message, and got
`⚠️ Could not reach the agent.` one second later. The message they typed again 20s
later worked — but the agent answered it as the first thing it had ever been told.

The agent and its daemon were healthy throughout. Tracing it end to end:

- the token mint succeeded (200) when the playground **opened** — that is
  `openPlayground`'s warm connect, not the send;
- **no WebSocket upgrade for it ever reached the ingress**, so neither the relay
  nor the daemon saw the dial at all;
- the send five seconds later minted nothing: `connect()` reuses a socket that is
  still `CONNECTING`, so the turn rode the warm dial that was already dying;
- when that socket failed, `sendTurn` reported the turn unsent and dropped it —
  no rebuild, no resend;
- the manual retry built a fresh connection and a **new conversation**, which is
  why the reply read as the opening of a brand new session.

So a transport blip in the browser, in a window the reader cannot see, silently
ate the one message that creates a conversation.

## The fix

`sendTurn` rebuilds the connection **once** and puts the same `turnId` on the
fresh socket when the dial fails before the frame reaches it. The rebuild
detaches the dead socket's handlers first — otherwise its `close` clears the
composer's busy flag out from under the turn that replaces it.

Not retried, deliberately:

- a CP verdict (`ApiError`): no relay pool configured, a daemon that cannot serve
  the conversation, a conversation that is not the caller's. Those are answers,
  and they keep their existing, specific copy.
- a failure *after* the frame reached the socket. That turn may already be
  admitted; recovering it is the reconnect's resend, which is unchanged (and is
  what keeps a re-sent multi-agent turn from landing under a second postId).

## Diagnosability

A refused browser dial was the one failure in this path that left no record
anywhere: the browser learns only that its socket failed, and the reasons worth
acting on — `agent unplaced`, `daemon offline` — live only inside the CP's verify
answer, which the relay discarded. A refused dial and a dial that never arrived
looked identical from every log. The relay now logs status + reason (never the
token) when it refuses an upgrade.

## Tests

- `PlaygroundSend.test.tsx`: a dial that dies before the frame is on the wire is
  rebuilt once and the **same** turn is delivered; a second failure reports the
  turn unsent; a 503 verdict is not rebuilt and keeps its own copy. Verified by
  mutation — reverting the rebuild fails the first two.
- `relay-browser-server.test.ts`: a refusal names the CP's verdict in the log.

`pnpm --filter @agentconnect.md/web test` (2534) and
`pnpm --filter @agentconnect.md/relay test` (657) pass, with typecheck and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
