### PR TITLE
fix(daemon): a sandbox that is down is not a daemon that has none

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -92,7 +92,9 @@ export const DaemonCapabilitiesDto = z.object({
   platforms: z.array(z.string()),
   runtimes: z.array(z.string()),
   acp: z.boolean(),
-  features: z.array(z.string())
+  features: z.array(z.string()),
+  /** Why a sandbox this daemon HAS is unusable right now; `features` still lists `sandbox`, because it refuses launches rather than running them unconfined. */
+  sandboxUnavailable: z.string().optional()
 })
 export const DaemonLoadDto = z.object({ cpu: z.number(), mem: z.number(), agents: z.number() })
 
@@ -850,6 +852,8 @@ export const AgentDto = z.object({
   sandboxSupported: z.boolean(),
   // #642: daemon policy forces the effective value true and makes it immutable.
   sandboxRequired: z.boolean(),
+  // Why the placed daemon cannot provide the sandbox it HAS; supported stays true, because such a session is refused, not run unconfined.
+  sandboxUnavailable: z.string().nullable(),
   // Distinct kinds of ENABLED inbound triggers on this agent — one mark per kind in the
   // list's integrations cell, without an org-wide hook list existing anywhere.
   hookKinds: z.array(z.enum(HOOK_KINDS))

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -252,16 +252,19 @@ function iconBasesOf(deps: HttpDeps): IconUrlBases {
 interface SandboxPolicy {
   supported: boolean
   required: boolean
+  /** Why a supported sandbox cannot be provided right now; null when it can. */
+  unavailable: string | null
 }
 
-const UNAVAILABLE_SANDBOX: SandboxPolicy = { supported: false, required: false }
+const NO_SANDBOX: SandboxPolicy = { supported: false, required: false, unavailable: null }
 
 function sandboxPolicyOf(daemon: DaemonView | null): SandboxPolicy {
-  if (!daemon) return UNAVAILABLE_SANDBOX
+  if (!daemon) return NO_SANDBOX
   const required = daemon.capabilities.features.includes('sandbox-required')
   return {
     supported: required || daemon.capabilities.features.includes('sandbox'),
-    required
+    required,
+    unavailable: daemon.capabilities.sandboxUnavailable ?? null
   }
 }
 
@@ -388,6 +391,7 @@ function toDto(
     runInSandbox: a.runInSandbox,
     sandboxSupported: placementView.sandbox.supported,
     sandboxRequired: placementView.sandbox.required,
+    sandboxUnavailable: placementView.sandbox.unavailable,
     hookKinds
   }
 }
@@ -399,7 +403,7 @@ interface PlacementView {
   ready: boolean
 }
 
-const NO_PLACEMENT: PlacementView = { daemonName: null, sandbox: UNAVAILABLE_SANDBOX, ready: false }
+const NO_PLACEMENT: PlacementView = { daemonName: null, sandbox: NO_SANDBOX, ready: false }
 
 function placementViewOf(deps: HttpDeps, daemon: DaemonView | null): PlacementView {
   const live = daemon ? deps.liveness.get(daemon.daemonId) : undefined

--- a/packages/control-plane/src/ports.ts
+++ b/packages/control-plane/src/ports.ts
@@ -178,6 +178,8 @@ export interface DaemonCapabilities {
   runtimes: string[]
   acp: boolean
   features: string[]
+  /** Why a sandbox this daemon HAS cannot be provided right now; absent when it can. */
+  sandboxUnavailable?: string
 }
 
 /** Last reported `Heartbeat.load`. */

--- a/packages/control-plane/src/registry/registryService.ts
+++ b/packages/control-plane/src/registry/registryService.ts
@@ -28,7 +28,15 @@ import type { Clock } from '../domain/clock.js'
 function normCapabilities(raw: unknown): DaemonCapabilities {
   const c = (raw ?? {}) as Record<string, unknown>
   const arr = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [])
-  return { platforms: arr(c.platforms), runtimes: arr(c.runtimes), acp: c.acp === true, features: arr(c.features) }
+  return {
+    platforms: arr(c.platforms),
+    runtimes: arr(c.runtimes),
+    acp: c.acp === true,
+    features: arr(c.features),
+    ...(typeof c.sandboxUnavailable === 'string' && c.sandboxUnavailable
+      ? { sandboxUnavailable: c.sandboxUnavailable }
+      : {})
+  }
 }
 
 /** Coerce the stored `load` JSON (null before the first heartbeat) into the typed shape. */

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -26,7 +26,13 @@ export async function seedDaemon(
   opts: {
     sessionEpoch?: bigint
     maxAgents?: number
-    capabilities?: { platforms: string[]; runtimes: string[]; acp: boolean; features: string[] }
+    capabilities?: {
+      platforms: string[]
+      runtimes: string[]
+      acp: boolean
+      features: string[]
+      sandboxUnavailable?: string
+    }
     visibility?: 'org' | 'restricted'
     sharedWith?: string[]
     createdByUserId?: string

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -208,6 +208,50 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(disable.json()).toMatchObject({ message: 'Run in sandbox is required by this daemon' })
   })
 
+  it('keeps Run in sandbox on a daemon whose sandbox is down, and reports why', async () => {
+    const app = build()
+    const downId = randomUUID()
+    const reason = 'microsandbox requires KVM, but this daemon cannot open /dev/kvm'
+    await seedDaemon(prisma, downId, {
+      capabilities: {
+        platforms: [],
+        runtimes: ['claude'],
+        acp: true,
+        features: ['sandbox'],
+        sandboxUnavailable: reason
+      }
+    })
+
+    // Supported, because such a daemon refuses the session rather than running it unconfined; reading the outage as "no sandbox" used to store false.
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'sandbox-down', runtime: 'claude', daemonId: downId, runInSandbox: true }
+    })
+    expect(created.statusCode).toBe(201)
+    expect(created.json()).toMatchObject({
+      runInSandbox: true,
+      sandboxSupported: true,
+      sandboxRequired: false,
+      sandboxUnavailable: reason
+    })
+
+    // …and turning it ON there is a real request the operator gets to make, not a 409.
+    const off = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'sandbox-down-off', runtime: 'claude', daemonId: downId }
+    })
+    expect(off.statusCode).toBe(201)
+    const enable = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${(off.json() as { id: string }).id}`,
+      payload: { runInSandbox: true }
+    })
+    expect(enable.statusCode).toBe(200)
+    expect(enable.json()).toMatchObject({ runInSandbox: true, sandboxUnavailable: reason })
+  })
+
   it('PUT /agents/:id/call-policy stores selected peer agents and clears the list for all', async () => {
     const app = build()
     const targetId = randomUUID()

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -94,6 +94,8 @@ export interface CpClientConnectionHost {
 export interface CpClientRegistrationHost {
   registrationPlatforms(): string[]
   registrationFeatures(): string[]
+  /** Set only when a configured sandbox is unusable; the CP keeps the `sandbox` capability either way. */
+  sandboxUnavailable(): string | undefined
   admittedRuntimeIds(): string[]
   reportedRuntimeIds(): string[]
   /** Registry id -> human-facing runtime name. */
@@ -246,15 +248,19 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
     generation: process.env[POD_TEMPLATE_HASH_ENV]?.trim() || undefined,
     heartbeatDefaultMs: host.heartbeatDefaultMs(),
     maxAgents: host.maxAgents(),
-    capabilities: () => ({
-      platforms: host.registrationPlatforms(),
-      // Report the human-facing tool name (e.g. "Claude Agent"), not the
-      // registry id ("claude-acp"); fall back to the id for user-defined or
-      // unnamed runtimes.
-      runtimes: host.admittedRuntimeIds().map((id) => host.runtimeNames()[id] ?? id),
-      acp: true,
-      features: host.registrationFeatures()
-    }),
+    capabilities: () => {
+      const sandboxUnavailable = host.sandboxUnavailable()
+      return {
+        platforms: host.registrationPlatforms(),
+        // Report the human-facing tool name (e.g. "Claude Agent"), not the
+        // registry id ("claude-acp"); fall back to the id for user-defined or
+        // unnamed runtimes.
+        runtimes: host.admittedRuntimeIds().map((id) => host.runtimeNames()[id] ?? id),
+        acp: true,
+        features: host.registrationFeatures(),
+        ...(sandboxUnavailable ? { sandboxUnavailable } : {})
+      }
+    },
     // Observed runtime profiles, sent as one `facts/daemon-runtimes` snapshot on
     // each register. Keyed by the registry id (the launch key), so the console can
     // offer a runtime whose value round-trips back to `this.runtimes[agent.runtime]`

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -557,7 +557,7 @@ import type {
   TaskList,
   TaskListReq
 } from '@agentconnect.md/protocol'
-import { formatErr, startFailureDetail } from './daemon/text.js'
+import { boundedDiagnostic, formatErr, startFailureDetail } from './daemon/text.js'
 import { isBuiltinSystemToolCall, type ApprovalRequestParts } from './daemon/tool-classification.js'
 import { buildTurnPlan, type TurnPlan } from './daemon/turn-plan.js'
 import { turnEvaluationReporter, type TurnEvaluationReporter } from './daemon/turn-evaluation.js'
@@ -5098,7 +5098,8 @@ export class Daemon {
   /** Why a configured sandbox cannot be used right now — the text the console shows instead of "no sandbox here". */
   private sandboxUnavailableReason(): string | undefined {
     if (this.cfg.sandbox.backend !== 'microsandbox' || this.microsandbox) return undefined
-    return this.microsandboxFailure ?? 'microsandbox is not initialized'
+    // Bounded before publishing: the log keeps the whole failure, while an over-long optional diagnostic would fail the register schema and strand the daemon.
+    return boundedDiagnostic(this.microsandboxFailure ?? '') || 'microsandbox is not initialized'
   }
 
   private registrationFeatures(): string[] {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5095,6 +5095,12 @@ export class Daemon {
     return platformIds()
   }
 
+  /** Why a configured sandbox cannot be used right now — the text the console shows instead of "no sandbox here". */
+  private sandboxUnavailableReason(): string | undefined {
+    if (this.cfg.sandbox.backend !== 'microsandbox' || this.microsandbox) return undefined
+    return this.microsandboxFailure ?? 'microsandbox is not initialized'
+  }
+
   private registrationFeatures(): string[] {
     return [
       ...(this.opts.agentName ? [] : ['agent-move-v1', 'workspace-convert-v1', 'workspace-edit-v2']),
@@ -5112,7 +5118,8 @@ export class Daemon {
       WORKSPACE_GIT_MESSAGE_FEATURE,
       WORKSPACE_GIT_REVIEW_FEATURE,
       WORKSPACE_GIT_WRITE_FEATURE,
-      ...((this.cfg.sandbox.backend === 'microsandbox' ? this.microsandbox : this.sandboxMechanism) ? ['sandbox'] : []),
+      // A failed microsandbox still HAS a sandbox: it refuses each launch rather than running it unconfined, and `sandboxUnavailable` says why.
+      ...(this.cfg.sandbox.backend === 'microsandbox' || this.sandboxMechanism ? ['sandbox'] : []),
       ...(this.cfg.security.requireSandbox ? ['sandbox-required'] : []),
       'memory-dreaming-v1',
       MEMORY_ENTRIES_V1_FEATURE,
@@ -18183,6 +18190,7 @@ export class Daemon {
       resolveInitialRegistry,
       registrationPlatforms: () => this.registrationPlatforms(),
       registrationFeatures: () => this.registrationFeatures(),
+      sandboxUnavailable: () => this.sandboxUnavailableReason(),
       admittedRuntimeIds: () => this.admittedRuntimeIds(),
       reportedRuntimeIds: () => this.reportedRuntimeIds(),
       runtimeNames: () => this.runtimeFacts.runtimeNames(),

--- a/packages/daemon/src/daemon/text.ts
+++ b/packages/daemon/src/daemon/text.ts
@@ -32,6 +32,17 @@ export function startFailureDetail(err: unknown, max = 240): string {
   return redacted.length > max ? `${redacted.slice(0, max - 1)}…` : redacted
 }
 
+/** One bounded single-line summary of a diagnostic that has to fit a wire schema; the full text belongs in the log. */
+export function boundedDiagnostic(text: string, max = 500): string {
+  const body = text
+    .split('\n')
+    .filter((line) => !/^\s+at\s/.test(line))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return body.length > max ? `${body.slice(0, max - 1)}…` : body
+}
+
 export function formatErrWithCauses(err: unknown): string {
   const parts: string[] = []
   const seen = new Set<unknown>()

--- a/packages/daemon/test/daemon-sandbox-capability.test.ts
+++ b/packages/daemon/test/daemon-sandbox-capability.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
+import { RegisterReq } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 
 const AGENT_ID = 'bot-a'
@@ -81,6 +82,36 @@ describe('the sandbox a daemon reports', () => {
     })
     expect(report.features).toContain('sandbox')
     expect(report.unavailable).toBeUndefined()
+  })
+
+  it('publishes a bounded summary, so a huge failure cannot strand the whole daemon', async () => {
+    // `msb pull` may hand back a megabyte of stderr; the register frame caps this field, and a
+    // rejected registration would take down the daemon's unsandboxed agents too.
+    const stderr = `boom ${'x'.repeat(4000)}`
+    const report = await sandboxReport((daemon) => {
+      daemon.cfg.sandbox.backend = 'microsandbox'
+      daemon.microsandbox = undefined
+      daemon.microsandboxFailure = `Error: ${stderr}\n    at Object.run (/opt/daemon/dist/index.js:1:1)`
+    })
+    expect(report.unavailable!.length).toBeLessThanOrEqual(500)
+    expect(report.unavailable).toContain('boom')
+    expect(report.unavailable!.endsWith('…')).toBe(true)
+    // Stack frames are log material, not console material.
+    expect(report.unavailable).not.toContain('at Object.run')
+
+    const decoded = RegisterReq.safeParse({
+      host: 'example-host',
+      capabilities: {
+        platforms: [],
+        runtimes: [],
+        acp: true,
+        features: report.features,
+        sandboxUnavailable: report.unavailable
+      },
+      maxAgents: 1,
+      localState: { assignments: [], crons: [], leases: [] }
+    })
+    expect(decoded.success).toBe(true)
   })
 
   it('claims nothing on a host whose SRT backend has no mechanism', async () => {

--- a/packages/daemon/test/daemon-sandbox-capability.test.ts
+++ b/packages/daemon/test/daemon-sandbox-capability.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+
+const AGENT_ID = 'bot-a'
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-sandbox-cap-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { 'arbitrary-acp': { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', AGENT_ID)
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: AGENT_ID,
+      name: AGENT_ID,
+      status: 'active',
+      runtime: 'arbitrary-acp',
+      builtin: true,
+      runInSandbox: true,
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' }
+    })
+  )
+  return root
+}
+
+/** Boots a daemon and reports what it would tell the CP about its sandbox, under `mutate`'s state. */
+async function sandboxReport(mutate: (daemon: Record<string, any>) => void): Promise<{
+  features: string[]
+  unavailable: string | undefined
+}> {
+  const daemon = new Daemon({
+    root: scaffold(),
+    hostFactory: () => ({ start: vi.fn(async () => {}), stop: vi.fn(async () => {}) }) as never
+  })
+  await daemon.start()
+  const anyDaemon = daemon as never as Record<string, any>
+  mutate(anyDaemon)
+  const report = { features: anyDaemon.registrationFeatures(), unavailable: anyDaemon.sandboxUnavailableReason() }
+  await daemon.stop().catch(() => {})
+  return report
+}
+
+describe('the sandbox a daemon reports', () => {
+  it('still claims the capability when a configured microsandbox failed, and says why', async () => {
+    const report = await sandboxReport((daemon) => {
+      daemon.cfg.sandbox.backend = 'microsandbox'
+      daemon.microsandbox = undefined
+      daemon.microsandboxFailure = 'cannot open /dev/kvm'
+    })
+    // Reporting no capability would read as "this host runs agents unconfined" — the opposite of the truth.
+    expect(report.features).toContain('sandbox')
+    expect(report.unavailable).toBe('cannot open /dev/kvm')
+  })
+
+  it('names the state even when the failure text was lost', async () => {
+    const report = await sandboxReport((daemon) => {
+      daemon.cfg.sandbox.backend = 'microsandbox'
+      daemon.microsandbox = undefined
+      daemon.microsandboxFailure = undefined
+    })
+    expect(report.features).toContain('sandbox')
+    expect(report.unavailable).toBe('microsandbox is not initialized')
+  })
+
+  it('reports a healthy microsandbox with no reason attached', async () => {
+    const report = await sandboxReport((daemon) => {
+      daemon.cfg.sandbox.backend = 'microsandbox'
+      daemon.microsandbox = { stopAll: vi.fn(async () => {}) }
+    })
+    expect(report.features).toContain('sandbox')
+    expect(report.unavailable).toBeUndefined()
+  })
+
+  it('claims nothing on a host whose SRT backend has no mechanism', async () => {
+    const report = await sandboxReport((daemon) => {
+      daemon.sandboxMechanism = undefined
+    })
+    expect(report.features).not.toContain('sandbox')
+    expect(report.unavailable).toBeUndefined()
+  })
+})

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -31,7 +31,9 @@ export const RegisterReq = z.object({
     platforms: z.array(Platform), // D3 adapters present
     runtimes: z.array(z.string()), // e.g. ["claude","codex"]
     acp: z.boolean(), // can this daemon host ACP sessions (D6)?
-    features: z.array(z.string()).default([]) // e.g. ["cli-wrapper-fallback","worktree-iso"]
+    features: z.array(z.string()).default([]), // e.g. ["cli-wrapper-fallback","worktree-iso"]
+    // Why a configured sandbox is unusable right now; `features` keeps `sandbox`, since such a daemon refuses a launch rather than running it unconfined.
+    sandboxUnavailable: z.string().max(2000).optional()
   }),
   maxAgents: z.number().int(), // concurrency ceiling for placement (C3)
   localState: z.object({

--- a/packages/web/src/components/console/CompactToggleField.test.tsx
+++ b/packages/web/src/components/console/CompactToggleField.test.tsx
@@ -61,4 +61,33 @@ describe('CompactToggleField', () => {
 
     expect(html).toContain('Run in sandbox')
   })
+
+  it('tells a BROKEN sandbox apart from a missing one, and keeps the setting editable', () => {
+    // The machine has a sandbox it cannot provide, so "uses its normal environment" would say the opposite of what happens.
+    const html = renderToStaticMarkup(
+      <SandboxField
+        checked
+        supported
+        required={false}
+        unavailable="microsandbox requires KVM, but this daemon cannot open /dev/kvm"
+        onChange={() => undefined}
+      />
+    )
+
+    expect(html).toContain('aria-label="Run in sandbox: Unavailable"')
+    expect(html).toContain('sessions that need one are refused rather than run unconfined')
+    expect(html).toContain('cannot open /dev/kvm')
+    expect(html).not.toContain('uses its normal environment')
+    // Supported, so the operator can still turn the setting off deliberately.
+    expect(html).not.toContain('aria-label="Run in sandbox: Unavailable" disabled=""')
+  })
+
+  it('keeps saying "Unavailable" plainly when the machine has no sandbox at all', () => {
+    const html = renderToStaticMarkup(
+      <SandboxField checked={false} supported={false} required={false} onChange={() => undefined} />
+    )
+
+    expect(html).toContain('Sandboxing is not available for the current selection')
+    expect(html).not.toContain('refused rather than run unconfined')
+  })
 })

--- a/packages/web/src/components/console/SandboxField.tsx
+++ b/packages/web/src/components/console/SandboxField.tsx
@@ -16,6 +16,7 @@ export function SandboxField({
   checked,
   supported,
   required,
+  unavailable,
   disabled,
   disabledDetail,
   clusterPlacement = false,
@@ -24,6 +25,8 @@ export function SandboxField({
   checked: boolean
   supported: boolean
   required: boolean
+  /** Why a sandbox the computer HAS cannot be provided right now — a different answer from having none. */
+  unavailable?: string | null
   disabled?: boolean
   disabledDetail?: string
   /** The selected placement is the cluster/pool, whose isolation is the pod, not this toggle. */
@@ -31,16 +34,20 @@ export function SandboxField({
   onChange: (checked: boolean) => void
 }) {
   if (clusterPlacement) return null
-  const status = required ? 'Required' : !supported ? 'Unavailable' : checked ? 'On' : 'Off'
-  const detail = required
-    ? 'Sandboxing is required on the selected computer. The runtime uses a private HOME and is confined to its workspace.'
-    : !supported
-      ? 'Sandboxing is not available for the current selection, so the runtime uses its normal environment.'
-      : disabled && disabledDetail
-        ? disabledDetail
-        : checked
-          ? 'The runtime runs in an OS sandbox with a private HOME and is confined to its workspace.'
-          : 'The runtime uses the selected computer environment without OS sandbox isolation.'
+  // A broken sandbox is not a missing one: the setting stands, and sessions are refused until it is fixed.
+  const down = supported && !!unavailable
+  const status = down ? 'Unavailable' : required ? 'Required' : !supported ? 'Unavailable' : checked ? 'On' : 'Off'
+  const detail = down
+    ? `The selected computer cannot provide its sandbox right now, so sessions that need one are refused rather than run unconfined. ${unavailable}`
+    : required
+      ? 'Sandboxing is required on the selected computer. The runtime uses a private HOME and is confined to its workspace.'
+      : !supported
+        ? 'Sandboxing is not available for the current selection, so the runtime uses its normal environment.'
+        : disabled && disabledDetail
+          ? disabledDetail
+          : checked
+            ? 'The runtime runs in an OS sandbox with a private HOME and is confined to its workspace.'
+            : 'The runtime uses the selected computer environment without OS sandbox isolation.'
 
   return (
     <CompactToggleField

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -323,6 +323,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   ]
   const sandboxRequired = daemon?.caps.features.includes('sandbox-required') ?? false
   const sandboxSupported = sandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
+  const sandboxUnavailable = daemon?.caps.sandboxUnavailable ?? null
   const effectiveRunInSandbox = sandboxRequired || (sandboxSupported && runInSandbox)
   // The pool advertises no `sandbox` capability, so its pod — not the triple above — is what encloses a session there.
   const isolationLabel = sessionIsolationLabel({
@@ -1031,6 +1032,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                 checked={effectiveRunInSandbox}
                 supported={sandboxSupported}
                 required={sandboxRequired}
+                unavailable={sandboxUnavailable}
                 clusterPlacement={placement?.kind === 'pool'}
                 onChange={setRunInSandbox}
               />

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -186,6 +186,7 @@ export default function EditAgentModal({
   // #642: the placed daemon reports whether sandboxing is available or mandatory.
   const [sandboxSupported, setSandboxSupported] = useState(agent.sandboxSupported)
   const [sandboxRequired, setSandboxRequired] = useState(agent.sandboxRequired)
+  const [sandboxUnavailable, setSandboxUnavailable] = useState(agent.sandboxUnavailable ?? null)
   const [repairPlacement, setRepairPlacement] = useState(false)
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
@@ -252,6 +253,7 @@ export default function EditAgentModal({
         initialRunInSandbox.current = dto.runInSandbox ?? false
         setSandboxSupported(dto.sandboxSupported ?? false)
         setSandboxRequired(dto.sandboxRequired ?? false)
+        setSandboxUnavailable(dto.sandboxUnavailable ?? null)
         const fresh: SharingValue = { visibility: dto.visibility, sharedWith: dto.sharedWith }
         setSharing(fresh)
         initialSharing.current = fresh
@@ -378,6 +380,7 @@ export default function EditAgentModal({
   const selectedSandboxSupported = daemonChanged
     ? selectedSandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
     : sandboxSupported
+  const selectedSandboxUnavailable = daemonChanged ? (daemon?.caps.sandboxUnavailable ?? null) : sandboxUnavailable
   const effectiveRunInSandbox = selectedSandboxRequired || (selectedSandboxSupported && runInSandbox)
   const poolServing = daemons.some((candidate) => candidate.pool && moveReady(candidate))
   const daemonOptions: DaemonSelectOption[] = [
@@ -949,6 +952,7 @@ export default function EditAgentModal({
                   checked={effectiveRunInSandbox}
                   supported={selectedSandboxSupported}
                   required={selectedSandboxRequired}
+                  unavailable={selectedSandboxUnavailable}
                   disabled={placementRequested}
                   disabledDetail="Save the computer change before adjusting sandboxing."
                   clusterPlacement={daemonId === POOL_PLACEMENT}

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -143,11 +143,15 @@ export default function DaemonDetailView() {
       }
     ]
   })
-  const sandboxUnavailable = runtimeEnvironment === 'sandbox' && !sandboxSupported
+  // A daemon whose configured sandbox is down reports the capability AND the reason: both mean no sandbox runtimes.
+  const sandboxDownReason = daemon.caps.sandboxUnavailable
+  const sandboxUnavailable = runtimeEnvironment === 'sandbox' && (!sandboxSupported || !!sandboxDownReason)
   const runtimes: FleetRuntime[] = sandboxUnavailable ? [] : unionRuntimes([{ ...daemon, runtimeModels }])
-  const runtimeEmpty = sandboxUnavailable
-    ? 'Sandbox is unavailable on this daemon.'
-    : 'No runtimes reported by this daemon.'
+  const runtimeEmpty = sandboxDownReason
+    ? `Sandbox is unavailable on this daemon. ${sandboxDownReason}`
+    : sandboxUnavailable
+      ? 'Sandbox is unavailable on this daemon.'
+      : 'No runtimes reported by this daemon.'
   const runtimeModeControl = sandboxRequired ? (
     <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">Sandbox</span>
   ) : (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -353,6 +353,7 @@ export interface AgentDto {
   runInSandbox: boolean // #642: persisted per-agent Run in sandbox preference
   sandboxSupported: boolean // #642: whether the placed daemon can provide an OS sandbox
   sandboxRequired: boolean // #642: whether daemon policy forces the effective value on
+  sandboxUnavailable: string | null // why a sandbox the daemon HAS cannot be provided right now
   hookKinds: HookKind[] // distinct kinds of enabled inbound triggers (list-view marks)
 }
 
@@ -1951,6 +1952,7 @@ export function agentFromDto(d: AgentDto): Agent {
     runInSandbox: d.runInSandbox ?? false,
     sandboxSupported: d.sandboxSupported ?? false,
     sandboxRequired: d.sandboxRequired ?? false,
+    sandboxUnavailable: d.sandboxUnavailable ?? null,
     hookKinds: d.hookKinds ?? [],
     integrations: [],
     workspace: ws

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -615,6 +615,8 @@ export interface Agent {
   sandboxSupported: boolean
   /** #642: whether daemon policy forces the effective value on and locks the toggle. */
   sandboxRequired: boolean
+  /** Why the placed daemon cannot provide the sandbox it HAS; supported stays true, since it refuses the session rather than running it unconfined. */
+  sandboxUnavailable?: string | null
   integrations: Integration[]
   /** Distinct kinds of enabled inbound triggers (hooks) — list-view marks. */
   hookKinds?: HookKind[]
@@ -2175,6 +2177,8 @@ export interface DaemonCaps {
   runtimes: string[]
   acp: boolean
   features: string[]
+  /** Why a sandbox this daemon HAS is unusable right now; `features` still lists `sandbox`, since it refuses such a session rather than running it unconfined. */
+  sandboxUnavailable?: string
 }
 
 /** One daemon-configured MCP server (protocol `FactsMcpServer`) — name +


### PR DESCRIPTION
Follow-up to #2006, which made a broken microsandbox *say* why it broke. This one fixes what the rest of the system concluded from it.

## One bit, two questions

A daemon advertised the `sandbox` capability only while its sandbox was **healthy**:

```ts
...((cfg.sandbox.backend === 'microsandbox' ? this.microsandbox : this.sandboxMechanism) ? ['sandbox'] : []),
```

So a microsandbox that failed to start became indistinguishable from a host that never had a sandbox — and those two states mean opposite things:

| | what actually happens to a sandboxed agent |
| --- | --- |
| host has no sandbox mechanism | it runs **unconfined** (fail-open, by design) |
| configured sandbox is down | every launch is **refused** (fail-closed) |

Everything downstream read the first meaning. Observed on a real daemon whose microsandbox could not reach KVM:

- The **Run in sandbox** field said *"Sandboxing is not available for the current selection, so the runtime uses its normal environment"* — describing an unconfined run that was not happening. The agent ran nowhere at all.
- The **daemon detail view** filed its sandboxed agents under the *host* runtime bucket, and offered host runtimes it was not going to use.
- The daemon still reported `status: ready`, `health: ok`.
- Worst: creating an agent on that daemon **silently stored `runInSandbox: false`**, because the create path reads an absent capability as "this daemon cannot", and turning a transient outage into a permanent setting change nobody asked for is a security-relevant edit, not a display bug.

## What changes

A daemon now advertises the capability from its **configuration** and reports the outage **separately**:

- `RegisterReq.capabilities.sandboxUnavailable` — optional, carries the daemon's own reason. `features` keeps `sandbox`.
- The CP's `SandboxPolicy` gains `unavailable`, and the agent DTO a `sandboxUnavailable`. `supported` stays true, so the stored preference survives and enabling it is still a request the operator may make — it is a temporary outage, not a property of the machine.
- `SandboxField` gets a third state: **Unavailable**, explaining that sessions needing a sandbox are refused rather than run unconfined, and quoting what the daemon reported. The toggle stays editable, so turning the sandbox off deliberately remains possible.
- `DaemonDetailView` reads the reason for its empty runtime list instead of inferring it from the missing capability.

Nothing changes for a host that genuinely has no sandbox: it advertises no capability and the field says exactly what it said before.

## Tests

- `daemon-sandbox-capability`: a failed microsandbox still claims the capability and reports its reason; a lost reason still names the state; a healthy one attaches none; an SRT host with no mechanism claims nothing.
- `agents.route`: an agent created on a daemon whose sandbox is down **keeps** `runInSandbox: true` and reports the reason, and enabling it there over PATCH is a 200, not a 409.
- `SandboxField`: the down state quotes the reason and never says "uses its normal environment"; the no-sandbox-at-all state is unchanged.

`typecheck` passes in all four packages; the CP integration suite (2009 tests), the web suite (2533), the protocol suite and the daemon suite are green apart from four host-dependent files that fail identically on this machine before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
