### PR TITLE
perf(workspace): parallelize session repository preparation

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -313,6 +313,12 @@ The primary checkout keeps its roles for `shared` isolation, the console's
 workspace views and `pullOnNewSession`; for confined sessions it is no longer
 the parent of anything.
 
+Session preparation runs at most two independent repository roots concurrently,
+including the working-directory root. Reference roots keep their default branches
+and fail independently; a working-directory failure is returned only after the
+other started preparations settle. Daemon-managed Git uses two checkout workers
+to reduce file materialization time on shared filesystems.
+
 ### What changes for a confined session
 
 - **Refs are a snapshot.** The clone's `refs/remotes/origin/*` are the remote's

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -202,6 +202,7 @@ function workspaceGitConfigPairs(repository?: string): ReadonlyArray<readonly [s
     ['core.fsmonitor', 'false'],
     ['core.sparseCheckout', 'false'],
     ['core.sparseCheckoutCone', 'false'],
+    ['checkout.workers', '2'],
     ['credential.helper', ''],
     ['http.followRedirects', 'false'],
     // Disable checkout- or server-selected secondary download locations.

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1875,14 +1875,17 @@ export class WorkspaceManager {
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, opts)
     if (request.isolation === 'shared') return primary
 
-    // A from-scratch primary keeps its scratch directory as the cwd — isolation has no clone to
-    // branch it off — but its secondaries still get per-session worktrees (decisions 4 and 5).
-    const cwd =
-      agent.workspace.mode === 'git-repo'
-        ? await this.prepareRootSessionDirectory(agent, this.primaryRoot(agent), request)
-        : undefined
-    await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent), request)
-    if (cwd === undefined) return primary
+    // Scratch keeps its original cwd while its secondary roots receive per-session directories.
+    const cwd = await this.prepareSessionRoots(
+      agent,
+      async () =>
+        agent.workspace.mode === 'git-repo'
+          ? await this.prepareRootSessionDirectory(agent, this.primaryRoot(agent), request)
+          : primary,
+      this.referenceRootsOf(agent),
+      request
+    )
+    if (agent.workspace.mode !== 'git-repo') return cwd
     const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
     return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
   }
@@ -1925,10 +1928,13 @@ export class WorkspaceManager {
     if (!prepared) {
       throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
     }
-    const cwd = await this.prepareRootSessionDirectory(agent, prepared, request)
-    await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent, prepared.subtreeName), request)
-    // The same post-steps the primary cwd gets, deliberately: skills install into the working
-    // directory, and the reviewed root is the one the model stands in. `agentDir` is the primary's.
+    const cwd = await this.prepareSessionRoots(
+      agent,
+      () => this.prepareRootSessionDirectory(agent, prepared, request),
+      this.referenceRootsOf(agent, prepared.subtreeName),
+      request
+    )
+    // Install skills in the reviewed root itself; agentDir belongs only to the primary root.
     const acpCwd = await this.withLocalSkills(agent, this.resolveRootAcpCwd(agent.id, cwd, undefined), opts)
     // Attested LAST, because the attestation says a session was placed here: a preparation that
     // failed a post-step must leave the caller's revision-only fallback a primary cwd it can use,
@@ -1976,32 +1982,43 @@ export class WorkspaceManager {
     ]
   }
 
-  /**
-   * Every reference root's worktree for this session, at the SAME id as the working directory's.
-   *
-   * Never a review checkout: the reviewed revision belongs to the one root the session is about,
-   * and the others ride along at their default branch as references (decision 5). Per-root failure
-   * is local like a clone failure (decision 7) — that root is absent from this session and nothing
-   * else about it changes.
-   */
-  private async prepareReferenceSessionWorktrees(
+  // Prepare at most two independent roots at once; reference failures remain local to that root.
+  private async prepareSessionRoots(
     agent: Agent,
+    prepareCwd: () => Promise<string>,
     roots: readonly { root: WorkspaceRoot; label: string }[],
     request: PrepareSessionWorkspaceRequest
-  ): Promise<void> {
+  ): Promise<string> {
     const rootRequest: PrepareSessionWorkspaceRequest = {
       sessionKey: request.sessionKey,
       isolation: 'session',
       ...(request.initiatedBy !== undefined ? { initiatedBy: request.initiatedBy } : {}),
       ...(request.confined ? { confined: true } : {})
     }
-    for (const { root, label } of roots) {
-      try {
-        await this.prepareRootSessionDirectory(agent, root, rootRequest)
-      } catch (err) {
-        workspaceLog.warn(`workspace: ${label} has no session worktree for agent "${agent.id}" (${formatErr(err)})`)
-      }
+    let cwd = ''
+    const preparations = [
+      async () => {
+        cwd = await prepareCwd()
+      },
+      ...roots.map(({ root, label }) => async () => {
+        try {
+          await this.prepareRootSessionDirectory(agent, root, rootRequest)
+        } catch (err) {
+          workspaceLog.warn(`workspace: ${label} has no session worktree for agent "${agent.id}" (${formatErr(err)})`)
+        }
+      })
+    ]
+    const pending = preparations.values()
+    const results = await Promise.allSettled(
+      Array.from({ length: Math.min(2, preparations.length) }, async () => {
+        for (const prepare of pending) await prepare()
+      })
+    )
+    // Drain started work before a required-root failure releases the daemon's workspace mutation gate.
+    for (const result of results) {
+      if (result.status === 'rejected') throw result.reason
     }
+    return cwd
   }
 
   /** The stable per-session worktree of one root, checked out at the reviewed revision when there is one. */
@@ -2366,13 +2383,16 @@ export class WorkspaceManager {
     await this.prepareSecondaryRoots(agent)
     const cwdRoot = reviewRoot ?? (await this.resumedReviewedRoot(agent, request))
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, {})
-    const cwd =
-      agent.workspace.mode === 'git-repo'
-        ? await this.prepareRootSessionClone(agent, this.primaryRootAt(agent, mount), request)
-        : undefined
-    await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent), request)
-    // A from-scratch session keeps the mount as its cwd — on its own pod, so it is private by construction.
-    if (cwd === undefined) return this.clusterWorkspaceCheckout(agent, mount)
+    const cwd = await this.prepareSessionRoots(
+      agent,
+      async () =>
+        agent.workspace.mode === 'git-repo'
+          ? await this.prepareRootSessionClone(agent, this.primaryRootAt(agent, mount), request)
+          : this.clusterWorkspaceCheckout(agent, mount),
+      this.referenceRootsOf(agent),
+      request
+    )
+    if (agent.workspace.mode !== 'git-repo') return cwd
     return this.resolveRootAcpCwd(agent.id, cwd, normalizeRepoSubdir(agent.workspace.agentDir))
   }
 

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -131,6 +131,7 @@ describe('gitEnvBase', () => {
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.fsmonitor', 'false'])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.sparseCheckout', 'false'])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.sparseCheckoutCone', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['checkout.workers', '2'])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['credential.helper', ''])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['fetch.bundleURI', ''])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['transfer.bundleURI', 'false'])

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
 import type { Agent } from '../src/agents/agent-schema.js'
 import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { createWorkspaceScope } from '../src/cp/workspace-scope.js'
@@ -373,6 +373,92 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
       await workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: KEY, isolation: 'session' })
     ).toEqual([realpathSync(infra)])
   })
+
+  it.each([false, true])(
+    'prepares two roots concurrently and drains them before returning (primary fails: %s)',
+    async (failPrimary) => {
+      const agent = agentFixture({
+        additionalRepos: [
+          { repoFullName: 'acme/lib-a', repoId: '41' },
+          { repoFullName: 'acme/lib-b', repoId: '42' }
+        ]
+      })
+      serveAll(agent)
+      const gate = () => {
+        let resolve!: () => void
+        const promise = new Promise<void>((done) => {
+          resolve = done
+        })
+        return { promise, resolve }
+      }
+      const started = Array.from({ length: 3 }, gate)
+      const release = Array.from({ length: 3 }, gate)
+      const primaryFinished = gate()
+      const clone = SeamRunner.prototype.clone
+      let active = 0
+      let peak = 0
+      const seen: number[] = []
+      const spy = vi.spyOn(SeamRunner.prototype, 'clone').mockImplementation(async function (
+        this: SeamRunner,
+        repo,
+        target,
+        options
+      ) {
+        if (!target.startsWith(leafOf(agent))) return await clone.call(this, repo, target, options)
+        const index = repo === PRIMARY_URL ? 0 : repo.includes('/lib-a') ? 1 : 2
+        seen.push(index)
+        active += 1
+        peak = Math.max(peak, active)
+        started[index]!.resolve()
+        try {
+          await release[index]!.promise
+          if (index === 0 && failPrimary) throw new Error('primary clone unavailable')
+          await clone.call(this, repo, target, options)
+        } finally {
+          active -= 1
+          if (index === 0) primaryFinished.resolve()
+        }
+      })
+      let settled = false
+      const prepared = workspaces.prepareSessionWorkspace(agent, confined()).then(
+        (cwd) => ({ cwd, error: undefined }),
+        (error: unknown) => ({ cwd: undefined, error })
+      )
+      void prepared.then(() => {
+        settled = true
+      })
+      try {
+        await Promise.all([started[0]!.promise, started[1]!.promise])
+        expect(seen).toEqual([0, 1])
+        expect(active).toBe(2)
+        release[1]!.resolve()
+        await started[2]!.promise
+        expect(active).toBe(2)
+        release[0]!.resolve()
+        await primaryFinished.promise
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        expect(settled).toBe(false)
+        release[2]!.resolve()
+        const result = await prepared
+        if (failPrimary) {
+          expect(result.error).toBeInstanceOf(Error)
+          expect((result.error as Error).message).toContain('primary clone unavailable')
+        } else {
+          expect(result.error).toBeUndefined()
+          expect(readFileSync(join(result.cwd!, 'README.md'), 'utf8')).toBe('seed\n')
+        }
+        for (const repo of ['lib-a', 'lib-b']) {
+          expect(readFileSync(join(leafOf(agent), 'repos', 'acme', repo, 'README.md'), 'utf8')).toBe('seed\n')
+        }
+        expect(peak).toBe(2)
+        expect(active).toBe(0)
+      } finally {
+        for (const gate of release) gate.resolve()
+        await prepared
+        spy.mockRestore()
+      }
+    }
+  )
 
   it('fetches a review into the clone, verifies HEAD exactly, and leaves no ref in the primary', async () => {
     const agent = agentFixture()


### PR DESCRIPTION
Session startup waits for each repository checkout in sequence. Prepare the working-directory and reference roots with a shared limit of two concurrent operations, and use two Git checkout workers through the existing trusted configuration environment.

Reference repositories retain their default branches and independent failure handling. A required-root failure waits for the remaining work to settle before releasing the workspace mutation gate. Local and Kubernetes session paths reuse the same scheduler.

Validation:
- 193 tests passed across session clones, secondary roots, cluster preparation, Git configuration, and native microsandbox Git.
- Deferred real-Git regressions verify the concurrency limit, continued scheduling while the primary is blocked, and draining after primary failure.
- Daemon typecheck, focused ESLint, and formatting checks passed.
- In an isolated two-vCPU microsandbox with cached Git objects, three repository checkouts on virtiofs fell from 10.27 s to 4.07 s median (three samples per configuration). This measures checkout only, excluding downloads and runtime startup.

Created by Codex . GPT-6
