### PR TITLE
feat(daemon): protect Amp file API keys in microsandbox

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -491,6 +491,20 @@ a new session; existing data is retained. Key values for unchanged bindings rota
 through the stopped-VM lifecycle; changed login identities or shared-key groups
 may require a new session. OAuth-only and SRT launches keep native seeding.
 
+Amp uses the same proxy for nonempty `apiKey@<service URL>` entries in its native
+`secrets.json`, including `XDG_DATA_HOME` relocation. The record's HTTPS host
+authorizes header injection; changing guest settings cannot authorize another
+destination. HTTP, custom ports, URL userinfo and malformed addresses retain
+placeholders without injection. Shared keys share a binding across their allowed
+hosts. Native JSONC settings, including `AMP_SETTINGS_FILE`, are projected into
+the private HOME with matching key values replaced. Unrelated credential records
+and guest-only logins retain native behavior; stopped-VM rotation preserves them.
+This covers native Amp CLI file login, not the adapter's separate
+`amp-acp/credentials.json` setup file, environment-only credentials, or arbitrary
+workspace configuration. SRT keeps native authentication. Amp ACP 0.9.0 and the
+native CLI were checked with synthetic credentials; an authenticated model/tool
+turn remains a release acceptance task.
+
 When a DeepSeek key is available, the daemon projects the credential seed files
 with that ref replaced by the placeholder; other provider refs, OAuth records and
 existing private logins are preserved. Without a DeepSeek key, normal seeding is

--- a/packages/daemon/src/microsandbox/amp-secrets.ts
+++ b/packages/daemon/src/microsandbox/amp-secrets.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
+import { objectFromJson } from '../runtimes/codex-config.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
+import { projectRuntimeHomeSeedFile } from '../runtimes/runtime-home.js'
+import { MAX_SEED_FILE_BYTES } from '../runtimes/runtime-seeded-credentials.js'
+import { replaceSecretValue } from './secret-values.js'
+import type { MicrosandboxCredentials, MicrosandboxSecret } from './secrets.js'
+
+function apiKeys(data: Record<string, unknown>): [string, string][] {
+  return Object.entries(data).filter(
+    (entry): entry is [string, string] =>
+      entry[0].startsWith('apiKey@') && typeof entry[1] === 'string' && Boolean(entry[1].trim())
+  )
+}
+
+function allowedHost(name: string): string[] {
+  try {
+    const url = new URL(name.slice('apiKey@'.length))
+    if (url.protocol === 'https:' && !url.port && !url.username && !url.password && /^[a-z0-9.-]+$/.test(url.hostname))
+      return [url.hostname]
+  } catch {
+    // Unresolved service addresses retain placeholders without authorizing key injection.
+  }
+  return []
+}
+
+export function prepareAmpSecrets(hostEnv: NodeJS.ProcessEnv): MicrosandboxCredentials | undefined {
+  const locations = runtimeStateLocations('amp-acp', hostEnv)
+  const auth = locations.find((location) => location.credentialFiles?.some((file) => file.format === 'amp'))!
+  let data: Record<string, unknown>
+  try {
+    const stat = lstatSync(auth.source)
+    if (stat.isSymbolicLink()) return undefined
+    if (!stat.isFile() || stat.size > MAX_SEED_FILE_BYTES) throw new Error('invalid credential source')
+    data = objectFromJson(readFileSync(auth.source, 'utf8'), 'Amp credential file')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw new Error('Cannot read the host Amp credential file')
+  }
+  const bindings = new Map<string, MicrosandboxSecret>()
+  const sharedKeys = new Map<string, MicrosandboxSecret>()
+  const replacements = new Map<string, string>()
+  for (const [name, value] of apiKeys(data).sort(([a], [b]) => a.localeCompare(b))) {
+    const env = `AC_AMP_API_${createHash('sha256').update(name).digest('hex').slice(0, 16).toUpperCase()}`
+    const secret = sharedKeys.get(value) ?? { env, placeholder: `msb-secret-${env}`, host: [], readValue: () => value }
+    secret.host = [...new Set([secret.host, allowedHost(name)].flat())].sort()
+    sharedKeys.set(value, secret)
+    bindings.set(name, secret)
+    replacements.set(value, secret.placeholder)
+  }
+  if (!bindings.size) return undefined
+  const configs = [
+    ...locations.filter((location) => location !== auth && location.source === hostEnv.AMP_SETTINGS_FILE),
+    ...locations
+      .filter((location) => location.destination === join('.config', 'amp'))
+      .map((location) => ({
+        source: join(location.source, 'settings.json'),
+        destination: join(location.destination, 'settings.json')
+      }))
+  ]
+  return {
+    secrets: [...sharedKeys.values()].filter((secret) => secret.host.length > 0),
+    replacements,
+    sources: locations.map((location) => location.source),
+    seedExclusions: [auth, ...configs].map((file) => file.destination),
+    preparePrivateHome(home) {
+      projectRuntimeHomeSeedFile(home, auth.destination, auth.source, (text, retained) => {
+        const projected = objectFromJson(text, 'Amp credential file')
+        const values = new Map(replacements)
+        for (const [name, value] of apiKeys(projected)) {
+          const binding = bindings.get(name)
+          if (!retained && (!binding || value !== binding.readValue()))
+            throw new Error('Host Amp credentials changed during preparation; retry launch')
+          if (binding) {
+            values.set(value, binding.placeholder)
+            projected[name] = binding.placeholder
+          }
+        }
+        return `${JSON.stringify(projected, (_name, value: unknown) =>
+          typeof value === 'string' ? replaceSecretValue(value, values) : value
+        )}\n`
+      })
+      for (const file of configs)
+        projectRuntimeHomeSeedFile(home, file.destination, file.source, (text) => {
+          const config = objectFromJson(stripJsonComments(text, { trailingCommas: true }), 'Amp settings file')
+          return `${JSON.stringify(config, (_name, value: unknown) =>
+            typeof value === 'string' ? replaceSecretValue(value, replacements) : value
+          )}\n`
+        })
+    }
+  }
+}

--- a/packages/daemon/src/microsandbox/secrets.ts
+++ b/packages/daemon/src/microsandbox/secrets.ts
@@ -12,6 +12,7 @@ import { preparePiSecrets } from './pi-secrets.js'
 import { prepareGrokSecrets } from './grok-secrets.js'
 import { prepareQwenSecrets } from './qwen-secrets.js'
 import { prepareOmpSecrets } from './omp-secrets.js'
+import { prepareAmpSecrets } from './amp-secrets.js'
 
 export interface MicrosandboxSecret {
   env: string
@@ -42,7 +43,8 @@ const CREDENTIAL_PREPARERS = new Map<
   ['codex-acp', prepareCodexApiSecret],
   ['grok-build', prepareGrokSecrets],
   ['qwen-code', prepareQwenSecrets],
-  ['omp', prepareOmpSecrets]
+  ['omp', prepareOmpSecrets],
+  ['amp-acp', prepareAmpSecrets]
 ])
 
 export function prepareMicrosandboxCredentials(

--- a/packages/daemon/test/microsandbox-amp-secrets.test.ts
+++ b/packages/daemon/test/microsandbox-amp-secrets.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { prepareMicrosandboxLaunch } from '../src/microsandbox/launch.js'
+import { prepareMicrosandboxCredentials } from '../src/microsandbox/secrets.js'
+
+const roots: string[] = []
+const key = 'fixture-amp-api-key'
+const name = 'apiKey@https://amp.example.test/'
+function write(path: string, value: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, typeof value === 'string' ? value : JSON.stringify(value))
+}
+function fixture(relocated = false) {
+  const root = mkdtempSync(join(tmpdir(), 'ac-amp-api-'))
+  roots.push(root)
+  const home = join(root, 'host')
+  const data = join(home, relocated ? 'data' : '.local/share')
+  const config = join(home, relocated ? 'config' : '.config')
+  const source = join(data, 'amp/secrets.json')
+  const settings = join(config, 'amp', relocated ? 'custom.json' : 'settings.json')
+  const scopeDir = join(root, 'agent')
+  const cwd = join(scopeDir, 'workspace')
+  mkdirSync(cwd, { recursive: true })
+  write(source, { [name]: key, 'oauth@example': { access: 'fixture-oauth' } })
+  write(settings, `// Native JSONC settings\n{"amp.url":"https://amp.example.test/","copy":"${key}"}`)
+  return {
+    source,
+    settings,
+    runtimeId: 'amp-acp',
+    runtime: { command: 'amp-acp', args: [], env: [] },
+    scopeDir,
+    cwd,
+    mounts: [],
+    stateSourceEnv: {
+      HOME: home,
+      ...(relocated ? { XDG_DATA_HOME: data, XDG_CONFIG_HOME: config, AMP_SETTINGS_FILE: settings } : {})
+    }
+  }
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe.skipIf(process.platform !== 'linux')('microsandbox Amp file credentials', () => {
+  it.each([false, true])('projects native file logins and settings, relocated=%s', (relocated) => {
+    const opts = fixture(relocated)
+    const launch = prepareMicrosandboxLaunch(opts)
+    const secret = launch.microsandbox.secrets![0]!
+    expect(secret.host).toEqual(['amp.example.test'])
+    expect(secret.readValue()).toBe(key)
+    expect(JSON.stringify(launch)).not.toContain(key)
+    expect(launch.env.AMP_API_KEY).toBeUndefined()
+    expect(JSON.parse(readFileSync(join(launch.env.XDG_DATA_HOME!, 'amp/secrets.json'), 'utf8'))).toEqual({
+      [name]: secret.placeholder,
+      'oauth@example': { access: 'fixture-oauth' }
+    })
+    const settings = launch.env.AMP_SETTINGS_FILE ?? join(launch.env.XDG_CONFIG_HOME!, 'amp/settings.json')
+    expect(JSON.parse(readFileSync(settings, 'utf8'))).toEqual({
+      'amp.url': 'https://amp.example.test/',
+      copy: secret.placeholder
+    })
+    expect(() =>
+      prepareMicrosandboxLaunch({
+        ...opts,
+        mounts: [{ source: opts.source, target: '/raw-credentials', mode: 'readonly' }]
+      })
+    ).toThrow(/protected host/)
+    expect(readFileSync(opts.source, 'utf8')).toContain(key)
+  })
+
+  it('unifies shared keys and leaves unsupported services protected without injection', () => {
+    const opts = fixture()
+    const credentials = {
+      [name]: key,
+      'apiKey@https://second.example.test': key,
+      'apiKey@http://plain.example.test': 'fixture-plain-key',
+      'apiKey@https://port.example.test:8443': 'fixture-port-key',
+      'apiKey@https://user@userinfo.example.test': 'fixture-userinfo-key',
+      'apiKey@invalid': 'fixture-invalid-key',
+      'mcp@example': { token: 'fixture-mcp-token' }
+    }
+    write(opts.source, credentials)
+    const launch = prepareMicrosandboxLaunch(opts)
+    expect(launch.microsandbox.secrets).toHaveLength(1)
+    expect(launch.microsandbox.secrets![0]!.host).toEqual(['amp.example.test', 'second.example.test'])
+    const privateAuth = JSON.parse(readFileSync(join(launch.env.XDG_DATA_HOME!, 'amp/secrets.json'), 'utf8'))
+    for (const name of Object.keys(credentials).filter((name) => name.startsWith('apiKey@')))
+      expect(privateAuth[name]).toMatch(/^msb-secret-AC_AMP_API_/)
+    expect(privateAuth[name]).toBe(privateAuth['apiKey@https://second.example.test'])
+    expect(privateAuth['mcp@example']).toEqual(credentials['mcp@example'])
+  })
+
+  it('preserves private state on key rotation and rejects redirected private files', () => {
+    const opts = fixture()
+    const first = prepareMicrosandboxLaunch(opts)
+    const authPath = join(first.env.XDG_DATA_HOME!, 'amp/secrets.json')
+    const credentials = JSON.parse(readFileSync(authPath, 'utf8'))
+    credentials['oauth@example'].access = 'fixture-refreshed'
+    credentials['apiKey@https://guest.example.test'] = 'fixture-guest-login'
+    write(authPath, credentials)
+    write(opts.source, { [name]: 'fixture-rotated-key' })
+    const next = prepareMicrosandboxLaunch(opts)
+    expect(next.microsandbox.secrets![0]!.placeholder).toBe(first.microsandbox.secrets![0]!.placeholder)
+    expect(next.microsandbox.secrets![0]!.readValue()).toBe('fixture-rotated-key')
+    expect(next.microsandbox.secrets![0]!.host).toEqual(['amp.example.test'])
+    expect(JSON.parse(readFileSync(authPath, 'utf8'))).toEqual(credentials)
+    rmSync(authPath)
+    symlinkSync(opts.source, authPath)
+    expect(() => prepareMicrosandboxLaunch(opts)).toThrow(/symlink/)
+    expect(readFileSync(opts.source, 'utf8')).toContain('fixture-rotated-key')
+  })
+})
+
+it('ignores missing native logins and reports malformed credentials without their contents', () => {
+  const opts = fixture()
+  rmSync(opts.source)
+  expect(prepareMicrosandboxCredentials('amp-acp', opts.runtime, opts.stateSourceEnv)).toBeUndefined()
+  write(opts.source, `${key}{`)
+  expect(() => prepareMicrosandboxCredentials('amp-acp', opts.runtime, opts.stateSourceEnv)).toThrow(
+    'Cannot read the host Amp credential file'
+  )
+})


### PR DESCRIPTION
Native Amp file logins currently copy their real API keys into a microsandbox session. Project `apiKey@<service URL>` records to placeholders and reuse the existing host-side TLS proxy for the corresponding HTTPS hosts. Shared keys share a binding; private settings and unrelated credential records survive stopped-VM key rotation. Unsupported destinations retain placeholders without plaintext fallback. SRT authentication is unchanged.

Validation: five focused Linux tests, existing native HOME tests, daemon typecheck, lint and formatting. An isolated KVM VM verified private-file key absence, allowed-host header substitution, unrelated-host rejection and stopped-VM rotation. Amp ACP 0.9.0 with native CLI 0.0.1788912097-g82ca44 read the projected file without an API-key environment variable and reached authentication with a synthetic key. A real authenticated model/tool turn is still pending because no Amp login was available for that test.

Scope is native Amp CLI `secrets.json` and matching values in seeded JSONC settings. Adapter-only setup credentials, environment-only logins and arbitrary workspace configuration remain outside this path. Limitations and Devin's separate Protobuf authentication incompatibility are tracked in #1874.

Created by Codex . GPT-6
