### PR TITLE
feat(daemon): protect Claude and Codex API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -329,6 +329,35 @@ a shared discovery descriptor retain the runtime probe's authentication result.
 
 ### API key protection
 
+Claude Code and Codex file-based API logins use microsandbox's built-in TLS proxy.
+The daemon discovers Claude's saved `primaryApiKey` in its active global config
+(including `CLAUDE_CONFIG_DIR` and the legacy `.config.json` layout), or Codex's
+`OPENAI_API_KEY` in `CODEX_HOME/auth.json`. Private copies contain placeholders;
+the raw host API credential file is not mounted. Claude retains the existing
+global-config seed allowlist, and private settings survive later preparation.
+Codex's private `auth.json` is a regular projected file, replacing the shared
+auth-file link for API logins. Matching key values in its seeded `config.toml`
+and launch environment are replaced too. No native authentication environment
+variable is added, so the runtime still selects its own authentication method.
+
+Claude authorizes its configured `ANTHROPIC_BASE_URL` host, defaulting to
+`api.anthropic.com`. Codex resolves the host `config.toml`, selected profile and
+`CODEX_CONFIG` overrides: the built-in provider uses `openai_base_url` or
+`api.openai.com`; a custom provider can use the file login when
+`requires_openai_auth = true`. `OPENAI_BASE_URL` does not control the pinned Codex
+runtime's routing. Unsupported endpoints keep the placeholder without receiving
+proxy injection; there is no plaintext fallback. Guest-side endpoint changes
+cannot authorize an additional host. This path covers registered `claude-acp`
+and `codex-acp` file logins, not keyring-only, helper-only or environment-only keys.
+
+Pure OAuth logins keep their existing shared credentials and native refresh.
+Claude can also keep a separate shared OAuth directory alongside its projected
+API config. If that directory contains the raw API config, launch refuses the
+overlapping mount. Codex files explicitly selecting a non-API authentication
+mode while also storing an API key are refused rather than exposing the key or
+silently changing native authentication. These mixed-source layouts remain
+compatibility follow-ups; this change does not add OAuth proxying.
+
 For DeepSeek Harness in microsandbox, the daemon resolves the standard
 `DEEPSEEK_API_KEY` reference using the existing credential-file descriptors and
 DSH parser (`.credentials.yaml`, including the legacy layout and version-1 refs,
@@ -391,7 +420,7 @@ trusted recipient of the key.
 
 The pinned SDK installs the proxy CA into the guest system bundle before execution.
 Combining it with operator-provided trust bundles is deferred: protected runtime
-launches explicitly refuse custom `TLS_TRUST_ENV`, `REQUESTS_CA_BUNDLE` or
+launches explicitly refuse custom `TLS_TRUST_ENV`, `CODEX_CA_CERTIFICATE`, `REQUESTS_CA_BUNDLE` or
 `CURL_CA_BUNDLE` settings instead of silently replacing them. Use SRT for those
 configurations until custom trust is supported.
 

--- a/packages/daemon/src/microsandbox/launch.ts
+++ b/packages/daemon/src/microsandbox/launch.ts
@@ -112,12 +112,15 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   )
   for (const path of [...writable, ...configDirs]) mkdirSync(path, { recursive: true, mode: 0o700 })
 
-  const credentials = prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
   const protectedCredentials = prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, hostEnv, opts.explicitEnv)
+  const credentials =
+    protectedCredentials?.shareNativeCredentials === false
+      ? undefined
+      : prepareSharedRuntimeCredentials({ runtimeId: opts.runtimeId, runtime: opts.runtime, hostEnv })
   if (
     protectedCredentials?.secrets.length &&
-    [...TLS_TRUST_ENV, 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'].some((name) =>
-      (opts.explicitEnv?.[name] ?? hostEnv[name])?.trim()
+    [...TLS_TRUST_ENV, ...(protectedCredentials.tlsTrustEnv ?? []), 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'].some(
+      (name) => (opts.explicitEnv?.[name] ?? hostEnv[name])?.trim()
     )
   ) {
     throw new Error(
@@ -238,13 +241,14 @@ export function prepareMicrosandboxLaunch(opts: PrepareMicrosandboxLaunchOptions
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   const claudeSettings = claudeRuntime ? prepareClaudeProtectedSettings(scopeDir, env) : undefined
-  const privateStateTargets = protectedCredentials
-    ? protectedCredentials.seedExclusions.map((path) => join(runtimeHome, path))
-    : credentialProfile === 'codex'
+  const privateStateTargets = [
+    ...(protectedCredentials?.seedExclusions.map((path) => join(runtimeHome, path)) ?? []),
+    ...(credentialProfile === 'codex'
       ? [join(runtimeHome, '.codex')]
       : claudeRuntime
         ? [join(runtimeHome, '.claude'), join(runtimeHome, '.claude.json')]
-        : []
+        : [])
+  ]
   const privateState = privateStateTargets.filter(existsSync).map((path) => realpathSync(path))
   const credentialSources = [...(credentials?.writablePaths ?? []), ...privateState].map((path) =>
     existsSync(path) ? realpathSync(path) : path

--- a/packages/daemon/src/microsandbox/native-api-secrets.ts
+++ b/packages/daemon/src/microsandbox/native-api-secrets.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
+import { CODEX_DEFAULT_ENDPOINT, objectFromJson, record } from '../runtimes/codex-config.js'
+import {
+  resolveClaudeCredentialSources,
+  resolveCodexCredentialSources
+} from '../runtimes/runtime-credential-sources.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { MAX_SEED_FILE_BYTES } from '../runtimes/runtime-seeded-credentials.js'
+import { replaceSecretValue } from './secret-values.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+function readFile(path: string): string | undefined {
+  try {
+    const stat = statSync(path)
+    if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) throw new Error('invalid source')
+    return readFileSync(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw new Error('Cannot read the host runtime API credential/configuration file')
+  }
+}
+
+function document(text: string | undefined): Record<string, unknown> {
+  return objectFromJson(text, 'Runtime API credential file')
+}
+
+function allowedHost(endpoint: unknown): string[] {
+  try {
+    if (typeof endpoint !== 'string') return []
+    const url = new URL(endpoint)
+    if (url.protocol === 'https:' && !url.port && !url.username && !url.password && /^[a-z0-9.-]+$/.test(url.hostname))
+      return [url.hostname]
+  } catch {
+    // Unsupported endpoints retain placeholders without authorizing the host-side key.
+  }
+  return []
+}
+
+function replaceValues(value: unknown, replacements: ReadonlyMap<string, string>): unknown {
+  if (typeof value === 'string') return replaceSecretValue(value, replacements)
+  if (Array.isArray(value)) return value.map((item) => replaceValues(item, replacements))
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, replaceValues(item, replacements)]))
+  }
+  return value
+}
+
+function mergeConfig(base: Record<string, unknown>, overrides: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...base }
+  for (const [key, value] of Object.entries(overrides)) {
+    result[key] =
+      value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)
+        ? mergeConfig(record(result[key], 'Codex configuration table'), value as Record<string, unknown>)
+        : value
+  }
+  return result
+}
+
+function fileCredential(
+  name: string,
+  key: string,
+  endpoint: unknown,
+  files: { source: string; destination: string; keys?: readonly string[]; toml?: boolean }[],
+  field: string,
+  shareNativeCredentials: boolean
+): MicrosandboxCredentials {
+  const secret: MicrosandboxSecret = {
+    env: `AC_${name}_API_KEY`,
+    placeholder: `msb-secret-AC_${name}_API_KEY`,
+    host: allowedHost(endpoint),
+    readValue: () => key
+  }
+  const replacements = new Map([[key, secret.placeholder]])
+  files = files.map((file) => ({ ...file, source: existsSync(file.source) ? realpathSync(file.source) : file.source }))
+  return {
+    secrets: secret.host.length ? [secret] : [],
+    replacements,
+    sources: files.map(({ source }) => source),
+    seedExclusions: files.map(({ destination }) => destination),
+    shareNativeCredentials,
+    preparePrivateHome(home) {
+      for (const file of files) {
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text, retained) => {
+          let data: Record<string, unknown>
+          try {
+            data = file.toml ? parseToml(text) : document(text)
+          } catch {
+            throw new Error('Cannot protect the runtime API credential/configuration file')
+          }
+          if (Object.hasOwn(data, field)) data[field] = secret.placeholder
+          const projected =
+            file.keys && !retained
+              ? Object.fromEntries(Object.entries(data).filter(([key]) => file.keys!.includes(key)))
+              : data
+          const replaced = replaceValues(projected, replacements) as Record<string, unknown>
+          return file.toml ? stringifyToml(replaced) : `${JSON.stringify(replaced)}\n`
+        })
+      }
+    }
+  }
+}
+
+export function prepareClaudeApiSecret(
+  hostEnv: NodeJS.ProcessEnv,
+  explicitEnv: Record<string, string>
+): MicrosandboxCredentials | undefined {
+  const source = resolveClaudeCredentialSources(hostEnv)
+  const key = document(readFile(source.globalConfigFile)).primaryApiKey
+  if (typeof key !== 'string' || !key.trim()) return undefined
+  const files = runtimeStateLocations('claude-acp', hostEnv).flatMap((location) =>
+    location.seedJsonKeys?.includes('primaryApiKey')
+      ? (location.seedFiles ?? ['']).map((file) => ({
+          source: join(location.source, file),
+          destination: join(location.destination, file),
+          keys: location.seedJsonKeys
+        }))
+      : []
+  )
+  return fileCredential(
+    'CLAUDE',
+    key,
+    explicitEnv.ANTHROPIC_BASE_URL ?? hostEnv.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com',
+    files,
+    'primaryApiKey',
+    existsSync(source.credentialFile)
+  )
+}
+
+export function prepareCodexApiSecret(
+  hostEnv: NodeJS.ProcessEnv,
+  explicitEnv: Record<string, string>
+): MicrosandboxCredentials | undefined {
+  const source = resolveCodexCredentialSources(hostEnv)
+  const auth = document(readFile(source.credentialFile))
+  const key = auth.OPENAI_API_KEY
+  if (typeof key !== 'string' || !key.trim()) return undefined
+  if (
+    (auth.auth_mode && auth.auth_mode !== 'apikey') ||
+    auth.personal_access_token ||
+    auth.bedrock_api_key ||
+    auth.bedrock_access_keys
+  ) {
+    throw new Error('Codex launch refused: combined API key and non-API authentication cannot be safely shared')
+  }
+  let config: Record<string, unknown>
+  try {
+    config = parseToml(readFile(join(source.configDir, 'config.toml')) ?? '')
+  } catch {
+    throw new Error('Cannot read the host Codex configuration file')
+  }
+  const overrides = objectFromJson(explicitEnv.CODEX_CONFIG ?? hostEnv.CODEX_CONFIG, 'CODEX_CONFIG')
+  const profile = overrides.profile ?? config.profile
+  const profiles = record(config.profiles, 'Codex profiles')
+  config = mergeConfig(
+    mergeConfig(config, record(typeof profile === 'string' ? profiles[profile] : undefined, 'Codex profile')),
+    overrides
+  )
+  const provider = config.model_provider ?? 'openai'
+  const custom = record(record(config.model_providers, 'Codex providers')[String(provider)], 'Codex provider')
+  const endpoint =
+    provider === 'openai'
+      ? (config.openai_base_url ?? CODEX_DEFAULT_ENDPOINT)
+      : custom.requires_openai_auth === true
+        ? custom.base_url
+        : undefined
+  return {
+    ...fileCredential(
+      'CODEX',
+      key,
+      endpoint,
+      [
+        { source: source.credentialFile, destination: join('.codex', 'auth.json') },
+        { source: join(source.configDir, 'config.toml'), destination: join('.codex', 'config.toml'), toml: true }
+      ],
+      'OPENAI_API_KEY',
+      false
+    ),
+    tlsTrustEnv: ['CODEX_CA_CERTIFICATE']
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -7,6 +7,7 @@ import { runtimeStateLocations } from '../runtimes/probe.js'
 import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
 import { MAX_SEED_FILE_BYTES, parseDshCredentialDocument } from '../runtimes/runtime-seeded-credentials.js'
 import { prepareOpenCodeSecrets } from './opencode-secrets.js'
+import { prepareClaudeApiSecret, prepareCodexApiSecret } from './native-api-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
@@ -21,6 +22,8 @@ export interface MicrosandboxCredentials {
   replacements: ReadonlyMap<string, string>
   sources: string[]
   seedExclusions: string[]
+  shareNativeCredentials?: boolean
+  tlsTrustEnv?: readonly string[]
   preparePrivateHome: (home: string) => void
 }
 
@@ -29,7 +32,9 @@ const CREDENTIAL_PREPARERS = new Map<
   (hostEnv: NodeJS.ProcessEnv, explicitEnv: Record<string, string>) => MicrosandboxCredentials | undefined
 >([
   ['dsh-acp', prepareDeepSeekSecret],
-  ['opencode', prepareOpenCodeSecrets]
+  ['opencode', prepareOpenCodeSecrets],
+  ['claude-acp', prepareClaudeApiSecret],
+  ['codex-acp', prepareCodexApiSecret]
 ])
 
 export function prepareMicrosandboxCredentials(

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -72,7 +72,7 @@ export function projectRuntimeHomeSeedFile(
   home: string,
   destination: string,
   source: string,
-  project: (text: string) => string | undefined
+  project: (text: string, retained: boolean) => string | undefined
 ): void {
   const target = containedDestination(home, destination)
   assertNoDestinationSymlink(home, target)
@@ -115,7 +115,7 @@ export function projectRuntimeHomeSeedFile(
     } finally {
       closeSync(input)
     }
-    const content = project(original)
+    const content = project(original, retained)
     if (content === undefined) {
       if (retained) throw new Error('Cannot protect the existing private runtime credential file')
       return

--- a/packages/daemon/test/microsandbox-launch.test.ts
+++ b/packages/daemon/test/microsandbox-launch.test.ts
@@ -733,12 +733,12 @@ describe('prepareMicrosandboxLaunch', () => {
     }
   })
 
-  it('reuses the native Codex auth-file link and exposes only the shared credential file', () => {
+  it('reuses the native Codex OAuth auth-file link and exposes only the shared credential file', () => {
     const opts = fixture()
     const hostCodex = join(opts.hostHome, '.codex')
     const auth = join(hostCodex, 'auth.json')
     mkdirSync(hostCodex)
-    writeFileSync(auth, JSON.stringify({ OPENAI_API_KEY: 'synthetic-test-key' }))
+    writeFileSync(auth, JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: 'synthetic-oauth-token' } }))
     const original = credentials.prepareSharedRuntimeCredentials
     vi.spyOn(credentials, 'prepareSharedRuntimeCredentials').mockImplementation((options) =>
       original({ ...options, platform: 'linux' })

--- a/packages/daemon/test/microsandbox-native-api-secrets.test.ts
+++ b/packages/daemon/test/microsandbox-native-api-secrets.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+
+const roots: string[] = []
+const key = 'fixture-native-api-key'
+function write(path: string, data: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, typeof data === 'string' ? data : JSON.stringify(data))
+}
+
+function fixture(runtimeId: 'claude-acp' | 'codex-acp') {
+  const root = mkdtempSync(join(tmpdir(), 'ac-native-api-'))
+  roots.push(root)
+  const hostHome = join(root, 'host')
+  const scopeDir = join(root, 'agent')
+  const cwd = join(scopeDir, 'workspace')
+  mkdirSync(cwd, { recursive: true })
+  mkdirSync(hostHome)
+  return {
+    root,
+    hostHome,
+    runtimeId,
+    runtime: { command: runtimeId === 'claude-acp' ? 'claude-agent-acp' : 'codex-acp', args: [], env: [] },
+    scopeDir,
+    cwd,
+    mounts: [],
+    stateSourceEnv: { HOME: hostHome }
+  }
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe.skipIf(process.platform !== 'linux')('microsandbox native file API credentials', () => {
+  it.each(['default', 'relocated', 'legacy'])(
+    'protects Claude %s login without changing native auth precedence',
+    (layout) => {
+      const opts = fixture('claude-acp')
+      const configDir = join(opts.hostHome, layout === 'default' ? '.claude' : 'configured-claude')
+      const source =
+        layout === 'default'
+          ? join(opts.hostHome, '.claude.json')
+          : join(configDir, layout === 'legacy' ? '.config.json' : '.claude.json')
+      const stateSourceEnv = {
+        ...opts.stateSourceEnv,
+        CODEX_CA_CERTIFICATE: '/tmp/codex-only-ca.pem',
+        ...(layout === 'default' ? {} : { CLAUDE_CONFIG_DIR: configDir })
+      }
+      const host = {
+        primaryApiKey: key,
+        additionalModelOptionsCache: { model: 'fixture-model' },
+        projects: { private: {} }
+      }
+      write(source, host)
+      const launchOpts = { ...opts, stateSourceEnv }
+      const launch = prepareMicrosandboxLaunch(launchOpts)
+      const secret = launch.microsandbox.secrets![0]!
+      expect(secret.host).toEqual(['api.anthropic.com'])
+      expect(secret.readValue()).toBe(key)
+      expect(launch.env.ANTHROPIC_API_KEY).toBeUndefined()
+      expect(launch.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
+      expect(JSON.stringify(launch)).not.toContain(key)
+      expect(launch.microsandbox.mounts.some(({ source }) => source === configDir)).toBe(false)
+      const path = join(launch.runtimeHome!, '.claude', layout === 'legacy' ? '.config.json' : '.claude.json')
+      const projected = JSON.parse(readFileSync(path, 'utf8'))
+      expect(projected).toEqual({
+        primaryApiKey: secret.placeholder,
+        additionalModelOptionsCache: host.additionalModelOptionsCache
+      })
+      expect(launch.toolSandbox!.protectedCredentialRoots).toContain(join(launch.runtimeHome!, '.claude'))
+      projected.projects = { workspace: { approved: true } }
+      write(path, projected)
+      write(source, { ...host, primaryApiKey: 'fixture-rotated-key' })
+      const resumed = prepareMicrosandboxLaunch(launchOpts)
+      expect(resumed.microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated-key')
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(projected)
+      expect(JSON.parse(readFileSync(source, 'utf8')).primaryApiKey).toBe('fixture-rotated-key')
+      expect(() => prepareMicrosandboxLaunch({ ...launchOpts, trustedRuntimeReadRoots: [source] })).toThrow(
+        'protected host credential'
+      )
+    }
+  )
+
+  it('keeps Claude OAuth shared while projecting a separate saved API key', () => {
+    const opts = fixture('claude-acp')
+    const credentialDir = join(opts.hostHome, '.claude')
+    const oauth = { claudeAiOauth: { accessToken: 'fixture-oauth', refreshToken: 'fixture-refresh', expiresAt: 1 } }
+    write(join(credentialDir, '.credentials.json'), oauth)
+    write(join(opts.hostHome, '.claude.json'), { primaryApiKey: key })
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(credentialDir)
+    expect(launch.microsandbox.mounts).toContainEqual({
+      source: credentialDir,
+      target: credentialDir,
+      mode: 'writable'
+    })
+    expect(JSON.parse(readFileSync(join(credentialDir, '.credentials.json'), 'utf8'))).toEqual(oauth)
+    const source = join(credentialDir, '.config.json')
+    write(source, { primaryApiKey: key })
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow('protected host credential source')
+  })
+
+  it('replaces Codex auth mounts with private placeholders and preserves config and key rotation', () => {
+    const opts = fixture('codex-acp')
+    const auth = join(opts.hostHome, '.codex', 'auth.json')
+    const config = join(opts.hostHome, '.codex', 'config.toml')
+    write(auth, { auth_mode: 'apikey', OPENAI_API_KEY: key, tokens: null })
+    write(
+      config,
+      `model = "fixture-model"\nopenai_base_url = "https://gateway.example.test/v1"\n[model_providers.other.http_headers]\nx-api-key = "${key}"\n`
+    )
+    const launch = prepareMicrosandboxLaunch(opts)
+    const secret = launch.microsandbox.secrets![0]!
+    expect(secret.host).toEqual(['gateway.example.test'])
+    expect(launch.env.OPENAI_API_KEY).toBeUndefined()
+    expect(launch.env.CODEX_API_KEY).toBeUndefined()
+    expect(JSON.stringify(launch)).not.toContain(key)
+    expect(launch.microsandbox.mounts.some(({ source }) => source === auth)).toBe(false)
+    const path = join(launch.runtimeHome!, '.codex', 'auth.json')
+    expect(lstatSync(path).isSymbolicLink()).toBe(false)
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({
+      auth_mode: 'apikey',
+      OPENAI_API_KEY: secret.placeholder,
+      tokens: null
+    })
+    expect(readFileSync(join(launch.runtimeHome!, '.codex', 'config.toml'), 'utf8')).not.toContain(key)
+    expect(launch.toolSandbox!.protectedCredentialRoots).toContain(join(launch.runtimeHome!, '.codex'))
+    write(auth, { auth_mode: 'apikey', OPENAI_API_KEY: 'fixture-rotated-key' })
+    expect(prepareMicrosandboxLaunch(opts).microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated-key')
+    expect(JSON.parse(readFileSync(path, 'utf8')).OPENAI_API_KEY).toBe(secret.placeholder)
+    expect(() =>
+      prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: auth, target: '/tmp/auth-alias', mode: 'readonly' }] })
+    ).toThrow('protected host')
+    write(auth, { auth_mode: 'chatgpt', OPENAI_API_KEY: key, tokens: { access_token: 'fixture-oauth' } })
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow('combined API key and non-API authentication')
+  })
+
+  it('resolves Codex file logins and provider profiles without treating OPENAI_BASE_URL as routing', () => {
+    const opts = fixture('codex-acp')
+    const configDir = join(opts.hostHome, 'configured-codex')
+    const auth = join(configDir, 'auth.json')
+    const actual = join(opts.hostHome, 'managed-auth.json')
+    write(actual, { OPENAI_API_KEY: key })
+    mkdirSync(configDir)
+    symlinkSync(actual, auth)
+    write(
+      join(configDir, 'config.toml'),
+      'profile="fixture"\n[profiles.fixture]\nmodel_provider="custom"\n[model_providers.custom]\nbase_url="https://custom.example.test/v1"\nrequires_openai_auth=true\n'
+    )
+    const launchOpts = {
+      ...opts,
+      stateSourceEnv: { ...opts.stateSourceEnv, CODEX_HOME: configDir, OPENAI_BASE_URL: 'https://unused.example.test' }
+    }
+    const launch = prepareMicrosandboxLaunch(launchOpts)
+    expect(launch.microsandbox.secrets![0]!.host).toEqual(['custom.example.test'])
+    expect(JSON.parse(readFileSync(join(launch.runtimeHome!, '.codex', 'auth.json'), 'utf8')).OPENAI_API_KEY).toMatch(
+      /^msb-secret-/
+    )
+    const override = prepareMicrosandboxLaunch({
+      ...launchOpts,
+      explicitEnv: {
+        CODEX_CONFIG: JSON.stringify({ model_provider: 'openai', openai_base_url: 'https://override.example.test/v1' })
+      }
+    })
+    expect(override.microsandbox.secrets![0]!.host).toEqual(['override.example.test'])
+    expect(() =>
+      prepareMicrosandboxLaunch({ ...launchOpts, explicitEnv: { CODEX_CA_CERTIFICATE: '/tmp/custom-ca.pem' } })
+    ).toThrow('custom TLS trust')
+  })
+
+  it.each(['claude-acp', 'codex-acp'] as const)(
+    'withholds %s API keys from unsupported HTTP endpoints',
+    (runtimeId) => {
+      const opts = fixture(runtimeId)
+      const claude = runtimeId === 'claude-acp'
+      const source = join(opts.hostHome, claude ? '.claude.json' : '.codex/auth.json')
+      write(source, claude ? { primaryApiKey: key } : { OPENAI_API_KEY: key })
+      const base = 'http://localhost:8080/v1'
+      const launch = prepareMicrosandboxLaunch({
+        ...opts,
+        explicitEnv: claude ? { ANTHROPIC_BASE_URL: base } : { CODEX_CONFIG: JSON.stringify({ openai_base_url: base }) }
+      })
+      expect(launch.microsandbox.secrets).toEqual([])
+      const text = readFileSync(join(launch.runtimeHome!, claude ? '.claude/.claude.json' : '.codex/auth.json'), 'utf8')
+      expect(text).not.toContain(key)
+      expect(text).toContain('msb-secret-')
+      expect(launch.env.NODE_EXTRA_CA_CERTS).toBeUndefined()
+    }
+  )
+})


### PR DESCRIPTION
Claude Code and Codex file-based API logins previously exposed their saved keys inside microsandbox. Project those keys into private credential files as placeholders and reuse the existing microsandbox TLS secret injection. Codex API logins no longer mount the host auth file. Pure OAuth retains native shared credentials and refresh, and SRT/Kubernetes authentication is unchanged.

Reuse native credential discovery and Claude's seed allowlist; retain private settings, support key rotation on stopped VM resume, and keep native tool credential denies. Resolve approved HTTPS destinations from the corresponding host configuration. Unsupported destinations receive no key injection, with no plaintext fallback. Document unsupported mixed-auth layouts and reject raw credential mounts.

Validation:
- Daemon typecheck, focused lint and formatting passed.
- Existing launch, driver and runtime HOME tests: 142 passed on macOS; Linux-only cases skipped there.
- Eight focused Linux credential projection tests passed in an isolated container.
- Isolated microsandbox 0.6.17 VMs: both native header formats, host-only key injection, fresh/resumed/rotated credentials, denied injection to another host, and guest file/process inspection passed using synthetic keys.
- Installed native Claude/Codex CLIs read the projected file login without injected authentication environment variables. Native VM HTTPS requests reached the real providers and received the expected authentication rejection for synthetic keys; no billable model turn was claimed.

Related: #1874

Created by Codex . GPT-6
