### PR TITLE
fix(daemon): a microsandbox host that cannot reach KVM says so

### DIFF
--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -13,6 +13,7 @@ import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-run
 import { canonicalPath, contains } from '../runtimes/read-roots.js'
 import { SinkRelPathSchema } from '../shim/file-sink.js'
 import { SANDBOX_MCP_BRIDGE_ENTRY } from '../shim/sandbox-paths.js'
+import { assertKvmAvailable } from './kvm.js'
 import { MICROSANDBOX_SOCKET_BRIDGE_COMMAND, MICROSANDBOX_SOCKET_BRIDGE_ARGS } from './socket-bridge.js'
 import { overlayMounts, OVERLAY_BASE_ROOT, OVERLAY_STATE_ROOT, prepareOverlayMounts } from './overlay.js'
 import type { MicrosandboxSecret } from './secrets.js'
@@ -60,6 +61,8 @@ export interface MicrosandboxManagerOptions {
     'Sandbox' | 'SandboxNotFoundError' | 'AgentClient' | 'Volume' | 'VolumeNotFoundError' | 'InvalidConfigError'
   >
   msbCommand: { command: string; args: string[] }
+  // Overridden by tests; the real check opens this host's /dev/kvm.
+  kvmPreflight?: () => void
   log?: Logger
   sockets: { mcp: string; gitcred: string }
 }
@@ -292,6 +295,8 @@ export class MicrosandboxManager {
   }
 
   private async probe(): Promise<K8sRuntimeTable> {
+    // Without this, an unreachable /dev/kvm surfaces only as the guest's SIGABRT, minutes after an image pull.
+    ;(this.options.kvmPreflight ?? assertKvmAvailable)()
     const bindings = join(this.options.root, 'microsandbox', 'bindings')
     await mkdir(bindings, { recursive: true, mode: 0o700 })
     for (const id of await this.persistedIds()) {

--- a/packages/daemon/src/microsandbox/kvm.ts
+++ b/packages/daemon/src/microsandbox/kvm.ts
@@ -1,0 +1,83 @@
+import { closeSync, constants, openSync, readFileSync, statSync } from 'node:fs'
+import { userInfo } from 'node:os'
+
+export const KVM_DEVICE = '/dev/kvm'
+
+/** What THIS PROCESS reaches — a group added after it started is in the user database but not in it. */
+export interface KvmObservation {
+  errorCode?: string
+  username: string
+  uid: number
+  group?: { gid: number; name?: string; heldByProcess: boolean; heldByUser: boolean }
+}
+
+/** The operator-facing sentence a failed observation earns, or undefined when KVM is reachable. */
+export function kvmPreflightFailure(observation: KvmObservation): string | undefined {
+  const { errorCode, username, uid, group } = observation
+  if (!errorCode) return undefined
+  const head = `microsandbox requires KVM, but this daemon cannot open ${KVM_DEVICE}`
+  if (errorCode === 'ENOENT') {
+    return `${head}: the device is absent — enable hardware virtualization on this host, or nested virtualization when the host is itself a virtual machine`
+  }
+  if (errorCode !== 'EACCES' && errorCode !== 'EPERM') return `${head} (${errorCode})`
+  // The process already holds the device's group, so membership is not what is denying it.
+  if (!group || group.heldByProcess) {
+    return `${head}: permission denied (${errorCode}) — check the device's owner, mode and ACL`
+  }
+  const name = group.name ?? String(group.gid)
+  if (group.heldByUser) {
+    return `${head}: user "${username}" is a member of group "${name}" but this process is not, so the membership postdates the process — restart the login session that owns the daemon (for the installed user service, "systemctl restart user@${uid}.service"), not just the service`
+  }
+  return `${head}: add user "${username}" to group "${name}" ("usermod -aG ${name} ${username}"), then start the daemon from a new login session`
+}
+
+/** Opens the device the way the guest will — O_RDWR, as this process, now. */
+export function observeKvm(): KvmObservation {
+  const { username, uid } = userInfo()
+  try {
+    closeSync(openSync(KVM_DEVICE, constants.O_RDWR))
+    return { username, uid }
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code ?? 'unknown'
+    const group = errorCode === 'EACCES' || errorCode === 'EPERM' ? deviceGroup(username) : undefined
+    return { errorCode, username, uid, ...(group ? { group } : {}) }
+  }
+}
+
+export function assertKvmAvailable(observe: () => KvmObservation = observeKvm): void {
+  const failure = kvmPreflightFailure(observe())
+  if (failure) throw new Error(failure)
+}
+
+function deviceGroup(username: string): KvmObservation['group'] {
+  let gid: number
+  try {
+    gid = statSync(KVM_DEVICE).gid
+  } catch {
+    return undefined
+  }
+  const held = new Set([...(process.getgroups?.() ?? []), ...(process.getgid ? [process.getgid()] : [])])
+  const heldByProcess = held.has(gid)
+  const entry = groupEntry(gid)
+  // A primary group lists no members, but then the process carries it and the question is moot.
+  return {
+    gid,
+    ...(entry ? { name: entry.name } : {}),
+    heldByProcess,
+    heldByUser: heldByProcess || !!entry?.members.includes(username)
+  }
+}
+
+function groupEntry(gid: number): { name: string; members: string[] } | undefined {
+  let file: string
+  try {
+    file = readFileSync('/etc/group', 'utf8')
+  } catch {
+    return undefined
+  }
+  for (const line of file.split('\n')) {
+    const [name, , id, members] = line.split(':')
+    if (name && id && Number(id) === gid) return { name, members: (members ?? '').split(',').filter(Boolean) }
+  }
+  return undefined
+}

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -346,6 +346,7 @@ async function fixture() {
     config: { image: 'test-image', cpus: 2, memoryMiB: 2048, diskGiB: 10 },
     sdk: fake.sdk,
     msbCommand: { command: process.execPath, args: ['-e', ''] },
+    kvmPreflight: () => {},
     sockets: { mcp: '/host/mcp.sock', gitcred: '/host/gitcred.sock' }
   }
   const manager = new MicrosandboxManager(options)

--- a/packages/daemon/test/microsandbox-kvm.test.ts
+++ b/packages/daemon/test/microsandbox-kvm.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { assertKvmAvailable, kvmPreflightFailure, type KvmObservation } from '../src/microsandbox/kvm.js'
+
+const base: KvmObservation = { username: 'agent', uid: 1000 }
+
+describe('microsandbox KVM preflight', () => {
+  it('passes when the device opens', () => {
+    expect(kvmPreflightFailure(base)).toBeUndefined()
+    expect(() => assertKvmAvailable(() => base)).not.toThrow()
+  })
+
+  it('names virtualization when the device is absent', () => {
+    const failure = kvmPreflightFailure({ ...base, errorCode: 'ENOENT' })
+    expect(failure).toContain('the device is absent')
+    expect(failure).toContain('nested virtualization')
+  })
+
+  it('separates a membership the process never inherited from one the user lacks', () => {
+    const group = { gid: 993, name: 'kvm', heldByProcess: false }
+    const stale = kvmPreflightFailure({ ...base, errorCode: 'EACCES', group: { ...group, heldByUser: true } })
+    expect(stale).toContain('is a member of group "kvm" but this process is not')
+    expect(stale).toContain('systemctl restart user@1000.service')
+    const missing = kvmPreflightFailure({ ...base, errorCode: 'EACCES', group: { ...group, heldByUser: false } })
+    expect(missing).toContain('usermod -aG kvm agent')
+    expect(missing).not.toContain('postdates')
+  })
+
+  it('falls back to the gid when the group has no name', () => {
+    const failure = kvmPreflightFailure({
+      ...base,
+      errorCode: 'EPERM',
+      group: { gid: 993, heldByProcess: false, heldByUser: false }
+    })
+    expect(failure).toContain('group "993"')
+  })
+
+  it('points at the device itself when the process already holds the group', () => {
+    const failure = kvmPreflightFailure({
+      ...base,
+      errorCode: 'EACCES',
+      group: { gid: 993, name: 'kvm', heldByProcess: true, heldByUser: true }
+    })
+    expect(failure).toContain('owner, mode and ACL')
+    expect(failure).not.toContain('usermod')
+  })
+
+  it('reports any other errno verbatim', () => {
+    expect(kvmPreflightFailure({ ...base, errorCode: 'EBUSY' })).toContain('(EBUSY)')
+  })
+
+  it('throws the failure it found', () => {
+    expect(() => assertKvmAvailable(() => ({ ...base, errorCode: 'ENOENT' }))).toThrow('microsandbox requires KVM')
+  })
+})


### PR DESCRIPTION
## The failure this came from

A self-hosted daemon on the microsandbox backend refused every sandboxed launch after a restart. All the operator got, in the daemon log and again in each refusal and each failed scheduled run, was the guest's own text:

```
microsandbox unavailable: Error: [BootStart] failed to start "...": sandbox
process exited (signal: 6 (SIGABRT) (core dumped)) before agent relay became
available
```

The actual cause was `/dev/kvm`: the daemon user had been added to the `kvm` group, but *after* the process that owns the daemon had already started, so the running process never carried the group. `id` showed the membership; `/proc/<pid>/status` did not. Nothing in the message pointed anywhere near that, and the diagnosis cost a host-level investigation.

## What changes

`MicrosandboxManager.probe()` opens `/dev/kvm` with `O_RDWR` before it does anything else, and turns a failure into a sentence that names the remedy:

| what it finds | what it says |
| --- | --- |
| device absent | enable hardware virtualization, or nested virtualization when the host is itself a VM |
| `EACCES`, user is in the device's group but the process is not | the membership postdates the process — restart the login session that owns the daemon (`systemctl restart user@<uid>.service` for the installed user service), not just the service |
| `EACCES`, user is not in the group | `usermod -aG <group> <user>`, then start the daemon from a new login session |
| process already holds the group | check the device's owner, mode and ACL |
| any other errno | reported with its code |

The middle row is the one worth separating out: restarting the service is the obvious move and it does not work, because a `systemd --user` manager keeps the credentials it was started with.

Being a preflight rather than a post-mortem also saves the image pull — the failing host spent 68s materializing an image it was never going to boot.

## Scope

Only the microsandbox backend. `probe()` runs from `prepare()`, which the daemon calls solely inside its `sandbox.backend === 'microsandbox'` branch; the SRT and Kubernetes paths are untouched.

The image pull path is deliberately **not** gated. `prepare-upgrade` also builds a manager, but a failure there aborts the whole upgrade (`packages/cli/src/upgrade.ts`), and a host whose KVM access is broken still has to be able to upgrade to a version that fixes it. Pulling an image needs no KVM, so it keeps working.

## Verification

- New unit tests cover every branch of the message and that `assertKvmAvailable` throws what it found.
- The check was run on a host exhibiting the original failure, under that daemon's exact credential set: it produced the "membership postdates the process" sentence with the correct group and the correct `systemctl` target. From a normal login session on the same host it passes.
- `pnpm --filter @agentconnect.md/daemon typecheck` and every microsandbox-touching suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
