### PR TITLE
feat(control-plane): getGithubApp MCP tool hands the agent the App install link

### DIFF
--- a/docs/designs/agent-assistant.md
+++ b/docs/designs/agent-assistant.md
@@ -224,6 +224,7 @@ Tools **call the CP service layer directly or reuse route-handler logic**, prese
 | `getUsage`                                                     | GET /usage                                                 | –       |
 | `listIntegrations` / `setChannelTrigger` / `removeIntegration` | GET · PATCH channels/:channelId · DELETE                   | –/✎(🔥) |
 | `listBots` / `listMembers` / `listAgentHooks` / `listHookRuns` | GET (metadata only, no secret)                             | –       |
+| `getGithubApp`                                                 | GET /github/app (mints the org-bound install link)         | –       |
 | `listGithubInstallations` / `listGithubRepositories`           | GET /github/installations(/:id/repositories)               | –       |
 | `getGithubRepositoryAccess`                                    | GET /github/installations/:id/repositories/:o/:r/access    | –       |
 | `getOperation` / `listOperations`                              | GET /agents/:id/webchat/:conversationId/mcp-operations(…)  | –       |

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -431,6 +431,18 @@ export const MCP_TOOLS: McpToolDef[] = [
           )
   },
   {
+    // The one read that hands the model something to SHOW, not just something to
+    // know: the install link is how "the App is not installed" turns into a step
+    // the user can take. The route mints a signed, one-shot, org-bound state on
+    // each call (starting a connection change), so it keeps its own viewer gate —
+    // a viewer's 403 is relayed as-is, never worked around here.
+    name: 'getGithubApp',
+    description:
+      'Whether this deployment has a GitHub App, its slug, and a fresh link to install the App on GitHub for THIS organization (`installUrl`: one-shot, org-bound, valid ~15 minutes). Call it when listGithubInstallations comes back empty, or when no installation covers the repository’s owner, and hand the link to the user verbatim — they pick the account and repositories on GitHub, and the setup callback claims the installation for the organization. 404 means the deployment has no GitHub App at all (an operator task); 403 means you may view but not connect — an editor or owner has to open the link.',
+    schema: NoArgs,
+    call: (ctx) => ctx.get(org(ctx, '/github/app'))
+  },
+  {
     name: 'listGithubInstallations',
     description:
       'The organization’s live installations of the deployment GitHub App — the account (owner) each covers, whether it grants all repositories or a selected set, and the pull-request/checks permissions its repositories carry. A repository is reachable ONLY through an installation listed here, so check this before pointing a workspace or a trigger at one. An empty list means the App is not installed yet; 404 means this deployment has no GitHub App at all.',

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -776,7 +776,12 @@ describe('POST /api/v1/mcp — tools act with the caller’s own authority', () 
       } as never
     })
     const githubKey = await mintKeyAs(DEFAULT_OWNER_ID)
-    const GITHUB_GATED = new Set(['listGithubInstallations', 'listGithubRepositories', 'getGithubRepositoryAccess'])
+    const GITHUB_GATED = new Set([
+      'getGithubApp',
+      'listGithubInstallations',
+      'listGithubRepositories',
+      'getGithubRepositoryAccess'
+    ])
     for (const tool of MCP_TOOLS) {
       const target = GITHUB_GATED.has(tool.name) ? { app: githubApp, key: githubKey } : { app, key }
       const out = await callTool(target.app, target.key, tool.name, idArgs[tool.name])


### PR DESCRIPTION
## What

Adds one read tool to the admin MCP catalog: **`getGithubApp`** → `GET /github/app`. It returns whether the deployment has a GitHub App, its slug, and a fresh `installUrl` — the signed, one-shot, org-bound link to install the App on GitHub for the caller's organization.

- `http/mcp/tools.ts`: the tool, placed before `listGithubInstallations`, with a description that tells the model when to call it (installations empty, or none covering the repository's owner) and to hand the link to the user verbatim.
- `test/integration/mcp.route.test.ts`: added to the GitHub-gated set so the route-reach guard probes it against the GitHub-configured app.
- `docs/designs/agent-assistant.md` §6.2: catalog row.

## Why

Seen in a webchat session with the built-in agent: when the GitHub App was not installed, the create-agent flow could only point at a console tab. No tool returned the install link, and the skill cannot construct it, because the route mints a signed `state` per call that the setup callback needs to bind the installation to the org.

## Reviewer notes

- Read tool, GET only. The route keeps its own `denyViewerWrite` gate (minting the link starts a connection change); a viewer's 403 is relayed as-is and the tool description says an editor/owner has to open the link.
- Each call mints a new state row (15-minute TTL, consumed once). The paired skill change tells the agent to call it only when an installation is actually missing and to fetch a fresh one rather than reuse an old link.
- Pairs with agentconnect-md/agentconnect-skill#5, which makes the code-reviewer template use it.

## Verification

- `vitest run src/http/mcp/tools.test.ts` — 37 passed.
- `vitest run --project integration test/integration/mcp.route.test.ts` — 34 passed (includes "every registered tool reaches a real route").
- Prettier clean on the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)