### PR TITLE
fix(daemon): start microsandbox VMs one at a time so disk locks cannot leak

### DIFF
--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
-import { mkdir, readFile, readdir, realpath, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, readlink, realpath, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, posix } from 'node:path'
 import { promisify } from 'node:util'
 import type { Sandbox, SandboxHandle } from 'microsandbox'
@@ -64,6 +64,8 @@ export interface MicrosandboxManagerOptions {
   msbCommand: { command: string; args: string[] }
   // Overridden by tests; the real check opens this host's /dev/kvm.
   kvmPreflight?: () => void
+  // Overridden by tests; the real lookup reads this host's /proc.
+  lockHolder?: (volume: string) => Promise<LockHolder | undefined>
   log?: Logger
   sockets: { mcp: string; gitcred: string }
   nextShimGeneration?: (subject: string) => Promise<number>
@@ -73,6 +75,7 @@ interface EnvironmentState {
   environment: MicrosandboxEnvironment
   spec: string
   sandbox: Promise<Sandbox>
+  started?: boolean
   active: number
   closing?: Promise<void>
   failed?: boolean
@@ -92,6 +95,11 @@ interface Binding {
   overlayVolume?: string
 }
 
+export interface LockHolder {
+  pid: number
+  sandbox?: string
+}
+
 const SpecImageSchema = z.object({ config: z.object({ image: z.string().min(1) }) })
 
 /** Owns VM lifecycle while exposing the existing ACP process-stream contract. */
@@ -100,6 +108,7 @@ export class MicrosandboxManager {
   private readonly bridges = new Map<string, MicrosandboxProcess>()
   private preparation?: Promise<K8sRuntimeTable>
   private closed = false
+  private startGate: Promise<void> = Promise.resolve()
 
   constructor(private readonly options: MicrosandboxManagerOptions) {}
 
@@ -350,7 +359,7 @@ export class MicrosandboxManager {
     }
     await this.prepareImage()
     const name = `${this.name('probe')}-${randomUUID().slice(0, 8)}`
-    let sandbox = await this.builder(name, []).create()
+    let sandbox = await this.serializeStart(() => this.builder(name, []).create())
     try {
       const output = await sandbox.exec(MICROSANDBOX_NODE, [
         '-e',
@@ -363,7 +372,7 @@ export class MicrosandboxManager {
       const table = K8sRuntimeTableSchema.parse(JSON.parse(output.stdout()))
       await sandbox.stopWithTimeout(STOP_TIMEOUT_MS)
       await sandbox.detach()
-      sandbox = await this.retryDiskOperation(async () => (await this.options.sdk.Sandbox.get(name)).startDetached())
+      sandbox = await this.startVm(name, async () => (await this.options.sdk.Sandbox.get(name)).startDetached())
       await sandbox.ping()
       this.options.log?.info('microsandbox: image, Node, Python/vsock, runtime table and disk resume verified')
       return table
@@ -413,8 +422,8 @@ export class MicrosandboxManager {
     }
   }
 
-  private async retryDiskOperation<T>(operation: () => Promise<T>): Promise<T> {
-    const deadline = Date.now() + 1_000
+  private async retryDiskOperation<T>(operation: () => Promise<T>, deadlineMs = 1_000): Promise<T> {
+    const deadline = Date.now() + deadlineMs
     for (;;) {
       try {
         return await operation()
@@ -431,6 +440,71 @@ export class MicrosandboxManager {
         await new Promise((resolve) => setTimeout(resolve, 25))
       }
     }
+  }
+
+  // The SDK clears CLOEXEC on a starting VM's disk locks, so a start spawned beside another one inherits its locks
+  // and keeps them after that VM stops (superradcompany/microsandbox#1558). One start at a time closes that window.
+  private async serializeStart<T>(operation: () => Promise<T>): Promise<T> {
+    const ahead = this.startGate
+    let done!: () => void
+    this.startGate = new Promise<void>((resolve) => (done = resolve))
+    await ahead
+    try {
+      return await operation()
+    } finally {
+      done()
+    }
+  }
+
+  /** The one place a VM starts: serialized, and retried once after an unrelated sandbox's inherited disk lock is released. */
+  private async startVm<T>(subject: string, start: () => Promise<T>): Promise<T> {
+    return this.serializeStart(async () => {
+      try {
+        return await this.retryDiskOperation(start)
+      } catch (error) {
+        const volume = lockedVolume(error, this.options.sdk)
+        if (!volume) throw error
+        const holder = await this.lockHolder(volume)
+        if (!(await this.releaseIdleHolder(volume, holder))) throw lockError(subject, volume, holder, error)
+        // The supervisor releases the lock as it exits, which the SDK can observe a moment later.
+        return await this.retryDiskOperation(start, 5_000)
+      }
+    })
+  }
+
+  /** The process whose inherited fd still locks this volume's disk, and the sandbox it belongs to. */
+  private async lockHolder(volume: string): Promise<LockHolder | undefined> {
+    if (this.options.lockHolder) return this.options.lockHolder(volume)
+    if (process.platform !== 'linux') return undefined
+    const disk = join(this.options.root, 'microsandbox', 'volumes', volume, 'disk.raw')
+    const entries = await readdir('/proc').catch(() => [])
+    for (const pid of entries.filter((entry) => /^\d+$/.test(entry))) {
+      const fds = await readdir(`/proc/${pid}/fd`).catch(() => [])
+      for (const fd of fds) {
+        if ((await readlink(`/proc/${pid}/fd/${fd}`).catch(() => undefined)) !== disk) continue
+        const argv = (await readFile(`/proc/${pid}/cmdline`, 'utf8').catch(() => '')).split('\0')
+        const named = argv.indexOf('--name')
+        return { pid: Number(pid), sandbox: named < 0 ? undefined : argv[named + 1] }
+      }
+    }
+    return undefined
+  }
+
+  /** Suspend the idle environment whose supervisor inherited this lock; refuse while that environment still has work. */
+  private async releaseIdleHolder(volume: string, holder?: LockHolder): Promise<boolean> {
+    if (!holder?.sandbox) return false
+    let id: string | undefined
+    for (const candidate of await this.environmentIds()) if (this.name(candidate) === holder.sandbox) id = candidate
+    const state = id === undefined ? undefined : this.environments.get(id)
+    // Only a settled start can be suspended: awaiting one queued behind this start would deadlock on the gate.
+    if (state && !(state.started && !state.closing && !state.failed && !state.active && !state.processes.size))
+      return false
+    this.options.log?.warn(
+      `microsandbox: suspending idle environment ${id ?? holder.sandbox} — it inherited the disk lock of volume "${volume}"`
+    )
+    if (id !== undefined && state) await this.suspend(id)
+    else await (await this.find(holder.sandbox))?.stopWithTimeout(STOP_TIMEOUT_MS)
+    return true
   }
 
   private async readBinding(id: string): Promise<Binding | undefined> {
@@ -532,7 +606,7 @@ export class MicrosandboxManager {
           await this.writeBinding(binding)
         }
       }
-      const sandbox = await this.retryDiskOperation(() => existing.connectOrStart({ detached: true }))
+      const sandbox = await this.startVm(environment.id, () => existing.connectOrStart({ detached: true }))
       try {
         await prepareOverlayMounts(sandbox, environment.mounts)
         await this.startBridge(environment.id, sandbox)
@@ -543,10 +617,12 @@ export class MicrosandboxManager {
         throw error
       }
     }
-    const sandbox = await this.builder(name, environment.mounts, environment.secrets)
-      .vsock(this.options.sockets.mcp, 5000)
-      .vsock(this.options.sockets.gitcred, 5001)
-      .create()
+    const sandbox = await this.startVm(environment.id, () =>
+      this.builder(name, environment.mounts, environment.secrets)
+        .vsock(this.options.sockets.mcp, 5000)
+        .vsock(this.options.sockets.gitcred, 5001)
+        .create()
+    )
     try {
       const persisted = await this.options.sdk.Sandbox.get(name)
       const binding: Binding = {
@@ -666,9 +742,12 @@ export class MicrosandboxManager {
       }
       this.environments.set(environment.id, state)
       const opening = state
-      void state.sandbox.catch(() => {
-        if (this.environments.get(environment.id) === opening) this.environments.delete(environment.id)
-      })
+      void state.sandbox.then(
+        () => (opening.started = true),
+        () => {
+          if (this.environments.get(environment.id) === opening) this.environments.delete(environment.id)
+        }
+      )
     }
     state.active++
     state.lastUsed = Date.now()
@@ -1029,4 +1108,21 @@ function stableJson(value: unknown): string {
 
 function hash(value: string): string {
   return createHash('sha256').update(value).digest('hex')
+}
+
+/** The named volume a start refused to lock, or undefined for any other failure. */
+function lockedVolume(error: unknown, sdk: MicrosandboxManagerOptions['sdk']): string | undefined {
+  if (!(error instanceof sdk.InvalidConfigError)) return undefined
+  return /volume "(.+)" is already attached with an incompatible disk mode$/.exec(error.message)?.[1]
+}
+
+function lockError(subject: string, volume: string, holder: LockHolder | undefined, cause: unknown): Error {
+  const held = holder
+    ? `pid ${holder.pid}${holder.sandbox === undefined ? '' : ` (sandbox ${holder.sandbox})`}`
+    : 'a process this daemon could not identify'
+  return new Error(
+    `microsandbox could not start ${subject}: volume "${volume}" is still locked by ${held}. A starting VM's disk ` +
+      'locks leak into unrelated sandbox processes (superradcompany/microsandbox#1558); stop that sandbox to release it.',
+    { cause }
+  )
 }

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -495,14 +495,16 @@ export class MicrosandboxManager {
     if (!holder?.sandbox) return false
     let id: string | undefined
     for (const candidate of await this.environmentIds()) if (this.name(candidate) === holder.sandbox) id = candidate
-    const state = id === undefined ? undefined : this.environments.get(id)
+    // A sandbox this daemon has no binding for can be running work no counter here can see.
+    if (id === undefined) return false
+    const state = this.environments.get(id)
     // Only a settled start can be suspended: awaiting one queued behind this start would deadlock on the gate.
     if (state && !(state.started && !state.closing && !state.failed && !state.active && !state.processes.size))
       return false
     this.options.log?.warn(
-      `microsandbox: suspending idle environment ${id ?? holder.sandbox} — it inherited the disk lock of volume "${volume}"`
+      `microsandbox: suspending idle environment ${id} — it inherited the disk lock of volume "${volume}"`
     )
-    if (id !== undefined && state) await this.suspend(id)
+    if (state) await this.suspend(id)
     else await (await this.find(holder.sandbox))?.stopWithTimeout(STOP_TIMEOUT_MS)
     return true
   }

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -1013,4 +1013,30 @@ describe('microsandbox process and VM ownership', () => {
     await busy.stop(0)
     await manager.stopAll()
   })
+
+  it('leaves a lock holder this daemon has no binding for running', async () => {
+    const { manager, options, request, created } = await fixture()
+    const sibling = { id: 'agent/session-sibling', mounts: [], workspaceRoot: '/workspace' }
+    const blocked = { id: 'agent/session-blocked', mounts: [], workspaceRoot: '/workspace' }
+    const idle = await manager.driverFor(sibling).launch(request)
+    await idle.stop(0)
+    await manager.suspend(sibling.id)
+    const vm = created[0]!
+    const stops = vm.stopWithTimeout.mock.calls.length
+    const bindings = join(options.root, 'microsandbox', 'bindings')
+    for (const file of await readdir(bindings)) await rm(join(bindings, file))
+    const volume = 'agentconnect-example-blocked-overlays'
+    options.lockHolder = async () => ({ pid: 4242, sandbox: vm.name })
+    interceptCreate(options, async () => {
+      throw new options.sdk.InvalidConfigError(
+        `invalid config: volume "${volume}" is already attached with an incompatible disk mode`
+      )
+    })
+    await expect(manager.driverFor(blocked).launch(request)).rejects.toThrow(
+      `volume "${volume}" is still locked by pid 4242 (sandbox ${vm.name})`
+    )
+    expect(vm.stopWithTimeout.mock.calls).toHaveLength(stops)
+    expect(created).toHaveLength(1)
+    await manager.stopAll()
+  })
 })

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -355,6 +355,23 @@ async function fixture() {
   return { ...fake, manager, options, environment, request }
 }
 
+/** Wrap the fake builder's terminal create() so a test can stall or fail a VM start. */
+function interceptCreate(
+  options: MicrosandboxManagerOptions,
+  around: (create: () => Promise<unknown>) => Promise<unknown>
+) {
+  const api = options.sdk.Sandbox as unknown as { builder: (name: string) => { create: () => Promise<unknown> } }
+  const build = api.builder.bind(api)
+  const intercepted = vi.fn((create: () => Promise<unknown>) => around(create))
+  vi.spyOn(api, 'builder').mockImplementation((name: string) => {
+    const builder = build(name)
+    const create = builder.create.bind(builder)
+    builder.create = () => intercepted(create)
+    return builder
+  })
+  return intercepted
+}
+
 describe('microsandbox process and VM ownership', () => {
   it.skipIf(process.platform === 'win32')('launches and resumes with the actual daemon support mounts', async () => {
     const { manager, options, environment, request, created } = await fixture()
@@ -923,5 +940,77 @@ describe('microsandbox process and VM ownership', () => {
     expect((await runtime.fromAgent.getReader().read()).value).toEqual(bytes)
     await runtime.stop(0)
     await manager.suspend(environment.id)
+  })
+
+  it('starts one VM at a time so a start cannot inherit the disk locks of another', async () => {
+    const { manager, options, request, created } = await fixture()
+    let active = 0
+    let peak = 0
+    const slowCreate = interceptCreate(options, async (create) => {
+      peak = Math.max(peak, ++active)
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        return await create()
+      } finally {
+        active--
+      }
+    })
+    const environments = ['agent/session-one', 'agent/session-two', 'agent/session-three'].map((id) => ({
+      id,
+      mounts: [],
+      workspaceRoot: '/workspace'
+    }))
+    const runtimes = await Promise.all(environments.map((env) => manager.driverFor(env).launch(request)))
+    expect(slowCreate).toHaveBeenCalledTimes(3)
+    expect(created).toHaveLength(3)
+    expect(peak).toBe(1)
+    await Promise.all(runtimes.map((runtime) => runtime.stop(0)))
+    await manager.stopAll()
+  })
+
+  it('suspends the idle sibling holding an inherited disk lock, then starts on the retry', async () => {
+    const { manager, options, request, created } = await fixture()
+    const sibling = { id: 'agent/session-sibling', mounts: [], workspaceRoot: '/workspace' }
+    const blocked = { id: 'agent/session-blocked', mounts: [], workspaceRoot: '/workspace' }
+    const idle = await manager.driverFor(sibling).launch(request)
+    await idle.stop(0)
+    const vm = created[0]!
+    const volume = 'agentconnect-example-blocked-overlays'
+    options.lockHolder = async () => ({ pid: 4242, sandbox: vm.name })
+    interceptCreate(options, async (create) => {
+      if (!vm.stopWithTimeout.mock.calls.length)
+        throw new options.sdk.InvalidConfigError(
+          `invalid config: volume "${volume}" is already attached with an incompatible disk mode`
+        )
+      return create()
+    })
+    const runtime = await manager.driverFor(blocked).launch(request)
+    expect(vm.stopWithTimeout).toHaveBeenCalledOnce()
+    expect(await manager.environmentIds()).toContain(sibling.id)
+    expect(created).toHaveLength(2)
+    await runtime.stop(0)
+    await manager.stopAll()
+  })
+
+  it('keeps a busy lock holder running and reports who holds the disk instead', async () => {
+    const { manager, options, request, created } = await fixture()
+    const sibling = { id: 'agent/session-sibling', mounts: [], workspaceRoot: '/workspace' }
+    const blocked = { id: 'agent/session-blocked', mounts: [], workspaceRoot: '/workspace' }
+    const busy = await manager.driverFor(sibling).launch(request)
+    const vm = created[0]!
+    const volume = 'agentconnect-example-blocked-overlays'
+    options.lockHolder = async () => ({ pid: 4242, sandbox: vm.name })
+    interceptCreate(options, async () => {
+      throw new options.sdk.InvalidConfigError(
+        `invalid config: volume "${volume}" is already attached with an incompatible disk mode`
+      )
+    })
+    await expect(manager.driverFor(blocked).launch(request)).rejects.toThrow(
+      `volume "${volume}" is still locked by pid 4242 (sandbox ${vm.name})`
+    )
+    expect(vm.stopWithTimeout).not.toHaveBeenCalled()
+    expect(created).toHaveLength(1)
+    await busy.stop(0)
+    await manager.stopAll()
   })
 })


### PR DESCRIPTION
## Why

A VM start `flock`s every named disk volume it attaches and clears `CLOEXEC` on those fds so the supervisor it is about to spawn inherits the locks. Every *other* process spawned from the same host process during that window inherits them too — including another sandbox's supervisor, which then keeps those locks alive long after the VM that owns them has stopped. The stopped environment can never start again:

```
invalid config: volume "<name>-overlays" is already attached with an incompatible disk mode
```

Restarting the daemon does not help, because supervisors are detached and survive it.

Seen in the field: a daemon start created 8 sandboxes in the same second; all 8 started, and as idle reclaim stopped the quiet ones, 13 disks belonging to stopped sandboxes stayed locked by the two VMs that were still running. One supervisor held 19 volume fds, 6 of them belonging to other sandboxes. The daemon process itself held none, so `detach()` handling was never the problem. Only v1.56.0 and later attach named disk volumes at all, which is why this had not appeared before.

## What changed

- **Starts are serialized.** `MicrosandboxManager` runs one `create()` / `connectOrStart()` / `startDetached()` at a time, so no supervisor is ever spawned inside another start's lock window. The gate covers the start call only — overlay preparation, bridge startup and everything else that awaits the VM stay outside it.
- **Bounded self-heal.** When a start still fails with that wording, the driver finds the holding process by walking `/proc/*/fd` for the volume's `disk.raw`, maps it back to one of this daemon's environments, and suspends it before retrying once — the same thing idle reclaim already does, so the sibling starts again on demand. A holder with an execution in flight, an unsettled start, or no mapping at all is left alone. Nothing is deleted or recreated: no volume removal, no VM teardown.
- **The failure explains itself.** Instead of the raw SDK sentence, the error names the environment, the volume, the holding pid and its sandbox, and points at the upstream issue.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/microsandbox-driver.test.ts test/microsandbox-launch.test.ts test/read-roots.test.ts test/daemon-smoke.test.ts` — 102 passed, 14 skipped.
- `pnpm --filter @agentconnect.md/daemon typecheck`, `eslint` and `prettier --check` on both changed files — clean.
- Three new driver tests: concurrent launches never overlap a start (peak concurrency asserted, and the assertion was mutation-checked — it fails with the gate bypassed); an idle holder is suspended and the start succeeds on the retry; a busy holder is left running and the error names the pid.
- Not exercised on a real KVM host from here — the new paths are covered against the suite's fake SDK only, and `/proc` scanning is Linux-only and degrades to "holder unknown" elsewhere.

## Upstream

superradcompany/microsandbox#1558 asks for the real fix: keep `CLOEXEC` on the lock fds and pass them explicitly to the VM child the way `--config-fd`, `--startup-fd` and `--lifecycle-lock-fd` already are. Until that lands, the serialization above is what keeps this from recurring.

Fixes #2013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
