### PR TITLE
fix(ci): reuse remote verification cache when saving runtime builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -391,6 +391,10 @@ jobs:
           outputs: type=cacheonly
           build-args: ${{ matrix.build_args }}
           build-contexts: ${{ matrix.build_contexts }}
+          cache-from: |
+            type=registry,ref=${{ matrix.cache_ref }}
+            type=registry,ref=${{ matrix.cache_ref }}-verify
+            type=registry,ref=${{ matrix.cache_ref }}-shim
           cache-to: type=registry,ref=${{ matrix.cache_ref }}-${{ steps.decision.outputs.unchanged == 'true' && 'shim' || 'verify' }},mode=max,compression=gzip,compression-level=1
 
       # Publish the verified runtime from the same builder; service and daemon cache exports retain their existing path.


### PR DESCRIPTION
Saving the runtime build cache could repeat a runtime-table check that the preceding step had already restored from GHCR. The save step started a separate BuildKit solve without the remote cache sources that supplied those records. A native benchmark reproduced an unnecessary table check taking about 45 seconds.

Import the same image, verification, and shim cache references when saving the cache. This completes the cache-export consolidation in #2005 while keeping export time visible as its own Actions step.

Validation:

- Workflow formatting, actionlint, and all eight existing runtime fingerprint/effective-version tests pass. Actionlint excludes two pre-existing stale action-metadata diagnostics after checking the upstream action schema.
- [Native Linux comparison](https://github.com/agentconnect-md/agentconnect/actions/runs/34559537796) of the complete revised path against the pre-#2005 configuration: rebuilding applications and shim took 434 → 341 seconds; rebuilding shim with cached applications took 252 → 250 seconds. These are individual samples using local cache exports and an image export without pushing, so they do not measure GHCR upload time or establish a repeatable release-wide speedup.
- Saving the cache reuses the runtime-table and ACP smoke results. Fresh builders restore both scenarios without repeating those probes. The separate alias-path shim export preserves the verification-cache index, and all measured shim payload hashes match.

Created by Codex . GPT-6
