### PR TITLE
feat(chart): let an install set the pool member's agent ceiling

### DIFF
--- a/charts/agentconnect/templates/daemon-pool-reconciler.yaml
+++ b/charts/agentconnect/templates/daemon-pool-reconciler.yaml
@@ -73,10 +73,8 @@ spec:
               # daemon the members run, so the two cannot disagree about what an orphan is.
               image: "{{ .Values.image.registry }}/{{ .Values.daemonPool.image }}:{{ $daemonTag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              # `args` replaces the image's CMD and leaves its tini ENTRYPOINT in place, so the
-              # node invocation is spelled out here — `args: ['reconcile','--once']` alone would
-              # ask tini to exec a binary named `reconcile`.
-              args: ['node', 'dist/index.js', 'reconcile', '--once']
+              # `args` replaces the image's CMD; the ENTRYPOINT already carries the node invocation.
+              args: ['reconcile', '--once']
               env:
                 # The same partial the members read (daemon-pool.yaml), so the namespace swept,
                 # the warm pool and the control-plane address cannot drift from the pool's.

--- a/charts/agentconnect/templates/daemon-pool.yaml
+++ b/charts/agentconnect/templates/daemon-pool.yaml
@@ -154,6 +154,10 @@ spec:
         - name: daemon-pool
           image: "{{ .Values.image.registry }}/{{ .Values.daemonPool.image }}:{{ $daemonTag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if not (kindIs "invalid" .Values.daemonPool.maxAgents) }}
+          # Restates the image's CMD, which `args` replaces wholesale. Null-guarded: 0 is unbounded.
+          args: ['run', '--k8s', '--max-agents', {{ .Values.daemonPool.maxAgents | int | quote }}]
+          {{- end }}
           env:
             # Shared with the orphan-reconciler CronJob (daemon-pool-reconciler.yaml): the CP
             # address, the warm pool, the sandbox namespace and the supervisor declaration come

--- a/charts/agentconnect/values.yaml
+++ b/charts/agentconnect/values.yaml
@@ -171,6 +171,9 @@ daemonPool:
   tag: ''
   # Three distinct Pod UIDs become three distinct install-wide pool members in the CP.
   replicas: 3
+  # Agents ONE member accepts duty for — held, not working: an idle agent still costs a duty entry.
+  # Null leaves the daemon's own default, 0 is unbounded. A member's config file is an emptyDir.
+  maxAgents: null
   # Existing Secret whose config.json is the strict data-plane document:
   # {"version":1,"databaseUrl":"postgresql://...","maxConnections":4}
   # Referenced BY NAME, like `secrets.existingSecret`: create it in the namespace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -224,8 +224,10 @@ USER 10002:10002
 
 # tini so a SIGTERM reaches the daemon and its drain actually runs — without it
 # PID 1 ignores the signal and every rollout ends in SIGKILL mid-drain.
-ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["node", "dist/index.js", "run", "--k8s"]
+# The interpreter is the entrypoint and the subcommand is the CMD, so a deployment that needs a
+# flag states `args` as the daemon's own argv instead of restating how the image is launched.
+ENTRYPOINT ["/usr/bin/tini", "--", "node", "dist/index.js"]
+CMD ["run", "--k8s"]
 
 # ────────────────────────────── web: build ──────────────────────────────────
 FROM manifests AS web-builder

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -66,6 +66,20 @@ abort('daemon-pool grace period must outlast the shutdown drain budget') unless 
 # deliberately left behind when everything else took the daemon-pool vocabulary.
 abort('daemon pool must use the fixed Kubernetes identity') unless pod['serviceAccountName'] == 'ac-cloud-daemon'
 abort('daemon pool must use its effective component tag') unless container['image'] == 'ghcr.io/agentconnect-md/daemon:v1.41.0-rc.89'
+# Unset leaves the image's own CMD, so an install that says nothing about the ceiling gets the
+# daemon's default rather than a chart-owned one.
+abort('an unset maxAgents must not override the image CMD') if container.key?('args')
+# 0 is the daemon's UNBOUNDED sentinel, so the guard has to test for null, not for truth — a
+# truthiness check would silently drop exactly the value that removes the ceiling.
+%w[256 0].each do |ceiling|
+  rendered_ceiling, error_ceiling, status_ceiling = Open3.capture3(*command, '--set', "daemonPool.maxAgents=#{ceiling}")
+  abort("rendering maxAgents=#{ceiling} failed:\n#{error_ceiling}") unless status_ceiling.success?
+  pooled = YAML.load_stream(rendered_ceiling).compact.find { |doc|
+    doc['kind'] == 'Deployment' && doc.dig('metadata', 'name') == 'example-agentconnect-daemon-pool'
+  }
+  args = pooled.dig('spec', 'template', 'spec', 'containers').find { |item| item['name'] == 'daemon-pool' }&.fetch('args', nil)
+  abort("maxAgents=#{ceiling} must reach the daemon as argv") unless args == ['run', '--k8s', '--max-agents', ceiling]
+end
 # Keyed from the EFFECTIVE full reference so a `runtime.image` pin or digest change rolls the
 # members and repeats runtime discovery exactly like a tag change does.
 abort('runtime image changes must roll daemon-pool probes') unless pod_template.dig('metadata', 'annotations', 'agentconnect.md/runtime-sandbox-image') == 'ghcr.io/agentconnect-md/runtime-sandbox:v1.41.0-rc.88'
@@ -291,9 +305,10 @@ abort('reconciler must run under the members security context') unless job_pod['
 reconcile_container = job_pod.fetch('containers').find { |item| item['name'] == 'reconcile' } || abort('missing reconcile container')
 # One image, one tag: the sweep's rules ship with the daemon the members run.
 abort('reconciler must run the daemon image at the pool tag') unless reconcile_container['image'] == container['image']
-# `args` replaces CMD and leaves the image's tini ENTRYPOINT in place, so the node invocation is
-# spelled out — `['reconcile', '--once']` alone would ask tini to exec a binary named `reconcile`.
-abort('reconciler must run exactly one sweep') unless reconcile_container['args'] == ['node', 'dist/index.js', 'reconcile', '--once']
+# `args` replaces CMD and leaves the image's ENTRYPOINT, which carries the node invocation, so a
+# subcommand is all this states. Pinned because the two sit in different files: an ENTRYPOINT that
+# stopped carrying it would leave this asking tini to exec a binary named `reconcile`.
+abort('reconciler must run exactly one sweep') unless reconcile_container['args'] == ['reconcile', '--once']
 abort('reconciler must satisfy the same container security context') unless reconcile_container['securityContext'] == container['securityContext']
 reconcile_env = reconcile_container.fetch('env').to_h { |item| [item.fetch('name'), item['value']] }
 # The anti-drift assertion the shared env partial exists for: a sweep pointed at another


### PR DESCRIPTION
Adds `daemonPool.maxAgents` so an install can raise the pool member's agent ceiling.

## Why

`limits.maxAgents` (default 32) bounds the agents a member **holds duty for** — held, not working. An idle agent still costs a duty entry; concurrent turns are bounded by session admission and the idle sweep, not by this number. So on a pool whose agents mostly sit idle, 32 is a ceiling on the roster, and reaching it leaves the next agent with no member to serve it.

A member had no way to be told otherwise: its config file lives in an emptyDir, so it is back at the schema default after every Pod replacement, and the chart exposed no knob.

## What changed

- **`daemonPool.maxAgents`** (default `null` — the daemon's own default stands), rendered as the container's `args`.
- Guarded with `kindIs "invalid"` rather than truthiness: **0 is the daemon's unbounded sentinel**, and a truth check would silently drop exactly the value that removes the ceiling. Both cases are pinned in the render contract.
- **The image's ENTRYPOINT now carries the node invocation** (`tini -- node dist/index.js`) and its CMD the subcommand (`run --k8s`), so a container states the daemon's own argv instead of restating how the image is launched. Other subcommands still work: `docker run <image> agent list`.
- The reconciler CronJob's args shed that prefix with it — `['reconcile', '--once']`.

## Compatibility

The chart and the daemon image are now coupled on the entrypoint split, and they ship together from one release. A **newer chart rendered against an older `image.tag`** would hand `reconcile --once` to a bare `tini --`, which fails the sweep — contained (`backoffLimit: 0`, one failed Job per tick, self-healing once the tag catches up), but worth knowing before pinning a chart and an image apart. The pool member itself is unaffected unless `maxAgents` is set, since nothing is rendered otherwise.

## Checks

`scripts/test-chart-render.rb` passes, extended with: unset renders no `args`, and `256` / `0` both reach the container as `['run', '--k8s', '--max-agents', <n>]`. `helm lint` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
