### PR TITLE
fix(daemon): an upgraded daemon stops hoarding the image it no longer boots

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -226,9 +226,9 @@ composition point. Do not add speculative backend branches throughout ACP.
 The current microsandbox integration supports Linux with usable KVM. Startup
 installs the pinned `microsandbox@0.6.17` package through the daemon's RuntimeStore,
 preserving its native platform package, and gives it a daemon-owned state home.
-It prepares the image, boots a temporary VM, validates the runtime table, and
-checks stop/start before admitting VM launches. Checking `/dev/kvm` alone would
-not establish availability. With `requireSandbox=true`, an unavailable backend
+It collects the cached images it no longer needs, prepares the image, boots a
+temporary VM, validates the runtime table, and checks stop/start before admitting
+VM launches. Checking `/dev/kvm` alone would not establish availability. With `requireSandbox=true`, an unavailable backend
 refuses startup. Otherwise the daemon can still serve unsandboxed agents, but a
 requested microsandbox launch fails explicitly, with no fallback to SRT or a host
 process. Existing optional-SRT fallback semantics are unchanged. The standalone
@@ -255,6 +255,19 @@ retention removes them. Sessions created in a legacy shared agent VM continue
 using that VM until its last session retires. Resource and mount changes still
 require environment recreation. Image
 digest resolution and in-place disk migration remain proposed.
+
+Because each release pins its own image, an upgraded daemon would otherwise leave
+the previous release's image cached forever. Startup therefore collects the image
+cache before it pulls, keeping the configured image and every image a persisted
+binding still records, which a retained VM validates when it starts, and removing
+the rest one reference at a time. Whole-cache pruning is not used: it removes any
+image no sandbox has booted, which includes the image a daemon just pulled and
+has not started a session on. A removal the backend refuses because a sandbox
+still boots from that image is kept and logged, and a cache that cannot be read
+is logged without failing startup, so collection never costs availability. The
+temporary preparation VM has a stable name and is reclaimed before it is
+recreated; a start interrupted before its teardown would otherwise leave a VM
+behind that pins a retired image.
 
 Workspace filesystem operations and skill publication use the same persistent
 Node shim and WebSocket protocol as Kubernetes. The local driver carries that

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -8,6 +8,7 @@ import { z } from 'zod'
 import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-driver.js'
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
+import { formatErr } from '../daemon/text.js'
 import { gitcredShimPath } from '../cp/gitcred-server.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import { canonicalPath, contains } from '../runtimes/read-roots.js'
@@ -59,7 +60,14 @@ export interface MicrosandboxManagerOptions {
   config: { image: string; cpus: number; memoryMiB: number; diskGiB: number }
   sdk: Pick<
     typeof import('microsandbox'),
-    'Sandbox' | 'SandboxNotFoundError' | 'AgentClient' | 'Volume' | 'VolumeNotFoundError' | 'InvalidConfigError'
+    | 'Sandbox'
+    | 'SandboxNotFoundError'
+    | 'AgentClient'
+    | 'Volume'
+    | 'VolumeNotFoundError'
+    | 'InvalidConfigError'
+    | 'Image'
+    | 'ImageInUseError'
   >
   msbCommand: { command: string; args: string[] }
   // Overridden by tests; the real check opens this host's /dev/kvm.
@@ -347,8 +355,11 @@ export class MicrosandboxManager {
     ;(this.options.kvmPreflight ?? assertKvmAvailable)()
     const bindings = join(this.options.root, 'microsandbox', 'bindings')
     await mkdir(bindings, { recursive: true, mode: 0o700 })
+    const keep = new Set([this.options.config.image])
     for (const id of await this.persistedIds()) {
       const binding = await this.readBinding(id)
+      // A retained VM boots from the image it was created with, so that image is not garbage.
+      if (binding) keep.add(SpecImageSchema.parse(JSON.parse(binding.spec)).config.image)
       const handle = await this.find(this.name(id))
       if (handle) {
         if (handle.id !== binding?.sandboxId) throw new Error('microsandbox persisted environment identity changed')
@@ -357,8 +368,11 @@ export class MicrosandboxManager {
         }
       }
     }
+    const name = this.name('probe')
+    await this.reclaimPreparation(name)
+    // Free the retired releases before the pull, so a tight disk is not asked to hold both.
+    await this.collectImages(keep)
     await this.prepareImage()
-    const name = `${this.name('probe')}-${randomUUID().slice(0, 8)}`
     let sandbox = await this.serializeStart(() => this.builder(name, []).create())
     try {
       const output = await sandbox.exec(MICROSANDBOX_NODE, [
@@ -380,6 +394,37 @@ export class MicrosandboxManager {
       await (await this.options.sdk.Sandbox.get(name)).destroy({ timeoutMs: STOP_TIMEOUT_MS })
       await sandbox.detach()
       await this.removeVolume(`${name}-docker`)
+    }
+  }
+
+  /** A daemon killed mid-preparation leaves this VM behind, and with it a pin on the image it booted. */
+  private async reclaimPreparation(name: string): Promise<void> {
+    const existing = await this.find(name)
+    if (!existing) return
+    this.options.log?.warn('microsandbox: removing the preparation VM an earlier start left behind')
+    await existing.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+    await this.removeVolume(`${name}-docker`)
+  }
+
+  /** Release the images of retired releases; msb refuses one a sandbox still boots from, which is the last word. */
+  private async collectImages(keep: ReadonlySet<string>): Promise<void> {
+    const images = await this.options.sdk.Image.list().catch((error: unknown) => {
+      this.options.log?.warn(`microsandbox: could not read the image cache — ${formatErr(error)}`)
+      return []
+    })
+    for (const image of images) {
+      if (keep.has(image.reference)) continue
+      try {
+        await this.options.sdk.Image.remove(image.reference)
+        const size = image.sizeBytes === null ? '' : ` (${(image.sizeBytes / 1024 ** 2).toFixed(0)} MiB)`
+        this.options.log?.info(`microsandbox: removed the unused image ${image.reference}${size}`)
+      } catch (error) {
+        if (error instanceof this.options.sdk.ImageInUseError) {
+          this.options.log?.warn(`microsandbox: kept image ${image.reference}, a sandbox outside this daemon uses it`)
+          continue
+        }
+        this.options.log?.warn(`microsandbox: could not remove image ${image.reference} — ${formatErr(error)}`)
+      }
     }
   }
 

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -400,9 +400,11 @@ export class MicrosandboxManager {
   /** A daemon killed mid-preparation leaves this VM behind, and with it a pin on the image it booted. */
   private async reclaimPreparation(name: string): Promise<void> {
     const existing = await this.find(name)
-    if (!existing) return
-    this.options.log?.warn('microsandbox: removing the preparation VM an earlier start left behind')
-    await existing.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+    if (existing) {
+      this.options.log?.warn('microsandbox: removing the preparation VM an earlier start left behind')
+      await existing.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+    }
+    // The disk outlives a VM destroyed just before cleanup, and this name is fixed, so creation would collide.
     await this.removeVolume(`${name}-docker`)
   }
 

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -833,6 +833,16 @@ describe('microsandbox process and VM ownership', () => {
     expect([...images.keys()]).toEqual(['test-image'])
   })
 
+  it('reclaims the preparation disk a start left behind after its VM was destroyed', async () => {
+    const { options, created, volumes } = await fixture()
+    await new MicrosandboxManager(options).prepare()
+    const probe = created[created.length - 1]!.name
+    // A start that exits between destroying the VM and removing its disk leaves the disk under a fixed name.
+    volumes.set(`${probe}-docker`, { attached: false })
+    await expect(new MicrosandboxManager(options).prepare()).resolves.toBeDefined()
+    expect(volumes.has(`${probe}-docker`)).toBe(false)
+  })
+
   it('starts when the image cache cannot be read', async () => {
     const { options, imageCache } = await fixture()
     imageCache.list.mockRejectedValueOnce(new Error('image cache is locked'))

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -55,6 +55,7 @@ function fakeSdk() {
   class SandboxNotFoundError extends Error {}
   class VolumeNotFoundError extends Error {}
   class InvalidConfigError extends Error {}
+  class ImageInUseError extends Error {}
   const volumes = new Map<string, { attached: boolean }>()
   const removeVolume = vi.fn(async (name: string) => {
     const volume = volumes.get(name)
@@ -66,6 +67,18 @@ function fakeSdk() {
   const created: FakeSandbox[] = []
   const processes: FakeExec[] = []
   let onRun: ((process: FakeExec) => void | Promise<void>) | undefined
+  const images = new Map<string, number | null>([['test-image', 4_194_304]])
+  const imageCache = {
+    list: vi.fn(async () => [...images].map(([reference, sizeBytes]) => ({ reference, sizeBytes }))),
+    remove: vi.fn(async (reference: string) => {
+      if (!images.has(reference)) throw new Error(`image not found: ${reference}`)
+      // The cache refuses an image any sandbox still boots from, stopped ones included.
+      for (const sandbox of sandboxes.values()) {
+        if (sandbox.spec.image === reference) throw new ImageInUseError('image in use by sandbox(es): 1')
+      }
+      images.delete(reference)
+    })
+  }
 
   class FakeSandbox {
     readonly id = `vm-${created.length}`
@@ -161,7 +174,9 @@ function fakeSdk() {
     SandboxNotFoundError,
     VolumeNotFoundError,
     InvalidConfigError,
+    ImageInUseError,
     Volume: { remove: removeVolume },
+    Image: imageCache,
     AgentClient: {
       async connectSandbox(name: string) {
         const sandbox = sandboxes.get(name)!
@@ -325,7 +340,16 @@ function fakeSdk() {
     created,
     processes,
     volumes,
+    images,
+    imageCache,
     removeVolume,
+    /** A VM this daemon does not know about: one an operator created, or one an interrupted start left behind. */
+    leak: (name: string, image: string) => {
+      const sandbox = new FakeSandbox(name)
+      sandbox.spec.image = image
+      sandboxes.set(name, sandbox)
+      return sandbox
+    },
     runWith: (callback: (process: FakeExec) => void | Promise<void>) => {
       onRun = callback
     }
@@ -765,6 +789,55 @@ describe('microsandbox process and VM ownership', () => {
       await restarted.discard(env.id)
     }
     expect(created).toHaveLength(2)
+  })
+
+  it('collects a retired release image and keeps the configured one before any VM boots', async () => {
+    const { options, images, imageCache } = await fixture()
+    images.set('previous-image', 3_145_728)
+    await expect(new MicrosandboxManager(options).prepare()).resolves.toBeDefined()
+    expect(imageCache.remove).toHaveBeenCalledExactlyOnceWith('previous-image')
+    expect([...images.keys()]).toEqual(['test-image'])
+  })
+
+  it('keeps the image of a retained VM until its environment is discarded', async () => {
+    const { manager, options, environment, request, images } = await fixture()
+    await (await manager.driverFor(environment).launch(request)).stop(0)
+    await manager.stopAll()
+    images.set('next-image', null)
+    const upgraded = { ...options, config: { ...options.config, image: 'next-image' } }
+    await new MicrosandboxManager(upgraded).prepare()
+    expect([...images.keys()]).toEqual(['test-image', 'next-image'])
+    await new MicrosandboxManager(upgraded).discard(environment.id)
+    await new MicrosandboxManager(upgraded).prepare()
+    expect([...images.keys()]).toEqual(['next-image'])
+  })
+
+  it('keeps an image a sandbox outside this daemon still boots from', async () => {
+    const { options, images, imageCache, leak } = await fixture()
+    images.set('shared-image', null)
+    leak('sandbox-outside-this-daemon', 'shared-image')
+    await expect(new MicrosandboxManager(options).prepare()).resolves.toBeDefined()
+    expect(imageCache.remove).toHaveBeenCalledExactlyOnceWith('shared-image')
+    expect([...images.keys()]).toEqual(['test-image', 'shared-image'])
+  })
+
+  it('reclaims the preparation VM an interrupted start left behind and frees its image', async () => {
+    const { options, images, created, leak } = await fixture()
+    await new MicrosandboxManager(options).prepare()
+    const probe = created[created.length - 1]!
+    expect(probe.destroy).toHaveBeenCalledOnce()
+    images.set('previous-image', null)
+    const abandoned = leak(probe.name, 'previous-image')
+    await expect(new MicrosandboxManager(options).prepare()).resolves.toBeDefined()
+    expect(abandoned.destroy).toHaveBeenCalledOnce()
+    expect([...images.keys()]).toEqual(['test-image'])
+  })
+
+  it('starts when the image cache cannot be read', async () => {
+    const { options, imageCache } = await fixture()
+    imageCache.list.mockRejectedValueOnce(new Error('image cache is locked'))
+    await expect(new MicrosandboxManager(options).prepare()).resolves.toBeDefined()
+    expect(imageCache.remove).not.toHaveBeenCalled()
   })
 
   it.each([false, true])('resumes with relocated support mounts (legacy guest helper=%s)', async (withGuestHelper) => {


### PR DESCRIPTION
Related: #1874

Each release pins its own sandbox image, so every upgrade pulled a new one and kept
the old one forever — nothing in the daemon had ever removed a cached image. A host
a few releases along holds several full images it can never boot again.

## What startup does now

It collects the image cache **before** it pulls, keeping:

- the configured image, and
- every image a persisted binding still records — a retained VM validates its
  image's cache when it starts, so that image is not garbage.

Everything else is removed one reference at a time, non-forcing, so the backend's
own refusal for an image a sandbox still boots from is a second guard behind the
keep set. A refused removal is kept and logged; a cache that cannot be read is
logged without failing startup. Collection never costs availability.

Whole-cache pruning is deliberately **not** used. The backend's prune removes any
image no sandbox has booted, which includes the image the daemon just pulled and
has not yet started a session on — using it would re-download the current image on
every restart.

The temporary preparation VM also moves from a random name to a stable one and is
reclaimed before it is recreated. A start interrupted before its teardown used to
leave a VM behind that pinned a retired image for good, which would have defeated
the collection above. A VM left behind by a version before this change is still
refused as in use and reported by name.

## Checked against the real backend first

Before writing any of this, against microsandbox v0.6.17 on a scratch cache:

| Check | Result |
| --- | --- |
| Prune with a cached image and no sandbox | Removes it, including one just pulled |
| Remove (non-forcing) with a **stopped** sandbox on it | Refused: `image in use by sandbox(es): 1` |
| Prune with that stopped sandbox present | Removes nothing |
| Reference normalization | None — the cache stores the string that was pulled, so exact matching is correct |
| SDK error type | A typed `ImageInUseError`, not a message to parse |

Confirmed against the 0.6.17 sources as well: the in-use check runs inside the
removal transaction over every sandbox row, and layers are reference-counted
through the manifest join, so shared layers survive.

## Tests

Five cases in the driver suite, three of which fail without the change: a retired
image collected while the configured one is kept before any VM has booted; a
retained VM's image kept until its environment is discarded, then collected; an
in-use refusal keeping the image without failing startup; the abandoned
preparation VM reclaimed and its image freed; an unreadable cache not failing
startup.

## Not in scope

Environments whose session row is gone but whose VM and binding remain: those pin
an image too, but the rule for identifying one safely deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
