### PR TITLE
fix(web): name a billing charge's agent from the roster alone

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -546,21 +546,22 @@ Invariants preserved:
   gone, not narrowed.
 
 - **Billing-ledger exception (accepted, product decision).** The billing
-  Transactions feed names an agent on a charge when that agent appears in the
-  viewer's `/usage?source=gateway` projection for the charge's period — i.e.
-  under exactly the intersection this section already uses for Analytics —
-  and renders the billing service's per-charge amount beside that name. A
-  named agent's per-charge amount may therefore include spend the projection
-  itself withholds (an agent with readable and private spend in the same
-  period is named for charges that cover both). This is a deliberate,
-  narrower cousin of the residual inference channel above and is accepted on
-  the same grounds: the ledger already publishes every charge's amount to
-  every member, and the stricter alternative — naming only in periods whose
-  projection withholds nothing — was shipped and blanked attribution for any
-  org with a single private session. What remains enforced: an agent absent
-  from the projection (no readable spend at all) is never named on any charge,
-  ids the roster cannot resolve are never rendered, and everything withheld on
-  a charge folds into one id-less rollup with no count and no partition.
+  Transactions feed names an agent on a charge when that agent is in the
+  viewer's own Agent roster — Agent visibility alone, with no Session
+  predicate — and renders the billing service's per-charge amount beside that
+  name. A named agent's per-charge amount may therefore be spend from sessions
+  the viewer cannot read. This is a deliberate, narrower cousin of the residual
+  inference channel above and is accepted on the same grounds: the ledger
+  already publishes every charge's amount to every member, so naming discloses
+  only which visible agent spent it, never a session's content or existence.
+  Two stricter gates were shipped and rolled back: naming only in periods whose
+  `/usage` projection withheld nothing blanked attribution for any org with a
+  single private session, and naming only agents present in the viewer's
+  `/usage?source=gateway` projection blanked any agent whose only spend in the
+  period ran in a session the viewer could not read — an agent the Agents page
+  names to that same viewer. What remains enforced: ids the roster cannot
+  resolve are never rendered, and everything withheld on a charge folds into
+  one id-less rollup with no count and no partition.
 
 - 404, never 403, for invisible sessions (no existence oracle).
 - A `?triggeredBy=` / `?channel=` query filter remains a filter, not an

--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -4,17 +4,18 @@
  *
  * Two sources, two different questions. The AMOUNTS come from the billing service's split —
  * the only thing that knows how one charge divides — and the PERMISSION to put a name beside
- * one comes from the CP's viewer-scoped `/usage` projection for that charge's period.
+ * one is Agent visibility alone: the viewer's own roster.
  *
- * The gate is per-agent MEMBERSHIP in the projection — the intersection under which Analytics
- * already names that agent to this viewer — per the billing exception in
- * `session-visibility.md` §5. A period-completeness gate was tried and blanked attribution for
- * any org with one private session. What §5 still forbids is pinned here: an agent in NO
- * readable session stays id-less, and withheld parts fold into one countless rollup.
+ * The Session predicate does not gate naming here — the billing exception in
+ * `session-visibility.md` §5. Gating on the viewer-scoped `/usage` projection was tried and
+ * blanked every agent whose only spend in the period ran in a session the viewer cannot read,
+ * even though the Agents page names that agent to them. What §5 still forbids is pinned here:
+ * an id the roster cannot resolve stays id-less, and withheld parts fold into one countless
+ * rollup.
  *
- * The fixtures are real figures from a test org: one August with three separate charges, whose
- * amounts sum to exactly the month's projected total. A period holds MANY charges — assuming
- * one charge per period is what blanked the whole feed before.
+ * The fixtures are real figures from a test org: one August with three separate charges. A
+ * period holds MANY charges — assuming one charge per period is what blanked the whole feed
+ * before.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -22,19 +23,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Agent } from '@/lib/data'
 
 const AGENT_ID = '8173602b-1d84-41c5-9777-22a6eb2d2b51'
-const debit = (id: string, amount: string) => ({
+const OTHER_ID = '4c1e9d2a-7b3f-4e8c-9a6d-2f5b8c1d0e7a'
+const debit = (id: string, amount: string, agentId = AGENT_ID) => ({
   type: 'debit' as const,
   id,
   period: '2026-08',
   amount,
   at: '2026-08-25T02:20:00.000Z',
-  agents: [{ agentId: AGENT_ID, amount }]
+  agents: [{ agentId, amount }]
 })
-const DEBITS = [debit('d1', '0.006822824'), debit('d2', '0.015224848'), debit('d3', '0.001036384')]
+const DEBITS = [
+  debit('d1', '0.006822824'),
+  debit('d2', '0.015224848'),
+  debit('d3', '0.001036384'),
+  // An agent outside the viewer's roster: withheld, whatever session it ran in.
+  debit('d4', '0.5', OTHER_ID)
+]
 
 const mocks = vi.hoisted(() => ({
-  fetchAgents: vi.fn(async () => [{ id: '8173602b-1d84-41c5-9777-22a6eb2d2b51', name: 'reviewer', runtime: 'claude' }]),
-  fetchAttribution: vi.fn(async () => new Set(['8173602b-1d84-41c5-9777-22a6eb2d2b51']))
+  fetchAgents: vi.fn(async () => [{ id: '8173602b-1d84-41c5-9777-22a6eb2d2b51', name: 'reviewer', runtime: 'claude' }])
 }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -47,8 +54,7 @@ vi.mock('next/navigation', () => ({
 }))
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<typeof import('@/lib/api')>('@/lib/api')),
-  fetchAgents: mocks.fetchAgents,
-  fetchGatewayAttribution: mocks.fetchAttribution
+  fetchAgents: mocks.fetchAgents
 }))
 vi.mock('@/lib/billing-api', async () => ({
   ...(await vi.importActual<typeof import('@/lib/billing-api')>('@/lib/billing-api')),
@@ -66,31 +72,22 @@ const roster = new Map([
   ['agt_1', agent('agt_1', 'reviewer')],
   ['agt_2', agent('agt_2', 'triage')]
 ])
-const proj = (...ids: string[]): ReadonlySet<string> => new Set(ids)
 
 describe('rowAttribution', () => {
-  it('names an agent the projection lists, for its exact per-row amount', () => {
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '0.006822824' }], proj('agt_1'), roster)
+  it('names an agent the roster resolves, for its exact per-row amount', () => {
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '0.006822824' }], roster)
     expect(chips).toEqual([{ key: 'agt_1', agent: roster.get('agt_1'), amount: '0.006822824' }])
   })
 
-  it('still names an agent when the period withholds OTHER spend — the billing exception', () => {
-    // The projection lists agt_1 (Analytics already names it to this viewer). Some of the
-    // period's spend being withheld no longer blanks the whole period — that gate blanked
-    // every org with one private session. Recorded in session-visibility.md §5.
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '100' }], proj('agt_1'), roster)
+  it('names a visible agent regardless of which sessions the spend ran in', () => {
+    // Agent visibility is the whole gate: a charge from a session the viewer cannot read is
+    // still named after the agent they can see. Recorded in session-visibility.md §5.
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '100' }], roster)
     expect(chips).toEqual([{ key: 'agt_1', agent: roster.get('agt_1'), amount: '100' }])
   })
 
-  it('withholds an agent the projection does not list at all', () => {
-    // No readable spend anywhere in the window ⇒ §5 still forbids naming it here.
-    const chips = rowAttribution([{ agentId: 'agt_2', amount: '3' }], proj('agt_1'), roster)
-    expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
-    expect(JSON.stringify(chips)).not.toContain('agt_2')
-  })
-
   it('withholds an agent the roster cannot resolve, id and all', () => {
-    const chips = rowAttribution([{ agentId: 'agt_gone', amount: '3' }], proj('agt_gone'), roster)
+    const chips = rowAttribution([{ agentId: 'agt_gone', amount: '3' }], roster)
     expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
     expect(JSON.stringify(chips)).not.toContain('agt_gone')
   })
@@ -102,7 +99,6 @@ describe('rowAttribution', () => {
         { agentId: 'x', amount: '0.1' },
         { agentId: 'y', amount: '0.2' }
       ],
-      proj('agt_1', 'x', 'y'),
       roster
     )
     expect(chips).toHaveLength(2)
@@ -116,32 +112,26 @@ describe('rowAttribution', () => {
         { agentId: 'agt_1', amount: '0.40' },
         { agentId: 'agt_2', amount: '2.50' }
       ],
-      proj('agt_1', 'agt_2'),
       roster
     )
     expect(chips.map((c) => c.agent?.name)).toEqual(['triage', 'reviewer'])
   })
 
-  it('fails closed while the projection is unloaded or errored', () => {
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], undefined, roster)
-    expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
-  })
-
   it('fails closed on an empty roster', () => {
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], proj('agt_1'), new Map())
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], new Map())
     expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
   })
 
   it('renders nothing when the service sent no split, or an empty one', () => {
-    expect(rowAttribution(undefined, proj('agt_1'), roster)).toEqual([])
-    expect(rowAttribution(null, proj('agt_1'), roster)).toEqual([])
-    expect(rowAttribution([], proj('agt_1'), roster)).toEqual([])
+    expect(rowAttribution(undefined, roster)).toEqual([])
+    expect(rowAttribution(null, roster)).toEqual([])
+    expect(rowAttribution([], roster)).toEqual([])
     // A zero part is noise, not attribution.
-    expect(rowAttribution([{ agentId: 'agt_1', amount: '0' }], proj('agt_1'), roster)).toEqual([])
+    expect(rowAttribution([{ agentId: 'agt_1', amount: '0' }], roster)).toEqual([])
   })
 
   it('drops a part whose amount is not a number rather than rendering NaN', () => {
-    expect(rowAttribution([{ agentId: 'agt_1', amount: 'twelve' }], proj('agt_1'), roster)).toEqual([])
+    expect(rowAttribution([{ agentId: 'agt_1', amount: 'twelve' }], roster)).toEqual([])
   })
 })
 
@@ -169,29 +159,35 @@ describe('the usage row', () => {
     ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
   })
 
-  it('asks the CP once for the period the rows share, not once per row', async () => {
-    await render()
-    expect(mocks.fetchAttribution).toHaveBeenCalledTimes(1)
-    expect(mocks.fetchAttribution).toHaveBeenCalledWith('2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1')
-  })
-
-  it('names the agent on EVERY charge in the period, not just one', async () => {
-    // A period holds many charges. Reconciling a monthly projection against a single row is
-    // what blanked all three of these before, so each one is asserted.
+  it('names the agent from the roster alone — no per-period usage read', async () => {
     const host = await render()
+    // The roster is the only read behind attribution; nothing else asks the CP about spend.
+    expect(mocks.fetchAgents).toHaveBeenCalled()
     const chips = [...host.querySelectorAll('[data-tx-agent]')]
     // Desktop shows the name; the share is disclosure — `title`, which the TooltipLayer opens on
     // hover and on keyboard focus (hence tabbable). The trailing amount span is the ≤768px copy
     // (visible where touch has neither hover nor focus), CSS-hidden on desktop but present in
     // textContent here. Sub-cent amounts keep significant digits rather than rounding to `$0.00`.
-    expect(chips.map((c) => c.textContent)).toEqual(['reviewer$0.006823', 'reviewer$0.01522', 'reviewer$0.001036'])
-    expect(chips.map((c) => c.getAttribute('title'))).toEqual([
+    expect(chips.slice(0, 3).map((c) => c.textContent)).toEqual([
+      'reviewer$0.006823',
+      'reviewer$0.01522',
+      'reviewer$0.001036'
+    ])
+    expect(chips.slice(0, 3).map((c) => c.getAttribute('title'))).toEqual([
       'reviewer — $0.006823',
       'reviewer — $0.01522',
       'reviewer — $0.001036'
     ])
     expect(chips[0]!.getAttribute('aria-label')).toBe('reviewer — $0.006823')
     expect(chips.every((c) => c.getAttribute('tabindex') === '0')).toBe(true)
-    expect(host.querySelector('[data-tx-agent-default]')).toBeNull()
+  })
+
+  it('folds an agent outside the roster into the id-less rollup', async () => {
+    const host = await render()
+    const rollups = [...host.querySelectorAll('[data-tx-agent-default]')]
+    expect(rollups).toHaveLength(1)
+    const chip = rollups[0]!.closest('[data-tx-agent]')!
+    expect(chip.getAttribute('title')).toBe('Agents you don’t have access to — $0.50')
+    expect(host.innerHTML).not.toContain(OTHER_ID)
   })
 })

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -38,7 +38,7 @@ import {
 } from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { fetchAgents, fetchGatewayAttribution } from '@/lib/api'
+import { fetchAgents } from '@/lib/api'
 import { agentLabel, type Agent } from '@/lib/data'
 import { sumAmounts } from '@/lib/amount'
 import { useOrgs } from '@/lib/org-context'
@@ -69,23 +69,15 @@ export interface TxAgentChip {
 // What a usage row may say about who spent the money.
 //
 // The AMOUNTS come from the billing service's own split — the only thing that knows how one
-// charge divides — and the PERMISSION to attach a name to one comes from the CP's viewer-scoped
-// `/usage` projection for that charge's period. They are different questions and neither source
-// can answer the other's.
+// charge divides — and the PERMISSION to attach a name to one is Agent visibility alone: the
+// viewer's own roster, the same list the Agents page shows them. The Session predicate does not
+// apply here (`session-visibility.md` §5): the ledger already publishes every charge's amount to
+// every member, so what naming discloses is only WHICH visible agent spent it.
 //
-// The gate is per-agent MEMBERSHIP in the projection, the same intersection (Agent visibility ∩
-// Session predicate) under which the Analytics page already names that agent to this viewer for
-// this window. A named agent's per-charge amount may therefore include spend the projection
-// withholds — an agent with $1 readable and $99 private is named for a charge covering the $99.
-// That is the deliberate billing exception recorded in `session-visibility.md` §5: a stricter
-// period-completeness gate was tried and blanked every org with any private session. What §5
-// still forbids holds: an agent in NO readable session stays id-less, and everything withheld
-// folds into ONE rollup — no count, no partition.
-//
-// `agentById` supplies the name and icon; an id it cannot resolve is not named either.
+// An id the roster cannot resolve — a restricted agent, or one since deleted — is never named,
+// and everything withheld folds into ONE rollup: no id, no count, no partition.
 export function rowAttribution(
   parts: BillingDebitAgent[] | null | undefined,
-  projection: ReadonlySet<string> | undefined,
   agentById: Map<string, Agent>
 ): TxAgentChip[] {
   if (!parts?.length) return []
@@ -94,9 +86,8 @@ export function rowAttribution(
   for (const part of parts) {
     const value = Number(part.amount)
     if (!Number.isFinite(value) || value === 0) continue
-    // Every clause fails CLOSED: no projection (unloaded or errored), an agent outside it, or
-    // an id the roster cannot resolve.
-    const agent = projection?.has(part.agentId) ? agentById.get(part.agentId) : undefined
+    // Fails CLOSED: an id the roster cannot resolve (unloaded, errored, or restricted) is withheld.
+    const agent = agentById.get(part.agentId)
     // The id never enters a chip it cannot name — `key` included, so it cannot leak through a
     // prop that ends up serialized.
     if (agent) named.push({ chip: { key: part.agentId, agent, amount: part.amount }, value })
@@ -106,13 +97,6 @@ export function rowAttribution(
   const chips = named.map(({ chip }) => chip)
   if (withheld.length) chips.push({ key: 'withheld', amount: sumAmounts(withheld) })
   return chips
-}
-
-// A debit's `period` is a UTC calendar month (`YYYY-MM`); these are its half-open window.
-const periodStart = (period: string) => `${period}-01T00:00:00.000Z`
-const nextPeriod = (period: string) => {
-  const [y, m] = period.split('-').map(Number) as [number, number]
-  return m === 12 ? `${y + 1}-01` : `${y}-${String(m + 1).padStart(2, '0')}`
 }
 
 // The Transactions filter, the same Usage / Top-ups split the Activity chart offers — plus
@@ -662,6 +646,9 @@ export default function BillingView() {
     () => (agentsError ? new Map<string, Agent>() : new Map((agents ?? []).map((a) => [a.id, a]))),
     [agents, agentsError]
   )
+  // Unloaded is not the same as empty: a pending roster must render NO chip rather than the
+  // fail-closed rollup, which would tell the reader they lack access and then take it back.
+  const rosterPending = agents === undefined && !agentsError
   const orgId = activeOrg?.id ?? null
   const router = useRouter()
   const pathname = usePathname()
@@ -792,23 +779,6 @@ export default function BillingView() {
   // under a pill that says Usage — a wrong answer is worse than a narrower one.
   const txItems = sideType ? loaded.filter((t) => t.type === sideType) : loaded
   const nextCursor = mine ? mine.nextCursor : (transactions.data?.nextCursor ?? null)
-
-  // Where a usage row's attribution comes from: the CP's viewer-scoped `/usage` projection,
-  // one read per period on screen. Per PERIOD and never unioned across them — spend a viewer
-  // may attribute in one month says nothing about another. Fail closed on error.
-  const periods = [...new Set(txItems.filter((t) => t.type === 'debit').map((t) => t.period))].sort()
-  const attribution = useSWR<Map<string, Set<string>>>(
-    orgId && periods.length ? consoleKeys.billingAttribution(orgId, periods.join(',')) : null,
-    async ([, , , joined]) => {
-      const wanted = (joined as string).split(',')
-      const reads = await Promise.all(
-        wanted.map((p) => fetchGatewayAttribution(periodStart(p), periodStart(nextPeriod(p)), orgId!))
-      )
-      return new Map(wanted.map((p, i) => [p, reads[i]!]))
-    }
-  )
-  const attributionIn = (period: string): ReadonlySet<string> | undefined =>
-    attribution.error ? undefined : attribution.data?.get(period)
 
   // Deep-link landing for a console that does not offer billing: the rail hides
   // the entry, so anyone here typed the URL or followed an old bookmark. Gated on
@@ -1085,19 +1055,14 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
-                        {/* Who the charge is attributed to. An agent is named only when BOTH
-                            visibility predicates clear; everything else is one id-less rollup
-                            with a default avatar. See `agentSplit` and billing-api.ts. */}
+                        {/* Who the charge is attributed to. An agent is named only when it is in
+                            the viewer's roster; everything else is one id-less rollup with a
+                            default avatar. See `rowAttribution` and billing-api.ts. */}
                         {!credit &&
                           (() => {
-                            // Nothing at all while the projection is in flight. Rendering the
-                            // fail-closed answer first would tell the reader they have no access
-                            // to an agent, then take it back a second later — a wrong statement,
-                            // not a slow one. Fail closed applies to a MISSING answer, not a
-                            // pending one.
-                            const split = attribution.isLoading
-                              ? []
-                              : rowAttribution(t.agents, attributionIn(t.period), agentById)
+                            // Nothing at all while the roster is in flight: fail closed applies
+                            // to a MISSING answer, not a pending one.
+                            const split = rosterPending ? [] : rowAttribution(t.agents, agentById)
                             // The description column shares the row with the amount, so the
                             // NAMED chips are capped. The rollup is appended after the cap: it
                             // is the one chip that must never be hidden behind a `+N`.

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -11,7 +11,6 @@ import {
   deleteMemoryRecord,
   deleteOrgIcon,
   fetchAllGithubRepos,
-  fetchGatewayAttribution,
   fetchConversations,
   fetchConversationByKey,
   fetchSessionFacets,
@@ -142,53 +141,6 @@ describe('session profile identity hints', () => {
 
     await expect(fetchMySessionIdentity('lark')).resolves.toEqual({ linked: true })
     await expect(fetchMySessionIdentity('feishu')).resolves.toEqual({ linked: false })
-  })
-})
-
-describe('fetchGatewayAttribution', () => {
-  afterEach(() => {
-    setApiOrgId(null)
-    vi.unstubAllGlobals()
-  })
-
-  const usage = (extra: Record<string, unknown>) => {
-    const calls: string[] = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string) => {
-        calls.push(url)
-        return new Response(
-          JSON.stringify({
-            from: 'x',
-            to: 'y',
-            totals: { sessions: 0, totalTokens: 0, costAmount: '0', costCurrency: null },
-            agents: [{ agentId: 'agt_1', costAmount: '1' }],
-            models: [],
-            sources: [],
-            series: { bucket: 'day', points: [] },
-            ...extra
-          }),
-          { status: 200, headers: { 'content-type': 'application/json' } }
-        )
-      })
-    )
-    return calls
-  }
-
-  it('scopes the read to the gateway ingress a charge settles from', async () => {
-    const calls = usage({})
-    await fetchGatewayAttribution('2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1')
-    expect(calls[0]).toContain('source=gateway')
-  })
-
-  it('returns projection MEMBERSHIP, unaffected by a withheld residual', async () => {
-    // The billing exception (`session-visibility.md` §5): an id in `/usage.agents` is one
-    // Analytics already names to this viewer, and that alone gates naming on the ledger —
-    // a period-completeness gate was tried and blanked every org with one private session.
-    const window = ['2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1'] as const
-
-    usage({ unattributed: { sessions: 2, totalTokens: 40, costAmount: '99' } })
-    expect(await fetchGatewayAttribution(...window)).toEqual(new Set(['agt_1']))
   })
 })
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3660,25 +3660,6 @@ export function usageWindow(range: UsageRange, now: Date = new Date()): { from: 
   return { from: from.toISOString(), to: to.toISOString() }
 }
 
-// The agents this viewer may see gateway spend attributed to, for one explicit window.
-//
-// `/usage` intersects Agent visibility with the request-time Session predicate, so an id in its
-// `agents` list is one the Analytics page ALREADY names to this viewer for this window — that
-// membership is the billing ledger's naming gate. Per the billing exception in
-// `session-visibility.md` §5, a named agent's per-charge amount may include spend the projection
-// itself withholds; accepted there deliberately, so do not "fix" it back to a period-completeness
-// gate — that shape blanked every org with any private session (#1498 follow-up). An id absent
-// from the list stays id-less on every billing row.
-//
-// `source=gateway` because that is the ingress a billing charge settles from (see the route's
-// own note): unscoped, a readable DAEMON session could qualify an agent whose gateway spend is
-// entirely private.
-export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<Set<string>> {
-  const query = new URLSearchParams({ from, to, source: 'gateway' })
-  const usage = await apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
-  return new Set(usage.agents.map((a) => a.agentId))
-}
-
 export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {
   // Send the viewer's tz offset so the CP buckets the spend series to local
   // day/hour (getTimezoneOffset ⇒ UTC − local; stable per client, not in the key).

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -59,13 +59,12 @@ export interface BillingAccount {
 // The debit arm's `agents` is the billing service's per-agent split of a charge — the real
 // per-ROW amounts, which is why it is mirrored: nothing else knows how one charge divides.
 //
-// It is NOT self-authorizing. The service holds no Agent or Session visibility, so its ids and
-// its amounts are both the ORG's, and rendering one as-is is the discovery
+// It is NOT self-authorizing. The service holds no Agent visibility, so its ids and its amounts
+// are both the ORG's, and rendering one as-is is the discovery
 // `docs/designs/authorization-policy.md` §4 forbids. The row may put an agent's name beside one
-// of these amounts only when that agent is in the CP's viewer-scoped `/usage` projection for the
-// charge's period (`fetchGatewayAttribution`) — the billing exception in
-// `session-visibility.md` §5. Ids outside it fold into one id-less rollup per charge. The gate
-// lives in `rowAttribution` in BillingView; nothing else may read this field.
+// of these amounts only when that agent is in the viewer's own roster (`fetchAgents`) — the
+// billing exception in `session-visibility.md` §5. Ids outside it fold into one id-less rollup
+// per charge. The gate lives in `rowAttribution` in BillingView; nothing else may read this field.
 export interface BillingCredit {
   type: 'credit'
   id: string

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -59,10 +59,6 @@ export const consoleKeys = {
     orgId: string | null | undefined,
     side: Side = 'all' as Side
   ) => consoleKey(orgId, 'billing-transactions', side),
-  /** The viewer-scoped gateway spend per agent, per UTC billing period (`YYYY-MM`). Keyed on
-   *  the periods actually on screen, joined — one read serves the whole feed. */
-  billingAttribution: (orgId: string | null | undefined, periods: string) =>
-    consoleKey(orgId, 'billing-attribution', periods),
   /** The credit rows of the last 30 days — paged out of the same feed, so it keys apart
    *  from the first page `billingTransactions` serves the Billing table. */
   billingTopUps: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-top-ups'),


### PR DESCRIPTION
## What changed

- `rowAttribution` in `BillingView.tsx` now decides whether a usage row shows an agent's name and icon by one test: is the `agentId` in the viewer's own agent roster. The `/usage?source=gateway` projection is no longer consulted.
- Removed the per-period usage SWR read, `consoleKeys.billingAttribution`, and `fetchGatewayAttribution` (plus its tests). The Billing page makes one fewer Control Plane request.
- Kept the "nothing while pending" guard, now keyed on the roster: a loading roster renders no chip instead of a fail-closed rollup that gets taken back a moment later.
- Rewrote `BillingView.agents.test.tsx` for the new gate, including a render case that puts an out-of-roster agent on a charge and asserts it folds into the id-less rollup with the id absent from the DOM.
- Updated the billing-ledger exception in `docs/designs/session-visibility.md` §5 and the field comment in `billing-api.ts`.

## Why

On a test org, two charges for a visible agent rendered as "Agents you don't have access to". The agent was in the roster, but its only spend that month ran in a session the viewer could not read, so it was absent from the viewer-scoped `/usage` projection and `unattributed.costAmount` equalled the two charges exactly. The Session predicate was gating a surface that only discloses which visible agent spent an amount the ledger already publishes to every member.

## Reviewer notes

- This is a product-policy change to `session-visibility.md` §5, recorded there alongside the two stricter gates that were shipped and rolled back.
- What still holds: an id the roster cannot resolve is never rendered (not even as a React key), and everything withheld on a charge folds into one rollup with no count and no partition.
- `pnpm --filter @agentconnect.md/web typecheck`, eslint and prettier are clean; the two touched test files pass (53 cases). The `ECONNREFUSED` log noise in the render test predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
