### PR TITLE
feat(daemon): protect Grok model API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -422,6 +422,25 @@ their existing behavior, including refreshed private OAuth state on resume.
 Pure OAuth launches do not enable secret injection. SRT authentication and tool
 policies are unchanged; it imports the native files without this VM proxy.
 
+Grok Build uses the same proxy for literal `model.<id>.api_key` values with an
+explicit HTTPS `base_url` in the host's `config.toml`. The shared state inventory
+honors `GROK_HOME` and `GROK_AUTH_PATH` and seeds only the native auth file plus
+`config.toml`, `managed_config.toml` and `requirements.toml`, excluding backups.
+Both discovery and VM projection inspect these files, including conditional TOML
+tables. Matching values and Bearer headers become placeholders; TOML dates,
+unrelated settings and refreshed guest OAuth state survive projection and resume.
+Repeated keys share a placeholder and their host-authorized destinations.
+
+Grok keys in cached `auth.json` API records, managed/requirements layers,
+version overrides or models without an explicit supported endpoint are hidden
+without authorizing injection. Inherited endpoints, interpolation, helpers and
+environment-only logins are not resolved. Those API configurations remain
+unavailable; there is no plaintext fallback. OAuth keeps its native behavior.
+Host system-wide `/etc/grok` files are not imported. Secrets stored only in
+arbitrary headers or extensions are outside discovery. Native Grok 1.0.25's
+per-model API path was verified with the SDK CA and a real ACP tool turn; its
+cached xAI API-login path still needs validation with a valid native login.
+
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
 existing private logins are preserved. Without a DeepSeek key, normal seeding is

--- a/packages/daemon/src/microsandbox/grok-secrets.ts
+++ b/packages/daemon/src/microsandbox/grok-secrets.ts
@@ -1,0 +1,136 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
+import { objectFromJson } from '../runtimes/codex-config.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { grokConfigApiKeys, MAX_SEED_FILE_BYTES } from '../runtimes/runtime-seeded-credentials.js'
+import { replaceSecretValue } from './secret-values.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function document(text: string, toml: boolean): Record<string, unknown> {
+  try {
+    return toml ? parseToml(text) : objectFromJson(text, 'Grok credential file')
+  } catch {
+    throw new Error('Cannot read the Grok credential/configuration file')
+  }
+}
+
+function readDocument(source: string, toml: boolean): Record<string, unknown> {
+  try {
+    const stat = lstatSync(source)
+    if (stat.isSymbolicLink()) return {}
+    if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) throw new Error('invalid source')
+    return document(readFileSync(source, 'utf8'), toml)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Cannot read the host Grok credential/configuration file')
+  }
+}
+
+function allowedHost(endpoint: unknown): string[] {
+  try {
+    if (typeof endpoint !== 'string' || endpoint.includes('$')) return []
+    const url = new URL(endpoint)
+    if (url.protocol === 'https:' && !url.port && !url.username && !url.password && /^[a-z0-9.-]+$/.test(url.hostname))
+      return [url.hostname]
+  } catch {
+    // Only an explicit host model route authorizes key injection.
+  }
+  return []
+}
+
+function apiKeys(data: Record<string, unknown>, toml: boolean) {
+  if (toml) return grokConfigApiKeys(data)
+  return Object.entries(data).flatMap(([scope, raw]) => {
+    const auth = object(raw)
+    return auth.auth_mode === 'api_key' && typeof auth.key === 'string' && auth.key.trim()
+      ? [{ path: [scope, 'key'], value: auth.key }]
+      : []
+  })
+}
+
+function replaceValues(value: unknown, replacements: ReadonlyMap<string, string>): unknown {
+  if (typeof value === 'string') return replaceSecretValue(value, replacements)
+  if (Array.isArray(value)) return value.map((item) => replaceValues(item, replacements))
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, replaceValues(item, replacements)]))
+  }
+  return value
+}
+
+export function prepareGrokSecrets(hostEnv: NodeJS.ProcessEnv): MicrosandboxCredentials | undefined {
+  const files = runtimeStateLocations('grok-build', hostEnv).flatMap((location) =>
+    (location.credentialFiles ?? []).map((file) => ({
+      source: join(location.source, file.path),
+      destination: join(location.destination, file.path),
+      toml: file.format === 'grok-config'
+    }))
+  )
+  const bindings = new Map<string, MicrosandboxSecret>()
+  const sharedKeys = new Map<string, MicrosandboxSecret>()
+  const replacements = new Map<string, string>()
+  const id = (destination: string, path: string[]) => JSON.stringify([destination, ...path])
+  for (const file of files) {
+    const data = readDocument(file.source, file.toml)
+    for (const { path, value } of apiKeys(data, file.toml)) {
+      const bindingId = id(file.destination, path)
+      const name = `AC_GROK_API_${createHash('sha256').update(bindingId).digest('hex').slice(0, 16).toUpperCase()}`
+      const model = object(object(data.model)[path[1]!])
+      const host =
+        file.destination === join('.grok', 'config.toml') &&
+        path.length === 3 &&
+        path[0] === 'model' &&
+        !value.includes('$')
+          ? allowedHost(model.base_url)
+          : []
+      const secret = sharedKeys.get(value) ?? {
+        env: name,
+        placeholder: `msb-secret-${name}`,
+        host: [],
+        readValue: () => value
+      }
+      secret.host = [...new Set([secret.host, host].flat())].sort()
+      sharedKeys.set(value, secret)
+      bindings.set(bindingId, secret)
+      replacements.set(value, secret.placeholder)
+    }
+  }
+  if (!bindings.size) return undefined
+  return {
+    secrets: [...sharedKeys.values()].filter((secret) => secret.host.length > 0),
+    replacements,
+    sources: files.map((file) => file.source),
+    seedExclusions: files.map((file) => file.destination),
+    preparePrivateHome(home) {
+      for (const file of files) {
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text, retained) => {
+          const data = document(text, file.toml)
+          const values = new Map(replacements)
+          const keys = apiKeys(data, file.toml).map((entry) => ({
+            ...entry,
+            binding: bindings.get(id(file.destination, entry.path))
+          }))
+          for (const { value, binding } of keys) {
+            if (!retained && !binding) throw new Error('Host Grok credentials changed during preparation; retry launch')
+            if (binding) values.set(value, binding.placeholder)
+          }
+          const projected = replaceValues(data, values) as Record<string, unknown>
+          for (const { path, binding } of keys) {
+            if (!binding) continue
+            const parent = path
+              .slice(0, -1)
+              .reduce((value, field) => value[field] as Record<string, unknown>, projected)
+            parent[path.at(-1)!] = binding.placeholder
+          }
+          return file.toml ? stringifyToml(projected) : `${JSON.stringify(projected)}\n`
+        })
+      }
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -9,6 +9,7 @@ import { MAX_SEED_FILE_BYTES, parseDshCredentialDocument } from '../runtimes/run
 import { prepareOpenCodeSecrets } from './opencode-secrets.js'
 import { prepareClaudeApiSecret, prepareCodexApiSecret } from './native-api-secrets.js'
 import { preparePiSecrets } from './pi-secrets.js'
+import { prepareGrokSecrets } from './grok-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
@@ -36,7 +37,8 @@ const CREDENTIAL_PREPARERS = new Map<
   ['opencode', prepareOpenCodeSecrets],
   ['pi-acp', preparePiSecrets],
   ['claude-acp', prepareClaudeApiSecret],
-  ['codex-acp', prepareCodexApiSecret]
+  ['codex-acp', prepareCodexApiSecret],
+  ['grok-build', prepareGrokSecrets]
 ])
 
 export function prepareMicrosandboxCredentials(

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -392,7 +392,11 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
       undefined,
       [{ path: '', format: 'grok' }]
     ),
-    ...state(env.GROK_HOME || join(home(env), '.grok'), '.grok')
+    ...state(env.GROK_HOME || join(home(env), '.grok'), '.grok', [], undefined, [
+      { path: 'config.toml', format: 'grok-config' },
+      { path: 'managed_config.toml', format: 'grok-config' },
+      { path: 'requirements.toml', format: 'grok-config' }
+    ])
   ],
 
   // Moonshot Kimi CLI — ~/.kimi (legacy) or ~/.kimi-code (newer, honors $KIMI_CODE_HOME).

--- a/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
@@ -13,6 +13,7 @@ export interface SeededCredentialFile {
   path: string
   format:
     | 'grok'
+    | 'grok-config'
     | 'pi'
     | 'pi-models'
     | 'opencode'
@@ -38,6 +39,14 @@ function record(value: unknown): Record<string, unknown> | undefined {
 
 function nonempty(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
+}
+
+export function grokConfigApiKeys(data: unknown, path: string[] = []): { path: string[]; value: string }[] {
+  return Object.entries(data && typeof data === 'object' ? data : {}).flatMap(([field, value]) => {
+    const next = [...path, field]
+    if (field === 'api_key' && nonempty(value)) return [{ path: next, value }]
+    return grokConfigApiKeys(value, next)
+  })
 }
 
 function oauth(value: Record<string, unknown>): boolean {
@@ -120,6 +129,14 @@ function hermesCredentialProviders(data: unknown): string[] {
 }
 
 function credentialsInFile(text: string, file: SeededCredentialFile): { present: boolean; providers: string[] } {
+  if (file.format === 'grok-config') {
+    const present = grokConfigApiKeys(parseToml(text)).some(
+      ({ path }) =>
+        (path.length === 3 && path[0] === 'model') ||
+        (path.length === 5 && path[0] === 'version_overrides' && path[2] === 'model')
+    )
+    return { present, providers: present ? ['xai'] : [] }
+  }
   if (file.format === 'devin') {
     const present = nonempty(parseToml(text).windsurf_api_key)
     return { present, providers: present ? ['devin'] : [] }

--- a/packages/daemon/test/microsandbox-grok-secrets.test.ts
+++ b/packages/daemon/test/microsandbox-grok-secrets.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+import { prepareMicrosandboxCredentials } from '../src/microsandbox/secrets.js'
+import { discoverSeededRuntimeCredentials } from '../src/runtimes/runtime-seeded-credentials.js'
+import { prepareRuntimeHome } from '../src/runtimes/runtime-home.js'
+
+const roots: string[] = []
+const key = 'fixture-grok-model-key'
+const oauth = { key: 'fixture-oauth', auth_mode: 'web_login', create_time: '2026-01-01T00:00:00Z', user_id: 'fixture' }
+function write(path: string, text: string) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, text)
+}
+function fixture(relocated = false) {
+  const root = mkdtempSync(join(tmpdir(), 'ac-grok-api-'))
+  roots.push(root)
+  const hostHome = join(root, 'host')
+  const source = join(hostHome, relocated ? 'configured-grok' : '.grok')
+  const authPath = relocated ? join(root, 'login.json') : join(source, 'auth.json')
+  const scopeDir = join(root, 'agent')
+  const cwd = join(scopeDir, 'workspace')
+  mkdirSync(cwd, { recursive: true })
+  return {
+    root,
+    source,
+    authPath,
+    runtimeId: 'grok-build',
+    runtime: { command: 'grok', args: ['agent', 'stdio'], env: [] },
+    scopeDir,
+    cwd,
+    mounts: [],
+    stateSourceEnv: { HOME: hostHome, ...(relocated ? { GROK_HOME: source, GROK_AUTH_PATH: authPath } : {}) }
+  }
+}
+const modelConfig = (value = key) =>
+  stringifyToml({
+    model: { custom: { api_key: value, base_url: 'https://api.example.test/v1', model: 'fixture-model' } },
+    models: { default: 'custom' },
+    extra_headers: { Authorization: `Bearer ${value}` },
+    timestamp: new Date('2026-01-01T00:00:00Z')
+  })
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+it('discovers config-only keys, including conditional arrays, without changing native key values', () => {
+  const opts = fixture(true)
+  write(join(opts.source, 'config.toml'), modelConfig())
+  write(
+    join(opts.source, 'requirements.toml'),
+    '[[version_overrides]]\n[version_overrides.model.other]\napi_key="fixture-conditional"\n'
+  )
+  expect(discoverSeededRuntimeCredentials('grok-build', opts.stateSourceEnv)).toEqual({
+    paths: [join(opts.source, 'config.toml'), join(opts.source, 'requirements.toml')],
+    providers: ['xai']
+  })
+  const nativeHome = prepareRuntimeHome('grok-build', join(opts.root, 'native'), opts.stateSourceEnv)
+  expect(readFileSync(join(nativeHome, '.grok/config.toml'), 'utf8')).toContain(key)
+  write(join(opts.source, 'config.toml'), '[extensions.example]\napi_key="fixture-unrelated"\n')
+  rmSync(join(opts.source, 'requirements.toml'))
+  expect(discoverSeededRuntimeCredentials('grok-build', opts.stateSourceEnv).paths).toEqual([])
+})
+
+describe.skipIf(process.platform !== 'linux')('microsandbox Grok API credentials', () => {
+  it.each([false, true])(
+    'protects model keys and preserves native OAuth and guest settings, relocated=%s',
+    (relocated) => {
+      const opts = fixture(relocated)
+      const configPath = join(opts.source, 'config.toml')
+      write(configPath, modelConfig())
+      write(opts.authPath, JSON.stringify({ 'https://accounts.x.ai/sign-in': oauth }))
+      write(join(opts.source, 'auth-backup.json'), JSON.stringify({ key }))
+      if (relocated)
+        write(join(opts.source, 'auth.json'), JSON.stringify({ ignored: { ...oauth, key: 'ignored-token' } }))
+      const launch = prepareMicrosandboxLaunch(opts)
+      const secret = launch.microsandbox.secrets![0]!
+      expect(secret.host).toEqual(['api.example.test'])
+      expect(secret.readValue()).toBe(key)
+      expect(launch.env.XAI_API_KEY).toBeUndefined()
+      expect(JSON.stringify(launch)).not.toContain(key)
+      const guest = launch.env.GROK_HOME!
+      const config = parseToml(readFileSync(join(guest, 'config.toml'), 'utf8'))
+      expect(config).toEqual(parseToml(modelConfig(secret.placeholder)))
+      expect(existsSync(join(guest, 'auth-backup.json'))).toBe(false)
+      expect(JSON.parse(readFileSync(launch.env.GROK_AUTH_PATH!, 'utf8'))).toEqual({
+        'https://accounts.x.ai/sign-in': oauth
+      })
+      write(
+        launch.env.GROK_AUTH_PATH!,
+        JSON.stringify({ 'https://accounts.x.ai/sign-in': { ...oauth, key: 'refreshed-oauth' } })
+      )
+      write(
+        join(guest, 'config.toml'),
+        modelConfig(secret.placeholder).replace('api.example.test', 'guest-chosen.example.test')
+      )
+      write(configPath, modelConfig('fixture-rotated'))
+      const resumed = prepareMicrosandboxLaunch(opts)
+      expect(resumed.microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated')
+      expect(resumed.microsandbox.secrets![0]!.host).toEqual(secret.host)
+      expect(readFileSync(join(guest, 'config.toml'), 'utf8')).toContain('guest-chosen.example.test')
+      expect(readFileSync(launch.env.GROK_AUTH_PATH!, 'utf8')).toContain('refreshed-oauth')
+      expect(readFileSync(opts.authPath, 'utf8')).not.toContain('refreshed-oauth')
+      expect(() =>
+        prepareMicrosandboxLaunch({
+          ...opts,
+          mounts: [{ source: configPath, target: '/raw-config', mode: 'readonly' }]
+        })
+      ).toThrow(/protected host/)
+    }
+  )
+
+  it('deduplicates keys and withholds unresolved, conditional, managed and cached API credentials', () => {
+    const opts = fixture()
+    write(
+      join(opts.source, 'config.toml'),
+      stringifyToml({
+        model: {
+          a: { api_key: key, base_url: 'https://a.example.test' },
+          b: { api_key: key, base_url: 'https://b.example.test' },
+          inherited: { api_key: 'fixture-inherited' },
+          http: { api_key: 'fixture-http', base_url: 'http://api.example.test' },
+          interpolation: { api_key: '$UNRESOLVED', base_url: 'https://api.example.test' }
+        },
+        version_overrides: [{ model: { c: { api_key: 'fixture-conditional', base_url: 'https://c.example.test' } } }]
+      })
+    )
+    write(
+      join(opts.source, 'managed_config.toml'),
+      '[model.managed]\napi_key="fixture-managed"\nbase_url="https://managed.example.test"\n'
+    )
+    write(
+      opts.authPath,
+      JSON.stringify({
+        'xai::api_key': { ...oauth, key: 'fixture-cached', auth_mode: 'api_key' },
+        'https://accounts.x.ai/sign-in': oauth
+      })
+    )
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toHaveLength(1)
+    expect(launch.microsandbox.secrets![0]!.host).toEqual(['a.example.test', 'b.example.test'])
+    for (const name of ['config.toml', 'managed_config.toml', 'auth.json']) {
+      const text = readFileSync(join(launch.env.GROK_HOME!, name), 'utf8')
+      expect(text).not.toMatch(/fixture-(grok|inherited|http|conditional|managed|cached)|\$UNRESOLVED/)
+      expect(text).toContain('msb-secret-')
+    }
+    expect(readFileSync(launch.env.GROK_AUTH_PATH!, 'utf8')).toContain('fixture-oauth')
+    const source = join(opts.source, 'config.toml')
+    write(source, readFileSync(source, 'utf8').replace(key, 'fixture-rotated'))
+    const resumed = prepareMicrosandboxLaunch(opts)
+    const models = parseToml(readFileSync(join(launch.env.GROK_HOME!, 'config.toml'), 'utf8')).model
+    expect(models).toMatchObject({
+      a: {
+        api_key: resumed.microsandbox.secrets!.find((secret) => secret.readValue() === 'fixture-rotated')!.placeholder
+      },
+      b: { api_key: resumed.microsandbox.secrets!.find((secret) => secret.readValue() === key)!.placeholder }
+    })
+  })
+
+  it('keeps OAuth-only native and refuses malformed files without echoing secrets', () => {
+    const opts = fixture()
+    write(opts.authPath, JSON.stringify({ 'https://accounts.x.ai/sign-in': oauth }))
+    expect(prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+    const target = join(opts.root, 'symlink-config')
+    write(target, modelConfig())
+    symlinkSync(target, join(opts.source, 'config.toml'))
+    expect(prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+    rmSync(join(opts.source, 'config.toml'))
+    write(join(opts.source, 'config.toml'), 'api_key="fixture-secret-error')
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow('Cannot read the host Grok credential/configuration file')
+    write(join(opts.source, 'config.toml'), modelConfig())
+    const launch = prepareMicrosandboxLaunch(opts)
+    write(join(launch.env.GROK_HOME!, 'config.toml'), 'api_key="fixture-retained-secret')
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow('Cannot read the Grok credential/configuration file')
+  })
+})


### PR DESCRIPTION
Grok model API keys previously entered the VM through its native config file. Protect literal `model.<id>.api_key` values in `config.toml` with the existing microsandbox TLS proxy, using explicit host-configured HTTPS endpoints. Reuse credential discovery, private HOME projection, mount checks and retained-VM secret lifecycle; no new daemon proxy or configuration option.

Seed only Grok's native auth and three user config files, honoring `GROK_HOME` and `GROK_AUTH_PATH`. Preserve OAuth and guest settings, and hide unsupported cached API logins, conditional/managed keys and unresolved routes without plaintext fallback. SRT continues reading native key values. Document the supported path and remaining limitations in the sandbox design.

Validation:
- Daemon typecheck, focused launch/discovery/HOME regressions and five Linux Grok projection cases.
- Isolated real microsandbox with native Grok 1.0.25: authenticated ACP prompt and native shell tool completed; real key absent from guest config, environment, process state and binding metadata.
- Synthetic-key wire substitution and wrong-host rejection; stopped-VM key rotation returned 401 for an invalid key and 200 after restoring the valid key, preserving guest OAuth state.
- Removed the test VM and temporary files; existing daemons and logins were unchanged.

Related: #1874.

Created by Codex . GPT-6
