### PR TITLE
perf(sandbox): unpack the DeepSeek harness once, in the image

### DIFF
--- a/docker/runtime-sandbox/install-core-harnesses.sh
+++ b/docker/runtime-sandbox/install-core-harnesses.sh
@@ -12,7 +12,7 @@ npm cache clean --force
 # The other two adapters ship their harness; this one carries an archive and unpacks 455 MB at first launch.
 # A session pod's volume starts empty, so every new session paid that — one launch here unpacks it once, by
 # the adapter's own code, so the integrity check and the archive's layout stay upstream's business.
-DSH_ACP_CACHE_DIR="$DSH_RUNTIME_DIR" timeout 300 dsh-acp </dev/null >/dev/null
+DSH_ACP_CACHE_DIR="$DSH_RUNTIME_DIR" timeout 300 dsh-acp < /dev/null > /dev/null
 # An ACP child's environment is an allowlist, so PATH is the only way to point the adapter at what it unpacked.
 ln -s $DSH_RUNTIME_DIR/*/node_modules/.bin/dsh /usr/local/bin/dsh
 node /tmp/bake-dsh-preset.mjs /opt/agentconnect/dsh/agent-presets/standard-no-search

--- a/docker/runtime-sandbox/install-core-harnesses.sh
+++ b/docker/runtime-sandbox/install-core-harnesses.sh
@@ -2,11 +2,22 @@
 # Install the shared ACP runtimes and derive the preset from the pinned DeepSeek package.
 set -eu
 
+DSH_RUNTIME_DIR=/opt/agentconnect/dsh-runtime
+
 npm install --global --no-fund --no-audit \
   "@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_VERSION}" \
   "@agentconnect.md/codex-acp@${CODEX_ACP_VERSION}" \
   "@openma/deepseek-harness-acp@${DEEPSEEK_HARNESS_ACP_VERSION}"
 npm cache clean --force
+# The other two adapters ship their harness; this one carries an archive and unpacks 455 MB at first launch.
+# A session pod's volume starts empty, so every new session paid that — one launch here unpacks it once, by
+# the adapter's own code, so the integrity check and the archive's layout stay upstream's business.
+DSH_ACP_CACHE_DIR="$DSH_RUNTIME_DIR" timeout 300 dsh-acp </dev/null >/dev/null
+# An ACP child's environment is an allowlist, so PATH is the only way to point the adapter at what it unpacked.
+ln -s $DSH_RUNTIME_DIR/*/node_modules/.bin/dsh /usr/local/bin/dsh
 node /tmp/bake-dsh-preset.mjs /opt/agentconnect/dsh/agent-presets/standard-no-search
-chown -R root:root /opt/agentconnect/dsh
-chmod -R a-w /opt/agentconnect/dsh
+# Shipping the archive as well would be the same tree twice, and a fallback that silently restores the unpack.
+rm "$(npm root -g)/@openma/deepseek-harness-acp/vendor/dsh-runtime.tgz"
+# The unpack ran as root, which leaves its directory 0700 — unreadable to the uid the runtime launches under.
+chown -R root:root /opt/agentconnect/dsh "$DSH_RUNTIME_DIR"
+chmod -R a+rX,a-w /opt/agentconnect/dsh "$DSH_RUNTIME_DIR"

--- a/docker/runtime-sandbox/verify-image.mjs
+++ b/docker/runtime-sandbox/verify-image.mjs
@@ -210,9 +210,23 @@ check('bakes the no-search DeepSeek preset the shim seeds', () => {
   return `${listing.trim()} (${rows.trim()} rows, read-only)`
 })
 
+// Without the installed harness the adapter unpacks its own, 455 MB, into the cache — and a session pod's volume
+// starts empty, so that lands on the first turn of every new session rather than once in this image.
+check('dsh-acp launches the installed harness instead of unpacking its own', () => {
+  const home = '/tmp/ac-dsh-probe'
+  const err = sh(
+    `rm -rf ${home}; mkdir -p ${home}; HOME=${home} timeout 90 dsh-acp </dev/null 2>&1 >/dev/null | head -5`
+  )
+  if (err) throw new Error(`the adapter did not start cleanly: ${err}`)
+  const cache = sh(`du -sh ${home}/.cache/dsh-acp 2>/dev/null | cut -f1`)
+  const harness = sh(`readlink -f "$(command -v dsh)"; rm -rf ${home}`)
+  if (cache) throw new Error(`the adapter unpacked ${cache} into its cache, so it did not find the installed harness`)
+  return harness
+})
+
 // Git runs INSIDE the sandbox over the shim's exec channel, so a missing git is every workspace operation failing.
 check('provides the executables the shim must resolve', () => {
-  const required = ['git', 'gh', 'node', 'claude-agent-acp', 'codex-acp', 'dsh-acp']
+  const required = ['git', 'gh', 'node', 'claude-agent-acp', 'codex-acp', 'dsh-acp', 'dsh']
   const missing = required.filter((bin) => sh(`command -v ${bin} >/dev/null && echo y || echo n`) === 'n')
   if (missing.length > 0) throw new Error(`missing: ${missing.join(', ')}`)
   return required.join(' ')


### PR DESCRIPTION
## What

`@openma/deepseek-harness-acp` does not ship the harness it runs — it carries an archive and unpacks it, 455 MB, into its cache the first time it launches. The Claude and Codex adapters carry theirs inside the npm package.

A session pod claims a warm sandbox whose volume starts empty, so that unpack ran once per session, on the first turn.

The build now launches the adapter once with `DSH_ACP_CACHE_DIR` pointed into the image. The unpack, and the integrity check around it, stay the adapter's own code — nothing here re-implements the archive's layout. The resulting launcher goes on PATH, which the adapter probes before its archive (`resolveHost` order: invoking directory, `dsh` on PATH, `npm root -g`, vendored archive); an ACP child's environment is an allowlist, so PATH is the only way to reach it. The archive is then dropped, since shipping it too would be the same tree twice and a fallback that silently restores the per-session unpack.

## Where the time was going

Measured end to end on a new session of a pool-placed agent, twice: 21 s from send to first token.

| phase | |
| --- | --- |
| routing, agent-pod bind, workspace check | ~3.5 s |
| warm-pool claim | 26 ms |
| unpacking the harness onto the session volume | ~7 s |
| cloning the session workspace | ~4–5 s |
| skills sync + ACP `session/new` | ~2 s |
| model first token | ~2 s |

The claim was never the problem. This removes the largest single phase.

## Verification

In a live sandbox, same image, same adapter:

- launcher on PATH → `dsh-acp` starts in 1 s and writes no cache
- without it → 9 s and 455 MB under the cache directory

The image's own verify stage now asserts exactly that: it runs `dsh-acp` with a disposable HOME and fails if a cache appears.

## Notes

- The unpack runs as root during the build, which leaves its directory `0700`; the existing `chmod` line now covers it so the uid the runtime launches under can read it.
- Image size is roughly unchanged: the unpacked tree replaces the archive in the same layer rather than joining it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
