### PR TITLE
perf(daemon): avoid redundant session workspace preparation

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -284,9 +284,9 @@ per-session sandbox policy need.
 
 ### The clone
 
-`git clone --filter=blob:none` — a blobless partial clone from the remote,
+`git clone --filter=blob:none --no-checkout` — a blobless partial clone from the remote,
 through the daemon's own credential path, exactly like the first clone of a
-primary today. It checks out the tip and carries the **whole** commit history
+primary today. It carries the **whole** commit history
 (messages, authors, trees); old file contents are fetched lazily on `blame`,
 `show` or `diff` of a past revision, which needs the session's read-tier fetch
 credential. Measured on a ~1,500-commit repository: ~4 s and 17 MB against 12 MB
@@ -310,8 +310,18 @@ Layout, one directory per session, removed whole at retirement:
 ```
 
 The primary checkout keeps its roles for `shared` isolation, the console's
-workspace views and `pullOnNewSession`; for confined sessions it is no longer
-the parent of anything.
+workspace views and unconfined worktrees; for confined sessions it is no longer
+the parent of anything. Confined session preparation retains shared checkout
+initialization, identity checks and submodule discovery, but does not pull those
+checkouts even with `pullOnNewSession` enabled. Shared sessions and unconfined
+worktrees still honor that setting. Skills are reconciled only in the final
+session working directory.
+
+A fresh session clone creates its generated branch at the default tip or verified
+review revision, then materializes that tree once with `reset --hard`. The clone
+stays in a staging directory until checkout and revision verification succeed;
+only then is it renamed to the session's final path. A failed checkout is cleaned
+up, so resume cannot mistake an unmaterialized clone for a ready workspace.
 
 Session preparation runs at most two independent repository roots concurrently,
 including the working-directory root. Reference roots keep their default branches

--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -311,10 +311,9 @@ Layout, one directory per session, removed whole at retirement:
 
 The primary checkout keeps its roles for `shared` isolation, the console's
 workspace views and unconfined worktrees; for confined sessions it is no longer
-the parent of anything. Confined session preparation retains shared checkout
-initialization, identity checks and submodule discovery, but does not pull those
-checkouts even with `pullOnNewSession` enabled. Shared sessions and unconfined
-worktrees still honor that setting. Skills are reconciled only in the final
+the parent of anything. Confined sessions retain shared checkout initialization and
+identity checks, but do not pull those checkouts. Shared sessions and unconfined
+worktrees still honor `pullOnNewSession`. Skills are reconciled only in the final
 session working directory.
 
 A fresh session clone creates its generated branch at the default tip or verified
@@ -324,10 +323,20 @@ only then is it renamed to the session's final path. A failed checkout is cleane
 up, so resume cannot mistake an unmaterialized clone for a ready workspace.
 
 Session preparation runs at most two independent repository roots concurrently,
-including the working-directory root. Reference roots keep their default branches
-and fail independently; a working-directory failure is returned only after the
-other started preparations settle. Daemon-managed Git uses two checkout workers
-to reduce file materialization time on shared filesystems.
+including the working-directory root. Confined discovery starts with the cwd root,
+then the primary reference and sorted remaining secondary roots. Fresh clones read
+`.gitmodules` from their chosen Git tree before checkout, reviews use the verified
+revision, and ordinary resumes read the retained working directory. Shared working
+trees never decide these exclusions. Discovery overlaps checkout with the next
+root's preparation; a
+submodule match waits for its parent to succeed before omitting the standalone
+root. A failed parent cannot hide another authorized repository, and a reviewed
+root always receives its own exact checkout.
+
+Reference roots keep their default branches and fail independently; a
+working-directory failure is returned only after the other started preparations
+settle. Daemon-managed Git uses two checkout workers to reduce file materialization
+time on shared filesystems.
 
 ### What changes for a confined session
 

--- a/docs/designs/multi-repository-workspaces.md
+++ b/docs/designs/multi-repository-workspaces.md
@@ -101,6 +101,13 @@ same shape, which is what lets one `WorkspaceRoot` drive both. A submodule root
 (decision 11) has the same entry but is never listed as an additional directory;
 ordinary sessions reach its content through the parent's submodule path.
 
+For confined sessions, decision 11 uses each session root's own tree, never a
+shared checkout: the selected revision before a fresh checkout or review reset,
+and the retained working directory on ordinary resume. Discovery precedes the
+next root while checkout may overlap it. An exclusion takes effect only after the
+parent finishes successfully; an unavailable parent leaves the authorized root
+eligible for its own clone. See [the confined preparation sequence](git-workspace-model.md#the-clone).
+
 A GitLab project's subtree is `repos/_gitlab/<project id>` rather than its path
 ([gitlab-com-integration.md §13.1](gitlab-com-integration.md)): a namespaced
 path has any depth, and the numeric id is what a rename cannot change, so the

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -47,7 +47,7 @@ import {
 } from './git-injection.js'
 import { GitTransportError, LocalGitRunner, type GitRunner } from './git-runner.js'
 import { localWorkspaceFs, type WorkspaceFs, type WorkspacePlacement } from './workspace-fs.js'
-import { gitmoduleRepos } from './gitmodules.js'
+import { githubSubmoduleRepo, gitmoduleRepos } from './gitmodules.js'
 import {
   GITLAB_ROOTS_DIR,
   gitlabSubtreeName,
@@ -759,10 +759,7 @@ export class WorkspaceManager {
   }
 
   // Prepare available secondary roots lazily, omitting failures and repositories already present as submodules.
-  async prepareSecondaryRoots(
-    agent: Agent,
-    pull = agent.workspace.pullOnNewSession
-  ): Promise<SecondaryWorkspaceRoot[]> {
+  async prepareSecondaryRoots(agent: Agent): Promise<SecondaryWorkspaceRoot[]> {
     const roots = this.secondaryRootsFor(agent)
     if (roots.length === 0) {
       this.readyRoots.delete(agent.id)
@@ -781,7 +778,7 @@ export class WorkspaceManager {
         )
         continue
       }
-      const prepared = await this.prepareSecondaryRoot(agent, root, pull)
+      const prepared = await this.prepareSecondaryRoot(agent, root)
       if (!prepared) continue
       for (const repo of await this.submoduleReposOf(agent.id, root.path)) submodules.add(repo)
       ready.push(prepared)
@@ -1180,15 +1177,15 @@ export class WorkspaceManager {
     return this.withSkills(agent, this.resolveAcpCwd(root, agentDir), opts)
   }
 
-  // Shared checkouts retain identity, submodule discovery and Console reads even when a session clones independently.
-  private async prepareWorkspaceRoots(agent: Agent, pull = agent.workspace.pullOnNewSession): Promise<string> {
-    const root = await this.preparePrimaryRoot(agent, pull)
-    await this.prepareSecondaryRoots(agent, pull)
+  // Shared sessions and unconfined worktrees discover references from these shared roots.
+  private async prepareWorkspaceRoots(agent: Agent): Promise<string> {
+    const root = await this.preparePrimaryRoot(agent)
+    await this.prepareSecondaryRoots(agent)
     return root
   }
 
   // Prepare the shared root; only the eventual session cwd must contain the configured agentDir.
-  private async preparePrimaryRoot(agent: Agent, pull: boolean): Promise<string> {
+  private async preparePrimaryRoot(agent: Agent, pull = agent.workspace.pullOnNewSession): Promise<string> {
     const cwd = agent.workspace.path
     // Fail unsafe config before using either a fresh or existing checkout.
     if (agent.workspace.mode === 'git-repo') normalizeRepoSubdir(agent.workspace.agentDir)
@@ -1859,9 +1856,14 @@ export class WorkspaceManager {
     const reviewRoot = this.reviewedSecondaryRoot(agent, request)
     // Resolve the durable reviewed cwd before shared shortcuts: scratch resumes can carry neither review nor isolation.
     const cwdRoot = reviewRoot ?? (await this.resumedReviewedRoot(agent, request))
-    const isolated = request.isolation === 'session' || cwdRoot !== undefined
-    const confined = isolated && this.confinedSessionTier(agent, request.sessionKey, request.confined)
-    const primary = await this.prepareWorkspaceRoots(agent, !confined && agent.workspace.pullOnNewSession)
+    if (
+      (request.isolation === 'session' || cwdRoot) &&
+      this.confinedSessionTier(agent, request.sessionKey, request.confined)
+    ) {
+      await this.preparePrimaryRoot(agent, false)
+      return this.prepareConfinedSession(agent, this.sandboxMountFor(agent.id), request, cwdRoot, opts)
+    }
+    const primary = await this.prepareWorkspaceRoots(agent)
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, opts)
     const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
     if (request.isolation === 'shared') {
@@ -1906,11 +1908,9 @@ export class WorkspaceManager {
     opts: PrepareWorkspaceOptions
   ): Promise<string> {
     // Reuse prepared roots; materialize a withheld submodule only when its own review needs it.
-    const pull =
-      !this.confinedSessionTier(agent, request.sessionKey, request.confined) && agent.workspace.pullOnNewSession
     const prepared =
       this.sessionSecondaryRoots(agent).find((entry) => repoKey(entry.subtreeName) === repoKey(root.subtreeName)) ??
-      (await this.prepareSecondaryRoot(agent, root, pull))
+      (await this.prepareSecondaryRoot(agent, root))
     if (!prepared) {
       throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
     }
@@ -2069,7 +2069,8 @@ export class WorkspaceManager {
   private async prepareRootSessionClone(
     agent: Agent,
     root: WorkspaceRoot,
-    request: PrepareSessionWorkspaceRequest
+    request: PrepareSessionWorkspaceRequest,
+    discover?: (read: () => Promise<Set<string>>) => Promise<void>
   ): Promise<string> {
     const fs = this.fsFor(agent.id)
     const id = this.sessionWorktreeId(request.sessionKey)
@@ -2094,7 +2095,7 @@ export class WorkspaceManager {
       const staged = `${cwd}.clone-${randomUUID()}`
       try {
         await this.cloneSessionRootAt(agent.id, root, staged)
-        await this.prepareSessionCloneCheckout(agent.id, root, staged, request, false)
+        await this.prepareSessionCloneCheckout(agent.id, root, staged, request, false, discover)
         // Publish only after checkout succeeds, so a failed no-checkout clone cannot be resumed as ready.
         await fs.rename(staged, cwd)
       } catch (err) {
@@ -2109,7 +2110,7 @@ export class WorkspaceManager {
         await this.convergeOriginInPlaceFor(agent.id, root, cwd)
         await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id, root.managed).catch(() => undefined)
       }
-      await this.prepareSessionCloneCheckout(agent.id, root, cwd, request, true)
+      await this.prepareSessionCloneCheckout(agent.id, root, cwd, request, true, discover)
     }
     // Reclaim only an empty legacy worktree stub; never remove a session's work.
     if (root.worktreesPath) await fs.rmdir(join(root.worktreesPath, id)).catch(() => false)
@@ -2122,7 +2123,8 @@ export class WorkspaceManager {
     root: WorkspaceRoot,
     cwd: string,
     request: PrepareSessionWorkspaceRequest,
-    attached: boolean
+    attached: boolean,
+    discover?: (read: () => Promise<Set<string>>) => Promise<void>
   ): Promise<void> {
     const id = this.sessionWorktreeId(request.sessionKey)
     // Into the clone, never the primary: the refs, and the exact-HEAD proof, are this session's alone.
@@ -2132,6 +2134,11 @@ export class WorkspaceManager {
     const target = review?.checkout ?? `refs/remotes/origin/${root.branch}`
     // Unsafe executable config gates the checkout itself, as it gates a worktree's creation.
     await assertSafeWorkspaceGitConfig(this.runnerFor(agentId, cwd))
+    await discover?.(() =>
+      attached && !review
+        ? this.submoduleReposOf(agentId, cwd)
+        : this.submoduleReposAtRevision(agentId, root, cwd, target)
+    )
     if (!attached) {
       await this.checkoutSessionBranch(agentId, root, cwd, target, request.initiatedBy)
     } else if (review) {
@@ -2143,6 +2150,32 @@ export class WorkspaceManager {
     if (review && (await this.revParse(agentId, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
       throw new Error('github review clone HEAD does not match the verified revision')
     }
+  }
+
+  // Inspect the selected tree before checkout, fetching only the declaration blob when a partial clone needs it.
+  private async submoduleReposAtRevision(
+    agentId: string,
+    root: WorkspaceRoot,
+    cwd: string,
+    revision: string
+  ): Promise<Set<string>> {
+    const git = this.runnerFor(agentId, cwd).withEnv(this.sessionCloneGitEnv(agentId, root))
+    const oid = (await git.raw(['rev-parse', '--revs-only', `${revision}:.gitmodules`])).trim()
+    if (!oid) return new Set()
+    const { out, overflow } = await git.readBounded(
+      ['config', '--blob', oid, '--no-includes', '--null', '--list'],
+      MAX_GITMODULES_BYTES
+    )
+    const repos = new Set<string>()
+    if (!overflow) {
+      for (const entry of out.toString('utf8').split('\0')) {
+        const separator = entry.indexOf('\n')
+        if (!/^submodule\..+\.url$/i.test(entry.slice(0, separator))) continue
+        const repo = githubSubmoduleRepo(entry.slice(separator + 1))
+        if (repo) repos.add(repo)
+      }
+    }
+    return repos
   }
 
   // A blobless partial clone of one root for a session (§11) — whole history, file contents on demand — straight from the remote through the daemon's credential path like a primary's first clone: never a hardlink of the primary (a session with write on its own `.git` could reach the shared inodes), never `--shared`; a remote that refuses the filter answers with a full clone, and a clone that fails fails the session.
@@ -2387,20 +2420,105 @@ export class WorkspaceManager {
       )
     }
     const reviewRoot = this.reviewedSecondaryRoot(agent, request)
-    await this.prepareSecondaryRoots(agent, false)
     const cwdRoot = reviewRoot ?? (await this.resumedReviewedRoot(agent, request))
-    if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, {})
-    const cwd = await this.prepareSessionRoots(
-      agent,
-      async () =>
-        agent.workspace.mode === 'git-repo'
-          ? await this.prepareRootSessionClone(agent, this.primaryRootAt(agent, mount), request)
-          : this.clusterWorkspaceCheckout(agent, mount),
-      this.referenceRootsOf(agent),
-      request
+    return this.prepareConfinedSession(agent, mount, request, cwdRoot, {})
+  }
+
+  // Discover roots in order, overlapping each checkout with the next root's preparation, with at most two in flight.
+  private async prepareConfinedSession(
+    agent: Agent,
+    mount: string | undefined,
+    request: PrepareSessionWorkspaceRequest,
+    cwdRoot: SecondaryWorkspaceRoot | undefined,
+    opts: PrepareWorkspaceOptions
+  ): Promise<string> {
+    const secondaries = this.secondaryRootsAt(agent, mount)
+    const plans = [
+      ...(agent.workspace.mode === 'git-repo'
+        ? [{ root: this.primaryRootAt(agent, mount), secondary: undefined, required: !cwdRoot }]
+        : []),
+      ...secondaries.map((root) => ({
+        root,
+        secondary: root,
+        required: repoKey(root.subtreeName) === repoKey(cwdRoot?.subtreeName ?? '')
+      }))
+    ].sort((a, b) => Number(b.required) - Number(a.required))
+    const referenceRequest = { ...request, review: undefined, reviewRepoFullName: undefined }
+    const owners = new Map<string, Promise<boolean>[]>()
+    const active = new Set<Promise<boolean>>()
+    const ready = new Map<string, SecondaryWorkspaceRoot>()
+    const failures: unknown[] = []
+    let cwd = this.primaryCheckoutAt(agent, mount)
+    for (const [index, plan] of plans.entries()) {
+      if (!plan.required && plan.secondary) {
+        // A failed parent cannot provide its submodule, so omit a root only after an owner succeeds.
+        const parents = owners.get(repoKey(plan.secondary.repoFullName)) ?? []
+        if ((await Promise.all(parents)).some(Boolean)) continue
+      }
+      if (active.size === 2) await Promise.race(active)
+      let discovered!: () => void
+      const discovery = new Promise<void>((resolve) => {
+        discovered = resolve
+      })
+      const preparation = (async () => {
+        const root = plan.secondary ? await this.prepareSecondaryRoot(agent, plan.secondary, false) : plan.root
+        if (!root) throw new Error(`session repository ${plan.root.cloneUrl} is unavailable`)
+        const path = await this.prepareRootSessionClone(
+          agent,
+          root,
+          plan.required ? request : referenceRequest,
+          async (read) => {
+            if (index < plans.length - 1) {
+              for (const repo of await read()) {
+                const parents = owners.get(repo) ?? []
+                parents.push(preparation)
+                owners.set(repo, parents)
+              }
+            }
+            discovered()
+          }
+        )
+        if (plan.required) cwd = path
+        if (plan.secondary) ready.set(plan.secondary.subtreeName, { ...plan.secondary, ...root })
+        return true
+      })()
+        .catch((err: unknown) => {
+          if (plan.required) failures.push(err)
+          else
+            workspaceLog.warn(
+              `workspace: reference repository ${plan.root.cloneUrl} is unavailable (${formatErr(err)})`
+            )
+          return false
+        })
+        .finally(() => {
+          active.delete(preparation)
+          discovered()
+        })
+      active.add(preparation)
+      await discovery
+    }
+    await Promise.all(active)
+    this.readyRoots.set(
+      agent.id,
+      secondaries.flatMap((root) => ready.get(root.subtreeName) ?? [])
     )
-    if (agent.workspace.mode !== 'git-repo') return cwd
-    return this.resolveRootAcpCwd(agent.id, cwd, normalizeRepoSubdir(agent.workspace.agentDir))
+    if (failures.length) throw failures[0]
+    const agentDir =
+      !cwdRoot && agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
+    const acpCwd = await this.withLocalSkills(
+      agent,
+      agent.workspace.mode === 'from-scratch' && !cwdRoot ? cwd : this.resolveRootAcpCwd(agent.id, cwd, agentDir),
+      opts
+    )
+    if (cwdRoot) {
+      await this.recordSessionCwdRoot(
+        agent.id,
+        dirname(cwdRoot.path),
+        this.sessionWorktreeId(request.sessionKey),
+        cwdRoot.repoFullName
+      )
+    }
+    return acpCwd
   }
 
   // The agent pod's cwd for a SHARED session, once its checkout is ready: the checkout itself, or a reviewed secondary root's exact worktree (decision 5); an isolated session never reaches here — it prepares on its own pod (§11).

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -758,15 +758,11 @@ export class WorkspaceManager {
     await fs.writeFile(marker, JSON.stringify({ repoFullName }, null, 2) + '\n', { mode: 0o600 })
   }
 
-  /**
-   * Materialize the agent's secondary roots and remember the ones a session may be handed.
-   *
-   * Lazy per decision 7: this runs at session start, and a root that cannot be prepared is omitted
-   * from THIS session rather than failing it. Decision 11 is applied in the same pass — a root that
-   * is already a submodule of an earlier one is neither prepared nor listed, so the model never sees
-   * the same repository twice at two different revisions.
-   */
-  async prepareSecondaryRoots(agent: Agent): Promise<SecondaryWorkspaceRoot[]> {
+  // Prepare available secondary roots lazily, omitting failures and repositories already present as submodules.
+  async prepareSecondaryRoots(
+    agent: Agent,
+    pull = agent.workspace.pullOnNewSession
+  ): Promise<SecondaryWorkspaceRoot[]> {
     const roots = this.secondaryRootsFor(agent)
     if (roots.length === 0) {
       this.readyRoots.delete(agent.id)
@@ -785,7 +781,7 @@ export class WorkspaceManager {
         )
         continue
       }
-      const prepared = await this.prepareSecondaryRoot(agent, root)
+      const prepared = await this.prepareSecondaryRoot(agent, root, pull)
       if (!prepared) continue
       for (const repo of await this.submoduleReposOf(agent.id, root.path)) submodules.add(repo)
       ready.push(prepared)
@@ -804,11 +800,15 @@ export class WorkspaceManager {
   }
 
   /** One secondary root's clone-or-converge, single-flighted per root like the primary's clone. */
-  async prepareSecondaryRoot(agent: Agent, root: SecondaryWorkspaceRoot): Promise<SecondaryWorkspaceRoot | undefined> {
+  async prepareSecondaryRoot(
+    agent: Agent,
+    root: SecondaryWorkspaceRoot,
+    pull = agent.workspace.pullOnNewSession
+  ): Promise<SecondaryWorkspaceRoot | undefined> {
     const key = this.cloneKey(agent.id, root.path)
     const inflight = this.secondaryInFlight.get(key)
     if (inflight) return await inflight
-    const started = this.materializeSecondaryRoot(agent, root).finally(() => {
+    const started = this.materializeSecondaryRoot(agent, root, pull).finally(() => {
       this.secondaryInFlight.delete(key)
     })
     this.secondaryInFlight.set(key, started)
@@ -817,7 +817,8 @@ export class WorkspaceManager {
 
   private async materializeSecondaryRoot(
     agent: Agent,
-    root: SecondaryWorkspaceRoot
+    root: SecondaryWorkspaceRoot,
+    pull: boolean
   ): Promise<SecondaryWorkspaceRoot | undefined> {
     const fs = this.fsFor(agent.id)
     const subtree = dirname(root.path)
@@ -825,15 +826,12 @@ export class WorkspaceManager {
     try {
       await fs.mkdir(subtree, 0o700)
       if ((await fs.stat(join(root.path, '.git'))) === 'missing') {
-        // The branch is not projected by the CP, so the remote's own HEAD decides it — resolved
-        // BEFORE the clone, because `--branch` is how the clone records it.
+        // The CP does not project the default branch; resolve remote HEAD before cloning with --branch.
         const branch = await this.resolveRemoteDefaultBranch(agent.id, root)
         const staged = `${root.path}.clone-${randomUUID()}`
         try {
           await this.cloneRootAt(agent.id, { ...root, branch }, staged)
-          // Attest first, publish last. A crash in between leaves a marker with no checkout, which
-          // the next session simply re-clones; the other order is what strands a checkout that no
-          // later session can attribute, and this code never deletes one to recover.
+          // Attest before publishing so a crash leaves a retryable marker, never an unattributable checkout.
           await fs.writeFile(
             marker,
             JSON.stringify(
@@ -850,10 +848,7 @@ export class WorkspaceManager {
         }
         return { ...root, path: this.canonicalWorkspacePath(agent.id, root.path), branch }
       }
-      // Identity is the numeric repo id, so a retired root whose owner/repo was later reused by a
-      // DIFFERENT repository is refused rather than adopted — and nothing on disk is touched
-      // (decision 12: retirement, never deletion). An origin URL cannot stand in for that id: it
-      // names the slug, which is exactly what a reuse keeps. No attestation ⇒ no root.
+      // Only the numeric repository id attests identity; refuse reused slugs without touching their old checkout.
       const recorded = parseSecondaryMaterialization(await fs.readFile(marker))
       if (recorded === undefined || !attestsRoot(recorded, root)) {
         workspaceLog.warn(
@@ -865,11 +860,10 @@ export class WorkspaceManager {
       const resolved = { ...root, branch: recorded.branch }
       await this.convergeOriginInPlaceFor(agent.id, resolved, root.path)
       await writeRepoHelperConfig(this.runnerFor(agent.id, root.path), agent.id, root.managed).catch(() => undefined)
-      if (agent.workspace.pullOnNewSession) await this.pullRoot(agent.id, resolved, root.path)
+      if (pull) await this.pullRoot(agent.id, resolved, root.path)
       return { ...resolved, path: this.canonicalWorkspacePath(agent.id, root.path) }
     } catch (err) {
-      // Degradation stays local to the root (decision 7): the session starts without it and the next
-      // one retries. Never throw out of session start over an additional repository.
+      // An unavailable reference root is omitted from this session and retried on the next preparation.
       workspaceLog.warn(
         `workspace: additional repository ${root.repoFullName} is unavailable to agent "${agent.id}" (${formatErr(err)})`
       )
@@ -1180,18 +1174,24 @@ export class WorkspaceManager {
   }
 
   async prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptions = {}): Promise<string> {
-    const acpCwd = await this.preparePrimaryRoot(agent)
-    // Every session goes through here, so this is where the secondary roots become available — and
-    // where a root that has left the set stops being handed out (decision 12).
-    await this.prepareSecondaryRoots(agent)
-    return this.withSkills(agent, acpCwd, opts)
+    const root = await this.prepareWorkspaceRoots(agent)
+    if (agent.workspace.mode === 'from-scratch') return this.withSkills(agent, root, opts)
+    const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+    return this.withSkills(agent, this.resolveAcpCwd(root, agentDir), opts)
   }
 
-  /** The primary checkout and the ACP cwd it resolves to — clone or converge+pull, as today. */
-  private async preparePrimaryRoot(agent: Agent): Promise<string> {
+  // Shared checkouts retain identity, submodule discovery and Console reads even when a session clones independently.
+  private async prepareWorkspaceRoots(agent: Agent, pull = agent.workspace.pullOnNewSession): Promise<string> {
+    const root = await this.preparePrimaryRoot(agent, pull)
+    await this.prepareSecondaryRoots(agent, pull)
+    return root
+  }
+
+  // Prepare the shared root; only the eventual session cwd must contain the configured agentDir.
+  private async preparePrimaryRoot(agent: Agent, pull: boolean): Promise<string> {
     const cwd = agent.workspace.path
     // Fail unsafe config before using either a fresh or existing checkout.
-    const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
+    if (agent.workspace.mode === 'git-repo') normalizeRepoSubdir(agent.workspace.agentDir)
     const root = agent.workspace.mode === 'git-repo' ? this.primaryRoot(agent) : undefined
     mkdirSync(cwd, { recursive: true })
 
@@ -1200,32 +1200,24 @@ export class WorkspaceManager {
       return cwd
     }
 
-    // git-repo, first session: no checkout yet → clone. Unlike pull, a clone has no
-    // on-disk fallback, so on failure we THROW (the session creation fails + the error
-    // surfaces) rather than silently proceeding with an empty dir (design §4.3).
+    // A first clone has no on-disk fallback, so failure must abort preparation.
     if (!existsSync(join(cwd, '.git'))) {
       await this.cloneRootAt(agent.id, root, root.path)
-      return this.resolveAcpCwd(cwd, agentDir)
+      return cwd
     }
 
-    // git-repo, existing checkout: the repo-local helper pin may carry a previous
-    // agent generation's id (agent deleted + recreated under the same name adopts
-    // the surviving checkout) — re-pin so agent-run git presents a live identity
-    // even where the env channel doesn't reach. Best-effort: a locked .git/config
-    // must not block the session; the session-env channel still covers this run.
+    // Re-pin adopted checkouts to the current agent; the session env remains available if the config is locked.
     if (root.githubApp) {
-      // The CP follows repository renames by numeric repo id. Repoint the existing
-      // checkout instead of treating that canonical URL refresh as a new workspace.
+      // Follow the CP's canonical repository rename without replacing the checkout.
       await this.convergeWorkspaceOrigin(agent, cwd)
       await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id, root.managed).catch(() => undefined)
     } else {
-      // Historical anonymous checkouts may still have credential-bearing or
-      // disallowed origins even after their CP row has been sanitized.
+      // Historical anonymous checkouts can retain unsafe origins after their CP row has been sanitized.
       await this.convergeWorkspaceOrigin(agent, cwd)
     }
 
-    if (agent.workspace.pullOnNewSession) await this.pullRoot(agent.id, root, cwd)
-    return this.resolveAcpCwd(cwd, agentDir)
+    if (pull) await this.pullRoot(agent.id, root, cwd)
+    return cwd
   }
 
   /** The agent's worktrees parent, wherever its workspace lives. Total by construction — a
@@ -1863,17 +1855,19 @@ export class WorkspaceManager {
       await this.forgetSessionCwdRoots(agent, id)
       return await this.prepareGithubRevisionOnlyWorkspace(agent, ...this.revisionOnlySessionTarget(agent, request))
     }
-    // Resolved before anything is materialized: a review naming a repository this agent has no root
-    // for must leave no worktree behind for the caller's revision-only fallback to step around.
+    // Reject unauthorized review roots before materializing anything that could obstruct revision-only fallback.
     const reviewRoot = this.reviewedSecondaryRoot(agent, request)
-    const primary = await this.prepareWorkspace(agent, opts)
-    // A session that already stands in a reviewed root keeps standing there. The request that
-    // re-prepares it after a host eviction or a daemon restart carries no review at all — and, for a
-    // scratch workspace, reports `shared` isolation — so this is resolved BEFORE either shortcut: the
-    // attestation on disk, not this process's memory, is what holds the working directory still.
+    // Resolve the durable reviewed cwd before shared shortcuts: scratch resumes can carry neither review nor isolation.
     const cwdRoot = reviewRoot ?? (await this.resumedReviewedRoot(agent, request))
+    const isolated = request.isolation === 'session' || cwdRoot !== undefined
+    const confined = isolated && this.confinedSessionTier(agent, request.sessionKey, request.confined)
+    const primary = await this.prepareWorkspaceRoots(agent, !confined && agent.workspace.pullOnNewSession)
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, opts)
-    if (request.isolation === 'shared') return primary
+    const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
+    if (request.isolation === 'shared') {
+      const cwd = agent.workspace.mode === 'git-repo' ? this.resolveAcpCwd(primary, agentDir) : primary
+      return this.withSkills(agent, cwd, opts)
+    }
 
     // Scratch keeps its original cwd while its secondary roots receive per-session directories.
     const cwd = await this.prepareSessionRoots(
@@ -1885,8 +1879,7 @@ export class WorkspaceManager {
       this.referenceRootsOf(agent),
       request
     )
-    if (agent.workspace.mode !== 'git-repo') return cwd
-    const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+    if (agent.workspace.mode === 'from-scratch') return this.withSkills(agent, cwd, opts)
     return this.withSkills(agent, this.resolveAcpCwd(cwd, agentDir), opts)
   }
 
@@ -1905,26 +1898,19 @@ export class WorkspaceManager {
     return agentDir === undefined ? root : join(root, ...agentDir.split('/'))
   }
 
-  /**
-   * A review whose subject is a secondary root: that root's exact worktree is the session's cwd, and
-   * the primary plus the remaining secondaries ride along at their default branches (decisions 5/6).
-   *
-   * The root is materialized HERE even when it is a submodule of another one (decision 11): such a
-   * root is withheld from ordinary sessions as an additional directory, but a review of its own pull
-   * request still gets the exact checkout every authorized repository is promised.
-   */
+  // A reviewed secondary owns the cwd at its exact revision, including submodules normally withheld from references.
   private async prepareReviewedRootWorkspace(
     agent: Agent,
     root: SecondaryWorkspaceRoot,
     request: PrepareSessionWorkspaceRequest,
     opts: PrepareWorkspaceOptions
   ): Promise<string> {
-    // Preparation already materialized every root it hands out; only a root it WITHHELD — a submodule
-    // root, or one it skipped — is materialized here, so an ordinary session's converge/pull is not
-    // repeated and decision 11 still owes this repository an exact checkout of its own pull request.
+    // Reuse prepared roots; materialize a withheld submodule only when its own review needs it.
+    const pull =
+      !this.confinedSessionTier(agent, request.sessionKey, request.confined) && agent.workspace.pullOnNewSession
     const prepared =
       this.sessionSecondaryRoots(agent).find((entry) => repoKey(entry.subtreeName) === repoKey(root.subtreeName)) ??
-      (await this.prepareSecondaryRoot(agent, root))
+      (await this.prepareSecondaryRoot(agent, root, pull))
     if (!prepared) {
       throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
     }
@@ -2108,6 +2094,8 @@ export class WorkspaceManager {
       const staged = `${cwd}.clone-${randomUUID()}`
       try {
         await this.cloneSessionRootAt(agent.id, root, staged)
+        await this.prepareSessionCloneCheckout(agent.id, root, staged, request, false)
+        // Publish only after checkout succeeds, so a failed no-checkout clone cannot be resumed as ready.
         await fs.rename(staged, cwd)
       } catch (err) {
         await fs.rmTree(staged)
@@ -2115,33 +2103,46 @@ export class WorkspaceManager {
         await fs.rmdir(canonicalSessionDir).catch(() => false)
         throw new Error(`session clone of ${root.cloneUrl} failed: ${formatErr(err)}`, { cause: err })
       }
-    } else if (root.githubApp) {
-      // A resumed clone gets what a resumed primary gets: the canonical origin and a live helper pin.
-      await this.convergeOriginInPlaceFor(agent.id, root, cwd)
-      await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id, root.managed).catch(() => undefined)
+    } else {
+      if (root.githubApp) {
+        // A resumed clone gets the canonical origin and a live helper pin.
+        await this.convergeOriginInPlaceFor(agent.id, root, cwd)
+        await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id, root.managed).catch(() => undefined)
+      }
+      await this.prepareSessionCloneCheckout(agent.id, root, cwd, request, true)
     }
+    // Reclaim only an empty legacy worktree stub; never remove a session's work.
+    if (root.worktreesPath) await fs.rmdir(join(root.worktreesPath, id)).catch(() => false)
+    return cwd
+  }
+
+  // A fresh clone checks out its final target once; a resumed ordinary session keeps its work.
+  private async prepareSessionCloneCheckout(
+    agentId: string,
+    root: WorkspaceRoot,
+    cwd: string,
+    request: PrepareSessionWorkspaceRequest,
+    attached: boolean
+  ): Promise<void> {
+    const id = this.sessionWorktreeId(request.sessionKey)
     // Into the clone, never the primary: the refs, and the exact-HEAD proof, are this session's alone.
     const review = request.review
-      ? await this.fetchReviewRevisionIn(agent.id, { ...root, path: cwd, worktreesPath: '' }, id, request.review, true)
+      ? await this.fetchReviewRevisionIn(agentId, { ...root, path: cwd, worktreesPath: '' }, id, request.review, true)
       : undefined
     const target = review?.checkout ?? `refs/remotes/origin/${root.branch}`
     // Unsafe executable config gates the checkout itself, as it gates a worktree's creation.
-    await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, cwd))
+    await assertSafeWorkspaceGitConfig(this.runnerFor(agentId, cwd))
     if (!attached) {
-      await this.checkoutSessionBranch(agent.id, root, cwd, target, request.initiatedBy)
+      await this.checkoutSessionBranch(agentId, root, cwd, target, request.initiatedBy)
     } else if (review) {
       // Tracked files alone follow the revision, as on the worktree tier: the session keeps its untracked and ignored intermediates across deliveries.
-      await this.runnerFor(agent.id, cwd)
-        .withEnv(this.sessionCloneGitEnv(agent.id, root))
+      await this.runnerFor(agentId, cwd)
+        .withEnv(this.sessionCloneGitEnv(agentId, root))
         .raw(['reset', '--hard', target])
     }
-    if (review && (await this.revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
+    if (review && (await this.revParse(agentId, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
       throw new Error('github review clone HEAD does not match the verified revision')
     }
-    // A stub this session left in the worktree parent is neither a worktree nor absent: reclaim it in ONE
-    // operation, which refuses anything that is not provably empty and so can never take a session's work.
-    if (root.worktreesPath) await fs.rmdir(join(root.worktreesPath, id)).catch(() => false)
-    return cwd
   }
 
   // A blobless partial clone of one root for a session (§11) — whole history, file contents on demand — straight from the remote through the daemon's credential path like a primary's first clone: never a hardlink of the primary (a session with write on its own `.git` could reach the shared inodes), never `--shared`; a remote that refuses the filter answers with a full clone, and a clone that fails fails the session.
@@ -2149,7 +2150,13 @@ export class WorkspaceManager {
     if (root.githubApp) await preWarmGitCred(agentId, 'clone')
     // Run in the target's parent, which names the pod that owns it: a runner with no cwd is the agent pod's.
     const git = this.runnerFor(agentId, dirname(cwd)).withEnv(this.sessionCloneGitEnv(agentId, root))
-    await git.clone(root.cloneUrl, cwd, ['--filter=blob:none', '--branch', root.branch, '--single-branch'])
+    await git.clone(root.cloneUrl, cwd, [
+      '--filter=blob:none',
+      '--no-checkout',
+      '--branch',
+      root.branch,
+      '--single-branch'
+    ])
     if (root.githubApp) await writeRepoHelperConfig(this.runnerFor(agentId, cwd), agentId, root.managed)
   }
 
@@ -2380,7 +2387,7 @@ export class WorkspaceManager {
       )
     }
     const reviewRoot = this.reviewedSecondaryRoot(agent, request)
-    await this.prepareSecondaryRoots(agent)
+    await this.prepareSecondaryRoots(agent, false)
     const cwdRoot = reviewRoot ?? (await this.resumedReviewedRoot(agent, request))
     if (cwdRoot) return await this.prepareReviewedRootWorkspace(agent, cwdRoot, request, {})
     const cwd = await this.prepareSessionRoots(

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -834,16 +834,23 @@ describe('per-session clones on the session pod (git-workspace-model §11)', () 
     // Staged beside its target and run from the session directory — the path that names the session's pod.
     expect(clone).toMatchObject({ cwd: sessionDirOf('sess-1') })
     expect(clone!.args[2]).toMatch(new RegExp(`^${cwd}\\.clone-`))
-    expect(clone!.args).toEqual(expect.arrayContaining(['--filter=blob:none', '--branch', 'main', '--single-branch']))
+    expect(clone!.args).toEqual(
+      expect.arrayContaining(['--filter=blob:none', '--no-checkout', '--branch', 'main', '--single-branch'])
+    )
+    const staged = clone!.args[2]
     // Put on its own branch at the remote's tip, in the clone, out of subcommands the sandbox admits; the checkout is the parent of nothing.
     const draw = calls.find((call) => call.args[0] === 'branch')
-    expect(draw).toMatchObject({ cwd })
+    expect(draw).toMatchObject({ cwd: staged })
     expect(draw!.args.slice(0, 2)).toEqual(['branch', '--no-track'])
     expect(draw!.args.at(-1)).toBe('refs/remotes/origin/main')
-    expect(calls.some((call) => call.cwd === cwd && call.args[0] === 'symbolic-ref' && call.args[1] === 'HEAD')).toBe(
+    expect(
+      calls.some((call) => call.cwd === staged && call.args[0] === 'symbolic-ref' && call.args[1] === 'HEAD')
+    ).toBe(true)
+    expect(calls.some((call) => call.cwd === staged && call.args[0] === 'reset' && call.args[1] === '--hard')).toBe(
       true
     )
-    expect(calls.some((call) => call.cwd === cwd && call.args[0] === 'reset' && call.args[1] === '--hard')).toBe(true)
+    expect(await pod.stat(`${cwd}/.git`)).toBe('dir')
+    expect(await pod.stat(staged!)).toBe('missing')
     expect(calls.some((call) => call.args[0] === 'worktree')).toBe(false)
     expect(await pod.stat(WORKTREES)).toBe('missing')
     // Nothing about it names the daemon's own bookkeeping directory, and nothing landed on this disk.
@@ -889,7 +896,7 @@ describe('per-session clones on the session pod (git-workspace-model §11)', () 
 
     // Into the clone's own object store, never the checkout's.
     const fetch = calls.find((call) => call.args[0] === 'fetch')
-    expect(fetch).toMatchObject({ cwd })
+    expect(fetch).toMatchObject({ cwd: calls.find((call) => call.args[0] === 'clone')!.args[2] })
     expect(fetch!.args).toContain(`+refs/pull/7/head:refs/agentconnect/reviews/${id}/head`)
     // The exact head is the start point, and HEAD is re-verified against it once the branch is drawn there.
     expect(calls.find((call) => call.args[0] === 'branch')!.args.at(-1)).toBe(head)
@@ -1094,8 +1101,10 @@ describe('secondary roots on the pod volume', () => {
     ])
 
     checkoutExists = true
+    calls.length = 0
     const isolated = { sessionKey: 'sess-2', isolation: 'session' as const, initiatedBy: 'alice' }
     const cwd = await workspaces.prepareClusterWorkspace(agent, POD_ROOT, isolated)
+    expect(calls.some((call) => call.args[0] === 'pull')).toBe(false)
     expect(cwd).toBe(sessionCloneOf('sess-2'))
     expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, isolated)).toEqual([
       sessionCloneOf('sess-2', 'acme/infra'),
@@ -1161,9 +1170,10 @@ describe('secondary roots on the pod volume', () => {
     expect(cwd).toBe(sessionCloneOf('sess-review', 'acme/infra'))
     // The reviewed refs were fetched into the session's OWN clone of the secondary, not the shared checkout.
     const fetch = calls.find((call) => call.args[0] === 'fetch')
-    expect(fetch).toMatchObject({ cwd })
+    const staged = calls.find((call) => call.args[0] === 'clone' && call.args[2]?.startsWith(`${cwd}.clone-`))!.args[2]
+    expect(fetch).toMatchObject({ cwd: staged })
     expect(fetch!.args).toContain(`+refs/pull/9/head:refs/agentconnect/reviews/${id}/head`)
-    expect(calls.find((call) => call.args[0] === 'branch' && call.cwd === cwd)!.args.at(-1)).toBe(head)
+    expect(calls.find((call) => call.args[0] === 'branch' && call.cwd === staged)!.args.at(-1)).toBe(head)
     // The primary rides along at its default branch, and the attestation holds the cwd across a
     // restart — a later hand-out that carries no review resolves the same working directory.
     expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -146,7 +146,7 @@ function substitute(value: string): string {
 /** Real git through the workspace runner seam, with exactly one substitution: a fixture repository's authorized URL becomes its `file://` bare, and `file:` joins the protocol allowlist. */
 class SeamRunner implements GitRunner {
   constructor(
-    private readonly cwd: string | undefined,
+    readonly cwd: string | undefined,
     private readonly abort: AbortSignal | undefined,
     private readonly env: Record<string, string> = {}
   ) {}
@@ -371,6 +371,138 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     expect(existsSync(join(agent.workspace.path, 'app'))).toBe(false)
   })
 
+  it.each(['primary', 'acme/parent'])(
+    'includes an authorized root after its submodule is removed from %s upstream',
+    async (parent) => {
+      const agent = agentFixture({
+        additionalRepos: [
+          ...(parent === 'primary' ? [] : [{ repoFullName: parent, repoId: '41' }]),
+          { repoFullName: 'example-co/library', repoId: '42' }
+        ]
+      })
+      agent.workspace.pullOnNewSession = true
+      const served = serveAll(agent)
+      const seed = served[parent]!.seed
+      writeFileSync(
+        join(seed, '.gitmodules'),
+        '[submodule "library"]\n\tpath = vendor/library\n\turl = https://github.com/example-co/library.git\n'
+      )
+      git(seed, ['add', '.gitmodules'])
+      git(seed, ['commit', '-qm', 'declare library submodule'])
+      git(seed, ['push', '-q', 'origin', 'HEAD'])
+      await workspaces.prepareWorkspace(agent)
+      for (const root of [workspaces.primaryRoot(agent), ...workspaces.secondaryRoots(agent)]) {
+        if (existsSync(join(root.path, '.git'))) git(root.path, ['remote', 'set-url', 'origin', root.cloneUrl])
+      }
+      expect((await workspaces.readySecondaryRoots(agent)).map((root) => root.repoFullName)).not.toContain(
+        'example-co/library'
+      )
+      git(seed, ['rm', '-q', '.gitmodules'])
+      git(seed, ['commit', '-qm', 'remove library submodule'])
+      git(seed, ['push', '-q', 'origin', 'HEAD'])
+
+      const pulls = vi.spyOn(SeamRunner.prototype, 'pull')
+      await workspaces.prepareSessionWorkspace(agent, confined())
+
+      expect(pulls).not.toHaveBeenCalled()
+      const ready = await workspaces.readySecondaryRoots(agent, confined())
+      expect(ready.map((root) => root.repoFullName)).toContain('example-co/library')
+      expect(readFileSync(join(leafOf(agent), 'repos', 'example-co', 'library', 'README.md'), 'utf8')).toBe('seed\n')
+    }
+  )
+
+  it.each(['new', 'review', 'resume'] as const)(
+    'discovers a submodule in the %s session tree even when the shared tree has none',
+    async (mode) => {
+      const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
+      const { primary } = mode === 'review' ? serveAllThroughShim(agent) : serveAll(agent)
+      await workspaces.prepareWorkspace(agent)
+      const root = workspaces.secondaryRoots(agent)[0]!
+      git(root.path, ['remote', 'set-url', 'origin', root.cloneUrl])
+      const request = confined()
+      const path = mode === 'resume' ? await workspaces.prepareSessionWorkspace(agent, request) : primary!.seed
+      writeFileSync(join(path, '.gitmodules'), '[submodule "infra"]\n\turl = https://github.com/acme/infra.git\n')
+      if (mode === 'review') {
+        const revision = publishPullRequest(primary!.seed, 'with submodule\n')
+        request.review = { pullNumber: 7, baseSha: revision.base, headSha: revision.head }
+      } else if (mode === 'new') {
+        git(path, ['add', '-A'])
+        git(path, ['commit', '-qm', 'add submodule'])
+        git(path, ['push', '-q', 'origin', 'HEAD'])
+      }
+
+      const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+
+      expect(readFileSync(join(cwd, '.gitmodules'), 'utf8')).toContain('acme/infra')
+      expect(existsSync(join(agent.workspace.path, '.gitmodules'))).toBe(false)
+      expect(await workspaces.readySecondaryRoots(agent, request)).toEqual([])
+      // A resumed session keeps its existing clone; a new one never creates the duplicate.
+      expect(existsSync(join(leafOf(agent), 'repos', 'acme', 'infra', '.git'))).toBe(mode === 'resume')
+    }
+  )
+
+  it('does not exclude a submodule root when its parent checkout fails', async () => {
+    const agent = agentFixture({
+      additionalRepos: [
+        { repoFullName: 'acme/parent', repoId: '41' },
+        { repoFullName: 'example-co/library', repoId: '42' }
+      ]
+    })
+    const served = serveAll(agent)
+    const seed = served['acme/parent']!.seed
+    writeFileSync(join(seed, '.gitmodules'), '[submodule "lib"]\n\turl = https://github.com/example-co/library.git\n')
+    git(seed, ['add', '-A'])
+    git(seed, ['commit', '-qm', 'add submodule'])
+    git(seed, ['push', '-q', 'origin', 'HEAD'])
+    const run = SeamRunner.prototype.raw
+    vi.spyOn(SeamRunner.prototype, 'raw').mockImplementation(function (this: SeamRunner, args) {
+      if (args[0] === 'reset' && this.cwd?.includes('/repos/acme/parent.clone-')) {
+        return Promise.reject(new Error('parent checkout failed'))
+      }
+      return run.call(this, args)
+    })
+
+    await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect((await workspaces.readySecondaryRoots(agent, confined())).map((root) => root.repoFullName)).toEqual([
+      'example-co/library'
+    ])
+    expect(readFileSync(join(leafOf(agent), 'repos', 'example-co', 'library', 'README.md'), 'utf8')).toBe('seed\n')
+  })
+
+  it('uses a reviewed secondary tree and resumes that cwd in a fresh manager over a scratch workspace', async () => {
+    const agent = agentFixture({
+      mode: 'from-scratch',
+      additionalRepos: [
+        { repoFullName: 'example-co/review', repoId: '41' },
+        { repoFullName: 'acme/library', repoId: '42' }
+      ]
+    })
+    const served = serveAll(agent)
+    const seed = served['example-co/review']!.seed
+    writeFileSync(join(seed, '.gitmodules'), '[submodule "lib"]\n\turl = https://github.com/acme/library.git\n')
+    const revision = publishPullRequest(seed, 'review with submodule\n')
+    const request = confined({
+      isolation: 'shared',
+      reviewRepoFullName: 'example-co/review',
+      review: { pullNumber: 7, baseSha: revision.base, headSha: revision.head }
+    })
+    const cwd = await workspaces.prepareSessionWorkspace(agent, request)
+    expect(cwd).toBe(realpathSync(join(leafOf(agent), 'repos', 'example-co', 'review')))
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(revision.head)
+    expect(await workspaces.sessionAdditionalRoots(agent, request)).toEqual([])
+    expect(existsSync(join(leafOf(agent), 'repos', 'acme', 'library'))).toBe(false)
+    const root = workspaces.secondaryRoots(agent).find((root) => root.repoFullName === 'example-co/review')!
+    for (const path of [root.path, cwd]) git(path, ['remote', 'set-url', 'origin', root.cloneUrl])
+    const fresh = new WorkspaceManager()
+    fresh.setGitRunnerResolver((_agentId, path, abort) => new SeamRunner(path, abort))
+    const resumed = { sessionKey: KEY, isolation: 'shared' as const }
+
+    expect(await fresh.prepareSessionWorkspace(agent, resumed)).toBe(cwd)
+    expect(await fresh.sessionAdditionalRoots(agent, resumed)).toEqual([])
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(revision.head)
+  })
+
   it('pins the credential helper in a github-app clone and converges its origin on resume', async () => {
     const agent = agentFixture({ githubApp: true })
     serveAll(agent)
@@ -450,26 +582,21 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
       const started = Array.from({ length: 3 }, gate)
       const release = Array.from({ length: 3 }, gate)
       const primaryFinished = gate()
-      const clone = SeamRunner.prototype.clone
+      const run = SeamRunner.prototype.raw
       let active = 0
       let peak = 0
       const seen: number[] = []
-      const spy = vi.spyOn(SeamRunner.prototype, 'clone').mockImplementation(async function (
-        this: SeamRunner,
-        repo,
-        target,
-        options
-      ) {
-        if (!target.startsWith(leafOf(agent))) return await clone.call(this, repo, target, options)
-        const index = repo === PRIMARY_URL ? 0 : repo.includes('/lib-a') ? 1 : 2
+      const spy = vi.spyOn(SeamRunner.prototype, 'raw').mockImplementation(async function (this: SeamRunner, args) {
+        if (args[0] !== 'reset' || !this.cwd?.startsWith(leafOf(agent))) return await run.call(this, args)
+        const index = this.cwd.includes('/workspace.clone-') ? 0 : this.cwd.includes('/lib-a.clone-') ? 1 : 2
         seen.push(index)
         active += 1
         peak = Math.max(peak, active)
         started[index]!.resolve()
         try {
           await release[index]!.promise
-          if (index === 0 && failPrimary) throw new Error('primary clone unavailable')
-          await clone.call(this, repo, target, options)
+          if (index === 0 && failPrimary) throw new Error('primary checkout unavailable')
+          return await run.call(this, args)
         } finally {
           active -= 1
           if (index === 0) primaryFinished.resolve()
@@ -498,7 +625,7 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
         const result = await prepared
         if (failPrimary) {
           expect(result.error).toBeInstanceOf(Error)
-          expect((result.error as Error).message).toContain('primary clone unavailable')
+          expect((result.error as Error).message).toContain('primary checkout unavailable')
         } else {
           expect(result.error).toBeUndefined()
           expect(readFileSync(join(result.cwd!, 'README.md'), 'utf8')).toBe('seed\n')

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
 import type { Agent } from '../src/agents/agent-schema.js'
 import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
@@ -456,7 +456,7 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     git(seed, ['push', '-q', 'origin', 'HEAD'])
     const run = SeamRunner.prototype.raw
     vi.spyOn(SeamRunner.prototype, 'raw').mockImplementation(function (this: SeamRunner, args) {
-      if (args[0] === 'reset' && this.cwd?.includes('/repos/acme/parent.clone-')) {
+      if (args[0] === 'reset' && this.cwd && basename(this.cwd).startsWith('parent.clone-')) {
         return Promise.reject(new Error('parent checkout failed'))
       }
       return run.call(this, args)
@@ -588,7 +588,8 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
       const seen: number[] = []
       const spy = vi.spyOn(SeamRunner.prototype, 'raw').mockImplementation(async function (this: SeamRunner, args) {
         if (args[0] !== 'reset' || !this.cwd?.startsWith(leafOf(agent))) return await run.call(this, args)
-        const index = this.cwd.includes('/workspace.clone-') ? 0 : this.cwd.includes('/lib-a.clone-') ? 1 : 2
+        const directory = basename(this.cwd)
+        const index = directory.startsWith('workspace.clone-') ? 0 : directory.startsWith('lib-a.clone-') ? 1 : 2
         seen.push(index)
         active += 1
         peak = Math.max(peak, active)

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -53,6 +53,7 @@ const remotes = new Map<string, string>()
 
 afterAll(() => rmSync(join(SHIM, '..'), { recursive: true, force: true }))
 afterEach(() => {
+  vi.restoreAllMocks()
   gitRuns.length = 0
   workspaces.setGitRunnerResolver(undefined)
   workspaces.setFsResolver(undefined)
@@ -317,6 +318,59 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     expect(workspaces.sessionWorktreePath(agent, KEY)).toBe(join(leafOf(agent), 'workspace'))
   })
 
+  it.each(['shared', 'worktree', 'clone'] as const)(
+    'prepares skills once and refreshes shared roots only when needed by the %s tier',
+    async (tier) => {
+      const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
+      agent.workspace.pullOnNewSession = true
+      const served = serveAll(agent)
+      await workspaces.prepareWorkspace(agent)
+      const roots = [workspaces.primaryRoot(agent), ...workspaces.secondaryRoots(agent)]
+      for (const root of roots) git(root.path, ['remote', 'set-url', 'origin', root.cloneUrl])
+      for (const remote of Object.values(served)) {
+        writeFileSync(join(remote.seed, 'README.md'), 'updated\n')
+        git(remote.seed, ['commit', '-qam', 'update'])
+        git(remote.seed, ['push', '-q', 'origin', 'HEAD'])
+      }
+      const installSkills = vi.fn(async () => [] as string[])
+      const pulls = vi.spyOn(SeamRunner.prototype, 'pull')
+      const cwd = await workspaces.prepareSessionWorkspace(
+        agent,
+        { sessionKey: KEY, isolation: tier === 'shared' ? 'shared' : 'session', confined: tier === 'clone' },
+        { installSkills }
+      )
+
+      expect(installSkills.mock.calls).toEqual([[agent, cwd]])
+      expect(readFileSync(join(cwd, 'README.md'), 'utf8')).toBe('updated\n')
+      expect(pulls).toHaveBeenCalledTimes(tier === 'clone' ? 0 : 2)
+      for (const root of roots) {
+        expect(readFileSync(join(root.path, 'README.md'), 'utf8')).toBe(tier === 'clone' ? 'seed\n' : 'updated\n')
+      }
+      if (tier === 'clone') {
+        expect(readFileSync(join(leafOf(agent), 'repos', 'acme', 'infra', 'README.md'), 'utf8')).toBe('updated\n')
+      }
+    }
+  )
+
+  it('resolves agentDir against the new session clone when the shared checkout predates it', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAll(agent)
+    await workspaces.prepareWorkspace(agent)
+    mkdirSync(join(primary!.seed, 'app'))
+    writeFileSync(join(primary!.seed, 'app', 'README.md'), 'new directory\n')
+    git(primary!.seed, ['add', '-A'])
+    git(primary!.seed, ['commit', '-qm', 'add app'])
+    git(primary!.seed, ['push', '-q', 'origin', 'HEAD'])
+    agent.workspace.agentDir = 'app'
+    agent.workspace.pullOnNewSession = true
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(cwd).toBe(realpathSync(join(leafOf(agent), 'workspace', 'app')))
+    expect(readFileSync(join(cwd, 'README.md'), 'utf8')).toBe('new directory\n')
+    expect(existsSync(join(agent.workspace.path, 'app'))).toBe(false)
+  })
+
   it('pins the credential helper in a github-app clone and converges its origin on resume', async () => {
     const agent = agentFixture({ githubApp: true })
     serveAll(agent)
@@ -363,9 +417,11 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     })
     serveAll(agent)
 
-    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    const installSkills = vi.fn(async () => [] as string[])
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined(), { installSkills })
 
     expect(cwd).toBe(agent.workspace.path)
+    expect(installSkills.mock.calls).toEqual([[agent, cwd]])
     const infra = join(leafOf(agent), 'repos', 'acme', 'infra')
     expect(statSync(join(infra, '.git')).isDirectory()).toBe(true)
     expect(existsSync(join(leafOf(agent), 'workspace'))).toBe(false)
@@ -465,11 +521,14 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     const { primary } = serveAll(agent)
     const first = publishPullRequest(primary!.seed, 'pr\n')
 
+    const installSkills = vi.fn(async () => [] as string[])
     const cwd = await workspaces.prepareSessionWorkspace(
       agent,
-      confined({ review: { pullNumber: 7, baseSha: first.base, headSha: first.head } })
+      confined({ review: { pullNumber: 7, baseSha: first.base, headSha: first.head } }),
+      { installSkills }
     )
 
+    expect(installSkills.mock.calls).toEqual([[agent, cwd]])
     const headRef = `refs/agentconnect/reviews/${idOf()}/head`
     expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(first.head)
     expect(git(cwd, ['rev-parse', headRef])).toBe(first.head)
@@ -533,6 +592,38 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     expect(existsSync(join(workspaces.agentRootFor(agent), 'worktrees'))).toBe(false)
     expect(existsSync(join(leafOf(agent), 'workspace'))).toBe(false)
     expect(workspaces.confinedSessionDir(agent, KEY)).toBeUndefined()
+  })
+
+  it('publishes a new clone only after its single checkout succeeds, and retries a failed checkout', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const run = SeamRunner.prototype.raw
+    let fail = true
+    let resets = 0
+    vi.spyOn(SeamRunner.prototype, 'raw').mockImplementation(function (this: SeamRunner, args) {
+      if (args[0] === 'reset') {
+        resets++
+        const cloned = gitRuns.find(({ args }) => args[0] === 'clone' && args.includes('--no-checkout'))!
+        expect(cloned).toBeDefined()
+        const staged = cloned.args[2]!
+        expect(existsSync(join(staged, '.git'))).toBe(true)
+        expect(existsSync(join(staged, 'README.md'))).toBe(false)
+        expect(existsSync(join(leafOf(agent), 'workspace'))).toBe(false)
+        if (fail) return Promise.reject(new Error('checkout interrupted'))
+      }
+      return run.call(this, args)
+    })
+
+    await expect(workspaces.prepareSessionWorkspace(agent, confined())).rejects.toThrow('checkout interrupted')
+    expect(existsSync(leafOf(agent))).toBe(false)
+    fail = false
+    gitRuns.length = 0
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(resets).toBe(2)
+    expect(readFileSync(join(cwd, 'README.md'), 'utf8')).toBe('seed\n')
+    expect(git(cwd, ['status', '--porcelain'])).toBe('')
+    expect(readdirSync(leafOf(agent))).toEqual(['workspace'])
   })
 
   it('resolves the console session root, and a repo-scoped one, to the clone', async () => {


### PR DESCRIPTION
Confined session startup pulled shared checkouts and reconciled skills there before preparing the session's own clones. Skip those shared pulls and reconcile skills only in the final working directory. Keep shared checkout initialization, repository identity checks and Console reads; shared sessions and unconfined worktrees still honor `pullOnNewSession`.

Determine submodule exclusions from the session's actual tree: the selected revision for a new clone or review, and the retained working directory on ordinary resume. Discover the working-directory root first, then the remaining roots in order, while overlapping checkout with the next preparation and keeping at most two repositories active. Omit a standalone root only after its parent succeeds, so a stale shared tree or failed reference cannot hide an authorized repository. Local sandboxes and Kubernetes use the same preparation path and existing shim commands.

Clone new session repositories with `--no-checkout`, then materialize only the final generated branch or verified review revision. Keep the clone staged until checkout and revision verification succeed, cleaning failed attempts so resume cannot accept an empty checkout. Resolve `agentDir` in the actual session checkout. Existing ordinary sessions keep their branch and untracked files.

Validation: 281 tests passed across seven workspace, Git and microsandbox suites. After refining reviewed-root ordering, all 96 tests in the two affected suites passed again. Daemon typecheck, ESLint and formatting passed. Real-Git coverage includes removed and newly declared submodules, exact review trees through the shim, ordinary resume, reviewed scratch-workspace resume, parent checkout failure, checkout retry and bounded concurrency. Live startup timing remains to be measured after deployment.

Created by Codex . GPT-6
