### PR TITLE
fix(skills): align sandbox receipts and admit execution duty before startup

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -279,8 +279,9 @@ through their host-side representation.
 
 Retired-root sweeps skip cold VMs; explicit Console reads may resume them. If
 optional microsandbox initialization fails, host file inspection remains
-available while VM launches remain refused. The shared Kubernetes skill receipt
-size limits and duty-authority requirements also apply to microsandbox.
+available while VM launches remain refused. Kubernetes and microsandbox share
+the paged skill receipt protocol and require duty admission before serving
+activation or explicit launch prepares a sandbox workspace.
 
 Kubernetes mode retains `K8sDriver`, its resource configuration, and image rollout.
 An explicitly configured local microsandbox backend

--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -82,6 +82,19 @@ digests and CLI-derived relative roots outside the agent-writable workspace.
   receipt-owned roots, and returns the applied ledger before ACP starts. Shared
   journal writes are fenced by duty term and SandboxClaim UID.
 
+The publisher, durable ledger, and shared shim admit up to 64 installed bundles,
+each with 64 files and relative paths of at most 1024 UTF-8 bytes. These selected
+installation limits are separate from the larger source snapshot manifest.
+`cluster-skills-v3` pages prior receipts, installation results, and verification
+requests within the 220 KiB control-message budget. Small receipts still use one
+reconcile round trip. Publication checks result capacity before changing workspace
+files; older shims retain their single-frame admission until their image is updated.
+
+Serving activation and explicit launch acquire and project execution duty before
+preparing a sandbox workspace. Claim admission runs outside the agent lifecycle
+queue because installing a granted bundle can use that queue itself. A replica-only
+unstage retains its move token but does not claim duty or start a non-holder runtime.
+
 Implementation anchors:
 
 | Building block                               | Location                                                          | Role                                                        |

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -940,7 +940,7 @@ export function buildContainer(
     placement: placementResolver,
     memberSets: repos.memberSet,
     liveness: connReg,
-    recomputeDuties: (orgId: string) => dutyRecompute.kick(orgId),
+    recomputeDuties: (orgId: string) => dutyRecompute.recomputeOrg(orgId),
     log: { warn: (o, m) => http.log.warn(o, m) }
   })
 

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -181,6 +181,7 @@ function make(
     workspaceRepoId?: bigint
     sourceDetachStarted?: () => void
     waitSourceDetach?: Promise<void>
+    recomputeDuties?: (orgId: string) => Promise<void>
     /** Which set each daemon belongs to (absent daemon ⇒ no set) + each set's members. */
     sets?: { setIdOf: Record<string, string>; members: Record<string, string[]> }
     /** Daemon ids the liveness fake reports READY; others read as disconnected. */
@@ -374,6 +375,7 @@ function make(
     httpBot: { syncBot: async () => void calls.push('http') } as unknown as HttpBotOrchestrator,
     collabRoutes: { broadcast: async () => void calls.push('collab') } as unknown as CollabRoutesService,
     mutations,
+    recomputeDuties: opts.recomputeDuties,
     sessionOwners: { releaseSession: (key) => void releasedLive.push(key as typeof SESSION_KEY) },
     ...(opts.sets
       ? {
@@ -739,6 +741,33 @@ describe('AgentMoveService', () => {
 
     expect(t.activations).toHaveLength(1)
     expect(t.activations[0]?.moveId).toBe(t.detaches[0]?.moveId)
+    expect(t.activations[0]?.unstageOnly).toBe(true)
+  })
+
+  it('waits for duty eligibility after target staging and before activation', async () => {
+    let markStarted!: () => void
+    let release!: () => void
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const resume = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const t = make({
+      recomputeDuties: async (orgId) => {
+        expect(orgId).toBe(ORG)
+        markStarted()
+        await resume
+      }
+    })
+    const pending = t.service.move(t.current(), onDaemon(TARGET))
+    await started
+    expect(t.current().daemonId).toBe(TARGET)
+    expect(t.calls).toContain(`detach:${TARGET}`)
+    expect(t.activations).toEqual([])
+    release()
+    await pending
+    expect(t.calls).toContain(`activate:${TARGET}`)
   })
 
   it('reconnect recovery releases a reported stale fence for an eligible member that serves nothing', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -133,9 +133,8 @@ export interface AgentMoveDeps {
    *  placement names no machine of its own. Absent ⇒ placement alone (the pre-duty behavior). */
   placement?: PlacementResolver
   log?: AgentMoveLog
-  /** Placement decides duty incumbency (design §4.4 soak policy), so a completed
-   *  move re-derives the org's groups. Fire-and-forget; the sweep is the backstop. */
-  recomputeDuties?: (orgId: string) => void
+  /** Re-derive placement eligibility before a target claims its execution duty. */
+  recomputeDuties?: (orgId: string) => Promise<void> | void
 }
 
 interface MoveBundle {
@@ -365,7 +364,7 @@ export class AgentMoveService {
     // Repairing a pool placement is the ledger's job: re-derive the duty group, clear any stale
     // member fence that would make the next grant a dark hold, and let the lease exchange install.
     if (placement.kind !== 'daemon') {
-      this.deps.recomputeDuties?.(agent.orgId)
+      await this.deps.recomputeDuties?.(agent.orgId)
       await this.unstageEligibleSources(agent, new Map(), placement)
       await this.convergeDerived(agent, (await this.snapshot(agent)).httpBotIds)
       return agent
@@ -600,7 +599,6 @@ export class AgentMoveService {
     let moved: AgentRecord | null
     try {
       moved = await this.deps.agents.movePlacement(agent.id, source, target, editor, opts)
-      if (moved) this.deps.recomputeDuties?.(moved.orgId)
     } catch (err) {
       await this.restoreSourceIfStillOwner(agent, source, sourceBundle)
       throw new AgentMoveFailed('failed to persist agent placement', err)
@@ -615,6 +613,7 @@ export class AgentMoveService {
     // through `duty/fetch` and starts serving. Committing the placement IS the move — a
     // synchronous activation would only name one member the ledger is free to replace next beat.
     if (target.kind !== 'daemon') {
+      await this.deps.recomputeDuties?.(moved.orgId)
       await this.unstageEligibleSources(moved, stagedSources, target)
       await this.convergeDerived(moved, sourceBundle.httpBotIds)
       return moved
@@ -680,7 +679,11 @@ export class AgentMoveService {
         'source unstage',
         await this.deps.control.agentActivate(
           daemonId,
-          { ...this.activationDefinition(agent, bundle), ...(moveId === undefined ? {} : { moveId }) },
+          {
+            ...this.activationDefinition(agent, bundle),
+            unstageOnly: true,
+            ...(moveId === undefined ? {} : { moveId })
+          },
           agent.orgId
         )
       )
@@ -1062,7 +1065,7 @@ export class AgentMoveService {
         source,
         editor
       )
-      if (restored) this.deps.recomputeDuties?.(restored.orgId)
+      if (restored) await this.deps.recomputeDuties?.(restored.orgId)
     } catch (err) {
       this.deps.log?.warn({ err, agentId: moved.id }, 'agent move: placement rollback failed')
     }
@@ -1099,6 +1102,7 @@ export class AgentMoveService {
     // complete snapshot synchronously while the staging tombstone remains armed.
     const moveId = randomUUID()
     requireAck(`${label} staging detach`, await this.detach(daemonId, agent.id, agent.orgId, { moveId }))
+    await this.deps.recomputeDuties?.(agent.orgId)
     requireAck(
       `${label} activate`,
       await this.deps.control.agentActivate(

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -111,6 +111,7 @@ export interface ConfigApplyGateHost {
   reserveAgentDrain(agentId: string): (preserveGate: boolean) => void
   agentRemovalPending(agentId: string): boolean
   agentDestructivePending(agentId: string): boolean
+  agentDrainVersion(agentId: string): number
   clearRemovalAfterDestruction(agentId: string): void
   clearRemovalForReadd(agentId: string): void
   queueAgentLifecycle<T>(
@@ -118,7 +119,13 @@ export interface ConfigApplyGateHost {
     work: () => Promise<T>,
     opts?: { failureOwner?: string; onSettled?: () => void }
   ): Promise<T>
-  queueAgentMove(kind: 'detach' | 'activate', agentId: string, moveId: string, work: () => Promise<Ack>): Promise<Ack>
+  queueAgentMove(
+    kind: 'detach' | 'activate',
+    agentId: string,
+    moveId: string,
+    work: () => Promise<Ack>,
+    admit?: () => Promise<Ack | undefined>
+  ): Promise<Ack>
 }
 
 /** Live agents, their hosts, workspaces, and the credentials bound to them. */
@@ -153,6 +160,7 @@ export interface ConfigApplyRuntimeHost {
   activationCapabilityError(agent: LoadedAgent): string | undefined
   /** True when this daemon holds the duty that serves the agent. */
   servesAgent(agentId: string): boolean
+  claimAgentDuty(agentId: string, isLifecycleCurrent: () => boolean): Promise<{ granted: boolean }>
   closeUnusedPlatformConnections(): Promise<void>
 }
 
@@ -526,7 +534,26 @@ export function applyAgentDetach(host: ConfigApplyHost, detach: AgentDetach): Pr
 
 export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivate): Promise<Ack> {
   const { agentId } = activate
-  return host.queueAgentMove('activate', agentId, activate.moveId ?? 'unstage', async () => {
+  const requiresRuntime = activate.moveId !== undefined && !activate.unstageOnly
+  const drainVersion = host.agentDrainVersion(agentId)
+  const isCurrent = (): boolean => {
+    const stage = host.moveStageMetadata().get(agentId)
+    return (
+      stage?.moveId === activate.moveId &&
+      stage?.state === 'staging' &&
+      host.moveStagedAgents().has(agentId) &&
+      host.drainingAgents().has(agentId) &&
+      !host.agentDestructivePending(agentId) &&
+      host.agentDrainVersion(agentId) === drainVersion &&
+      !host.singleAgentMode()
+    )
+  }
+  const admit = async (): Promise<Ack | undefined> => {
+    if (!requiresRuntime || !isCurrent() || host.servesAgent(agentId)) return
+    const claim = await host.claimAgentDuty(agentId, isCurrent)
+    if (!claim.granted) return { ok: false, reason: 'agent/activate: execution duty is not ready' }
+  }
+  const work = async (): Promise<Ack> => {
     if (host.singleAgentMode()) {
       return { ok: false, reason: 'agent move is unavailable in --agent single-agent mode' }
     }
@@ -543,6 +570,12 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
       !host.drainingAgents().has(agentId)
     ) {
       return { ok: false, reason: 'agent/activate: staging fence is missing or superseded' }
+    }
+    if (host.agentDrainVersion(agentId) !== drainVersion) {
+      return { ok: false, reason: 'agent/activate: superseded by a newer agent drain' }
+    }
+    if (requiresRuntime && !host.servesAgent(agentId)) {
+      return { ok: false, reason: 'agent/activate: execution duty is not ready' }
     }
     // Capacity counts agents, not hosts: a confined agent's per-session hosts are bounded by session admission.
     const capacityUsed = host.agents().size + host.activatingAgents().size
@@ -631,7 +664,7 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
         return { ok: false, reason: `agent/activate: ${capabilityError}` }
       }
       let rollbackPreparedWorkspace: (() => void) | undefined
-      if (activate.prepareWorkspace || activate.reconcileWorkspace) {
+      if ((activate.prepareWorkspace || activate.reconcileWorkspace) && host.servesAgent(agentId)) {
         try {
           // A prior incarnation of this agent id must relinquish every
           // queued/running preparation before activation rewrites or
@@ -655,13 +688,10 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
           return { ok: false, reason: `agent/activate: workspace preparation failed: ${(err as Error).message}` }
         }
       }
-      // Prove ACP can initialize under the still-closed gate; the workspace reconciled first, so the
-      // spawned runtime and its sandbox bind the new directory rather than an unlinked old one.
-      // An unstage restores the replica, not serving authority: a non-holder must not bind the sandbox (#1093).
-      // Read HERE, never captured: a revoke landing during the awaits above already stopped this host.
-      // Tokened stays host-proving: its target is the placement, or a source whose duty the move never released.
-      if (activate.moveId !== undefined || host.servesAgent(agentId)) {
+      // Re-read duty at the execution boundary; a move token cannot authorize a sandbox after a revoke.
+      if (requiresRuntime || host.servesAgent(agentId)) {
         try {
+          if (!host.servesAgent(agentId)) throw new Error('execution duty was revoked during activation')
           // Key-server mode gives every session its own credential-scoped host, so there is no
           // shared agent host to prove — reconciling the workspace is the whole of the proof.
           if (host.keyServer()) await host.prepareAgentWorkspace(agent, undefined, undefined, true)
@@ -680,7 +710,7 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
           return { ok: false, reason: `agent/activate: ${(err as Error).message}` }
         }
       }
-      if (host.agentDestructivePending(agentId)) {
+      if (host.agentDestructivePending(agentId) || (requiresRuntime && !host.servesAgent(agentId))) {
         host.moveStagedAgents().add(agentId)
         await host.stopHost(agentId).catch(() => {})
         try {
@@ -693,7 +723,9 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
           ok: false,
           reason: host.agentRemovalPending(agentId)
             ? 'agent/activate: superseded by agent removal'
-            : 'agent/activate: superseded by a newer agent drain'
+            : !host.servesAgent(agentId)
+              ? 'agent/activate: execution duty was revoked during activation'
+              : 'agent/activate: superseded by a newer agent drain'
         }
       }
       try {
@@ -716,7 +748,8 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
       host.preparingWorkspaces().delete(agentId)
       host.activatingAgents().delete(agentId)
     }
-  })
+  }
+  return host.queueAgentMove('activate', agentId, activate.moveId ?? 'unstage', work, admit)
 }
 
 export async function listAgentPermissionRequests(
@@ -820,16 +853,28 @@ export function applyCollabRoutes(host: ConfigApplyRegistryHost, snap: CollabRou
   host.cpCollab().replace(snap)
 }
 
-export function applyAgentLaunch(host: ConfigApplyHost, launch: AgentLaunch): Promise<AgentLaunched> {
+export async function applyAgentLaunch(host: ConfigApplyHost, launch: AgentLaunch): Promise<AgentLaunched> {
+  const drainVersion = host.agentDrainVersion(launch.agentId)
+  const isCurrent = (): boolean =>
+    host.agents().has(launch.agentId) &&
+    !host.moveStagedAgents().has(launch.agentId) &&
+    !host.agentDestructivePending(launch.agentId) &&
+    host.agentDrainVersion(launch.agentId) === drainVersion
+  // Claim outside the lifecycle queue because admitting the grant may install an agent through that same queue.
+  if (isCurrent() && !host.servesAgent(launch.agentId)) {
+    const claim = await host.claimAgentDuty(launch.agentId, isCurrent)
+    if (!claim.granted) throw new Error('agent/launch: execution duty is not ready')
+  }
   return host.queueAgentLifecycle(launch.agentId, async () => {
     if (host.moveStagedAgents().has(launch.agentId)) {
       throw new Error(`agent/launch: agent ${launch.agentId} is staged for a daemon move`)
     }
     const agent = host.agents().get(launch.agentId)
     if (!agent) throw new Error(`agent/launch: unknown agent ${launch.agentId}`)
-    if (host.agentDestructivePending(launch.agentId)) {
+    if (host.agentDestructivePending(launch.agentId) || host.agentDrainVersion(launch.agentId) !== drainVersion) {
       throw new Error(`agent/launch: superseded by a newer agent drain for ${launch.agentId}`)
     }
+    if (!host.servesAgent(launch.agentId)) throw new Error('agent/launch: execution duty is not ready')
     // Revive a stopped agent only after every older lifecycle mutation has
     // settled. The queue prevents launch from clearing a slow remove's gate.
     host.drainingAgents().delete(launch.agentId)

--- a/packages/daemon/src/cp/duty-coordinator.ts
+++ b/packages/daemon/src/cp/duty-coordinator.ts
@@ -570,17 +570,7 @@ export class DutyCoordinator {
     await this.onDutyChanged()
   }
 
-  /** Claim one agent's duty because a trigger for it arrived here. A win is
-   *  installed exactly like a `duty/grant`, so the same converge path runs.
-   *  Refuses without asking the CP when this member must not take new work:
-   *  capacity is the member's own call (design D14), and a drain in progress
-   *  would either hand the fresh lease straight back or pin it to an agent whose
-   *  gate is about to drop the very turn that triggered the claim.
-   *
-   *  Both gates are checked AFTER the round trip, not instead of it. Refusing to
-   *  ask would suppress the very answer that makes a stale delivery routable —
-   *  the incumbent's identity — turning a re-routable trigger into a drop. So a
-   *  full or draining member still asks, and hands back anything it wins. */
+  /** Claim, install and project duty before a trigger or admitted lifecycle operation can run. */
   async claimDutyForTrigger(
     agentId: string,
     isLifecycleCurrent?: () => boolean

--- a/packages/daemon/src/cp/duty-coordinator.ts
+++ b/packages/daemon/src/cp/duty-coordinator.ts
@@ -581,10 +581,16 @@ export class DutyCoordinator {
    *  ask would suppress the very answer that makes a stale delivery routable —
    *  the incumbent's identity — turning a re-routable trigger into a drop. So a
    *  full or draining member still asks, and hands back anything it wins. */
-  async claimDutyForTrigger(agentId: string): Promise<{ granted: boolean; holder?: string }> {
-    // A drain that has already begun is the one case worth short-circuiting: it
-    // cannot be resolved by learning a holder, because this member is leaving.
-    if (this.host.dutyClaimsSuspended() || this.host.drainingAgents().has(agentId)) {
+  async claimDutyForTrigger(
+    agentId: string,
+    isLifecycleCurrent?: () => boolean
+  ): Promise<{ granted: boolean; holder?: string }> {
+    // An explicit lifecycle admission can claim behind its own drain gate, while its operation remains current.
+    const blocked = () =>
+      this.host.dutyClaimsSuspended() ||
+      this.host.draining() ||
+      (isLifecycleCurrent ? !isLifecycleCurrent() : this.host.drainingAgents().has(agentId))
+    if (blocked()) {
       this.log.debug(`duty: not claiming ${agentId} while draining`)
       return { granted: false }
     }
@@ -606,8 +612,7 @@ export class DutyCoordinator {
       // The group we were actually given may cover several agents, so capacity
       // is judged against it — never against the single agent we asked about.
       const arriving = grant.members.filter((m) => m.kind === 'agent' && !this.duties.holdsAgent(m.refId)).length
-      const draining =
-        this.host.dutyClaimsSuspended() || this.host.draining() || this.host.drainingAgents().has(agentId)
+      const draining = blocked()
       if (draining || arriving > this.dutyHeadroomForPendingClaim()) {
         const why = draining ? 'a drain started while the claim was in flight' : 'it does not fit remaining capacity'
         this.log.info(`duty: handing ${grant.groupId} straight back — ${why}`)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1309,6 +1309,7 @@ export class Daemon {
    *  distinct reservation because they do not necessarily delete CP authority,
    *  but an older launch/activate must still be unable to reopen the gate. */
   private pendingAgentDrains = new Map<string, { count: number; preexisting: boolean; preserve: boolean }>()
+  private agentDrainVersions = new Map<string, number>()
   // dispatchOne leases close the pre-pending gap: a turn captures its platform
   // connection before sessions.handle() returns and before it appears in `pending`.
   // Agent detach waits these leases before archiving/closing the last connection.
@@ -17465,6 +17466,7 @@ export class Daemon {
   }
 
   private reserveAgentRemoval(agentId: string): { release: () => boolean; markerError?: Error } {
+    this.agentDrainVersions.set(agentId, (this.agentDrainVersions.get(agentId) ?? 0) + 1)
     // Publish the live fail-closed boundary before the durable write. A local
     // filesystem failure must leave the old replica dark in this process.
     this.drainingAgents.add(agentId)
@@ -17537,6 +17539,7 @@ export class Daemon {
    *  rolls back a gate introduced solely by reservations whose operations all
    *  ended without establishing a destructive state. */
   private reserveAgentDrain(agentId: string): (preserveGate: boolean) => void {
+    this.agentDrainVersions.set(agentId, (this.agentDrainVersions.get(agentId) ?? 0) + 1)
     let reservation = this.pendingAgentDrains.get(agentId)
     if (!reservation) {
       reservation = { count: 0, preexisting: this.drainingAgents.has(agentId), preserve: false }
@@ -17630,7 +17633,8 @@ export class Daemon {
     kind: 'detach' | 'activate',
     agentId: string,
     moveId: string,
-    work: () => Promise<Ack>
+    work: () => Promise<Ack>,
+    admit?: () => Promise<Ack | undefined>
   ): Promise<Ack> {
     const key = `${kind}:${agentId}:${moveId}`
     const duplicate = this.agentMoveInFlight.get(key)
@@ -17639,11 +17643,14 @@ export class Daemon {
     // Detach admission must close the gate before the lifecycle body queues,
     // but duplicate retransmits join the exact same promise/reservation.
     const releaseDrain = kind === 'detach' ? this.reserveAgentDrain(agentId) : undefined
-    const lifecycle = this.queueAgentLifecycle(
-      agentId,
-      work,
-      kind === 'detach' ? { failureOwner: `detach:${moveId}` } : {}
-    )
+    const queue = () =>
+      this.queueAgentLifecycle(agentId, work, kind === 'detach' ? { failureOwner: `detach:${moveId}` } : {})
+    // Admission may install duty bundles through the lifecycle queue; duplicate moves still share its result.
+    const lifecycle = admit
+      ? Promise.resolve()
+          .then(admit)
+          .then((ack) => ack ?? queue())
+      : queue()
     const run = releaseDrain
       ? lifecycle.then(
           (ack) => {
@@ -18111,6 +18118,7 @@ export class Daemon {
       reserveAgentDrain: (agentId) => this.reserveAgentDrain(agentId),
       agentRemovalPending: (agentId) => this.agentRemovalPending(agentId),
       agentDestructivePending: (agentId) => this.agentDestructivePending(agentId),
+      agentDrainVersion: (agentId) => this.agentDrainVersions.get(agentId) ?? 0,
       clearRemovalAfterDestruction: (agentId) => this.clearRemovalAfterDestruction(agentId),
       clearRemovalForReadd: (agentId) => this.clearRemovalForReadd(agentId),
       queueAgentLifecycle: <T>(
@@ -18118,7 +18126,7 @@ export class Daemon {
         work: () => Promise<T>,
         opts?: { failureOwner?: string; onSettled?: () => void }
       ): Promise<T> => this.queueAgentLifecycle(agentId, work, opts),
-      queueAgentMove: (kind, agentId, moveId, work) => this.queueAgentMove(kind, agentId, moveId, work),
+      queueAgentMove: (kind, agentId, moveId, work, admit) => this.queueAgentMove(kind, agentId, moveId, work, admit),
       agents: () => this.agents,
       workspaces: () => this.workspaces,
       runtimes: () => this.runtimes,
@@ -18142,6 +18150,7 @@ export class Daemon {
       ): Promise<T> => this.enqueueAgentWorkspacePreparation(agent, operation, expectedWarmHost, allowAgentDrain),
       activationCapabilityError: (agent) => this.activationCapabilityError(agent),
       servesAgent: (agentId) => this.servesAgent(agentId),
+      claimAgentDuty: (agentId, isCurrent) => this.dutyCoordinator.claimDutyForTrigger(agentId, isCurrent),
       closeUnusedPlatformConnections: () => this.connections.closeUnusedPlatformConnections(),
       applyDutyGrant: (grants) => this.dutyCoordinator.applyDutyGrant(grants),
       applyDutyRevoke: (revocations) => this.dutyCoordinator.applyDutyRevoke(revocations),

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -471,7 +471,12 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     skillClientFor: (subject) => {
       const session = boundSession(subject)
       if (!session?.hasCapability('skills')) return undefined
-      return new ClusterSkillClient(session, session.hasCapability('skills-wide'))
+      return new ClusterSkillClient(
+        session,
+        session.hasCapability('skills-wide'),
+        false,
+        session.hasCapability('skills-receipts')
+      )
     },
     workspaceIncarnationFor: (subject) => driver.currentLaunch(subject)?.claimUid,
     shimGenerationFor: (subject) => driver.currentLaunch(subject)?.generation,

--- a/packages/daemon/src/k8s/sandbox-identity.ts
+++ b/packages/daemon/src/k8s/sandbox-identity.ts
@@ -106,7 +106,8 @@ export const RUNTIME_GRANTS: ShimCapability[] = [
   'tunnel',
   'automerge',
   'skills',
-  'skills-wide'
+  'skills-wide',
+  'skills-receipts'
 ]
 
 /** A probe sandbox asks the image what it provides and then RUNS those runtimes to read the

--- a/packages/daemon/src/microsandbox/shim.ts
+++ b/packages/daemon/src/microsandbox/shim.ts
@@ -84,7 +84,8 @@ export async function microsandboxSkillTarget(shim: MicrosandboxShim, cwd: strin
         request: (capability, request, options) => shim.session.request(capability, { cwd, request }, options)
       },
       shim.session.hasCapability('skills-wide'),
-      true
+      true,
+      shim.session.hasCapability('skills-receipts')
     )
   }
 }
@@ -229,7 +230,7 @@ export async function startMicrosandboxShim(input: {
           subject,
           sandboxUid: sandbox.id,
           generation,
-          grants: ['read', 'skills', 'skills-wide'],
+          grants: ['read', 'skills', 'skills-wide', 'skills-receipts'],
           podName: subject
         },
         TIMEOUT_MS

--- a/packages/daemon/src/shim/client.ts
+++ b/packages/daemon/src/shim/client.ts
@@ -269,12 +269,14 @@ export class ShimClient {
           }
           expected = { agentId: frame.agentId, generation: frame.generation }
           const token = (this.deps.readToken ?? (() => readFileSync(SHIM_IDENTITY_TOKEN_PATH, 'utf8').trim()))()
+          const supported = frame.supportedFeatures ?? ['cluster-skills-v1', 'cluster-skills-v2']
+          const features = this.deps.features?.filter((feature) => supported.includes(feature))
           transport.send(
             JSON.stringify({
               type: 'shim/identity',
               token,
               ...(this.deps.workspaceRoot ? { workspaceRoot: this.deps.workspaceRoot } : {}),
-              ...(this.deps.features?.length ? { features: this.deps.features } : {})
+              ...(features?.length ? { features } : {})
             } satisfies Extract<ShimFrame, { type: 'shim/identity' }>)
           )
           return

--- a/packages/daemon/src/shim/dialer.ts
+++ b/packages/daemon/src/shim/dialer.ts
@@ -13,6 +13,7 @@ import {
   SHIM_TOKEN_AUDIENCE,
   SHIM_WS_PATH,
   parseShimFrame,
+  ShimFeatureSchema,
   type ShimFrame,
   type ShimIdentity,
   type ShimRejected
@@ -389,7 +390,8 @@ export class ShimDialer {
         JSON.stringify({
           type: 'shim/hello',
           agentId: record.agentId,
-          generation: record.generation
+          generation: record.generation,
+          supportedFeatures: ShimFeatureSchema.options
         } satisfies Extract<ShimFrame, { type: 'shim/hello' }>)
       )
     })
@@ -426,10 +428,17 @@ export class ShimDialer {
   private negotiate(record: SpawnRecord, identity: ShimIdentity): SpawnRecord {
     const supportsSkills = identity.features?.includes('cluster-skills-v1') === true
     const supportsWideSkills = supportsSkills && identity.features?.includes('cluster-skills-v2') === true
+    const supportsReceipts = supportsWideSkills && identity.features?.includes('cluster-skills-v3') === true
     return {
       ...record,
       grants: record.grants.filter((grant) =>
-        grant === 'skills' ? supportsSkills : grant === 'skills-wide' ? supportsWideSkills : true
+        grant === 'skills'
+          ? supportsSkills
+          : grant === 'skills-wide'
+            ? supportsWideSkills
+            : grant === 'skills-receipts'
+              ? supportsReceipts
+              : true
       )
     }
   }

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -64,7 +64,7 @@ async function main(): Promise<number> {
           : exec(capability, payload, abort, context),
     // Reported in the hello so daemon-built pod paths are anchored on this filesystem.
     workspaceRoot,
-    features: ['cluster-skills-v1', 'cluster-skills-v2'],
+    features: ['cluster-skills-v1', 'cluster-skills-v2', 'cluster-skills-v3'],
     log
   })
   await server.start(port, localIdentity ? '127.0.0.1' : undefined)

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -68,7 +68,7 @@ export const ShimDialHelloSchema = z.object({
   type: z.literal('shim/hello'),
   agentId: z.string().min(1),
   generation: z.number().int().nonnegative(),
-  supportedFeatures: z.array(ShimFeatureSchema).max(16).optional()
+  supportedFeatures: z.array(z.string().min(1).max(80)).max(16).optional()
 })
 
 /** The shim answers the dialer's hello by proving which pod accepted it. */

--- a/packages/daemon/src/shim/protocol.ts
+++ b/packages/daemon/src/shim/protocol.ts
@@ -27,7 +27,7 @@ export const SHIM_WORKSPACE_ROOT_ENV = 'AC_SHIM_WORKSPACE_ROOT'
 export const DEFAULT_SHIM_WORKSPACE_ROOT = '/agent'
 
 /** `cluster-skills-v2` admits the widened skill manifest; a v1-only shim still gets the narrow one. */
-export const ShimFeatureSchema = z.enum(['cluster-skills-v1', 'cluster-skills-v2'])
+export const ShimFeatureSchema = z.enum(['cluster-skills-v1', 'cluster-skills-v2', 'cluster-skills-v3'])
 export type ShimFeature = z.infer<typeof ShimFeatureSchema>
 
 /** Operations the daemon may ask a bound shim to perform. Every one is authorized
@@ -54,6 +54,8 @@ export const ShimCapabilitySchema = z.enum([
   'skills',
   /** The same channel at the widened manifest limits — all the daemon learns from `cluster-skills-v2`. */
   'skills-wide',
+  // Bounded paging of prior and installed skill receipts.
+  'skills-receipts',
   /** Report which runtimes this image actually provides, by asking them. The daemon cannot learn
    *  this any other way: `--k8s` runs no local runtime, and anything it states from its own
    *  configuration is a claim about an image it never opened. */
@@ -65,7 +67,8 @@ export type ShimCapability = z.infer<typeof ShimCapabilitySchema>
 export const ShimDialHelloSchema = z.object({
   type: z.literal('shim/hello'),
   agentId: z.string().min(1),
-  generation: z.number().int().nonnegative()
+  generation: z.number().int().nonnegative(),
+  supportedFeatures: z.array(ShimFeatureSchema).max(16).optional()
 })
 
 /** The shim answers the dialer's hello by proving which pod accepted it. */

--- a/packages/daemon/src/shim/skill-client.ts
+++ b/packages/daemon/src/shim/skill-client.ts
@@ -1,4 +1,5 @@
 import type { ShimRequester } from './channels.js'
+import { ClusterSkillLedgerSchema } from '../store/cluster-skill-ledger.js'
 import {
   ClusterSkillBeginReplySchema,
   ClusterSkillBeginSchema,
@@ -6,6 +7,12 @@ import {
   ClusterSkillManifestReplySchema,
   ClusterSkillManifestSchema,
   ClusterSkillReconcileReplySchema,
+  ClusterSkillReconcileResultSchema,
+  ClusterSkillPriorSchema,
+  ClusterSkillPriorReplySchema,
+  ClusterSkillReceiptPageSchema,
+  ClusterSkillVerifySchema,
+  skillControlPages,
   ClusterSkillUploadReplySchema,
   ClusterSkillVerifyReplySchema,
   LEGACY_MAX_CLUSTER_SKILL_FILES,
@@ -13,7 +20,6 @@ import {
   MAX_CLUSTER_SKILL_CHUNK_BYTES,
   MAX_CLUSTER_SKILL_CONTROL_BYTES,
   MAX_CLUSTER_SKILL_FILES,
-  MAX_CLUSTER_SKILL_MANIFEST_PAGE,
   MAX_CLUSTER_SKILL_TOTAL_BYTES,
   type ClusterSkillBegin,
   type ClusterSkillBeginReply,
@@ -24,16 +30,14 @@ import {
   type ClusterSkillVerifyReply
 } from './skill-protocol.js'
 
-/** Room for a page's op/operationId/handle/moreFiles keys around the file rows. */
-const MANIFEST_PAGE_ENVELOPE_BYTES = 512
-
 export class ClusterSkillClient {
   /** `wide` mirrors the peer's `cluster-skills-v2` grant. */
   constructor(
     private readonly requester: ShimRequester,
     private readonly wide = false,
     // Enabled when the caller supplies a matching shim bundle; retained images may predate this field.
-    readonly fileModes = false
+    readonly fileModes = false,
+    private readonly receiptPaging = false
   ) {}
 
   /** What the BOUND image admits, so a caller can drop one oversized source instead of failing a launch. */
@@ -52,7 +56,7 @@ export class ClusterSkillClient {
     if (input.files.length > maxFiles || total > maxTotalBytes) {
       throw new Error('cluster skill sources exceed what this sandbox image admits')
     }
-    const pages = this.wide ? pageFiles(input.files) : [input.files]
+    const pages = this.wide ? skillControlPages(input.files) : [input.files]
     const request = ClusterSkillBeginSchema.parse({
       op: 'begin',
       ...input,
@@ -87,15 +91,65 @@ export class ClusterSkillClient {
     }
   }
 
-  async reconcile(input: Omit<ClusterSkillReconcile, 'op'>): Promise<ClusterSkillReconcileReply> {
-    const request = ClusterSkillReconcileSchema.parse({ op: 'reconcile', ...input })
-    return ClusterSkillReconcileReplySchema.parse(
-      await this.requester.request('skills', request, { timeoutMs: 15 * 60_000 })
+  async reconcile(input: Omit<ClusterSkillReconcile, 'op' | 'priorRootCount'>): Promise<ClusterSkillReconcileReply> {
+    if (!this.receiptPaging) {
+      const request = ClusterSkillReconcileSchema.parse({ op: 'reconcile', ...input })
+      return ClusterSkillReconcileReplySchema.parse(
+        await this.requester.request('skills', request, { timeoutMs: 15 * 60_000 })
+      )
+    }
+    const priorRoots = ClusterSkillLedgerSchema.parse({ roots: input.priorRoots }).roots
+    const request = { op: 'reconcile' as const, ...input, priorRoots, priorRootCount: priorRoots.length }
+    if (Buffer.byteLength(JSON.stringify(request)) > MAX_CLUSTER_SKILL_CONTROL_BYTES) {
+      request.priorRoots = []
+      ClusterSkillReconcileSchema.parse(request)
+      let offset = 0
+      for (const roots of skillControlPages(priorRoots)) {
+        const page = ClusterSkillPriorSchema.parse({
+          op: 'prior',
+          operationId: input.operationId,
+          handle: input.handle,
+          offset,
+          roots
+        })
+        const reply = ClusterSkillPriorReplySchema.parse(await this.requester.request('skills', page))
+        offset += roots.length
+        if (reply.received !== offset) throw new Error('inconsistent prior skill receipt offset')
+      }
+    }
+    let page = ClusterSkillReceiptPageSchema.parse(
+      await this.requester.request('skills', ClusterSkillReconcileSchema.parse(request), { timeoutMs: 15 * 60_000 })
     )
+    const result = { roots: [...page.roots], conflicts: page.conflicts }
+    while (page.nextOffset !== undefined) {
+      if (page.nextOffset !== result.roots.length) throw new Error('inconsistent skill receipt offset')
+      page = ClusterSkillReceiptPageSchema.parse(
+        await this.requester.request('skills', {
+          op: 'receipt',
+          operationId: input.operationId,
+          handle: input.handle,
+          offset: page.nextOffset
+        })
+      )
+      if (page.roots.length === 0 || JSON.stringify(page.conflicts) !== JSON.stringify(result.conflicts))
+        throw new Error('inconsistent skill receipt page')
+      result.roots.push(...page.roots)
+      ClusterSkillReconcileResultSchema.parse(result)
+    }
+    return ClusterSkillReconcileResultSchema.parse(result)
   }
 
   async verify(roots: ClusterSkillReconcile['priorRoots']): Promise<ClusterSkillVerifyReply> {
-    return ClusterSkillVerifyReplySchema.parse(await this.requester.request('skills', { op: 'verify', roots }))
+    ClusterSkillLedgerSchema.parse({ roots })
+    const intact: boolean[] = []
+    for (const page of skillControlPages(roots)) {
+      const reply = ClusterSkillVerifyReplySchema.parse(
+        await this.requester.request('skills', ClusterSkillVerifySchema.parse({ op: 'verify', roots: page }))
+      )
+      if (reply.intact.length !== page.length) throw new Error('inconsistent skill verification receipt')
+      intact.push(...reply.intact)
+    }
+    return { intact }
   }
 
   private async uploadChunk(
@@ -119,22 +173,4 @@ export class ClusterSkillClient {
       })
     )
   }
-}
-
-/** Split a manifest into frame-safe pages, on BYTES as well as count: the count cap is a coarse
- *  guard and long paths blow the control-byte budget well before 512 rows. */
-function pageFiles(files: ClusterSkillFile[]): ClusterSkillFile[][] {
-  const budget = MAX_CLUSTER_SKILL_CONTROL_BYTES - MANIFEST_PAGE_ENVELOPE_BYTES
-  const pages: ClusterSkillFile[][] = [[]]
-  let bytes = 0
-  for (const file of files) {
-    const row = Buffer.byteLength(JSON.stringify(file)) + 1
-    if (pages.at(-1)!.length > 0 && (pages.at(-1)!.length >= MAX_CLUSTER_SKILL_MANIFEST_PAGE || bytes + row > budget)) {
-      pages.push([])
-      bytes = 0
-    }
-    pages.at(-1)!.push(file)
-    bytes += row
-  }
-  return pages
 }

--- a/packages/daemon/src/shim/skill-handler.ts
+++ b/packages/daemon/src/shim/skill-handler.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from 'node:crypto'
 import { lstat, mkdir, open, readdir, readFile, rm, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { inspectLocalSkillSource } from '../skills/skill-source-snapshot.js'
+import { ClusterSkillLedgerSchema } from '../store/cluster-skill-ledger.js'
 import { PINNED_SKILLS_CLI_VERSION, stageSkillsCliCell } from '../skills/skills-cli-cell.js'
 import {
   reconcileSkillBundles,
@@ -13,6 +14,8 @@ import {
 import {
   ClusterSkillRequestSchema,
   ClusterSkillReconcileReplySchema,
+  ClusterSkillReconcileResultSchema,
+  skillReceiptPage,
   MAX_CLUSTER_SKILL_FILES,
   MAX_CLUSTER_SKILL_SOURCES,
   MAX_CLUSTER_SKILL_TOTAL_BYTES,
@@ -25,7 +28,11 @@ import {
   type ClusterSkillReconcileReply,
   type ClusterSkillUpload,
   type ClusterSkillUploadReply,
-  type ClusterSkillVerifyReply
+  type ClusterSkillVerifyReply,
+  type ClusterSkillPrior,
+  type ClusterSkillPriorReply,
+  type ClusterSkillReceipt,
+  type ClusterSkillReceiptPage
 } from './skill-protocol.js'
 
 interface Operation {
@@ -38,6 +45,8 @@ interface Operation {
   skillsAgentId: string
   authority: ClusterSkillBegin['authority']
   abort: AbortController
+  priorRoots: ClusterSkillReconcile['priorRoots']
+  result?: ClusterSkillReconcileReply
 }
 
 export interface ClusterSkillRequestContext {
@@ -77,6 +86,8 @@ export class ClusterSkillHandler {
     | ClusterSkillUploadReply
     | ClusterSkillReconcileReply
     | ClusterSkillVerifyReply
+    | ClusterSkillPriorReply
+    | ClusterSkillReceiptPage
   > {
     const parsed = ClusterSkillRequestSchema.parse(payload)
     if (abort?.aborted) {
@@ -86,6 +97,8 @@ export class ClusterSkillHandler {
     if (parsed.op === 'begin') return await this.begin(parsed, context)
     if (parsed.op === 'manifest') return this.manifest(parsed)
     if (parsed.op === 'upload') return await this.upload(parsed, abort)
+    if (parsed.op === 'prior') return this.prior(parsed, context)
+    if (parsed.op === 'receipt') return this.receipt(parsed, context)
     if (parsed.op === 'verify') {
       if (!this.deps.workspaceRoot) throw new Error('cluster skill verification is unavailable')
       return {
@@ -155,7 +168,8 @@ export class ClusterSkillHandler {
       abort: new AbortController(),
       files: new Map(),
       pendingManifest: input.moreFiles === true,
-      declaredBytes: 0
+      declaredBytes: 0,
+      priorRoots: []
     }
     this.operations.set(handle, operation)
     this.declare(operation, input.files)
@@ -192,21 +206,64 @@ export class ClusterSkillHandler {
     }
   }
 
+  private operationFor(
+    input: { handle: string; operationId: string },
+    context?: ClusterSkillRequestContext
+  ): Operation {
+    const operation = this.operations.get(input.handle)
+    if (!operation || operation.operationId !== input.operationId)
+      throw new Error('unknown cluster skill staging handle')
+    this.assertBoundAuthority(operation.authority, context)
+    const current = this.highestTerms.get(operation.authority.workspaceIncarnation)
+    if (
+      operation.abort.signal.aborted ||
+      current?.term !== operation.authority.term ||
+      current.daemonId !== operation.authority.daemonId
+    )
+      throw new Error('cluster skill reconciliation lost duty authority')
+    return operation
+  }
+
+  private prior(input: ClusterSkillPrior, context?: ClusterSkillRequestContext): ClusterSkillPriorReply {
+    const operation = this.operationFor(input, context)
+    if (operation.result || input.offset !== operation.priorRoots.length)
+      throw new Error('unexpected prior skill receipt offset')
+    const roots = ClusterSkillLedgerSchema.parse({ roots: [...operation.priorRoots, ...input.roots] }).roots
+    if (new Set(roots.map((root) => root.path)).size !== roots.length)
+      throw new Error('duplicate prior skill receipt root')
+    operation.priorRoots = roots
+    return { received: roots.length }
+  }
+
+  private async receipt(
+    input: ClusterSkillReceipt,
+    context?: ClusterSkillRequestContext
+  ): Promise<ClusterSkillReceiptPage> {
+    const operation = this.operationFor(input, context)
+    if (!operation.result) throw new Error('cluster skill receipt is not ready')
+    const page = skillReceiptPage(operation.result, input.offset)
+    if (page.nextOffset === undefined) await this.discard(input.handle)
+    return page
+  }
+
   private async reconcile(
     input: ClusterSkillReconcile,
     abort?: AbortSignal,
     context?: ClusterSkillRequestContext
-  ): Promise<ClusterSkillReconcileReply> {
-    const operation = this.operations.get(input.handle)
-    if (!operation || operation.operationId !== input.operationId)
-      throw new Error('unknown cluster skill staging handle')
-    this.assertBoundAuthority(input.authority, context)
+  ): Promise<ClusterSkillReceiptPage> {
+    const operation = this.operationFor(input, context)
+    if (operation.result) throw new Error('cluster skill reconciliation is already complete')
     if (JSON.stringify(operation.authority) !== JSON.stringify(input.authority)) {
       throw new Error('cluster skill authority changed during staging')
     }
-    const current = this.highestTerms.get(input.authority.workspaceIncarnation)
-    if (!current || current.term !== input.authority.term || current.daemonId !== input.authority.daemonId) {
-      throw new Error('cluster skill reconciliation lost duty authority')
+    if (input.priorRootCount !== undefined) {
+      const roots = ClusterSkillLedgerSchema.parse({ roots: [...operation.priorRoots, ...input.priorRoots] }).roots
+      if (roots.length !== input.priorRootCount) throw new Error('cluster skill prior receipt is incomplete')
+      if (new Set(roots.map((root) => root.path)).size !== roots.length)
+        throw new Error('duplicate prior skill receipt root')
+      input = { ...input, priorRoots: roots }
+    } else if (operation.priorRoots.length) {
+      throw new Error('cluster skill prior receipt count is missing')
     }
     if (!this.deps.workspaceRoot || !this.deps.stateRoot) throw new Error('cluster skill publication is unavailable')
     if (operation.pendingManifest) throw new Error('cluster skill manifest is incomplete')
@@ -230,6 +287,17 @@ export class ClusterSkillHandler {
       throw new Error('reconcile source was not declared')
     }
     const sourceMeta = new Map(input.sources.map((source) => [source.sourceId, source]))
+    const ownedRoot = (root: Omit<CandidateSkillBundle, 'sourceDir'>) => {
+      const source = sourceMeta.get(root.sourceKey)
+      if (!source) throw new Error('cluster skill publisher returned an unknown source')
+      return {
+        path: root.relativeRoot,
+        sourceId: root.sourceKey,
+        sourceKind: source.sourceKind,
+        digest: root.treeDigest,
+        files: root.files.map(({ path, mode, size, sha256 }) => ({ path, mode, size, sha256 }))
+      }
+    }
     const candidates: CandidateSkillBundle[] = []
     const cleanups: Array<() => void> = []
     try {
@@ -264,6 +332,23 @@ export class ClusterSkillHandler {
           })
         }
       }
+      // Validate the largest possible result before publication; conflicts and installed roots are subsets of this set.
+      const desiredRoots = [
+        ...new Map(candidates.map((candidate) => [candidate.relativeRoot, ownedRoot(candidate)])).values()
+      ]
+      const desired = ClusterSkillReconcileResultSchema.parse({
+        roots: desiredRoots,
+        conflicts: desiredRoots.map((root) => root.path)
+      })
+      if (input.priorRootCount === undefined) ClusterSkillReconcileReplySchema.parse(desired)
+      else {
+        let offset = 0
+        do {
+          const page = skillReceiptPage(desired, offset)
+          if (page.nextOffset === undefined) break
+          offset = page.nextOffset
+        } while (true)
+      }
       const result = await reconcileSkillBundles({
         cwd: this.deps.workspaceRoot,
         stateDir: this.deps.stateRoot,
@@ -288,19 +373,19 @@ export class ClusterSkillHandler {
         publicationKey: input.replayKey,
         candidates
       })
-      const roots = result.owned.map((root) => {
-        const source = sourceMeta.get(root.sourceKey)
-        if (!source) throw new Error('cluster skill publisher returned an unknown source')
-        return {
-          path: root.relativeRoot,
-          sourceId: root.sourceKey,
-          sourceKind: source.sourceKind,
-          digest: root.treeDigest,
-          files: root.files.map(({ path, mode, size, sha256 }) => ({ path, mode, size, sha256 }))
-        }
+      const reply = ClusterSkillReconcileResultSchema.parse({
+        roots: result.owned.map(ownedRoot),
+        conflicts: result.conflicts
       })
+      if (input.priorRootCount !== undefined) {
+        operation.result = reply
+        return await this.receipt(
+          { op: 'receipt', handle: input.handle, operationId: input.operationId, offset: 0 },
+          context
+        )
+      }
       await this.discard(operation.handle)
-      return ClusterSkillReconcileReplySchema.parse({ roots, conflicts: result.conflicts })
+      return ClusterSkillReconcileReplySchema.parse(reply)
     } finally {
       for (const cleanup of cleanups) cleanup()
     }

--- a/packages/daemon/src/shim/skill-protocol.ts
+++ b/packages/daemon/src/shim/skill-protocol.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 import { createHash } from 'node:crypto'
+import { ClusterSkillOwnedRootSchema, ClusterSkillPathSchema } from '../store/cluster-skill-ledger.js'
+import { MAX_SKILL_BUNDLES } from '../skills/skill-limits.js'
 
 export const MAX_CLUSTER_SKILL_SOURCES = 64
 // A Git source is a whole collection repo; these mirror GIT_SKILL_SOURCE_SNAPSHOT_LIMITS, and the
@@ -22,15 +24,7 @@ const DecimalTermSchema = z
   .string()
   .regex(/^(?:0|[1-9][0-9]*)$/)
   .max(40)
-const RelativeSkillPathSchema = z
-  .string()
-  .min(1)
-  .max(512)
-  .refine((value) => {
-    if (value.includes('\0') || value.startsWith('/') || value.startsWith('\\')) return false
-    const parts = value.replaceAll('\\', '/').split('/')
-    return parts.every((part) => part.length > 0 && part !== '.' && part !== '..')
-  }, 'path must be a contained relative path')
+const RelativeSkillPathSchema = ClusterSkillPathSchema
 
 export const ClusterSkillAuthoritySchema = z
   .object({
@@ -123,26 +117,7 @@ export const ClusterSkillSourceSchema = z
   })
   .strict()
 
-export const ClusterSkillPriorRootSchema = z
-  .object({
-    path: RelativeSkillPathSchema,
-    sourceId: z.string().min(1).max(160),
-    sourceKind: z.enum(['agent', 'managed', 'dream']),
-    digest: Sha256Schema,
-    files: z
-      .array(
-        z
-          .object({
-            path: RelativeSkillPathSchema,
-            mode: z.number().int().min(0).max(0o777),
-            size: z.number().int().nonnegative(),
-            sha256: Sha256Schema
-          })
-          .strict()
-      )
-      .max(64)
-  })
-  .strict()
+export const ClusterSkillPriorRootSchema = ClusterSkillOwnedRootSchema
 
 export const ClusterSkillReconcileSchema = z
   .object({
@@ -150,7 +125,8 @@ export const ClusterSkillReconcileSchema = z
     operationId: z.string().uuid(),
     handle: z.string().min(16).max(128),
     authority: ClusterSkillAuthoritySchema,
-    priorRoots: z.array(ClusterSkillPriorRootSchema).max(256),
+    priorRoots: z.array(ClusterSkillPriorRootSchema).max(MAX_SKILL_BUNDLES),
+    priorRootCount: z.number().int().min(0).max(MAX_SKILL_BUNDLES).optional(),
     replayKey: z.string().regex(/^[a-f0-9]{64}$/),
     allowDesiredAdoption: z.boolean(),
     sources: z.array(ClusterSkillSourceSchema).max(MAX_CLUSTER_SKILL_SOURCES)
@@ -162,8 +138,6 @@ export const ClusterSkillReconcileSchema = z
       if (ids.has(source.sourceId)) ctx.addIssue({ code: 'custom', message: 'duplicate reconcile source' })
       ids.add(source.sourceId)
     }
-    const receiptFiles = value.priorRoots.reduce((total, root) => total + root.files.length, 0)
-    if (receiptFiles > MAX_CLUSTER_SKILL_FILES) ctx.addIssue({ code: 'custom', message: 'prior receipt exceeds limit' })
     if (Buffer.byteLength(JSON.stringify(value)) > MAX_CLUSTER_SKILL_CONTROL_BYTES) {
       ctx.addIssue({ code: 'custom', message: 'reconcile request exceeds frame-safe limit' })
     }
@@ -172,7 +146,28 @@ export const ClusterSkillReconcileSchema = z
 export const ClusterSkillVerifySchema = z
   .object({
     op: z.literal('verify'),
-    roots: z.array(ClusterSkillPriorRootSchema).max(256)
+    roots: z.array(ClusterSkillPriorRootSchema).max(MAX_SKILL_BUNDLES)
+  })
+  .strict()
+  .superRefine(assertSkillControlSize)
+
+export const ClusterSkillPriorSchema = z
+  .object({
+    op: z.literal('prior'),
+    operationId: z.string().uuid(),
+    handle: z.string().min(16).max(128),
+    offset: z.number().int().min(0).max(MAX_SKILL_BUNDLES),
+    roots: z.array(ClusterSkillPriorRootSchema).min(1).max(MAX_SKILL_BUNDLES)
+  })
+  .strict()
+  .superRefine(assertSkillControlSize)
+
+export const ClusterSkillReceiptSchema = z
+  .object({
+    op: z.literal('receipt'),
+    operationId: z.string().uuid(),
+    handle: z.string().min(16).max(128),
+    offset: z.number().int().min(0).max(MAX_SKILL_BUNDLES)
   })
   .strict()
 
@@ -181,8 +176,14 @@ export const ClusterSkillRequestSchema = z.discriminatedUnion('op', [
   ClusterSkillManifestSchema,
   ClusterSkillUploadSchema,
   ClusterSkillReconcileSchema,
-  ClusterSkillVerifySchema
+  ClusterSkillVerifySchema,
+  ClusterSkillPriorSchema,
+  ClusterSkillReceiptSchema
 ])
+
+export const ClusterSkillPriorReplySchema = z
+  .object({ received: z.number().int().min(0).max(MAX_SKILL_BUNDLES) })
+  .strict()
 
 export const ClusterSkillBeginReplySchema = z.object({ handle: z.string().min(16).max(128) }).strict()
 export const ClusterSkillManifestReplySchema = z
@@ -191,42 +192,13 @@ export const ClusterSkillManifestReplySchema = z
 export const ClusterSkillUploadReplySchema = z
   .object({ received: z.number().int().nonnegative().max(MAX_CLUSTER_SKILL_FILE_BYTES), complete: z.boolean() })
   .strict()
-export const ClusterSkillReconcileReplySchema = z
+export const ClusterSkillReconcileResultSchema = z
   .object({
-    roots: z
-      .array(
-        z
-          .object({
-            path: RelativeSkillPathSchema,
-            sourceId: z.string().min(1).max(160),
-            sourceKind: z.enum(['agent', 'managed', 'dream']),
-            digest: Sha256Schema,
-            files: z
-              .array(
-                z
-                  .object({
-                    path: RelativeSkillPathSchema,
-                    mode: z.number().int().min(0).max(0o777),
-                    size: z.number().int().nonnegative(),
-                    sha256: Sha256Schema
-                  })
-                  .strict()
-              )
-              .max(64)
-          })
-          .strict()
-      )
-      .max(256),
-    conflicts: z.array(RelativeSkillPathSchema).max(512)
+    roots: z.array(ClusterSkillPriorRootSchema).max(MAX_SKILL_BUNDLES),
+    conflicts: z.array(RelativeSkillPathSchema).max(MAX_SKILL_BUNDLES)
   })
   .strict()
   .superRefine((value, ctx) => {
-    const receiptFiles = value.roots.reduce((total, root) => total + root.files.length, 0)
-    if (receiptFiles > MAX_CLUSTER_SKILL_FILES)
-      ctx.addIssue({ code: 'custom', message: 'result receipt exceeds limit' })
-    if (Buffer.byteLength(JSON.stringify(value)) > MAX_CLUSTER_SKILL_CONTROL_BYTES) {
-      ctx.addIssue({ code: 'custom', message: 'reconcile response exceeds frame-safe limit' })
-    }
     const paths = new Set<string>()
     for (const root of value.roots) {
       if (paths.has(root.path)) ctx.addIssue({ code: 'custom', message: 'duplicate result root' })
@@ -236,6 +208,54 @@ export const ClusterSkillReconcileReplySchema = z
       }
     }
   })
+
+export const ClusterSkillReconcileReplySchema = ClusterSkillReconcileResultSchema.superRefine(assertSkillControlSize)
+export const ClusterSkillReceiptPageSchema = ClusterSkillReconcileResultSchema.safeExtend({
+  nextOffset: z.number().int().min(1).max(MAX_SKILL_BUNDLES).optional()
+}).superRefine(assertSkillControlSize)
+
+function assertSkillControlSize(value: unknown, ctx: z.RefinementCtx): void {
+  if (Buffer.byteLength(JSON.stringify(value)) > MAX_CLUSTER_SKILL_CONTROL_BYTES) {
+    ctx.addIssue({ code: 'custom', message: 'skill control message exceeds frame-safe limit' })
+  }
+}
+
+// A receipt root stays whole; its own file and path limits guarantee it fits in one page.
+export function skillControlPages<T>(
+  rows: T[],
+  maxRows = MAX_CLUSTER_SKILL_MANIFEST_PAGE,
+  overheadBytes = 2048
+): T[][] {
+  const budget = MAX_CLUSTER_SKILL_CONTROL_BYTES - overheadBytes
+  const pages: T[][] = [[]]
+  let bytes = 0
+  for (const row of rows) {
+    const size = Buffer.byteLength(JSON.stringify(row)) + 1
+    if (size > budget) throw new Error('skill control row exceeds frame-safe limit')
+    if (pages.at(-1)!.length > 0 && (pages.at(-1)!.length >= maxRows || bytes + size > budget)) {
+      pages.push([])
+      bytes = 0
+    }
+    pages.at(-1)!.push(row)
+    bytes += size
+  }
+  return pages
+}
+
+export function skillReceiptPage(result: ClusterSkillReconcileReply, offset: number): ClusterSkillReceiptPage {
+  if (offset > result.roots.length) throw new Error('skill receipt offset exceeds result')
+  const overhead = Buffer.byteLength(
+    JSON.stringify({ roots: [], conflicts: result.conflicts, nextOffset: MAX_SKILL_BUNDLES })
+  )
+  const roots = skillControlPages(result.roots.slice(offset), MAX_SKILL_BUNDLES, overhead)[0]!
+  const nextOffset = offset + roots.length
+  return ClusterSkillReceiptPageSchema.parse({
+    roots,
+    conflicts: result.conflicts,
+    ...(nextOffset < result.roots.length ? { nextOffset } : {})
+  })
+}
+
 export const ClusterSkillVerifyReplySchema = z.object({ intact: z.array(z.boolean()).max(512) }).strict()
 
 export type ClusterSkillBegin = z.infer<typeof ClusterSkillBeginSchema>
@@ -248,5 +268,9 @@ export type ClusterSkillVerify = z.infer<typeof ClusterSkillVerifySchema>
 export type ClusterSkillRequest = z.infer<typeof ClusterSkillRequestSchema>
 export type ClusterSkillBeginReply = z.infer<typeof ClusterSkillBeginReplySchema>
 export type ClusterSkillUploadReply = z.infer<typeof ClusterSkillUploadReplySchema>
-export type ClusterSkillReconcileReply = z.infer<typeof ClusterSkillReconcileReplySchema>
+export type ClusterSkillReconcileReply = z.infer<typeof ClusterSkillReconcileResultSchema>
+export type ClusterSkillPrior = z.infer<typeof ClusterSkillPriorSchema>
+export type ClusterSkillPriorReply = z.infer<typeof ClusterSkillPriorReplySchema>
+export type ClusterSkillReceipt = z.infer<typeof ClusterSkillReceiptSchema>
+export type ClusterSkillReceiptPage = z.infer<typeof ClusterSkillReceiptPageSchema>
 export type ClusterSkillVerifyReply = z.infer<typeof ClusterSkillVerifyReplySchema>

--- a/packages/daemon/src/skills/cluster-skill-coordinator.ts
+++ b/packages/daemon/src/skills/cluster-skill-coordinator.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { ClusterSkillReconcileAuthority, ClusterSkillLedger } from '../store/cluster-skill-ledger.js'
 import type { ClusterSkillClient } from '../shim/skill-client.js'
-import { ClusterSkillReconcileReplySchema, type ClusterSkillFile } from '../shim/skill-protocol.js'
+import { ClusterSkillReconcileResultSchema, type ClusterSkillFile } from '../shim/skill-protocol.js'
 import { inspectLocalSkillSource, type SkillSourceSnapshotLimits } from './skill-source-snapshot.js'
 
 export interface ClusterSkillSnapshotSource {
@@ -115,7 +115,7 @@ export class ClusterSkillCoordinator {
     if (!(await this.store.authorizeClusterSkillMutation({ ...authority, priorRevision: begun.priorRevision }))) {
       throw new Error('cluster skill reconciliation lost duty authority')
     }
-    const reply = ClusterSkillReconcileReplySchema.parse(
+    const reply = ClusterSkillReconcileResultSchema.parse(
       await input.client.reconcile({
         operationId: authority.operationId,
         handle,

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -4,16 +4,12 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { under } from '../fs/contained-path.js'
 import { inspectLocalSkillSource } from './skill-source-snapshot.js'
+import { MAX_SKILL_BUNDLES, MAX_SKILL_PATH_BYTES, MAX_SKILL_RECEIPT_FILES } from './skill-limits.js'
 import { canonicalSkillMutationRoot, runSkillWorkspaceMutation } from './skill-workspace-mutator.js'
 import { withSkillMutationHelperLease, type SkillMutationHelperLease } from './skill-workspace-lock-lease.js'
 
-// An applying/cleanup journal can contain two complete receipt sets: up to 64
-// bundles × 64 files × a 1 KiB path in each set, plus 4 KiB source keys and JSON
-// escaping. Control characters and backslashes are rejected below, bounding
-// remaining string escaping to at most 2×. The legal worst case is below 24 MiB;
-// 32 MiB leaves structural headroom while keeping hostile state reads capped.
+// Two sets of 64 bundles × 64 files × 1 KiB paths, source keys and JSON escaping fit below this bounded journal read.
 export const MAX_SKILL_LEDGER_BYTES = 32 * 1024 * 1024
-const MAX_RECEIPT_FILES = 64
 const MAX_RECEIPT_BYTES = 4 * 1024 * 1024
 const MAX_RECEIPT_FILE_BYTES = 512 * 1024
 const MAX_LAYOUT_SEGMENTS = 8
@@ -462,6 +458,7 @@ async function reconcileSkillBundlesLocked(
     }
 
     const deduped = dedupeCandidates(await canonicalizeCandidates(options.cwd, options.candidates))
+    if (deduped.length > MAX_SKILL_BUNDLES) throw safety('skill installation exceeds its bundle limit')
     const gitResolutions = validateGitResolutions(options.gitResolutions ?? [])
     for (const candidate of deduped) {
       validateCandidate(candidate)
@@ -523,6 +520,9 @@ async function reconcileSkillBundlesLocked(
       const canonical = await canonicalizeRelativeRoot(options.cwd, root)
       const priorEntry = priorByPath.get(canonical)
       if (priorEntry && !candidateRoots.has(canonical) && !kept.has(canonical)) kept.set(canonical, priorEntry)
+    }
+    if (adopted.length + kept.size + candidates.length > MAX_SKILL_BUNDLES) {
+      throw safety('skill installation exceeds its bundle limit')
     }
     const paths = [
       ...new Set([
@@ -781,7 +781,12 @@ export function treeDigest(files: SkillFileReceipt[]): string {
 }
 
 function validateRelativeRoot(value: string): void {
-  if (isAbsolute(value) || value.includes('\0') || value.includes('\\') || Buffer.byteLength(value, 'utf8') > 1_024) {
+  if (
+    isAbsolute(value) ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    Buffer.byteLength(value, 'utf8') > MAX_SKILL_PATH_BYTES
+  ) {
     throw safety(`unsafe skill receipt path: ${value}`)
   }
   const parts = value.split('/')
@@ -807,7 +812,7 @@ function validateReceipt(bundle: SkillBundleReceipt): void {
     !/^[a-f0-9]{64}$/.test(bundle.treeDigest) ||
     !Array.isArray(bundle.files) ||
     bundle.files.length === 0 ||
-    bundle.files.length > MAX_RECEIPT_FILES
+    bundle.files.length > MAX_SKILL_RECEIPT_FILES
   ) {
     throw safety('invalid skill bundle receipt')
   }
@@ -824,7 +829,7 @@ function validateReceipt(bundle: SkillBundleReceipt): void {
       CONTROL_RE.test(file.path) ||
       parts.some((part) => !part || part === '.' || part === '..') ||
       parts.length > 32 ||
-      Buffer.byteLength(file.path, 'utf8') > 1_024 ||
+      Buffer.byteLength(file.path, 'utf8') > MAX_SKILL_PATH_BYTES ||
       (file.mode !== 0o600 && file.mode !== 0o700) ||
       !Number.isSafeInteger(file.size) ||
       file.size < 0 ||
@@ -1294,7 +1299,7 @@ function validateGitResolutions(value: unknown): SkillGitResolution[] {
 }
 
 function parseOwnedList(value: unknown): OwnedSkillBundle[] {
-  if (!Array.isArray(value) || value.length > 64) throw safety('skill ownership ledger is invalid')
+  if (!Array.isArray(value) || value.length > MAX_SKILL_BUNDLES) throw safety('skill ownership ledger is invalid')
   return value.map((entry) => {
     validateOwned(entry as OwnedSkillBundle)
     return entry as OwnedSkillBundle
@@ -1302,7 +1307,7 @@ function parseOwnedList(value: unknown): OwnedSkillBundle[] {
 }
 
 function parseReceiptList(value: unknown): SkillBundleReceipt[] {
-  if (!Array.isArray(value) || value.length > 64) throw safety('skill ownership ledger is invalid')
+  if (!Array.isArray(value) || value.length > MAX_SKILL_BUNDLES) throw safety('skill ownership ledger is invalid')
   return value.map((entry) => {
     validateReceipt(entry as SkillBundleReceipt)
     return entry as SkillBundleReceipt

--- a/packages/daemon/src/skills/skill-limits.ts
+++ b/packages/daemon/src/skills/skill-limits.ts
@@ -1,0 +1,3 @@
+export const MAX_SKILL_BUNDLES = 64
+export const MAX_SKILL_RECEIPT_FILES = 64
+export const MAX_SKILL_PATH_BYTES = 1024

--- a/packages/daemon/src/skills/skill-source-snapshot.ts
+++ b/packages/daemon/src/skills/skill-source-snapshot.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { constants, promises as fsp, type Stats } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { TextDecoder } from 'node:util'
+import { MAX_SKILL_PATH_BYTES, MAX_SKILL_RECEIPT_FILES } from './skill-limits.js'
 
 export interface SkillSourceSnapshotLimits {
   maxFiles: number
@@ -14,12 +15,12 @@ export interface SkillSourceSnapshotLimits {
 }
 
 export const DEFAULT_SKILL_SOURCE_SNAPSHOT_LIMITS: Readonly<SkillSourceSnapshotLimits> = {
-  maxFiles: 64,
+  maxFiles: MAX_SKILL_RECEIPT_FILES,
   maxTotalBytes: 4 * 1024 * 1024,
   maxFileBytes: 512 * 1024,
   maxEntries: 256,
   maxDepth: 32,
-  maxPathBytes: 1024
+  maxPathBytes: MAX_SKILL_PATH_BYTES
 }
 
 /** A Git source is a whole collection repo — skills plus docs, tests and tooling — not one bundle. */
@@ -29,7 +30,7 @@ export const GIT_SKILL_SOURCE_SNAPSHOT_LIMITS: Readonly<SkillSourceSnapshotLimit
   maxFileBytes: 16 * 1024 * 1024,
   maxEntries: 65_536,
   maxDepth: 64,
-  maxPathBytes: 1024
+  maxPathBytes: MAX_SKILL_PATH_BYTES
 }
 
 export interface SkillSourceSnapshotOptions {

--- a/packages/daemon/src/store/cluster-skill-ledger.ts
+++ b/packages/daemon/src/store/cluster-skill-ledger.ts
@@ -1,8 +1,17 @@
 import { z } from 'zod'
+import { MAX_SKILL_BUNDLES, MAX_SKILL_PATH_BYTES, MAX_SKILL_RECEIPT_FILES } from '../skills/skill-limits.js'
+
+export const ClusterSkillPathSchema = z
+  .string()
+  .min(1)
+  .refine((value) => {
+    if (Buffer.byteLength(value) > MAX_SKILL_PATH_BYTES || /[\x00-\x1f\x7f\\]/.test(value)) return false
+    return value.split('/').every((part) => part.length > 0 && part !== '.' && part !== '..')
+  }, 'path must be a bounded contained relative path')
 
 export const ClusterSkillOwnedRootSchema = z
   .object({
-    path: z.string().min(1).max(512),
+    path: ClusterSkillPathSchema,
     sourceId: z.string().min(1).max(160),
     sourceKind: z.enum(['agent', 'managed', 'dream']),
     digest: z.string().regex(/^[a-f0-9]{64}$/),
@@ -10,20 +19,20 @@ export const ClusterSkillOwnedRootSchema = z
       .array(
         z
           .object({
-            path: z.string().min(1).max(512),
+            path: ClusterSkillPathSchema,
             mode: z.number().int().min(0).max(0o777),
             size: z.number().int().nonnegative(),
             sha256: z.string().regex(/^[a-f0-9]{64}$/)
           })
           .strict()
       )
-      .max(64)
+      .max(MAX_SKILL_RECEIPT_FILES)
   })
   .strict()
 
 export const ClusterSkillLedgerSchema = z
   .object({
-    roots: z.array(ClusterSkillOwnedRootSchema).max(256),
+    roots: z.array(ClusterSkillOwnedRootSchema).max(MAX_SKILL_BUNDLES),
     gitResolutions: z
       .array(
         z
@@ -37,11 +46,6 @@ export const ClusterSkillLedgerSchema = z
       .optional()
   })
   .strict()
-  .superRefine((value, ctx) => {
-    if (value.roots.reduce((total, root) => total + root.files.length, 0) > 256) {
-      ctx.addIssue({ code: 'custom', message: 'cluster skill ledger receipt exceeds limit' })
-    }
-  })
 
 export type ClusterSkillLedger = z.infer<typeof ClusterSkillLedgerSchema>
 

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -15,6 +15,8 @@ import {
 import { RegisterReq, type AgentSpec, type DutyGrantEntry } from '@agentconnect.md/protocol'
 import { agentRemovalObligationsDir } from '../../src/paths.js'
 import { fakeSlackAppFactory } from '../fakes/slack-app.js'
+import { ClusterSkillClient } from '../../src/shim/skill-client.js'
+import { ClusterSkillHandler } from '../../src/shim/skill-handler.js'
 
 const MOVE_ID = '77777777-7777-4777-8777-777777777777'
 const MOVE_ID_2 = '88888888-8888-4888-8888-888888888888'
@@ -75,6 +77,14 @@ function makeDaemon(root: string) {
 }
 
 const seam = (d: Daemon) => (d as any).cpConfigApply()
+
+function signal() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
 
 /** Make the daemon a duty-governed pool member — `frame` scope is what `dutyEnforced()` reads. */
 function poolMember(daemon: Daemon, client: Record<string, unknown> = {}) {
@@ -505,19 +515,21 @@ describe('Daemon CP agent → memory + reconcile', () => {
     await daemon.stop()
   })
 
-  it('a token-less activate on a member that holds no duty releases the fence without a host (#1093)', async () => {
+  it.each([undefined, MOVE_ID])('unstage with token %s restores a non-holder without claiming duty', async (moveId) => {
     const root = root1()
     writeAgent(root, 'bot-a')
     const { daemon, hosts } = makeDaemon(root)
     await daemon.start()
     const fetchDutyAgent = vi.fn(async () => ({ bundle: DUTY_BUNDLE }))
-    poolMember(daemon, { fetchDutyAgent })
+    const claimDuty = vi.fn()
+    poolMember(daemon, { fetchDutyAgent, claimDuty })
     expect((daemon as any).servesAgent('bot-a')).toBe(false)
 
     await expect(seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).resolves.toEqual({ ok: true })
     await expect(
       seam(daemon).applyAgentActivate({
         agentId: 'bot-a',
+        ...(moveId ? { moveId, unstageOnly: true } : {}),
         spec: { name: 'bot-a', runtime: 'claude' },
         integrations: [],
         crons: []
@@ -534,6 +546,7 @@ describe('Daemon CP agent → memory + reconcile', () => {
     await (daemon as any).flushReconcile()
     expect(hosts).toEqual([])
     expect((daemon as any).hosts.has('bot-a')).toBe(false)
+    expect(claimDuty).not.toHaveBeenCalled()
 
     // The duty grant is what starts it, and the current replica makes that install a no-fetch.
     await (daemon as any).dutyCoordinator.admitDutyGrants([dutyGrant('bot-a')])
@@ -542,6 +555,137 @@ describe('Daemon CP agent → memory + reconcile', () => {
     await (daemon as any).ensureHostAsync('bot-a')
     expect(hosts.map((h) => h.id)).toEqual(['bot-a'])
     await daemon.stop()
+  })
+
+  // This fixture executes the Linux sandbox's real filesystem publisher on the test host.
+  it.skipIf(process.platform === 'win32').each([
+    ['launch', false],
+    ['activate', false],
+    ['launch', true],
+    ['activate', true]
+  ] as const)(
+    '%s admits duty before sandbox preparation and honors a completed stop: %s',
+    async (kind, stopWhileClaiming) => {
+      const root = root1()
+      writeAgent(root, 'bot-a')
+      const { daemon, hosts } = makeDaemon(root)
+      const d = daemon as any
+      await daemon.start()
+      try {
+        d.runtimeCatalog.entries.claude = { ...d.runtimeCatalog.entries.claude, skillsAgentId: 'claude-code' }
+        if (kind === 'activate') {
+          expect(await seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).toEqual({ ok: true })
+        }
+        const claimed = signal()
+        const releaseClaim = signal()
+        const claimDuty = vi.fn(async () => {
+          claimed.resolve()
+          await releaseClaim.promise
+          return { granted: true, grant: dutyGrant('bot-a') }
+        })
+        poolMember(daemon, { claimDuty, fetchDutyAgent: async () => ({ bundle: DUTY_BUNDLE }) })
+        const workspace = join(root, 'sandbox-workspace')
+        mkdirSync(workspace)
+        const handler = new ClusterSkillHandler({
+          stagingRoot: join(root, 'staging'),
+          workspaceRoot: workspace,
+          stateRoot: join(root, 'state')
+        })
+        const client = new ClusterSkillClient({ request: (_cap, payload) => handler.handle(payload) }, true, true, true)
+        d.k8sPlane = {
+          withSandbox: async (_subject: unknown, fn: () => Promise<unknown>) => fn(),
+          ensureChannel: async () => {},
+          workspaceRootFor: () => workspace,
+          workspaceIncarnationFor: () => 'workspace',
+          shimGenerationFor: () => 1,
+          skillClientFor: () => client
+        }
+        const prepare = vi.spyOn(d.workspaces, 'prepareClusterWorkspace').mockResolvedValue(workspace)
+        const activate = {
+          agentId: 'bot-a',
+          moveId: MOVE_ID,
+          spec: { name: 'bot-a', runtime: 'claude' },
+          integrations: [],
+          crons: []
+        }
+        const pending =
+          kind === 'activate'
+            ? seam(daemon).applyAgentActivate(activate)
+            : seam(daemon).applyAgentLaunch({ agentId: 'bot-a' })
+        await claimed.promise
+        expect(prepare).not.toHaveBeenCalled()
+        expect(hosts).toEqual([])
+        const duplicate = kind === 'activate' ? seam(daemon).applyAgentActivate(activate) : undefined
+        if (stopWhileClaiming) {
+          expect(await seam(daemon).applyAgentStop({ agentId: 'bot-a', launchId: 'launch', reason: 'test' })).toEqual({
+            ok: true
+          })
+        }
+        releaseClaim.resolve()
+        if (stopWhileClaiming) {
+          if (kind === 'activate') {
+            expect(await pending).toEqual({ ok: false, reason: 'agent/activate: execution duty is not ready' })
+            expect(await duplicate).toEqual(await pending)
+          } else await expect(pending).rejects.toThrow('agent/launch: execution duty is not ready')
+          expect(d.cpClient.releaseDuties).toHaveBeenCalledWith([GROUP_ID])
+          expect(prepare).not.toHaveBeenCalled()
+          expect(hosts).toEqual([])
+          return
+        }
+        if (kind === 'activate') {
+          expect(await pending).toEqual({ ok: true })
+          expect(await duplicate).toEqual({ ok: true })
+        } else expect(await pending).toMatchObject({ agentId: 'bot-a' })
+        expect(claimDuty).toHaveBeenCalledTimes(1)
+        expect(prepare).toHaveBeenCalled()
+        expect(hosts.map((host) => host.id)).toEqual(['bot-a'])
+        expect(d.servesAgent('bot-a')).toBe(true)
+      } finally {
+        d.k8sPlane = undefined
+        await daemon.stop()
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it('a superseding detach returns an in-flight activation claim without preparing a workspace', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    const d = daemon as any
+    await daemon.start()
+    try {
+      expect(await seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })).toEqual({ ok: true })
+      const claimed = signal()
+      const releaseClaim = signal()
+      poolMember(daemon, {
+        claimDuty: async () => {
+          claimed.resolve()
+          await releaseClaim.promise
+          return { granted: true, grant: dutyGrant('bot-a') }
+        }
+      })
+      const prepare = vi.spyOn(d.workspaces, 'prepareWorkspaceForActivation')
+      const pending = seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        moveId: MOVE_ID,
+        spec: { name: 'bot-a', runtime: 'claude' },
+        integrations: [],
+        crons: [],
+        prepareWorkspace: true
+      })
+      await claimed.promise
+      expect(await seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID_2 })).toEqual({ ok: true })
+      releaseClaim.resolve()
+      expect(await pending).toEqual({ ok: false, reason: 'agent/activate: execution duty is not ready' })
+      expect(d.cpClient.releaseDuties).toHaveBeenCalledWith([GROUP_ID])
+      expect(prepare).not.toHaveBeenCalled()
+      expect(hosts).toEqual([])
+      expect(readAgentMoveStage(join(root, 'agents'), 'bot-a')).toMatchObject({ moveId: MOVE_ID_2, state: 'staging' })
+    } finally {
+      await daemon.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
   it('a token-less activate still proves its host on the member that holds the duty', async () => {

--- a/packages/daemon/test/direct-connect-credentials.test.ts
+++ b/packages/daemon/test/direct-connect-credentials.test.ts
@@ -83,6 +83,7 @@ describe('provider credentials in the direct-connect stage', () => {
       'materialize',
       'read',
       'skills',
+      'skills-receipts',
       'skills-wide',
       'tunnel'
     ])

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -202,7 +202,17 @@ describe('cluster spawn driver', () => {
         subject: 'agent-a',
         sandboxUid: 'sandbox-uid-1',
         generation: 1,
-        grants: ['acp', 'materialize', 'exec', 'read', 'tunnel', 'automerge', 'skills', 'skills-wide'],
+        grants: [
+          'acp',
+          'materialize',
+          'exec',
+          'read',
+          'tunnel',
+          'automerge',
+          'skills',
+          'skills-wide',
+          'skills-receipts'
+        ],
         podName: 'sb-1'
       }
     ])

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -260,7 +260,7 @@ describe('sandbox shim dial-in', () => {
     })
     const { endpoint } = await sandbox({
       workspaceRoot: workspace,
-      features: ['cluster-skills-v1'],
+      features: ['cluster-skills-v1', 'cluster-skills-v2', 'cluster-skills-v3'],
       backoff: fastBackoff(),
       handle: (capability, payload, abort, context) =>
         capability === 'skills' ? handler.handle(payload, abort, context) : Promise.resolve(undefined)
@@ -277,7 +277,7 @@ describe('sandbox shim dial-in', () => {
       log: quiet
     })
     dialers.push(dialer)
-    const spawn: SpawnRecord = { ...record(), grants: ['skills'] }
+    const spawn: SpawnRecord = { ...record(), grants: ['skills', 'skills-wide', 'skills-receipts'] }
     await dialer.connect(endpoint, spawn, 8_000)
     await waitFor(() => session.isAttached())
 
@@ -290,7 +290,8 @@ describe('sandbox shim dial-in', () => {
       workspaceIncarnation: 'claim',
       shimGeneration: 1
     }
-    const client = new ClusterSkillClient(session)
+    expect(session.hasCapability('skills-receipts')).toBe(true)
+    const client = new ClusterSkillClient(session, true, true, true)
     const operationId = randomUUID()
     const file = {
       sourceId: 'managed:channel',

--- a/packages/daemon/test/shim-dial-in.test.ts
+++ b/packages/daemon/test/shim-dial-in.test.ts
@@ -366,6 +366,20 @@ describe('sandbox shim dial-in', () => {
 
 /** k8s-daemon-pool §7: what the daemon accepts as proof that the socket it dialed is the pod it launched. */
 describe('dial-in identity handshake', () => {
+  it.each([undefined, ['cluster-skills-v1', 'cluster-skills-v2', 'future-feature']])(
+    'advertises only peer-compatible features when the daemon offers %j',
+    async (supportedFeatures) => {
+      const { port } = await sandbox({ features: ['cluster-skills-v1', 'cluster-skills-v2', 'cluster-skills-v3'] })
+      const { socket, frames } = await rawDial(port)
+      socket.send(JSON.stringify({ type: 'shim/hello', agentId: 'agent-a', generation: 1, supportedFeatures }))
+      await waitFor(() => frames.length > 0)
+      expect(JSON.parse(frames[0]!)).toMatchObject({
+        type: 'shim/identity',
+        features: ['cluster-skills-v1', 'cluster-skills-v2']
+      })
+    }
+  )
+
   it('fails the dial when the shim answers with anything but its identity', async () => {
     const clock = new VirtualClock()
     const warnings: string[] = []

--- a/packages/daemon/test/shim-handshake.test.ts
+++ b/packages/daemon/test/shim-handshake.test.ts
@@ -214,12 +214,21 @@ describe('shim feature negotiation', () => {
       })
       const connection = await runVirtual(
         clock,
-        dialer.connect(SCRIPTED_ENDPOINT, record({ grants: ['skills', 'skills-wide'] as never }), 500)
+        dialer.connect(
+          SCRIPTED_ENDPOINT,
+          record({ grants: ['skills', 'skills-wide', 'skills-receipts'] as never }),
+          500
+        )
       )
       return connection.binding.grants
     }
     expect(await grantsFor(['cluster-skills-v1'])).toEqual(['skills'])
     expect(await grantsFor(['cluster-skills-v1', 'cluster-skills-v2'])).toEqual(['skills', 'skills-wide'])
+    expect(await grantsFor(['cluster-skills-v1', 'cluster-skills-v2', 'cluster-skills-v3'])).toEqual([
+      'skills',
+      'skills-wide',
+      'skills-receipts'
+    ])
   })
 })
 
@@ -315,7 +324,12 @@ describe('shim handshake', () => {
     expect(connection.binding.grants).toEqual(['materialize'])
     expect(connection.issuedCredential).toMatch(/^[\w-]{20,}$/)
     // The daemon announced the launch it expects to bind before the pod proved anything.
-    expect(peers[0]!.received[0]).toEqual({ type: 'shim/hello', agentId: 'agent-a', generation: 3 })
+    expect(peers[0]!.received[0]).toEqual({
+      type: 'shim/hello',
+      agentId: 'agent-a',
+      generation: 3,
+      supportedFeatures: ['cluster-skills-v1', 'cluster-skills-v2', 'cluster-skills-v3']
+    })
     // The audience is what makes handing over the pod's own token safe: a token minted
     // for anything else must not authenticate here.
     expect(review.reviewToken).toHaveBeenCalledWith('projected-token', [SHIM_TOKEN_AUDIENCE])

--- a/packages/daemon/test/shim-skill-handler.test.ts
+++ b/packages/daemon/test/shim-skill-handler.test.ts
@@ -1,14 +1,18 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { chmod, lstat, mkdir, mkdtemp, readFile, symlink, utimes, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ShimRequester } from '../src/shim/channels.js'
 import { ClusterSkillClient } from '../src/shim/skill-client.js'
 import { ClusterSkillHandler } from '../src/shim/skill-handler.js'
-import { MAX_CLUSTER_SKILL_CHUNK_BYTES } from '../src/shim/skill-protocol.js'
+import { MAX_CLUSTER_SKILL_CHUNK_BYTES, MAX_CLUSTER_SKILL_CONTROL_BYTES } from '../src/shim/skill-protocol.js'
 import { inspectLocalSkillSource } from '../src/skills/skill-source-snapshot.js'
 import { treeDigest } from '../src/skills/skill-install-ledger.js'
+import { ClusterSkillCoordinator } from '../src/skills/cluster-skill-coordinator.js'
+import { legacySandboxSkillLedger } from '../src/skills/sandbox-skill-ledger.js'
+import { LocalStore } from '../src/store/local-store.js'
+import { memoryStoreDatabase } from './store-support.js'
 
 const sha256 = (value: Buffer): string => createHash('sha256').update(value).digest('hex')
 
@@ -34,6 +38,194 @@ async function fixture(content = Buffer.from('hello')) {
 }
 
 describe('cluster skill shim staging', () => {
+  it('rejects an oversized selected skill set before publishing any workspace files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-admission-'))
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace)
+    try {
+      const authority = {
+        groupId: 'g',
+        term: '1',
+        daemonId: 'd',
+        agentId: 'a',
+        workspaceIncarnation: 'w',
+        shimGeneration: 1
+      }
+      const handler = new ClusterSkillHandler({
+        stagingRoot: join(root, 'staging'),
+        workspaceRoot: workspace,
+        stateRoot: join(root, 'state')
+      })
+      const client = new ClusterSkillClient({ request: (_cap, payload) => handler.handle(payload) }, true, true, true)
+      const operationId = randomUUID()
+      const bodies = Array.from({ length: 65 }, (_, index) =>
+        Buffer.from(`---\nname: skill-${index}\ndescription: fixture\n---\n# Fixture\n`)
+      )
+      const files = bodies.map((body, index) => ({
+        sourceId: 'source',
+        path: `skill-${index}/SKILL.md`,
+        size: body.length,
+        sha256: sha256(body)
+      }))
+      const { handle } = await client.begin({ operationId, authority, skillsAgentId: 'codex', files })
+      for (const [index, file] of files.entries()) await client.upload(operationId, handle, file, bodies[index]!)
+      await expect(
+        client.reconcile({
+          operationId,
+          handle,
+          authority,
+          priorRoots: [],
+          replayKey: 'a'.repeat(64),
+          allowDesiredAdoption: false,
+          sources: [{ sourceId: 'source', sourceKind: 'managed', selections: [] }]
+        })
+      ).rejects.toThrow()
+      expect(await readdir(workspace)).toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses incomplete, out-of-order and superseded prior receipts before publication', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-prior-'))
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace)
+    try {
+      const handler = new ClusterSkillHandler({
+        stagingRoot: join(root, 'staging'),
+        workspaceRoot: workspace,
+        stateRoot: join(root, 'state')
+      })
+      const operationId = randomUUID()
+      const authority = {
+        groupId: 'g',
+        term: '1',
+        daemonId: 'd',
+        agentId: 'a',
+        workspaceIncarnation: 'w',
+        shimGeneration: 1
+      }
+      const { handle } = await new ClusterSkillClient(
+        { request: (_cap, payload) => handler.handle(payload) },
+        true,
+        true,
+        true
+      ).begin({ operationId, authority, skillsAgentId: 'codex', files: [] })
+      const files = [{ path: 'SKILL.md', mode: 0o600, size: 0, sha256: sha256(Buffer.alloc(0)) }]
+      const roots = [
+        { path: '.agents/skills/one', sourceId: 'source', sourceKind: 'managed', digest: treeDigest(files), files }
+      ]
+      await expect(handler.handle({ op: 'prior', operationId, handle, offset: 1, roots })).rejects.toThrow(
+        'unexpected prior skill receipt offset'
+      )
+      await expect(handler.handle({ op: 'prior', operationId, handle, offset: 0, roots })).resolves.toEqual({
+        received: 1
+      })
+      await expect(
+        handler.handle({
+          op: 'reconcile',
+          operationId,
+          handle,
+          authority,
+          priorRoots: [],
+          priorRootCount: 2,
+          replayKey: 'a'.repeat(64),
+          allowDesiredAdoption: false,
+          sources: []
+        })
+      ).rejects.toThrow('cluster skill prior receipt is incomplete')
+      await handler.handle({
+        op: 'begin',
+        operationId: randomUUID(),
+        authority: { ...authority, term: '2' },
+        skillsAgentId: 'codex',
+        files: []
+      })
+      await expect(handler.handle({ op: 'prior', operationId, handle, offset: 1, roots })).rejects.toThrow(
+        'lost duty authority'
+      )
+      expect(await readdir(workspace)).toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('commits, migrates, verifies and removes a receipt larger than one frame', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ac-skill-receipts-'))
+    const workspace = join(root, 'workspace')
+    const stateRoot = join(root, 'state')
+    await mkdir(workspace)
+    const store = await LocalStore.open({
+      database: memoryStoreDatabase(),
+      shared: true,
+      ownerId: 'member-a',
+      orgForAgent: () => 'org'
+    })
+    try {
+      const authority = {
+        groupId: 'g',
+        term: '1',
+        daemonId: 'member-a',
+        agentId: 'a',
+        workspaceIncarnation: 'workspace'
+      }
+      await store.projectDutyWriteFence({ groupId: 'g', term: '1', daemonId: 'member-a' })
+      const sources = []
+      const nested = ['a', 'b', 'c', 'd'].map((letter) => letter.repeat(180))
+      for (let index = 0; index < 6; index++) {
+        const name = `skill-${index}`
+        const sourceDir = join(root, name)
+        await mkdir(join(sourceDir, ...nested), { recursive: true })
+        await writeFile(join(sourceDir, 'SKILL.md'), `---\nname: ${name}\ndescription: fixture\n---\n# Fixture\n`)
+        for (let file = 1; file < 50; file++) await writeFile(join(sourceDir, ...nested, `file-${file}.txt`), 'fixture')
+        sources.push({
+          sourceId: name,
+          sourceKind: 'managed' as const,
+          sourceDir,
+          selections: [name],
+          expectedLeaves: [name]
+        })
+      }
+      const handler = new ClusterSkillHandler({
+        stagingRoot: join(root, 'staging'),
+        workspaceRoot: workspace,
+        stateRoot
+      })
+      const requests: string[] = []
+      const client = new ClusterSkillClient(
+        {
+          request: async (_capability, payload) => {
+            expect(Buffer.byteLength(JSON.stringify(payload))).toBeLessThanOrEqual(MAX_CLUSTER_SKILL_CONTROL_BYTES)
+            requests.push((payload as { op: string }).op)
+            const reply = await handler.handle(payload)
+            expect(Buffer.byteLength(JSON.stringify(reply))).toBeLessThanOrEqual(MAX_CLUSTER_SKILL_CONTROL_BYTES)
+            return reply
+          }
+        },
+        true,
+        true,
+        true
+      )
+      const coordinator = new ClusterSkillCoordinator(store)
+      const common = { authority, skillsAgentId: 'codex', shimGeneration: 1, client }
+      const ledger = await coordinator.reconcile({ ...common, sources })
+      expect(ledger.roots.flatMap((root) => root.files)).toHaveLength(300)
+      expect(Buffer.byteLength(JSON.stringify(ledger))).toBeGreaterThan(MAX_CLUSTER_SKILL_CONTROL_BYTES)
+      expect((await store.clusterSkillLedger('a', 'workspace'))?.ledger).toEqual(ledger)
+      expect((await legacySandboxSkillLedger('cluster-shim', workspace, stateRoot))?.roots).toHaveLength(6)
+      expect(await client.verify(ledger.roots)).toEqual({ intact: Array(6).fill(true) })
+      expect(requests.filter((op) => op === 'verify').length).toBeGreaterThan(1)
+      expect(requests).toContain('receipt')
+      await expect(coordinator.reconcile({ ...common, sources: [] })).resolves.toMatchObject({ roots: [] })
+      expect(requests.filter((op) => op === 'prior').length).toBeGreaterThan(1)
+      expect(await readdir(join(workspace, '.agents/skills'))).toEqual([])
+      expect((await store.clusterSkillLedger('a', 'workspace'))?.revision).toBe(2)
+    } finally {
+      await store.close()
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 120_000)
+
   it('assembles a paged manifest and enforces the totals no single page can see', async () => {
     const root = await mkdtemp(join(tmpdir(), 'ac-shim-paged-'))
     const handler = new ClusterSkillHandler({ stagingRoot: join(root, 'staging'), inactiveMs: 1_000 })

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -539,6 +539,8 @@ export const AgentActivate = z.object({
   agentId: z.string().uuid(),
   /** Absent ⇒ authoritative unstage: release any fence held, and start no host unless the duty is held. */
   moveId: z.string().uuid().optional(),
+  /** Restore an eligible replica without claiming duty; the move token still fences the unstage. */
+  unstageOnly: z.boolean().optional(),
   /**
    * One authoritative, acknowledged bootstrap bundle. Unlike the live CRUD
    * EVTs, these definitions are synchronously persisted under the staging gate


### PR DESCRIPTION
Large skill installations could publish files and then fail to save their ownership receipt because the publisher, shim frames, and durable ledger admitted different sizes. Serving activation could also prepare a sandbox before acquiring its execution duty. Both paths are shared by Kubernetes and microsandbox.

- Share the 64-bundle, 64-file-per-bundle, 1024-byte-path limits; negotiate paged prior receipts, results, and verification without adding round trips for small reconciliations. Reject unsupported results before workspace publication.
- Acquire and project duty before serving activation or explicit launch, outside the lifecycle queue used to install duty bundles. Preserve startup proof, duplicate move coalescing, and newer stop/detach precedence. Replica-only unstage keeps its move token without claiming duty.
- Await placement eligibility recomputation before target activation. Older shim images continue to use their existing single-frame protocol until updated.

Validation: 208 focused daemon/control-plane tests passed, including real skills CLI publication of 300 files with long paths, durable receipt migration/removal, WebSocket negotiation with older and newer peers, oversized admission, and lifecycle races. Daemon, control-plane, and protocol typechecks, changed-file ESLint/Prettier, and the packaged shim build passed. No live services were changed.

Fixes #2001. Fixes #2002.

Created by Codex . GPT-6
