### PR TITLE
feat(daemon): protect OMP SQLite API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -473,6 +473,24 @@ and guest-refreshed OAuth state survives API-key rotation. SRT imports the same
 native files without enabling this VM proxy. Native Qwen 0.23.3's OpenAI-compatible
 API path was verified with the SDK CA and a real ACP tool turn.
 
+Oh My Pi uses the same proxy for API keys in its native `agent.db`, honoring
+`PI_CODING_AGENT_DIR`. The existing credential-table extractor writes placeholders
+before inserting any row into the private database; API keys never enter its
+journal during seeding. Native OAuth and login metadata are preserved. Routing
+covers the audited built-in Anthropic, OpenAI, DeepSeek, Google, xAI, OpenRouter,
+Groq and Mistral endpoints. Unknown providers keep placeholders without injection.
+Custom model files are not part of the existing HOME seed; model-file-only keys,
+broker/command/environment credentials and OAuth protection remain outside this
+path. Native OMP 18.1.17 completed an ACP model/tool turn through this proxy.
+
+OMP resume checks a host-only copy of the private database and WAL, opened through
+directory/file descriptors without following guest symlinks. The original files
+are never rewritten, preserving OAuth refreshes and usage records. This check is
+bounded to 256 MiB combined. Retained plaintext or incompatible API records require
+a new session; existing data is retained. Key values for unchanged bindings rotate
+through the stopped-VM lifecycle; changed login identities or shared-key groups
+may require a new session. OAuth-only and SRT launches keep native seeding.
+
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
 existing private logins are preserved. Without a DeepSeek key, normal seeding is

--- a/packages/daemon/src/microsandbox/omp-secrets.ts
+++ b/packages/daemon/src/microsandbox/omp-secrets.ts
@@ -1,0 +1,165 @@
+import { createHash } from 'node:crypto'
+import { closeSync, constants, fstatSync, lstatSync, mkdtempSync, openSync, readSync, rmSync, writeSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import { extractOmpCredentials, readOmpApiCredentials } from '../runtimes/omp-credentials.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { withDescentSync } from '../shim/safe-descent.js'
+import { replaceSecretValue } from './secret-values.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+// OMP 18.1.17 bundled providers; custom model files are not part of the existing native HOME seed.
+const HOSTS: Record<string, string> = {
+  anthropic: 'api.anthropic.com',
+  openai: 'api.openai.com',
+  deepseek: 'api.deepseek.com',
+  google: 'generativelanguage.googleapis.com',
+  xai: 'api.x.ai',
+  openrouter: 'openrouter.ai',
+  groq: 'api.groq.com',
+  mistral: 'api.mistral.ai'
+}
+const PLACEHOLDER = /^msb-secret-AC_OMP_API_[A-F0-9]{16}$/
+const MAX_RETAINED_BYTES = 256 * 1024 * 1024
+
+// Inspect a private copy: SQLite must never resolve guest-controlled journal paths on the host.
+function checkRetainedDatabase(parent: string, bindings: ReadonlyMap<string, MicrosandboxSecret>): boolean {
+  const temporary = mkdtempSync(join(tmpdir(), 'ac-omp-retained-'))
+  let bytes = 0
+  try {
+    for (const suffix of ['', '-wal']) {
+      let input: number
+      try {
+        input = openSync(
+          join(parent, `agent.db${suffix}`),
+          constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+        )
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+        if (!suffix) {
+          for (const sidecar of ['-wal', '-shm', '-journal']) {
+            try {
+              lstatSync(join(parent, `agent.db${sidecar}`))
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+              throw error
+            }
+            throw new Error('orphaned private database sidecar')
+          }
+          return false
+        }
+        continue
+      }
+      try {
+        const stat = fstatSync(input)
+        bytes += stat.size
+        if (!stat.isFile() || bytes > MAX_RETAINED_BYTES) throw new Error('invalid private database')
+        const output = openSync(join(temporary, `agent.db${suffix}`), 'wx', 0o600)
+        try {
+          const chunk = Buffer.alloc(64 * 1024)
+          let offset = 0
+          while (offset < stat.size) {
+            const count = readSync(input, chunk, 0, Math.min(chunk.length, stat.size - offset), offset)
+            if (!count) throw new Error('private database changed during inspection')
+            let written = 0
+            while (written < count) written += writeSync(output, chunk, written, count - written)
+            offset += count
+          }
+          if (readSync(input, chunk, 0, 1, offset)) throw new Error('private database grew during inspection')
+        } finally {
+          closeSync(output)
+        }
+      } finally {
+        closeSync(input)
+      }
+    }
+    for (const row of readOmpApiCredentials(join(temporary, 'agent.db'))) {
+      const binding = bindings.get(`${row.id}:${row.provider}`)
+      if (!PLACEHOLDER.test(row.key) || (binding && row.key !== binding.placeholder))
+        throw new Error('unprotected or changed private credentials')
+    }
+    return true
+  } catch {
+    throw new Error(
+      'Cannot reuse the OMP private credential database safely; start a new session. Existing data has been retained.'
+    )
+  } finally {
+    rmSync(temporary, { recursive: true, force: true })
+  }
+}
+
+export function prepareOmpSecrets(hostEnv: NodeJS.ProcessEnv): MicrosandboxCredentials | undefined {
+  const location = runtimeStateLocations('omp', hostEnv)[0]!
+  const source = join(location.source, 'agent.db')
+  const rows = readOmpApiCredentials(source)
+  if (!rows.length) return undefined
+  const bindings = new Map<string, MicrosandboxSecret>()
+  const sharedKeys = new Map<string, MicrosandboxSecret>()
+  const replacements = new Map<string, string>()
+  for (const row of rows.sort((a, b) => a.id - b.id)) {
+    const id = `${row.id}:${row.provider}`
+    const env = `AC_OMP_API_${createHash('sha256').update(id).digest('hex').slice(0, 16).toUpperCase()}`
+    const secret = sharedKeys.get(row.key) ?? {
+      env,
+      placeholder: `msb-secret-${env}`,
+      host: [],
+      readValue: () => row.key
+    }
+    const host =
+      Object.hasOwn(HOSTS, row.provider) && !row.key.startsWith('!') && !row.key.includes('$')
+        ? [HOSTS[row.provider]!]
+        : []
+    secret.host = [...new Set([secret.host, host].flat())].sort()
+    bindings.set(id, secret)
+    sharedKeys.set(row.key, secret)
+    replacements.set(row.key, secret.placeholder)
+  }
+  const project = (value: unknown): string =>
+    JSON.stringify(value, (_name, entry: unknown) =>
+      typeof entry === 'string' ? replaceSecretValue(entry, replacements) : entry
+    )
+  return {
+    secrets: [...sharedKeys.values()].filter((secret) => secret.host.length > 0),
+    replacements,
+    sources: [
+      location.source,
+      ...['agent.db', 'agent.db-wal', 'agent.db-shm', 'agent.db-journal', ...(location.seedFiles ?? [])].map((file) =>
+        join(location.source, file)
+      )
+    ],
+    seedExclusions: [
+      join(location.destination, 'agent.db'),
+      ...(location.seedFiles ?? []).map((file) => join(location.destination, file))
+    ],
+    preparePrivateHome(home) {
+      withDescentSync(home, location.destination.split('/'), (parent) => {
+        if (checkRetainedDatabase(parent, bindings)) return
+        extractOmpCredentials(source, join(parent, 'agent.db'), (row) => {
+          try {
+            const data: unknown = JSON.parse(String(row.data))
+            if (row.credential_type === 'api_key') {
+              const key = (data as { key?: unknown })?.key
+              const binding = bindings.get(`${row.id}:${row.provider}`)
+              if (typeof key === 'string' && key.trim() && (!binding || key !== binding.readValue()))
+                throw new Error('changed source')
+            }
+            return { ...row, data: project(data) }
+          } catch {
+            throw new Error('Host OMP credentials changed or could not be projected; retry launch')
+          }
+        })
+      })
+      for (const file of location.seedFiles ?? []) {
+        projectRuntimeHomeSeedFile(home, join(location.destination, file), join(location.source, file), (text) => {
+          try {
+            return stringifyYaml(JSON.parse(project(parseYaml(text))))
+          } catch {
+            throw new Error('Cannot project the OMP configuration file')
+          }
+        })
+      }
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -11,6 +11,7 @@ import { prepareClaudeApiSecret, prepareCodexApiSecret } from './native-api-secr
 import { preparePiSecrets } from './pi-secrets.js'
 import { prepareGrokSecrets } from './grok-secrets.js'
 import { prepareQwenSecrets } from './qwen-secrets.js'
+import { prepareOmpSecrets } from './omp-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
@@ -40,7 +41,8 @@ const CREDENTIAL_PREPARERS = new Map<
   ['claude-acp', prepareClaudeApiSecret],
   ['codex-acp', prepareCodexApiSecret],
   ['grok-build', prepareGrokSecrets],
-  ['qwen-code', prepareQwenSecrets]
+  ['qwen-code', prepareQwenSecrets],
+  ['omp', prepareOmpSecrets]
 ])
 
 export function prepareMicrosandboxCredentials(

--- a/packages/daemon/src/runtimes/omp-credentials.ts
+++ b/packages/daemon/src/runtimes/omp-credentials.ts
@@ -22,7 +22,7 @@ function rowBytes(row: Record<string, SQLInputValue>): number {
   return Object.values(row).reduce<number>((total, value) => total + valueBytes(value), 0)
 }
 
-/** Query provider names only; expired or disabled logins remain discoverable for reauthentication. */
+// Query provider names only; expired or disabled logins remain discoverable for reauthentication.
 export function discoverOmpCredentialProviders(sourcePath: string): string[] {
   let source: DatabaseSync | undefined
   try {
@@ -53,11 +53,49 @@ export function discoverOmpCredentialProviders(sourcePath: string): string[] {
   }
 }
 
-/**
- * Copy only OMP's credential schema and rows into a fresh private database.
- * Reviewed against can1357/oh-my-pi b0d04e517335ada4e00ef8dc93aad9f4d1be8d21.
- */
-export function extractOmpCredentials(sourcePath: string, destinationPath: string): void {
+export interface OmpApiCredential {
+  id: number
+  provider: string
+  key: string
+}
+
+export function readOmpApiCredentials(sourcePath: string): OmpApiCredential[] {
+  let source: DatabaseSync | undefined
+  try {
+    const stat = lstatSync(sourcePath)
+    if (stat.isSymbolicLink()) return []
+    if (!stat.isFile()) throw new Error('invalid source')
+    source = new DatabaseSync(sourcePath, { readOnly: true })
+    source.exec('PRAGMA trusted_schema=OFF')
+    const credentials: OmpApiCredential[] = []
+    let bytes = 0
+    for (const row of source
+      .prepare("SELECT id, provider, data FROM auth_credentials WHERE credential_type = 'api_key'")
+      .iterate()) {
+      if (typeof row.id !== 'number' || typeof row.provider !== 'string' || typeof row.data !== 'string')
+        throw new Error('invalid credential')
+      bytes += Buffer.byteLength(row.data)
+      if (Buffer.byteLength(row.data) > MAX_ROW_BYTES || bytes > MAX_TOTAL_BYTES)
+        throw new Error('oversized credentials')
+      const data = JSON.parse(row.data) as { key?: unknown }
+      if (typeof data?.key === 'string' && data.key.trim())
+        credentials.push({ id: row.id, provider: row.provider, key: data.key })
+    }
+    return credentials
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw new Error('Cannot read the OMP API credential database')
+  } finally {
+    source?.close()
+  }
+}
+
+// Copy only native credential tables; projection runs before any row reaches the private database or journal.
+export function extractOmpCredentials(
+  sourcePath: string,
+  destinationPath: string,
+  project: (row: Record<string, SQLInputValue>) => Record<string, SQLInputValue> = (row) => row
+): void {
   if (!existsSync(sourcePath)) return
   if (existsSync(destinationPath)) {
     if (lstatSync(destinationPath).isSymbolicLink()) {
@@ -76,8 +114,7 @@ export function extractOmpCredentials(sourcePath: string, destinationPath: strin
   let sourceTransaction = false
   try {
     source = new DatabaseSync(sourcePath, { readOnly: true })
-    // Pin all allowlisted reads to one snapshot. This matters in WAL mode: without
-    // a source-side transaction, the two table reads can observe different commits.
+    // Keep both allowlisted tables on the same WAL snapshot.
     source.exec('BEGIN')
     sourceTransaction = true
     destination = new DatabaseSync(tempPath)
@@ -110,7 +147,8 @@ export function extractOmpCredentials(sourcePath: string, destinationPath: strin
         if (totalBytes > MAX_TOTAL_BYTES) {
           throw new Error(`OMP credential payload exceeds ${MAX_TOTAL_BYTES} bytes`)
         }
-        insert.run(...columns.map((column) => row[column] ?? null))
+        const projected = table === 'auth_credentials' ? project(row) : row
+        insert.run(...columns.map((column) => projected[column] ?? null))
       }
     }
 

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -304,7 +304,7 @@ export function prepareRuntimeHome(
       assertNoDestinationSymlink(home, credentialDestination)
       seedLocation(home, join(location.source, file.path), credentialDestination, excluded)
     }
-    if (runtimeId === 'omp') {
+    if (runtimeId === 'omp' && !excluded.has(join(destination, 'agent.db'))) {
       extractOmpCredentials(join(location.source, 'agent.db'), join(destination, 'agent.db'))
     }
   }

--- a/packages/daemon/test/microsandbox-omp-secrets.test.ts
+++ b/packages/daemon/test/microsandbox-omp-secrets.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+import { prepareMicrosandboxCredentials } from '../src/microsandbox/secrets.js'
+import { discoverOmpCredentialProviders, readOmpApiCredentials } from '../src/runtimes/omp-credentials.js'
+import { prepareRuntimeHome } from '../src/runtimes/runtime-home.js'
+
+const roots: string[] = []
+const key = 'fixture-omp-api-key'
+const oauth = { access: 'fixture-oauth-access', refresh: 'fixture-oauth-refresh', expires: 1 }
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'ac-omp-api-'))
+  roots.push(root)
+  const source = join(root, 'host', 'relocated-omp')
+  const scopeDir = join(root, 'agent'),
+    cwd = join(scopeDir, 'workspace')
+  mkdirSync(source, { recursive: true })
+  mkdirSync(cwd, { recursive: true })
+  const db = new DatabaseSync(join(source, 'agent.db'))
+  db.exec(`
+    CREATE TABLE auth_schema_version (id INTEGER PRIMARY KEY, version INTEGER NOT NULL);
+    CREATE TABLE auth_credentials (
+      id INTEGER PRIMARY KEY, provider TEXT, credential_type TEXT, data TEXT,
+      disabled_cause TEXT, identity_key TEXT, created_at INTEGER, updated_at INTEGER
+    );
+    INSERT INTO auth_schema_version VALUES (1, 7);
+    CREATE TABLE cache (key TEXT PRIMARY KEY, value TEXT);
+    INSERT INTO cache VALUES ('host-only', 'private-host-cache');
+  `)
+  db.prepare('INSERT INTO auth_credentials VALUES (?, ?, ?, ?, ?, NULL, 1, 1)').run(
+    1,
+    'deepseek',
+    'api_key',
+    JSON.stringify({ key, source: 'login' }),
+    'expired'
+  )
+  db.prepare('INSERT INTO auth_credentials VALUES (?, ?, ?, ?, NULL, NULL, 1, 1)').run(
+    2,
+    'anthropic',
+    'oauth',
+    JSON.stringify(oauth)
+  )
+  db.close()
+  writeFileSync(join(source, 'config.yml'), 'modelRoles:\n  default: deepseek/deepseek-v4-flash\n')
+  return {
+    root,
+    source,
+    scopeDir,
+    cwd,
+    mounts: [],
+    runtimeId: 'omp',
+    runtime: { command: 'omp', args: ['acp'], env: [] },
+    stateSourceEnv: { HOME: join(root, 'host'), PI_CODING_AGENT_DIR: source }
+  }
+}
+function withDatabase<T>(path: string, work: (db: DatabaseSync) => T): T {
+  const db = new DatabaseSync(path)
+  try {
+    return work(db)
+  } finally {
+    db.close()
+  }
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+it('keeps discovery and SRT native SQLite seeding unchanged', () => {
+  const opts = fixture()
+  expect(discoverOmpCredentialProviders(join(opts.source, 'agent.db'))).toEqual(['anthropic', 'deepseek'])
+  const home = prepareRuntimeHome('omp', opts.scopeDir, opts.stateSourceEnv)
+  expect(readOmpApiCredentials(join(home, '.omp/agent/agent.db'))[0]?.key).toBe(key)
+  withDatabase(join(opts.source, 'agent.db'), (db) =>
+    db.exec("DELETE FROM auth_credentials WHERE credential_type='api_key'")
+  )
+  expect(prepareMicrosandboxCredentials('omp', opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+})
+
+describe.skipIf(process.platform !== 'linux')('microsandbox OMP SQLite API credentials', () => {
+  it('seeds placeholders directly from a host WAL snapshot, with native OAuth and no host cache', () => {
+    const opts = fixture(),
+      source = join(opts.source, 'agent.db')
+    const host = new DatabaseSync(source)
+    try {
+      host.exec(
+        'PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE padding(data BLOB); INSERT INTO padding VALUES(zeroblob(3145728)); PRAGMA wal_checkpoint(TRUNCATE);'
+      )
+      host
+        .prepare('UPDATE auth_credentials SET data=? WHERE id=1')
+        .run(JSON.stringify({ key: 'fixture-wal-key', source: 'login' }))
+      const launch = prepareMicrosandboxLaunch(opts),
+        secret = launch.microsandbox.secrets![0]!
+      expect(secret.readValue()).toBe('fixture-wal-key')
+      expect(secret.host).toEqual(['api.deepseek.com'])
+      expect(JSON.stringify(launch)).not.toContain('fixture-wal-key')
+      const directory = launch.env.PI_CODING_AGENT_DIR!
+      expect(readOmpApiCredentials(join(directory, 'agent.db'))[0]?.key).toBe(secret.placeholder)
+      for (const file of readdirSync(directory, { withFileTypes: true }).filter((file) => file.isFile()))
+        expect(readFileSync(join(directory, file.name)).includes(Buffer.from('fixture-wal-key'))).toBe(false)
+      withDatabase(join(directory, 'agent.db'), (db) => {
+        expect(JSON.parse(String(db.prepare('SELECT data FROM auth_credentials WHERE id=2').get()!.data))).toEqual(
+          oauth
+        )
+        expect(db.prepare("SELECT name FROM sqlite_master WHERE name IN ('cache', 'padding')").all()).toEqual([])
+      })
+      expect(readOmpApiCredentials(source)[0]?.key).toBe('fixture-wal-key')
+      for (const path of [opts.source, source, `${source}-wal`])
+        expect(() =>
+          prepareMicrosandboxLaunch({ ...opts, mounts: [{ source: path, target: '/raw-state', mode: 'readonly' }] })
+        ).toThrow(/protected host/)
+    } finally {
+      host.close()
+    }
+  })
+
+  it('rotates host values without rewriting retained SQLite, including live OAuth and usage WAL state', () => {
+    const opts = fixture(),
+      launch = prepareMicrosandboxLaunch(opts)
+    const path = join(launch.env.PI_CODING_AGENT_DIR!, 'agent.db'),
+      guest = new DatabaseSync(path)
+    try {
+      guest.exec(
+        "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE usage_history(value TEXT); PRAGMA wal_checkpoint(TRUNCATE); INSERT INTO usage_history VALUES('guest-usage');"
+      )
+      guest
+        .prepare('UPDATE auth_credentials SET data=? WHERE id=2')
+        .run(JSON.stringify({ ...oauth, access: 'fixture-refreshed' }))
+      const before = [readFileSync(path), readFileSync(`${path}-wal`)]
+      withDatabase(join(opts.source, 'agent.db'), (db) =>
+        db
+          .prepare('UPDATE auth_credentials SET data=? WHERE id=1')
+          .run(JSON.stringify({ key: 'fixture-rotated-key', source: 'login' }))
+      )
+      const resumed = prepareMicrosandboxLaunch(opts)
+      expect(resumed.microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated-key')
+      expect(resumed.microsandbox.secrets![0]!.placeholder).toBe(launch.microsandbox.secrets![0]!.placeholder)
+      expect([readFileSync(path), readFileSync(`${path}-wal`)]).toEqual(before)
+      expect(guest.prepare('SELECT value FROM usage_history').get()!.value).toBe('guest-usage')
+      expect(String(guest.prepare('SELECT data FROM auth_credentials WHERE id=2').get()!.data)).toContain(
+        'fixture-refreshed'
+      )
+    } finally {
+      guest.close()
+    }
+  })
+
+  it('hides unknown providers and refuses retained plaintext or changed host credentials without rewriting them', () => {
+    const opts = fixture()
+    withDatabase(join(opts.source, 'agent.db'), (db) =>
+      db.exec("UPDATE auth_credentials SET provider='custom-provider' WHERE id=1")
+    )
+    const launch = prepareMicrosandboxLaunch(opts),
+      path = join(launch.env.PI_CODING_AGENT_DIR!, 'agent.db')
+    expect(launch.microsandbox.secrets).toEqual([])
+    expect(readOmpApiCredentials(path)[0]?.key).toMatch(/^msb-secret-/)
+    withDatabase(path, (db) => db.prepare('UPDATE auth_credentials SET data=? WHERE id=1').run(JSON.stringify({ key })))
+    const before = readFileSync(path)
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow(/start a new session/)
+    expect(readFileSync(path)).toEqual(before)
+    const fresh = fixture(),
+      protection = prepareMicrosandboxCredentials('omp', fresh.runtime, fresh.stateSourceEnv)!
+    const home = prepareRuntimeHome('omp', fresh.scopeDir, fresh.stateSourceEnv, undefined, protection.seedExclusions)
+    expect(existsSync(join(home, '.omp/agent/agent.db'))).toBe(false)
+    withDatabase(join(fresh.source, 'agent.db'), (db) =>
+      db.prepare('UPDATE auth_credentials SET data=? WHERE id=1').run(JSON.stringify({ key: 'fixture-changed' }))
+    )
+    expect(() => protection.preparePrivateHome(home)).toThrow(/changed/)
+    expect(existsSync(join(home, '.omp/agent/agent.db'))).toBe(false)
+  })
+
+  it('refuses private database and WAL symlinks and orphan sidecars', () => {
+    for (const suffix of ['', '-wal']) {
+      const opts = fixture(),
+        launch = prepareMicrosandboxLaunch(opts)
+      const path = join(launch.env.PI_CODING_AGENT_DIR!, `agent.db${suffix}`)
+      rmSync(path, { force: true })
+      symlinkSync(join(opts.source, 'agent.db'), path)
+      expect(() => prepareMicrosandboxLaunch(opts)).toThrow(/start a new session/)
+      expect(readOmpApiCredentials(join(opts.source, 'agent.db'))[0]?.key).toBe(key)
+    }
+    const opts = fixture(),
+      privateDir = join(opts.scopeDir, 'home/.omp/agent')
+    mkdirSync(privateDir, { recursive: true })
+    writeFileSync(join(privateDir, 'agent.db-wal'), 'orphan')
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow(/start a new session/)
+    expect(existsSync(join(privateDir, 'agent.db'))).toBe(false)
+  })
+})


### PR DESCRIPTION
Oh My Pi's native SQLite login currently copies saved API keys into the guest. Project those keys to stable placeholders before inserting any row into the private database, and inject the real values with the existing microsandbox TLS proxy.

Reuse the native state inventory and credential-table extractor. OAuth rows and login metadata keep their native behavior. Retained databases are checked through a bounded, descriptor-opened host copy of the database and WAL; the original database is never rewritten. Value changes to unchanged credential rows use the existing stopped-VM secret update without losing guest OAuth refreshes or usage records. Native login with a different API key inserts a new record, so that change requires a new session under the existing binding contract. An unprotected or incompatible retained database is preserved rather than migrated in place.

Scope is SQLite API logins for eight audited built-in providers. Unknown destinations keep placeholders without real-key injection. Custom model files, auth brokers, environment-only credentials, and OAuth protection are outside this change. SRT keeps its existing native seeding behavior.

Validation: five focused tests pass on Linux; the existing runtime-HOME tests pass locally; daemon typecheck, changed-file lint, and formatting pass. An isolated KVM VM with OMP 18.1.17 completed a native ACP model/tool turn. Guest database/process inspection found no real API key; the real provider returned 200, then 401 after stopped-VM key replacement, then 200 after restoration, with the guest database and OAuth record preserved.

Related to #1874.

Created by Codex . GPT-6
