### PR TITLE
feat(daemon): protect Qwen file API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -454,6 +454,25 @@ arbitrary headers or extensions are outside discovery. Native Grok 1.0.25's
 per-model API path was verified with the SDK CA and a real ACP tool turn; its
 cached xAI API-login path still needs validation with a valid native login.
 
+Qwen Code uses the same proxy for keys saved in `settings.json`: model-provider
+`envKey` references to the file's `env` values (including native protocol defaults
+and `providerProtocol` mappings), plus legacy `security.auth.apiKey`. This is file
+credential import; environment-only logins are not added. Shared discovery and
+private-HOME seeding honor `QWEN_HOME`, and private launches pin both `QWEN_HOME`
+and `QWEN_RUNTIME_DIR`. The seed inventory includes native settings, OAuth and
+account files, excluding settings backups and runtime snapshots.
+
+Only explicit HTTPS model `baseUrl` or legacy auth `baseUrl` values from the host
+settings authorize proxy injection. Missing or unsupported endpoints, unknown
+protocols and interpolation keep placeholders without importing a plaintext key.
+Default endpoints, `.env`, workspace/CLI overrides and extra keys stored only in
+arbitrary fields are outside this path. Matching key values and Bearer headers in
+the seeded files are replaced; repeated keys share their authorized destinations.
+Guest edits cannot authorize new hosts. OAuth-only launches retain native seeding,
+and guest-refreshed OAuth state survives API-key rotation. SRT imports the same
+native files without enabling this VM proxy. Native Qwen 0.23.3's OpenAI-compatible
+API path was verified with the SDK CA and a real ACP tool turn.
+
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
 existing private logins are preserved. Without a DeepSeek key, normal seeding is

--- a/packages/daemon/src/microsandbox/qwen-secrets.ts
+++ b/packages/daemon/src/microsandbox/qwen-secrets.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
+import { objectFromJson } from '../runtimes/codex-config.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { MAX_SEED_FILE_BYTES, qwenSettingsApiKeys } from '../runtimes/runtime-seeded-credentials.js'
+import { replaceSecretValue } from './secret-values.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+function document(text: string, settings: boolean): unknown {
+  try {
+    return settings
+      ? objectFromJson(stripJsonComments(text.replace(/^\uFEFF/, '')), 'Qwen settings file')
+      : JSON.parse(text)
+  } catch {
+    throw new Error('Cannot read the Qwen credential/configuration file')
+  }
+}
+
+function readSettings(source: string): Record<string, unknown> {
+  try {
+    const stat = lstatSync(source)
+    if (stat.isSymbolicLink()) return {}
+    if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) throw new Error('invalid source')
+    return document(readFileSync(source, 'utf8'), true) as Record<string, unknown>
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw new Error('Cannot read the host Qwen settings file')
+  }
+}
+
+function allowedHost(endpoint: unknown): string[] {
+  try {
+    if (typeof endpoint !== 'string' || endpoint.includes('$')) return []
+    const url = new URL(endpoint)
+    if (url.protocol === 'https:' && !url.port && !url.username && !url.password && /^[a-z0-9.-]+$/.test(url.hostname))
+      return [url.hostname]
+  } catch {
+    // Unresolved routes keep placeholders without authorizing key injection.
+  }
+  return []
+}
+
+export function prepareQwenSecrets(hostEnv: NodeJS.ProcessEnv): MicrosandboxCredentials | undefined {
+  const files = runtimeStateLocations('qwen-code', hostEnv).flatMap((location) =>
+    [...(location.seedFiles ?? []), ...(location.credentialFiles ?? []).map((file) => file.path)].map((path) => ({
+      source: join(location.source, path),
+      destination: join(location.destination, path),
+      settings: path === 'settings.json'
+    }))
+  )
+  const settingsFile = files.find((file) => file.settings)!
+  const bindings = new Map<string, MicrosandboxSecret>()
+  const sharedKeys = new Map<string, MicrosandboxSecret>()
+  const replacements = new Map<string, string>()
+  for (const ref of qwenSettingsApiKeys(readSettings(settingsFile.source))) {
+    const id = JSON.stringify(ref.path)
+    const name = `AC_QWEN_API_${createHash('sha256').update(id).digest('hex').slice(0, 16).toUpperCase()}`
+    const secret = sharedKeys.get(ref.value) ?? {
+      env: name,
+      placeholder: `msb-secret-${name}`,
+      host: [],
+      readValue: () => ref.value
+    }
+    secret.host = [
+      ...new Set([secret.host, ref.value.includes('$') ? [] : ref.endpoints.flatMap(allowedHost)].flat())
+    ].sort()
+    sharedKeys.set(ref.value, secret)
+    bindings.set(id, secret)
+    replacements.set(ref.value, secret.placeholder)
+  }
+  if (!bindings.size) return undefined
+  return {
+    secrets: [...sharedKeys.values()].filter((secret) => secret.host.length > 0),
+    replacements,
+    sources: files.map((file) => file.source),
+    seedExclusions: files.map((file) => file.destination),
+    preparePrivateHome(home) {
+      for (const file of files) {
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text, retained) => {
+          if (!file.destination.endsWith('.json')) return replaceSecretValue(text, replacements)
+          const data = document(text, file.settings)
+          if (file.settings) {
+            for (const ref of qwenSettingsApiKeys(data)) {
+              const binding = bindings.get(JSON.stringify(ref.path))
+              if (!retained && !binding)
+                throw new Error('Host Qwen credentials changed during preparation; retry launch')
+            }
+            for (const [id, binding] of bindings) {
+              const path = JSON.parse(id) as string[]
+              const parent = path
+                .slice(0, -1)
+                .reduce<unknown>(
+                  (value, field) =>
+                    value && typeof value === 'object' ? (value as Record<string, unknown>)[field] : undefined,
+                  data
+                )
+              if (parent && typeof parent === 'object' && Object.hasOwn(parent, path.at(-1)!)) {
+                const target = parent as Record<string, unknown>
+                target[path.at(-1)!] = binding.placeholder
+              }
+            }
+          }
+          return `${JSON.stringify(data, (_key, value: unknown) =>
+            typeof value === 'string' ? replaceSecretValue(value, replacements) : value
+          )}\n`
+        })
+      }
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -10,6 +10,7 @@ import { prepareOpenCodeSecrets } from './opencode-secrets.js'
 import { prepareClaudeApiSecret, prepareCodexApiSecret } from './native-api-secrets.js'
 import { preparePiSecrets } from './pi-secrets.js'
 import { prepareGrokSecrets } from './grok-secrets.js'
+import { prepareQwenSecrets } from './qwen-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
@@ -38,7 +39,8 @@ const CREDENTIAL_PREPARERS = new Map<
   ['pi-acp', preparePiSecrets],
   ['claude-acp', prepareClaudeApiSecret],
   ['codex-acp', prepareCodexApiSecret],
-  ['grok-build', prepareGrokSecrets]
+  ['grok-build', prepareGrokSecrets],
+  ['qwen-code', prepareQwenSecrets]
 ])
 
 export function prepareMicrosandboxCredentials(

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -1,5 +1,5 @@
 import { accessSync, constants, existsSync } from 'node:fs'
-import { basename, delimiter, dirname, join } from 'node:path'
+import { basename, delimiter, dirname, join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { CURATED_RUNTIME_CATALOG } from './curated.js'
@@ -208,12 +208,15 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
     ...state(join(home(env), '.gemini', 'tmp'), join('.gemini', 'tmp'), [])
   ],
 
-  // Qwen Code (Gemini-CLI fork) — ~/.qwen.
-  'qwen-code': (env) =>
-    state(join(home(env), '.qwen'), '.qwen', undefined, undefined, [
+  // Seed native Qwen config and login files, excluding settings backups and runtime snapshots.
+  'qwen-code': (env) => {
+    const configured = env.QWEN_HOME || join(home(env), '.qwen')
+    const source = resolve(configured.replace(/^~(?=[/\\]|$)/, () => home(env)))
+    return state(source, '.qwen', ['mcp-oauth-tokens.json', 'google_accounts.json', 'installation_id'], undefined, [
       { path: 'oauth_creds.json', format: 'oauth', provider: 'qwen' },
       { path: 'settings.json', format: 'qwen-settings' }
-    ]),
+    ])
+  },
 
   // GitHub Copilot CLI — ~/.copilot (honors $COPILOT_HOME).
   'github-copilot-cli': (env) =>

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -334,6 +334,8 @@ const AMBIENT_STATE_ENV = new Set([
   'PI_CODING_AGENT_DIR',
   'GROK_HOME',
   'GROK_AUTH_PATH',
+  'QWEN_HOME',
+  'QWEN_RUNTIME_DIR',
   'CLINE_DIR',
   'CLINE_DATA_DIR',
   'CLINE_PROVIDER_SETTINGS_PATH',
@@ -416,6 +418,7 @@ const RUNTIME_PRIVATE_ENV: Record<string, RuntimePrivateEnv> = {
   omp: (home) => ({ PI_CODING_AGENT_DIR: join(home, '.omp', 'agent') }),
   'pi-acp': (home) => ({ PI_CODING_AGENT_DIR: join(home, '.pi', 'agent') }),
   'grok-build': (home) => ({ GROK_HOME: join(home, '.grok'), GROK_AUTH_PATH: join(home, '.grok', 'auth.json') }),
+  'qwen-code': (home) => ({ QWEN_HOME: join(home, '.qwen'), QWEN_RUNTIME_DIR: join(home, '.qwen') }),
   cline: (home) => ({
     CLINE_DIR: join(home, '.cline'),
     CLINE_DATA_DIR: join(home, '.cline', 'data')

--- a/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-seeded-credentials.ts
@@ -49,6 +49,57 @@ export function grokConfigApiKeys(data: unknown, path: string[] = []): { path: s
   })
 }
 
+const QWEN_DEFAULT_KEYS: Record<string, string> = {
+  openai: 'OPENAI_API_KEY',
+  'openai-responses': 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  'vertex-ai': 'GOOGLE_API_KEY'
+}
+
+export function qwenSettingsApiKeys(data: unknown) {
+  const settings = record(data) ?? {}
+  const env = record(settings.env) ?? {}
+  const protocols = record(settings.providerProtocol) ?? {}
+  const providers = record(settings.modelProviders) ?? {}
+  const auth = record(record(settings.security)?.auth) ?? {}
+  const refs: { path: string[]; value: string; provider: string; endpoints: unknown[] }[] = []
+  for (const [provider, raw] of Object.entries(providers)) {
+    if (!Array.isArray(raw)) continue
+    const protocol = QWEN_DEFAULT_KEYS[provider] ? provider : String(protocols[provider] ?? '')
+    for (const entry of raw) {
+      const model = record(entry) ?? {}
+      const name = model.envKey ?? QWEN_DEFAULT_KEYS[protocol]
+      if (!nonempty(model.id) || !nonempty(name) || !nonempty(env[name])) continue
+      refs.push({
+        path: ['env', name],
+        value: env[name],
+        provider,
+        endpoints: QWEN_DEFAULT_KEYS[protocol] ? [model.baseUrl] : []
+      })
+    }
+  }
+  const selected = nonempty(auth.selectedType) ? auth.selectedType : ''
+  const defaultKey = QWEN_DEFAULT_KEYS[selected]
+  if (defaultKey && nonempty(env[defaultKey])) {
+    refs.push({ path: ['env', defaultKey], value: env[defaultKey], provider: selected, endpoints: [auth.baseUrl] })
+  }
+  if (nonempty(auth.apiKey)) {
+    const models = Object.entries(providers).flatMap(([provider, entries]) =>
+      (provider === selected || protocols[provider] === selected) && Array.isArray(entries) ? entries : []
+    )
+    refs.push({
+      path: ['security', 'auth', 'apiKey'],
+      value: auth.apiKey,
+      provider: selected,
+      endpoints: QWEN_DEFAULT_KEYS[selected]
+        ? [auth.baseUrl, ...models.filter((model) => !record(model)?.envKey).map((model) => record(model)?.baseUrl)]
+        : []
+    })
+  }
+  return refs
+}
+
 function oauth(value: Record<string, unknown>): boolean {
   return (
     typeof value.access === 'string' &&
@@ -177,20 +228,9 @@ function credentialsInFile(text: string, file: SeededCredentialFile): { present:
     return { present, providers: present ? ['github-copilot'] : [] }
   }
   if (file.format === 'qwen-settings') {
-    const stored = record(data) ?? {}
-    const env = record(stored.env) ?? {}
-    const providers = Object.entries(record(stored.modelProviders) ?? {}).flatMap(([provider, models]) =>
-      provider &&
-      Array.isArray(models) &&
-      models.some((entry) => {
-        const model = record(entry) ?? {}
-        return nonempty(model.id) && nonempty(model.envKey) && nonempty(env[model.envKey])
-      })
-        ? [provider]
-        : []
-    )
-    const auth = record(record(stored.security)?.auth) ?? {}
-    if (nonempty(auth.selectedType) && nonempty(auth.apiKey)) providers.push(auth.selectedType)
+    const providers = qwenSettingsApiKeys(data)
+      .map((ref) => ref.provider)
+      .filter(nonempty)
     return { present: providers.length > 0, providers: [...new Set(providers)] }
   }
   if (file.format === 'auggie') {

--- a/packages/daemon/test/microsandbox-qwen-secrets.test.ts
+++ b/packages/daemon/test/microsandbox-qwen-secrets.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+import { prepareMicrosandboxCredentials } from '../src/microsandbox/secrets.js'
+import { discoverSeededRuntimeCredentials } from '../src/runtimes/runtime-seeded-credentials.js'
+import { prepareRuntimeHome, runtimeHomeEnvironment } from '../src/runtimes/runtime-home.js'
+
+const roots: string[] = []
+const key = 'fixture-qwen-api-key'
+const oauth = { access_token: 'fixture-oauth', refresh_token: 'fixture-refresh', expiry_date: 1 }
+function write(path: string, data: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, typeof data === 'string' ? data : JSON.stringify(data))
+}
+function fixture(relocated = false) {
+  const root = mkdtempSync(join(tmpdir(), 'ac-qwen-api-'))
+  roots.push(root)
+  const hostHome = join(root, 'host')
+  const source = join(hostHome, relocated ? 'configured-qwen' : '.qwen')
+  const scopeDir = join(root, 'agent'),
+    cwd = join(scopeDir, 'workspace')
+  mkdirSync(cwd, { recursive: true })
+  return {
+    root,
+    source,
+    scopeDir,
+    cwd,
+    mounts: [],
+    runtimeId: 'qwen-code',
+    runtime: { command: 'qwen', args: ['--acp'], env: [] },
+    stateSourceEnv: {
+      HOME: hostHome,
+      ...(relocated ? { QWEN_HOME: '~/configured-qwen', QWEN_RUNTIME_DIR: '/host/runtime' } : {})
+    }
+  }
+}
+function config(value = key) {
+  return {
+    env: { MODEL_KEY: value },
+    security: { auth: { selectedType: 'openai' } },
+    modelProviders: { openai: [{ id: 'fixture-model', envKey: 'MODEL_KEY', baseUrl: 'https://api.example.test/v1' }] },
+    model: { name: 'fixture-model' },
+    extra: { Authorization: `Bearer ${value}` }
+  }
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+it('uses the shared file references for discovery and native HOME seeding, including default keys', () => {
+  const opts = fixture(true),
+    path = join(opts.source, 'settings.json')
+  write(path, {
+    modelProviders: { openai: [{ id: 'fixture-model' }], custom: [{ id: 'fixture-model' }] },
+    providerProtocol: { custom: 'anthropic' },
+    env: { OPENAI_API_KEY: key, ANTHROPIC_API_KEY: key }
+  })
+  expect(discoverSeededRuntimeCredentials(opts.runtimeId, opts.stateSourceEnv)).toEqual({
+    paths: [path],
+    providers: ['openai', 'custom']
+  })
+  const home = prepareRuntimeHome(opts.runtimeId, opts.scopeDir, opts.stateSourceEnv)
+  expect(readFileSync(join(home, '.qwen/settings.json'), 'utf8')).toContain(key)
+  const env = runtimeHomeEnvironment(opts.runtimeId, home, {}, opts.stateSourceEnv)
+  expect(env.QWEN_HOME).toBe(join(home, '.qwen'))
+  expect(env.QWEN_RUNTIME_DIR).toBe(env.QWEN_HOME)
+})
+
+describe.skipIf(process.platform !== 'linux')('microsandbox Qwen API credentials', () => {
+  it.each([false, true])(
+    'projects file env credentials and preserves OAuth and guest edits, relocated=%s',
+    (relocated) => {
+      const opts = fixture(relocated),
+        source = join(opts.source, 'settings.json')
+      write(source, '// Native JSONC settings\n' + JSON.stringify(config()))
+      write(join(opts.source, 'settings.json.backup'), config())
+      write(join(opts.source, 'oauth_creds.json'), oauth)
+      write(join(opts.source, 'mcp-oauth-tokens.json'), [oauth])
+      const launch = prepareMicrosandboxLaunch(opts),
+        secret = launch.microsandbox.secrets![0]!
+      expect(secret.host).toEqual(['api.example.test'])
+      expect(secret.readValue()).toBe(key)
+      expect(JSON.stringify(launch)).not.toContain(key)
+      expect(launch.env.MODEL_KEY).toBeUndefined()
+      const guest = launch.env.QWEN_HOME!,
+        settings = join(guest, 'settings.json')
+      expect(JSON.parse(readFileSync(settings, 'utf8'))).toEqual(config(secret.placeholder))
+      expect(existsSync(join(guest, 'settings.json.backup'))).toBe(false)
+      expect(JSON.parse(readFileSync(join(guest, 'mcp-oauth-tokens.json'), 'utf8'))).toEqual([oauth])
+      write(join(guest, 'oauth_creds.json'), { ...oauth, access_token: 'fixture-refreshed' })
+      const edited = config(secret.placeholder)
+      edited.modelProviders.openai[0]!.baseUrl = 'https://guest-chosen.example.test'
+      write(settings, edited)
+      write(source, config('fixture-rotated-key'))
+      const resumed = prepareMicrosandboxLaunch(opts)
+      expect(resumed.microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated-key')
+      expect(resumed.microsandbox.secrets![0]!.host).toEqual(secret.host)
+      expect(JSON.parse(readFileSync(settings, 'utf8'))).toEqual(edited)
+      expect(readFileSync(join(guest, 'oauth_creds.json'), 'utf8')).toContain('fixture-refreshed')
+      expect(readFileSync(join(opts.source, 'oauth_creds.json'), 'utf8')).not.toContain('fixture-refreshed')
+      expect(() =>
+        prepareMicrosandboxLaunch({ ...opts, mounts: [{ source, target: '/raw-config', mode: 'readonly' }] })
+      ).toThrow(/protected host/)
+    }
+  )
+
+  it('protects legacy credentials and shared keys across providers, including independent rotation', () => {
+    const opts = fixture(),
+      source = join(opts.source, 'settings.json')
+    const settings = {
+      env: { FIRST_KEY: key, SECOND_KEY: key },
+      modelProviders: {
+        openai: [{ id: 'one', envKey: 'FIRST_KEY', baseUrl: 'https://one.example.test' }],
+        custom: [
+          { id: 'two', envKey: 'SECOND_KEY', baseUrl: 'https://two.example.test' },
+          { id: 'legacy', baseUrl: 'https://custom-legacy.example.test' }
+        ]
+      },
+      providerProtocol: { custom: 'openai' },
+      security: { auth: { selectedType: 'openai', apiKey: key, baseUrl: 'https://legacy.example.test' } }
+    }
+    write(source, settings)
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toHaveLength(1)
+    expect(launch.microsandbox.secrets![0]!.host).toEqual([
+      'custom-legacy.example.test',
+      'legacy.example.test',
+      'one.example.test',
+      'two.example.test'
+    ])
+    settings.env.FIRST_KEY = 'fixture-rotated-key'
+    write(source, settings)
+    const resumed = prepareMicrosandboxLaunch(opts)
+    const stored = JSON.parse(readFileSync(join(resumed.env.QWEN_HOME!, 'settings.json'), 'utf8'))
+    expect(stored.env.FIRST_KEY).toBe(
+      resumed.microsandbox.secrets!.find((secret) => secret.readValue() === settings.env.FIRST_KEY)!.placeholder
+    )
+    expect(stored.env.SECOND_KEY).toBe(stored.security.auth.apiKey)
+    expect(stored.env.FIRST_KEY).not.toBe(stored.env.SECOND_KEY)
+  })
+
+  it('hides unsupported keys, keeps missing credentials undiscovered, and sanitizes unused retained env fields', () => {
+    const opts = fixture(),
+      source = join(opts.source, 'settings.json')
+    const settings = {
+      env: { BAD_URL: 'fixture-bad', NO_URL: 'fixture-no-url', TEMPLATE: '${PRIVATE_KEY}', UNKNOWN: 'fixture-unknown' },
+      modelProviders: {
+        openai: [
+          { id: 'one', envKey: 'BAD_URL', baseUrl: 'http://api.example.test' },
+          { id: 'two', envKey: 'NO_URL' },
+          { id: 'three', envKey: 'TEMPLATE', baseUrl: 'https://api.example.test' },
+          { id: 'missing', envKey: 'MISSING' }
+        ],
+        unknown: [{ id: 'four', envKey: 'UNKNOWN', baseUrl: 'https://unknown.example.test' }]
+      }
+    }
+    write(source, settings)
+    expect(discoverSeededRuntimeCredentials(opts.runtimeId, opts.stateSourceEnv).providers).toEqual([
+      'openai',
+      'unknown'
+    ])
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toEqual([])
+    const path = join(launch.env.QWEN_HOME!, 'settings.json')
+    const stored = JSON.parse(readFileSync(path, 'utf8'))
+    expect(Object.values(stored.env).every((value) => String(value).startsWith('msb-secret-'))).toBe(true)
+    write(path, { env: settings.env, modelProviders: {} })
+    prepareMicrosandboxLaunch(opts)
+    expect(readFileSync(path, 'utf8')).not.toMatch(/fixture-bad|fixture-no-url|fixture-unknown|PRIVATE_KEY/)
+  })
+
+  it('keeps OAuth-only native, skips symlinked sources and refuses malformed settings without quoting keys', () => {
+    const opts = fixture(),
+      source = join(opts.source, 'settings.json')
+    write(source, { security: { auth: { selectedType: 'qwen-oauth' } } })
+    write(join(opts.source, 'oauth_creds.json'), oauth)
+    expect(prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(JSON.parse(readFileSync(join(launch.env.QWEN_HOME!, 'oauth_creds.json'), 'utf8'))).toEqual(oauth)
+    rmSync(source)
+    const actual = join(opts.root, 'actual.json')
+    write(actual, config())
+    symlinkSync(actual, source)
+    expect(prepareMicrosandboxCredentials(opts.runtimeId, opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+    rmSync(source)
+    write(source, '{"env":{"MODEL_KEY":"fixture-invalid')
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow('Cannot read the host Qwen settings file')
+  })
+})


### PR DESCRIPTION
Qwen Code stores native API logins in `settings.json`. Importing that file into a microsandbox previously exposed its real keys to the agent. The daemon now projects placeholders and uses the existing microsandbox TLS proxy to inject keys only for host-configured HTTPS destinations.

- Reuse the credential-discovery descriptors for saved model `envKey` references, protocol defaults/custom mappings, and legacy `security.auth.apiKey`. Honor `QWEN_HOME` and seed only native configuration/login files, excluding backups and runtime snapshots.
- Preserve private settings and OAuth state on resume. Refresh host API bindings when a stopped VM restarts; guest endpoint edits cannot authorize additional destinations. Unsupported or unresolved destinations retain placeholders without a plaintext fallback.
- Keep SRT's native authentication and existing tool policy. Environment-only login, default endpoint inference, and workspace/CLI routing are outside this change; the design records these limits.

Validation: daemon typecheck; existing probe, runtime-HOME and microsandbox-launch regressions; all six focused cases under Linux; formatting and ESLint. An isolated Linux VM running native Qwen 0.23.3 completed an ACP shell-tool turn through a real API-compatible provider. Verified key absence from guest configuration/process information and serialized bindings, allowed-host injection, rejection at an unrelated host using a synthetic key, and stopped-VM rotation (200 → 401 → 200) while retaining private OAuth state. The test VM and temporary files were removed; existing daemons and host logins were unchanged.

Native contract audited against [Qwen 0.23.3 model-provider configuration](https://github.com/QwenLM/qwen-code/blob/v0.23.3/docs/users/configuration/model-providers.md) and its pinned authentication resolver.

Tracking: #1874.

Created by Codex . GPT-6
