### PR TITLE
feat(daemon): protect pi API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -401,6 +401,27 @@ API records for providers configured only inside the guest retain their native l
 behavior on resume; they are not host-managed proxy credentials. Blank or malformed
 API keys are not selected for protection and do not prevent preparing other records.
 
+pi uses the same proxy for file-based `type: api_key` records in `auth.json` and
+provider `apiKey` fields in `models.json`, honoring `PI_CODING_AGENT_DIR`. Its
+shared state descriptors now discover and seed `models.json` for both SRT and
+microsandbox. The VM receives projected auth, model and settings files; matching
+key values and Bearer headers are replaced, and host files remain unchanged.
+Providers sharing a literal key share a placeholder and their authorized hosts.
+Routing uses the host's JSONC `models.json` provider and model `baseUrl` values,
+with audited defaults for Anthropic, OpenAI, DeepSeek, Google, xAI, OpenRouter,
+Groq and Mistral. Guest model edits cannot authorize additional destinations.
+
+This pi path supports literal API keys. Command-based keys, interpolation and
+structured provider `env` credentials are replaced by inert placeholders without
+executing helpers or importing their secret values. Unknown providers and
+unsupported endpoints also retain placeholders without proxy injection; their
+keys are never mounted as a fallback. Extra secrets stored only in arbitrary
+headers or extensions are not discovered by this path. Symlinked host files are
+skipped, matching native HOME seeding. OAuth records and guest-only logins retain
+their existing behavior, including refreshed private OAuth state on resume.
+Pure OAuth launches do not enable secret injection. SRT authentication and tool
+policies are unchanged; it imports the native files without this VM proxy.
+
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
 existing private logins are preserved. Without a DeepSeek key, normal seeding is

--- a/packages/daemon/src/microsandbox/pi-secrets.ts
+++ b/packages/daemon/src/microsandbox/pi-secrets.ts
@@ -1,0 +1,146 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
+import { objectFromJson } from '../runtimes/codex-config.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { MAX_SEED_FILE_BYTES } from '../runtimes/runtime-seeded-credentials.js'
+import { replaceSecretValue } from './secret-values.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+// Audited pi 0.85.1 built-ins; other providers require a host models.json HTTPS baseUrl.
+const DEFAULT_ORIGINS: Record<string, string> = {
+  anthropic: 'https://api.anthropic.com',
+  openai: 'https://api.openai.com',
+  deepseek: 'https://api.deepseek.com',
+  google: 'https://generativelanguage.googleapis.com',
+  xai: 'https://api.x.ai',
+  openrouter: 'https://openrouter.ai',
+  groq: 'https://api.groq.com',
+  mistral: 'https://api.mistral.ai'
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function document(text: string, jsonc = false): Record<string, unknown> {
+  text = text.replace(/^\uFEFF/, '')
+  return objectFromJson(
+    jsonc ? stripJsonComments(text, { trailingCommas: true }) : text,
+    'pi credential/configuration file'
+  )
+}
+
+function readDocument(path: string, jsonc = false): Record<string, unknown> {
+  try {
+    const stat = lstatSync(path)
+    if (stat.isSymbolicLink()) return {}
+    if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) throw new Error('invalid source')
+    return document(readFileSync(path, 'utf8'), jsonc)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Cannot read the host pi credential/configuration file')
+  }
+}
+
+function nonempty(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function allowedHost(endpoint: unknown): string[] {
+  try {
+    if (typeof endpoint !== 'string') return []
+    const url = new URL(endpoint)
+    if (url.protocol === 'https:' && !url.port && !url.username && !url.password && /^[a-z0-9.-]+$/.test(url.hostname))
+      return [url.hostname]
+  } catch {
+    // Unresolved endpoints never authorize key injection.
+  }
+  return []
+}
+
+export function preparePiSecrets(hostEnv: NodeJS.ProcessEnv): MicrosandboxCredentials | undefined {
+  const locations = runtimeStateLocations('pi-acp', hostEnv)
+  const files = locations.flatMap((location) =>
+    (location.seedFiles ?? ['']).map((path) => ({
+      source: join(location.source, path),
+      destination: join(location.destination, path),
+      format: location.credentialFiles?.[0]?.format
+    }))
+  )
+  const authFile = files.find((file) => file.format === 'pi')!
+  const modelsFile = files.find((file) => file.format === 'pi-models')!
+  const auth = readDocument(authFile.source)
+  const providers = object(readDocument(modelsFile.source, true).providers)
+  const bindings = new Map<string, MicrosandboxSecret>()
+  const sharedKeys = new Map<string, MicrosandboxSecret>()
+  const replacements = new Map<string, string>()
+  const add = (provider: string, kind: string, value: unknown, env?: unknown) => {
+    const scopedEnv = object(env)
+    if (!nonempty(value) && !Object.values(scopedEnv).some(nonempty)) return
+    const name = `PI_API_${createHash('sha256').update(`${kind}:${provider}`).digest('hex').slice(0, 16).toUpperCase()}`
+    const literal = nonempty(value) && !value.startsWith('!') && !value.includes('$') && !Object.keys(scopedEnv).length
+    const config = object(providers[provider])
+    const endpoints = [
+      config.baseUrl ?? DEFAULT_ORIGINS[provider],
+      ...(Array.isArray(config.models) ? config.models.map((model) => object(model).baseUrl) : [])
+    ]
+    const secret: MicrosandboxSecret = {
+      env: name,
+      placeholder: `msb-secret-${name}`,
+      host: literal ? [...new Set(endpoints.flatMap(allowedHost))].sort() : [],
+      readValue: () => (nonempty(value) ? value : '')
+    }
+    const shared = literal ? sharedKeys.get(value) : undefined
+    if (shared) shared.host = [...new Set([shared.host, secret.host].flat())].sort()
+    else if (literal) sharedKeys.set(value, secret)
+    const binding = shared ?? secret
+    bindings.set(`${kind}:${provider}`, binding)
+    for (const raw of [value, ...Object.values(scopedEnv)]) {
+      if (nonempty(raw)) replacements.set(raw, binding.placeholder)
+    }
+  }
+  for (const [provider, raw] of Object.entries(auth).sort(([a], [b]) => a.localeCompare(b))) {
+    const value = object(raw)
+    if (value.type === 'api_key') add(provider, 'auth', value.key, value.env)
+  }
+  for (const [provider, raw] of Object.entries(providers).sort(([a], [b]) => a.localeCompare(b))) {
+    add(provider, 'models', object(raw).apiKey)
+  }
+  if (!bindings.size) return undefined
+  const project = (value: unknown): string =>
+    JSON.stringify(value, (_key, item: unknown) =>
+      typeof item === 'string' ? replaceSecretValue(item, replacements) : item
+    )
+  return {
+    secrets: [...sharedKeys.values()].filter((secret) => secret.host.length > 0),
+    replacements,
+    sources: files.map((file) => file.source),
+    seedExclusions: files.map((file) => file.destination),
+    preparePrivateHome(home) {
+      for (const file of files) {
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text) => {
+          const data = document(text, file.format === 'pi-models')
+          if (file.format === 'pi') {
+            for (const [provider, raw] of Object.entries(data)) {
+              const value = object(raw)
+              const binding = bindings.get(`auth:${provider}`)
+              if (value.type === 'api_key' && binding) {
+                data[provider] = { type: 'api_key', key: binding.placeholder }
+              }
+            }
+          } else if (file.format === 'pi-models') {
+            for (const [provider, raw] of Object.entries(object(data.providers))) {
+              const value = object(raw)
+              const binding = bindings.get(`models:${provider}`)
+              if (binding && nonempty(value.apiKey)) value.apiKey = binding.placeholder
+            }
+          }
+          return `${project(data)}\n`
+        })
+      }
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -8,6 +8,7 @@ import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
 import { MAX_SEED_FILE_BYTES, parseDshCredentialDocument } from '../runtimes/runtime-seeded-credentials.js'
 import { prepareOpenCodeSecrets } from './opencode-secrets.js'
 import { prepareClaudeApiSecret, prepareCodexApiSecret } from './native-api-secrets.js'
+import { preparePiSecrets } from './pi-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
@@ -33,6 +34,7 @@ const CREDENTIAL_PREPARERS = new Map<
 >([
   ['dsh-acp', prepareDeepSeekSecret],
   ['opencode', prepareOpenCodeSecrets],
+  ['pi-acp', preparePiSecrets],
   ['claude-acp', prepareClaudeApiSecret],
   ['codex-acp', prepareCodexApiSecret]
 ])

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -246,8 +246,7 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
     ...state(join(home(env), '.opencode'), '.opencode')
   ],
 
-  // pi (svkozak pi-acp npx adapter) — auth/settings live below the agent dir;
-  // sessions, downloaded binaries, and adapter state must remain agent-private.
+  // pi imports auth/model configuration; sessions, binaries and adapter state remain agent-private.
   'pi-acp': (env) => [
     ...state(
       join(env.PI_CODING_AGENT_DIR || join(home(env), '.pi', 'agent'), 'auth.json'),
@@ -255,6 +254,13 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
       undefined,
       undefined,
       [{ path: '', format: 'pi' }]
+    ),
+    ...state(
+      join(env.PI_CODING_AGENT_DIR || join(home(env), '.pi', 'agent'), 'models.json'),
+      join('.pi', 'agent', 'models.json'),
+      undefined,
+      undefined,
+      [{ path: '', format: 'pi-models' }]
     ),
     ...state(env.PI_CODING_AGENT_DIR, join('.pi', 'agent'), ['settings.json']),
     ...state(join(home(env), '.pi'), '.pi', [join('agent', 'settings.json')])

--- a/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
@@ -14,6 +14,7 @@ export interface SeededCredentialFile {
   format:
     | 'grok'
     | 'pi'
+    | 'pi-models'
     | 'opencode'
     | 'oauth'
     | 'claude-oauth'
@@ -142,8 +143,16 @@ function credentialsInFile(text: string, file: SeededCredentialFile): { present:
   }
   const json = text.replace(/^\uFEFF/, '')
   const data: unknown = JSON.parse(
-    file.format === 'copilot' || file.format === 'qwen-settings' ? stripJsonComments(json) : json
+    file.format === 'copilot' || file.format === 'qwen-settings' || file.format === 'pi-models'
+      ? stripJsonComments(json, { trailingCommas: file.format === 'pi-models' })
+      : json
   )
+  if (file.format === 'pi-models') {
+    const providers = Object.entries(record(record(data)?.providers) ?? {}).flatMap(([provider, value]) =>
+      provider && nonempty(record(value)?.apiKey) ? [provider] : []
+    )
+    return { present: providers.length > 0, providers }
+  }
   if (file.format === 'copilot') {
     const present = Object.entries(record(record(data)?.copilotTokens) ?? {}).some(
       ([account, token]) => nonempty(account) && nonempty(token)

--- a/packages/daemon/test/microsandbox-pi-secrets.test.ts
+++ b/packages/daemon/test/microsandbox-pi-secrets.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+import { prepareMicrosandboxCredentials } from '../src/microsandbox/secrets.js'
+import { discoverSeededRuntimeCredentials } from '../src/runtimes/runtime-seeded-credentials.js'
+import { prepareRuntimeHome } from '../src/runtimes/runtime-home.js'
+
+const roots: string[] = []
+const key = 'fixture-pi-api-key'
+const oauth = { type: 'oauth', access: 'fixture-oauth', refresh: 'fixture-refresh', expires: 1 }
+function write(path: string, data: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, typeof data === 'string' ? data : JSON.stringify(data))
+}
+function fixture(relocated = false) {
+  const root = mkdtempSync(join(tmpdir(), 'ac-pi-api-'))
+  roots.push(root)
+  const hostHome = join(root, 'host')
+  const source = join(hostHome, relocated ? 'configured-pi' : '.pi/agent')
+  const scopeDir = join(root, 'agent')
+  const cwd = join(scopeDir, 'workspace')
+  mkdirSync(cwd, { recursive: true })
+  return {
+    root,
+    source,
+    runtimeId: 'pi-acp',
+    runtime: { command: 'pi-acp', args: [], env: [] },
+    scopeDir,
+    cwd,
+    mounts: [],
+    stateSourceEnv: { HOME: hostHome, ...(relocated ? { PI_CODING_AGENT_DIR: source } : {}) }
+  }
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe.skipIf(process.platform !== 'linux')('microsandbox pi API credentials', () => {
+  it.each([false, true])('protects file logins and preserves refreshed OAuth, relocated=%s', (relocated) => {
+    const opts = fixture(relocated)
+    const source = join(opts.source, 'auth.json')
+    write(source, { deepseek: { type: 'api_key', key }, 'github-copilot': oauth })
+    write(join(opts.source, 'settings.json'), { defaultProvider: 'deepseek', extra: key })
+    const launch = prepareMicrosandboxLaunch(opts)
+    const secret = launch.microsandbox.secrets![0]!
+    expect(secret.host).toEqual(['api.deepseek.com'])
+    expect(secret.readValue()).toBe(key)
+    expect(launch.env.DEEPSEEK_API_KEY).toBeUndefined()
+    expect(JSON.stringify(launch)).not.toContain(key)
+    const path = join(launch.env.PI_CODING_AGENT_DIR!, 'auth.json')
+    const auth = JSON.parse(readFileSync(path, 'utf8'))
+    expect(auth).toEqual({ deepseek: { type: 'api_key', key: secret.placeholder }, 'github-copilot': oauth })
+    expect(readFileSync(join(launch.env.PI_CODING_AGENT_DIR!, 'settings.json'), 'utf8')).not.toContain(key)
+    auth['github-copilot'].access = 'fixture-refreshed'
+    auth.local = { type: 'api_key', key: 'fixture-guest-key' }
+    write(path, auth)
+    write(source, { deepseek: { type: 'api_key', key: 'fixture-rotated-key' }, 'github-copilot': oauth })
+    const resumed = prepareMicrosandboxLaunch(opts)
+    expect(resumed.microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated-key')
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(auth)
+    expect(JSON.parse(readFileSync(source, 'utf8'))['github-copilot']).toEqual(oauth)
+    expect(() => prepareMicrosandboxLaunch({ ...opts, trustedRuntimeReadRoots: [opts.source] })).toThrow(
+      'protected host credential'
+    )
+  })
+
+  it('uses host JSONC model routes and deduplicates shared keys across auth and models', () => {
+    const opts = fixture()
+    write(join(opts.source, 'auth.json'), { openai: { type: 'api_key', key }, deepseek: { type: 'api_key', key } })
+    write(
+      join(opts.source, 'models.json'),
+      `\uFEFF{
+        // Host-authorized model endpoints.
+        "providers": {
+          "openai": {"baseUrl":"https://gateway.example.test/v1","headers":{"x-api-key":"${key}"}},
+          "custom": {"apiKey":"${key}","baseUrl":"https://custom.example.test/v1","api":"openai-completions",
+            "models":[{"id":"fixture-model","baseUrl":"https://model.example.test/v1"}],},
+        },
+      }`
+    )
+    const discovery = discoverSeededRuntimeCredentials('pi-acp', opts.stateSourceEnv)
+    expect(discovery.providers.sort()).toEqual(['custom', 'deepseek', 'openai'])
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toHaveLength(1)
+    const secret = launch.microsandbox.secrets![0]!
+    expect(secret.host).toEqual([
+      'api.deepseek.com',
+      'custom.example.test',
+      'gateway.example.test',
+      'model.example.test'
+    ])
+    const path = join(launch.env.PI_CODING_AGENT_DIR!, 'models.json')
+    const models = JSON.parse(readFileSync(path, 'utf8'))
+    expect(models.providers.custom.apiKey).toBe(secret.placeholder)
+    expect(models.providers.openai.headers['x-api-key']).toBe(secret.placeholder)
+    models.providers.openai.baseUrl = 'https://guest-chosen.example.test'
+    write(path, models)
+    const resumed = prepareMicrosandboxLaunch(opts)
+    expect(resumed.microsandbox.secrets![0]!.host).toEqual(secret.host)
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(models)
+  })
+
+  it('discovers and protects a models-only API login while keeping shared native HOME seeding', () => {
+    const opts = fixture(true)
+    write(join(opts.source, 'models.json'), {
+      providers: { custom: { apiKey: key, baseUrl: 'https://api.example.test', api: 'openai-completions', models: [] } }
+    })
+    expect(discoverSeededRuntimeCredentials('pi-acp', opts.stateSourceEnv).providers).toEqual(['custom'])
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets![0]!.host).toEqual(['api.example.test'])
+    expect(readFileSync(join(launch.env.PI_CODING_AGENT_DIR!, 'models.json'), 'utf8')).not.toContain(key)
+    const nativeHome = prepareRuntimeHome('pi-acp', join(opts.root, 'native'), opts.stateSourceEnv)
+    expect(readFileSync(join(nativeHome, '.pi/agent/models.json'), 'utf8')).toContain(key)
+  })
+
+  it('withholds unsupported credentials without executing helpers or leaking scoped secrets', () => {
+    const opts = fixture()
+    const marker = join(opts.root, 'helper-executed')
+    write(join(opts.source, 'auth.json'), {
+      unknown: { type: 'api_key', key: 'fixture-unknown-key' },
+      helper: { type: 'api_key', key: `!touch ${marker}` },
+      structured: { type: 'api_key', key: '$KEY', env: { KEY: 'fixture-scoped-key', OTHER: 'fixture-other-key' } },
+      deepseek: { type: 'api_key', key },
+      'github-copilot': oauth
+    })
+    write(join(opts.source, 'models.json'), {
+      providers: { unknown: { baseUrl: 'http://localhost:8080' }, helper: { baseUrl: 'https://api.example.test' } }
+    })
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toHaveLength(1)
+    expect(launch.microsandbox.secrets![0]!.readValue()).toBe(key)
+    const auth = JSON.parse(readFileSync(join(launch.env.PI_CODING_AGENT_DIR!, 'auth.json'), 'utf8'))
+    for (const provider of ['unknown', 'helper', 'structured']) {
+      expect(auth[provider]).toEqual({ type: 'api_key', key: expect.stringMatching(/^msb-secret-/) })
+    }
+    expect(auth['github-copilot']).toEqual(oauth)
+    expect(JSON.stringify(launch)).not.toContain('fixture-scoped-key')
+    expect(existsSync(marker)).toBe(false)
+  })
+
+  it('leaves pure OAuth on the native path and skips symlinked host files', () => {
+    const opts = fixture()
+    write(join(opts.source, 'auth.json'), { 'github-copilot': oauth })
+    expect(prepareMicrosandboxCredentials('pi-acp', opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toBeUndefined()
+    expect(JSON.parse(readFileSync(join(launch.env.PI_CODING_AGENT_DIR!, 'auth.json'), 'utf8'))).toEqual({
+      'github-copilot': oauth
+    })
+    const other = fixture()
+    const actual = join(other.root, 'managed.json')
+    write(actual, { deepseek: { type: 'api_key', key } })
+    mkdirSync(other.source, { recursive: true })
+    symlinkSync(actual, join(other.source, 'auth.json'))
+    expect(prepareMicrosandboxCredentials('pi-acp', other.runtime, other.stateSourceEnv)).toBeUndefined()
+    expect(prepareMicrosandboxCredentials('custom-pi', other.runtime, opts.stateSourceEnv)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
pi file logins currently copy real API keys into the guest. Project `auth.json` API records and `models.json` provider keys into placeholders, using the existing microsandbox TLS secret proxy for authenticated requests. OAuth and guest-only credentials retain their native behavior; SRT keeps its existing authentication and tool policies.

Reuse the runtime state descriptors for model-file discovery and seeding. Authorize HTTPS destinations from host model configuration or audited provider defaults. Shared keys use one proxy binding; unsupported destinations, command keys, interpolation, and structured provider credentials stay hidden without plaintext fallback. Limitations are documented in the sandbox design and tracked in #1874.

Validation: daemon typecheck and targeted ESLint passed; 217 existing tests passed locally, and all 6 pi projection tests passed in Linux. An isolated VM using the published full runtime image completed an authenticated native pi/ACP shell-tool turn, verified credential absence from guest files/process state, exercised custom-model key injection and wrong-host rejection, and passed stop/resume key rotation with private OAuth state preserved. The existing daemon configuration and services were not changed; the test VM and temporary files were removed.

Created by Codex . GPT-6
