### PR TITLE
fix(chart): give agent sandboxes their own image pull secrets value

### DIFF
--- a/charts/agentconnect/templates/daemon-pool-runtime.yaml
+++ b/charts/agentconnect/templates/daemon-pool-runtime.yaml
@@ -63,10 +63,11 @@ spec:
     spec:
       # The only credential an agent gets is the audience-scoped projection below.
       automountServiceAccountToken: false
-      {{- with $.Values.imagePullSecrets }}
-      # The same install-wide pull secrets every chart-rendered pod carries: these pods are
-      # created by the agent-sandbox controller from this template, so an install pulling
-      # from a private mirror needs them here or the first sandbox stops in ImagePullBackOff.
+      {{- with $runtime.imagePullSecrets }}
+      # The SANDBOX pull secrets, deliberately not `.Values.imagePullSecrets`: the controller
+      # creates these pods in `sandboxNamespace`, and the kubelet resolves a pull secret in the
+      # pod's own namespace, so the install-wide value would name a Secret that is not there.
+      # Empty by default — the runtime-sandbox image is public.
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/agentconnect/values.yaml
+++ b/charts/agentconnect/values.yaml
@@ -74,7 +74,10 @@ image:
   pullPolicy: Always
 
 # Registry pull secrets, referenced BY NAME — the chart never holds the credential
-# itself (same rule as `secrets` below). Applied to every pod this chart renders.
+# itself (same rule as `secrets` below). Applied to every pod this chart renders into the
+# RELEASE namespace. Agent sandbox pods are NOT among them — the agent-sandbox controller
+# creates those in `daemonPool.sandboxNamespace`, and a pull secret resolves in the pod's own
+# namespace — so they have their own `daemonPool.runtime.imagePullSecrets`.
 #
 # The first-party images (control-plane, web, relay, daemon, mem0*) are PUBLIC, so the
 # default empty list is enough for them. An image you host privately is not: an anonymous
@@ -327,6 +330,20 @@ daemonPool:
     # full reference outright; empty ⇒ `<image.registry>/runtime-sandbox:<tag>`.
     tag: ''
     image: ''
+    # Pull secrets for the sandbox pods ONLY, separate from the install-wide `imagePullSecrets`
+    # on purpose: these pods are created by the agent-sandbox controller in `sandboxNamespace`,
+    # and a pull secret is resolved in the pod's OWN namespace. The install-wide value names a
+    # Secret in the release namespace, so referencing it here would only log
+    # FailedToRetrieveImagePullSecret on every sandbox.
+    #
+    # Empty is right whenever the runtime-sandbox image is publicly readable, which is the
+    # default. Set it only when that image is private, and create the dockerconfigjson Secret in
+    # `sandboxNamespace` yourself — the chart names it and never holds the credential. Same
+    # shape as the install-wide value:
+    #
+    #   imagePullSecrets:
+    #     - name: <pull-secret-name>
+    imagePullSecrets: []
     # Pre-warmed spares held ready in the warm pool. Each spare is a STANDING COST — a running
     # sandbox pod and one bound workspace PVC apiece, held whether or not anybody claims it — and
     # what it buys is narrow: only the FIRST mint for a new agent gets a warm sandbox instead of a

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -24,8 +24,9 @@ command = [
   '--set-json', 'daemonPool.runtime.nodeSelector={"example.com/agents":"true"}',
   '--set-json', 'daemonPool.runtime.tolerations=' \
     '[{"key":"example.com/agents","operator":"Equal","value":"true","effect":"NoSchedule"}]',
-  # Set to prove propagation into controller-created sandbox pods, not just chart-rendered ones.
+  # Both pull-secret wires, set to different names so the render proves they stay separate.
   '--set-json', 'imagePullSecrets=[{"name":"example-pull"}]',
+  '--set-json', 'daemonPool.runtime.imagePullSecrets=[{"name":"example-sandbox-pull"}]',
   # Off here so the object-count assertions below see only chart-owned objects, not the
   # vendored stack; the defaults render at the end covers the default-on stack.
   '--set', 'installCRD=false'
@@ -234,9 +235,13 @@ abort('runtime container must root the workspace and place the shim listener') u
 shim_listen = runtime_container.fetch('env').find { |item| item['name'] == 'AC_SHIM_PORT' }&.fetch('value')
 abort('the shim listener, the dialer, and the policy must share one port') unless
   shim_listen == env['AC_K8S_SHIM_PORT'] && Integer(shim_listen) == ingress['ports'].first['port']
-# Controller-created sandbox pods must carry the same install-wide pull secrets as every
-# chart-rendered pod, or a private-mirror install stops at its first sandbox.
-abort('sandboxes must carry the install-wide pull secrets') unless template_pod['imagePullSecrets'] == [{ 'name' => 'example-pull' }]
+# Two pull-secret wires, one per namespace, and they must not cross. A chart-rendered pod lands
+# in the release namespace and takes the install-wide value; a sandbox pod is created by the
+# controller in the sandbox namespace, where the kubelet resolves the secret, so it takes
+# `daemonPool.runtime.imagePullSecrets`. Cross them and the reference names a Secret that is not
+# in the pod's namespace — FailedToRetrieveImagePullSecret on every sandbox.
+abort('chart-rendered pods must carry the install-wide pull secrets') unless pod['imagePullSecrets'] == [{ 'name' => 'example-pull' }]
+abort('sandboxes must carry their own pull secrets, not the install-wide ones') unless template_pod['imagePullSecrets'] == [{ 'name' => 'example-sandbox-pull' }]
 abort('runtime container must satisfy restricted Pod Security') unless runtime_container['securityContext'] == {
   'allowPrivilegeEscalation' => false, 'capabilities' => { 'drop' => ['ALL'] }
 }
@@ -430,6 +435,10 @@ default_pool = defaults_find.call('Deployment', 'example-agentconnect-daemon-poo
 default_oc = defaults_find.call('Deployment', 'example-agentconnect-open-connector')
 default_warm = defaults_find.call('SandboxWarmPool', 'example-agentconnect-runtime-pool')
 abort('defaults must hold three warm spares') unless default_warm.dig('spec', 'replicas') == 3
+# The runtime-sandbox image is public, so the sandbox pull secrets stay empty until an install
+# hosting it privately sets them — and an empty list must render no key at all, not `null`.
+default_template_pod = defaults_find.call('SandboxTemplate', 'example-agentconnect-runtime').dig('spec', 'podTemplate', 'spec')
+abort('defaults must name no sandbox pull secrets') if default_template_pod.key?('imagePullSecrets')
 # The pool's data-plane Secret is referenced by a default NAME the operator creates, like
 # `secrets.existingSecret` — a required-but-empty value would fail the default render outright.
 default_data_plane = default_pool.dig('spec', 'template', 'spec', 'volumes').find { |v| v['name'] == 'data-plane' }


### PR DESCRIPTION
## The bug

`templates/daemon-pool-runtime.yaml` rendered the install-wide
`.Values.imagePullSecrets` into the `SandboxTemplate`'s `podTemplate`. Those pods are not
created by Helm — the agent-sandbox controller mints them in
`daemonPool.sandboxNamespace`, and the kubelet resolves a pull secret **in the pod's own
namespace**. Wherever the sandbox namespace is not the release namespace, the reference
names a Secret that does not exist there, and every sandbox pod gets:

```
Warning  FailedToRetrieveImagePullSecret  ...  Unable to retrieve some image pull secrets
```

The pull still succeeds — the runtime-sandbox image is public, so the kubelet falls back to
an anonymous pull — so this has been noise rather than breakage. It is still a real
misconfiguration, and a warning that always fires is one an operator learns to scroll past.

One value cannot name a Secret in two namespaces, so this is not fixable by deleting or by
rewiring; the sandbox side needs its own input.

## The change

Sandboxes read a new `daemonPool.runtime.imagePullSecrets`, **empty by default**, so a
default render names nothing at all and the warning is gone. An install that hosts the
runtime-sandbox image privately sets that value and creates the dockerconfigjson Secret in
the sandbox namespace, where the kubelet can actually resolve it — something the
install-wide value could never express.

Every other template keeps `.Values.imagePullSecrets` unchanged: those pods render into the
release namespace, where that Secret does exist. I checked the whole chart — the
`SandboxTemplate` was the only object placing a pod outside the release namespace, and
nothing in the chart replicates a Secret into the sandbox namespace
(`templates/agents-namespace.yaml` creates only the Namespace and its default-deny
NetworkPolicy), so there is no second instance of this bug to fix.

Rendered behaviour, by scenario:

| scenario | release-namespace pods | sandbox pods |
| --- | --- | --- |
| defaults | none | none |
| install-wide set, sandbox value unset | install-wide | **none** (was: install-wide → warning) |
| both set | install-wide | sandbox value |

## Trade-off

One case does lose something. An install that pulls the runtime-sandbox image from a
private registry **and** happens to leave `sandboxNamespace` empty (so sandboxes land in the
release namespace) was, until now, covered by the install-wide value alone. After this
change that install must also set `daemonPool.runtime.imagePullSecrets` — the same Secret
name, one extra line. The upgrade is silent: sandboxes keep pulling until the image cache
misses, then fail with `ImagePullBackOff` rather than at render time.

I'd rather have that than keep a warning firing on every sandbox in the split-namespace
layout, which is the shape any install running agents is steered toward. The alternative —
keeping the install-wide reference as a fallback when the two namespaces match — encodes
"the value works or doesn't depending on another value", which is harder to reason about
than one input per namespace. Worth a line in the chart release notes.

A possible follow-up, deliberately **not** in this PR: have the chart create the pull Secret
in the sandbox namespace from a single source, so one input covers both namespaces. That
means the chart holding a credential, which it does not do anywhere today (`imagePullSecrets`
and `secrets` are both by-name references), so it is a policy change rather than a refactor.

## Verification

- `helm lint charts/agentconnect` — clean.
- `ruby scripts/test-chart-render.rb` — the render contract now pins both wires and proves
  they do not cross: a chart-rendered pod carries the install-wide value, a sandbox pod
  carries its own, and the pure-defaults render names no sandbox pull secrets.
- Mutation-checked all three new assertions, including re-wiring the sandbox back to
  `.Values.imagePullSecrets` — that reproduces the original bug and the contract fails on
  it, so the regression cannot come back silently.
- Rendered all three scenarios in the table above and inspected which pod lands in which
  namespace with which secret.
- No TypeScript changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
