### PR TITLE
fix(daemon): refresh retained microsandbox VMs

### DIFF
--- a/docs/designs/daemon-sandbox-backends.md
+++ b/docs/designs/daemon-sandbox-backends.md
@@ -162,7 +162,10 @@ defaults. The local `chat` command uses them when running with SRT.
 
 Restart the daemon after editing `config.json`. A retained microsandbox session
 uses the updated environment when its runtime restarts; changing only
-`sandbox.env` does not require discarding its VM or disks.
+`sandbox.env` does not require replacing its VM. Changes to mounts, VM resources,
+credential scope, or image content replace the VM while retaining its host-mounted
+workspace, HOME, and memory. The VM root disk and its Docker and Overlay write
+volumes are disposable across replacement; put durable files in host mounts.
 
 ### Shared bases with session-local writes
 
@@ -773,8 +776,9 @@ to verify the final images and exercise a real ACP session through the shim.
 An explicit daemon image overrides this metadata. Development builds remove
 release metadata and require an explicit image; they do not derive a default
 from the development package version. Release defaults and explicit image
-overrides select the image for newly created VMs. Retained VMs continue using
-their recorded image.
+overrides select the image for newly created VMs. Retained environments compare
+the recorded platform manifest identity with the configured image: another tag
+for the same digest reuses the VM, while changed content replaces it on refresh.
 
 The full image contains `bubblewrap` and `socat` for native credential shields;
 bubblewrap supports `--argv0` so Codex can start while its state directory is
@@ -862,9 +866,19 @@ added for them.
 - Before admitting new VM launches, daemon restart stops recorded owned VMs that
   are still running. It retains their disks and replaces the socket bridge and ACP
   processes on the next start; it does not adopt the old running processes.
-- Existing bindings may retain the retired helper's exact read-only mount. Its
-  file remains an inert mount source; new VMs do not mount it. VM identity and the
-  full persisted configuration hash still have to match.
+- Agent installation starts a background workspace prefetch that refreshes changed
+  agent-level VMs without awaiting all agents before daemon readiness. Unchanged
+  VMs remain asleep; session-owned VMs refresh on their next use. Workspace preparation
+  for that agent joins the same queue. Activation and refresh prepare mounts without
+  starting ACP; initialization and session loading happen at the actual runtime wake.
+- A replacement stops the old VM, creates a fresh candidate with the desired
+  mounts, verifies mount presence and permissions, and atomically commits its binding.
+  Only then are the old VM and its owned disks removed. A failed candidate preserves
+  the old binding and reports failure rather than silently using obsolete settings.
+  Durable candidate and retirement records permit cleanup after an interrupted swap.
+- VM identity and the full persisted configuration hash must still match their
+  binding before refresh. An externally altered VM is refused, not automatically
+  adopted or erased. Host-mounted files are never copied or deleted by VM replacement.
 - Retirement uses existing dirty/unpushed-work protection before deleting a
   session's retained storage. VM removal deletes its private disk and binding;
   operator-owned host mount contents are not deleted by VM removal.

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -692,9 +692,13 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
       if (requiresRuntime || host.servesAgent(agentId)) {
         try {
           if (!host.servesAgent(agentId)) throw new Error('execution duty was revoked during activation')
-          // Key-server mode gives every session its own credential-scoped host, so there is no
-          // shared agent host to prove — reconciling the workspace is the whole of the proof.
-          if (host.keyServer()) await host.prepareAgentWorkspace(agent, undefined, undefined, true)
+          // VM activation prepares the workspace; ACP initialization belongs to the first wake.
+          if (
+            host.keyServer() ||
+            (host.cfg().sandbox.backend === 'microsandbox' &&
+              (host.cfg().security.requireSandbox || agent.runInSandbox))
+          )
+            await host.prepareAgentWorkspace(agent, undefined, undefined, true)
           else await host.ensureHostAsync(agentId, { allowAgentDrain: true })
         } catch (err) {
           host.moveStagedAgents().add(agentId)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3738,13 +3738,7 @@ export class Daemon {
     this.memoryHomeMigrations.reconcile()
   }
 
-  /**
-   * Fire-and-forget eager clone of a git-repo workspace so the checkout is warm
-   * before the first message. Deliberately NOT awaited: reconcile must not block on
-   * the network (design §4.3), and `prepareWorkspace` is the authoritative clone
-   * (awaited + hard-fail) at session start — so a prefetch failure here is only
-   * logged and harmlessly retried then. No-op for from-scratch / already-cloned.
-   */
+  // Prefetch checkouts and refresh retained VMs without blocking reconcile; session preparation retries failures.
   private prefetchClone(agent: LoadedAgent): void {
     if (this.preparingWorkspaces.has(agent.id)) return
     if (this.draining || this.drainingAgents.has(agent.id) || this.safetyDrainingAgents.has(agent.id)) return
@@ -4290,6 +4284,11 @@ export class Daemon {
       )
     }
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
+    if (!request && this.microsandbox && this.usesMicrosandbox(agent)) {
+      const loaded = this.agents.get(agent.id)
+      if (loaded)
+        await this.microsandbox.prepareEnvironment(this.microsandboxContext(loaded, agent.workspace.path).environment)
+    }
     const opts = {
       ...(this.usesMicrosandbox(agent)
         ? { installSkills: (value: Agent, cwd: string) => this.reconcileMicrosandboxSkills(value, cwd) }
@@ -4579,11 +4578,15 @@ export class Daemon {
     })
   }
 
-  private runAgentWorkspacePrefetch(agent: Agent): Promise<void> {
-    // A cluster workspace materializes on the pod's volume at session time; a local prefetch
-    // would clone the repository onto this daemon's own disk instead.
-    if (this.k8sPlane) return Promise.resolve()
-    return this.workspaces.prefetchWorkspace(agent)
+  private async runAgentWorkspacePrefetch(agent: Agent): Promise<void> {
+    // Cluster workspaces materialize on the pod's volume at session time.
+    if (this.k8sPlane) return
+    await this.workspaces.prefetchWorkspace(agent)
+    if (this.microsandbox && this.usesMicrosandbox(agent)) {
+      const loaded = this.agents.get(agent.id)
+      if (loaded)
+        await this.microsandbox.refreshEnvironment(this.microsandboxContext(loaded, agent.workspace.path).environment)
+    }
   }
 
   private workspacePreparationAuthority(agent: Agent): string {

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
-import { mkdir, readFile, readdir, readlink, realpath, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, readlink, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, posix } from 'node:path'
 import { promisify } from 'node:util'
 import type { Sandbox, SandboxHandle } from 'microsandbox'
@@ -9,7 +9,6 @@ import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-dri
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
 import { formatErr } from '../daemon/text.js'
-import { gitcredShimPath } from '../cp/gitcred-server.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import { canonicalPath, contains } from '../runtimes/read-roots.js'
 import { SinkRelPathSchema } from '../shim/file-sink.js'
@@ -29,6 +28,7 @@ import {
 
 const runFile = promisify(execFile)
 const STOP_TIMEOUT_MS = 10_000
+const REPLACEMENT_LABEL = 'io.agentconnect.vm-replacement'
 const RUNTIME_TABLE_PATH = '/opt/agentconnect/runtime/k8s-runtimes.json'
 const IMAGE_PROBE_SCRIPT = `
 const { existsSync, readFileSync } = require('node:fs');
@@ -38,6 +38,20 @@ const table = JSON.parse(readFileSync(process.argv[1], 'utf8'));
 const bridge = process.argv[2];
 if (existsSync(bridge)) table.mcpBridge = { command: process.execPath, args: [bridge] };
 process.stdout.write(JSON.stringify(table));
+`
+
+const MOUNT_PROBE_SCRIPT = String.raw`
+const fs = require('node:fs');
+const unescape = value => value.replace(/\\([0-7]{3})/g, (_, octal) => String.fromCharCode(parseInt(octal, 8)));
+const mounted = new Map(fs.readFileSync('/proc/self/mountinfo', 'utf8').trim().split('\n').map(line => {
+  const fields = line.split(' ');
+  return [unescape(fields[4]), fields[5].split(',')];
+}));
+for (const mount of JSON.parse(process.argv[1])) {
+  fs.statSync(mount.target);
+  const flags = mounted.get(mount.target);
+  if (!flags || flags.includes('ro') !== (mount.mode === 'readonly')) throw new Error('workspace mount verification failed: ' + mount.target);
+}
 `
 
 export interface MicrosandboxEnvironment {
@@ -93,14 +107,21 @@ interface EnvironmentState {
   shim?: Promise<MicrosandboxShim>
 }
 
-interface Binding {
-  version: 1
-  spec: string
+interface OwnedSandbox {
+  sandboxName?: string
   sandboxId: string
   configHash: string
-  environmentId: string
   dockerVolume?: string
   overlayVolume?: string
+}
+
+interface Binding extends OwnedSandbox {
+  version: 1
+  spec: string
+  environmentId: string
+  imageIdentity?: string
+  replacement?: string
+  retired?: OwnedSandbox[]
 }
 
 export interface LockHolder {
@@ -117,6 +138,7 @@ export class MicrosandboxManager {
   private preparation?: Promise<K8sRuntimeTable>
   private closed = false
   private startGate: Promise<void> = Promise.resolve()
+  private readonly imageIdentities = new Map<string, Promise<string | undefined>>()
 
   constructor(private readonly options: MicrosandboxManagerOptions) {}
 
@@ -138,6 +160,32 @@ export class MicrosandboxManager {
 
   driverFor(environment: MicrosandboxEnvironment): SpawnDriver {
     return { launch: (request) => this.launch(environment, request) }
+  }
+
+  // Warm only the VM and mounts; ACP starts when a caller launches a runtime.
+  async prepareEnvironment(environment: MicrosandboxEnvironment): Promise<void> {
+    const { state, release } = this.acquire(environment)
+    let ready!: () => void
+    const pending = new Promise<void>((resolve) => {
+      ready = resolve
+    })
+    state.pending.add(pending)
+    try {
+      await state.sandbox
+    } finally {
+      state.pending.delete(pending)
+      release()
+      ready()
+    }
+  }
+
+  // Agent activation refreshes retained VMs in the background without waking unchanged ones.
+  async refreshEnvironment(environment: MicrosandboxEnvironment): Promise<void> {
+    const binding = await this.readBinding(environment.id)
+    if (!binding) return
+    const desired = await this.desiredSpec(environment, binding)
+    if (binding.spec === desired.spec && desired.sameImage && !binding.replacement && !binding.retired?.length) return
+    await this.prepareEnvironment(environment)
   }
 
   async withShim<T>(environment: MicrosandboxEnvironment, work: (shim: MicrosandboxShim) => Promise<T>): Promise<T> {
@@ -285,6 +333,37 @@ export class MicrosandboxManager {
     return join(this.options.root, 'microsandbox', 'bindings', `${this.name(id)}.json`)
   }
 
+  private sandboxName(id: string, binding?: OwnedSandbox): string {
+    return binding?.sandboxName ?? this.name(id)
+  }
+
+  private imageIdentity(reference: string): Promise<string | undefined> {
+    let identity = this.imageIdentities.get(reference)
+    if (!identity) {
+      identity = this.options.sdk.Image.get(reference).then(
+        (image) =>
+          image.manifestDigest && image.os && image.architecture
+            ? `${image.os}/${image.architecture}@${image.manifestDigest}`
+            : undefined,
+        () => undefined
+      )
+      this.imageIdentities.set(reference, identity)
+    }
+    return identity
+  }
+
+  private async desiredSpec(environment: MicrosandboxEnvironment, binding?: Binding) {
+    const imageIdentity = await this.imageIdentity(this.options.config.image)
+    if (!imageIdentity) throw new Error('microsandbox configured image has no cached platform manifest identity')
+    const previousImage = binding ? SpecImageSchema.parse(JSON.parse(binding.spec)).config.image : undefined
+    const sameImage = imageIdentity === binding?.imageIdentity
+    return {
+      spec: this.spec(environment, sameImage ? previousImage! : this.options.config.image),
+      imageIdentity,
+      sameImage
+    }
+  }
+
   private spec(environment: MicrosandboxEnvironment, image = this.options.config.image): string {
     return stableJson({
       version: 2,
@@ -357,15 +436,25 @@ export class MicrosandboxManager {
     await mkdir(bindings, { recursive: true, mode: 0o700 })
     const keep = new Set([this.options.config.image])
     for (const id of await this.persistedIds()) {
-      const binding = await this.readBinding(id)
-      // A retained VM boots from the image it was created with, so that image is not garbage.
-      if (binding) keep.add(SpecImageSchema.parse(JSON.parse(binding.spec)).config.image)
-      const handle = await this.find(this.name(id))
-      if (handle) {
-        if (handle.id !== binding?.sandboxId) throw new Error('microsandbox persisted environment identity changed')
-        if (handle.status === 'running' || handle.status === 'starting' || handle.status === 'draining') {
-          await handle.stopWithTimeout(STOP_TIMEOUT_MS)
+      try {
+        const binding = await this.readBinding(id)
+        if (binding) keep.add(SpecImageSchema.parse(JSON.parse(binding.spec)).config.image)
+        const handle = await this.find(this.sandboxName(id, binding))
+        if (handle) {
+          if (handle.id !== binding?.sandboxId) throw new Error('microsandbox persisted environment identity changed')
+          if (handle.status === 'running' || handle.status === 'starting' || handle.status === 'draining') {
+            await handle.stopWithTimeout(STOP_TIMEOUT_MS)
+          }
         }
+        if (binding) {
+          // Capture legacy cache identity before pulling a tag that could have moved.
+          if (!binding.imageIdentity) {
+            const imageIdentity = await this.imageIdentity(SpecImageSchema.parse(JSON.parse(binding.spec)).config.image)
+            if (imageIdentity) await this.writeBinding({ ...binding, imageIdentity })
+          }
+        }
+      } catch (error) {
+        this.options.log?.warn(`microsandbox: environment ${id} is unavailable — ${formatErr(error)}`)
       }
     }
     const name = this.name('probe')
@@ -373,6 +462,7 @@ export class MicrosandboxManager {
     // Free the retired releases before the pull, so a tight disk is not asked to hold both.
     await this.collectImages(keep)
     await this.prepareImage()
+    this.imageIdentities.delete(this.options.config.image)
     let sandbox = await this.serializeStart(() => this.builder(name, []).create())
     try {
       const output = await sandbox.exec(MICROSANDBOX_NODE, [
@@ -541,7 +631,9 @@ export class MicrosandboxManager {
   private async releaseIdleHolder(volume: string, holder?: LockHolder): Promise<boolean> {
     if (!holder?.sandbox) return false
     let id: string | undefined
-    for (const candidate of await this.environmentIds()) if (this.name(candidate) === holder.sandbox) id = candidate
+    for (const candidate of await this.environmentIds()) {
+      if (this.sandboxName(candidate, await this.readBinding(candidate)) === holder.sandbox) id = candidate
+    }
     // A sandbox this daemon has no binding for can be running work no counter here can see.
     if (id === undefined) return false
     const state = this.environments.get(id)
@@ -561,14 +653,24 @@ export class MicrosandboxManager {
       const value: unknown = JSON.parse(await readFile(this.bindingPath(id), 'utf8'))
       if (!value || typeof value !== 'object') throw new Error('invalid binding')
       const binding = value as Partial<Binding>
+      const validOwned = (owned: OwnedSandbox): boolean => {
+        const name = this.sandboxName(id, owned)
+        return (
+          (name === this.name(id) || new RegExp(`^${this.name(id)}-[a-f0-9]{32}$`).test(name)) &&
+          typeof owned.sandboxId === 'string' &&
+          typeof owned.configHash === 'string' &&
+          (owned.dockerVolume === undefined || owned.dockerVolume === `${name}-docker`) &&
+          (owned.overlayVolume === undefined || owned.overlayVolume === `${name}-overlays`)
+        )
+      }
       if (
         binding.version !== 1 ||
         binding.environmentId !== id ||
         typeof binding.spec !== 'string' ||
-        typeof binding.sandboxId !== 'string' ||
-        typeof binding.configHash !== 'string' ||
-        (binding.dockerVolume !== undefined && binding.dockerVolume !== `${this.name(id)}-docker`) ||
-        (binding.overlayVolume !== undefined && binding.overlayVolume !== `${this.name(id)}-overlays`)
+        !validOwned(binding as Binding) ||
+        (binding.imageIdentity !== undefined && typeof binding.imageIdentity !== 'string') ||
+        (binding.replacement !== undefined && !/^[a-f0-9]{32}$/.test(binding.replacement)) ||
+        (binding.retired !== undefined && (!Array.isArray(binding.retired) || !binding.retired.every(validOwned)))
       ) {
         throw new Error('invalid binding')
       }
@@ -586,62 +688,30 @@ export class MicrosandboxManager {
       if (contains(source, stateRoot) || contains(stateRoot, source))
         throw new Error('microsandbox mounts cannot expose host sandbox state')
     }
-    const name = this.name(environment.id)
-    const binding = await this.readBinding(environment.id)
-    // Image changes apply to new environments; retained disks keep their original image.
-    const image = binding ? SpecImageSchema.parse(JSON.parse(binding.spec)).config.image : this.options.config.image
-    const spec = this.spec(environment, image)
+    let binding = await this.readBinding(environment.id)
+    if (binding) {
+      await this.cleanReplacement(binding)
+      binding = await this.cleanRetired(binding)
+    }
+    const name = this.sandboxName(environment.id, binding)
+    const { spec, imageIdentity: targetIdentity, sameImage } = await this.desiredSpec(environment, binding)
     const existing = await this.find(name)
     if (binding || existing) {
-      let matchingSpec = binding?.spec === spec
-      if (binding && !matchingSpec) {
-        const helper = canonicalPath(
-          join(this.options.root, 'run', 'microsandbox-helpers', 'git-credential'),
-          process.env
-        )
-        const legacyMounts = environment.mounts.map((mount) =>
-          mount.source === helper && mount.target === gitcredShimPath(this.options.root) && mount.mode === 'readonly'
-            ? {
-                ...mount,
-                source: canonicalPath(join(this.options.root, 'microsandbox', 'helpers', 'git-credential'), process.env)
-              }
-            : mount
-        )
-        // Retained VMs may still own the old exact read-only helper mount; new mounts use the public support directory.
-        matchingSpec = binding.spec === this.spec({ ...environment, mounts: legacyMounts }, image)
-        const source = await realpath(join(this.options.root, 'microsandbox', 'helpers', 'guest.js')).catch(
-          (error: NodeJS.ErrnoException) => {
-            if (error.code === 'ENOENT') return undefined
-            throw error
-          }
-        )
-        // Retain an older VM's disk when only the retired, read-only guest helper mount differs.
-        if (source && !matchingSpec) {
-          matchingSpec =
-            binding.spec ===
-            this.spec(
-              {
-                ...environment,
-                mounts: [...legacyMounts, { source, target: '/opt/agentconnect-local/guest.js', mode: 'readonly' }]
-              },
-              image
-            )
-        }
-      }
+      const matchingSpec = binding?.spec === spec
       if (
         !binding ||
         !existing ||
-        !matchingSpec ||
         binding.sandboxId !== existing.id ||
         binding.configHash !== hash(stableJson(existing.config()))
       ) {
         throw new Error(
-          `microsandbox environment ${environment.id} has missing or changed persisted configuration. Restore the previous configuration and runtime credentials, or start a new session. Existing session data has been retained.`
+          `microsandbox environment ${environment.id} has missing or changed persisted configuration. Restore its recorded VM identity and configuration before retrying. Existing session data has been retained.`
         )
       }
       if (existing.status === 'running' || existing.status === 'starting' || existing.status === 'draining') {
         await existing.stopWithTimeout(STOP_TIMEOUT_MS)
       }
+      if (!matchingSpec || !sameImage) return this.replace(environment, binding, targetIdentity)
       if (environment.secrets?.length) {
         const result = await existing.modify({
           secrets: Object.fromEntries(environment.secrets.map((secret) => [secret.env, { value: secret.readValue() }])),
@@ -680,6 +750,7 @@ export class MicrosandboxManager {
         spec,
         sandboxId: persisted.id,
         configHash: hash(stableJson(persisted.config())),
+        imageIdentity: targetIdentity,
         dockerVolume: `${name}-docker`,
         ...(overlayMounts(environment.mounts).length ? { overlayVolume: `${name}-overlays` } : {})
       }
@@ -695,6 +766,110 @@ export class MicrosandboxManager {
       await rm(this.bindingPath(environment.id), { force: true })
       throw error
     }
+  }
+
+  private async destroyOwned(id: string, owned: OwnedSandbox): Promise<void> {
+    const handle = await this.find(this.sandboxName(id, owned))
+    if (handle) {
+      if (handle.id !== owned.sandboxId || hash(stableJson(handle.config())) !== owned.configHash)
+        throw new Error('microsandbox retired environment identity changed')
+      await handle.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+    }
+    for (const volume of [owned.dockerVolume, owned.overlayVolume]) if (volume) await this.removeVolume(volume)
+  }
+
+  private async cleanRetired(binding: Binding): Promise<Binding> {
+    if (!binding.retired?.length) return binding
+    try {
+      for (const owned of binding.retired) await this.destroyOwned(binding.environmentId, owned)
+      delete binding.retired
+      await this.writeBinding(binding)
+    } catch (error) {
+      this.options.log?.warn(`microsandbox: retired VM cleanup will retry — ${formatErr(error)}`)
+    }
+    return binding
+  }
+
+  private async cleanReplacement(binding: Binding): Promise<void> {
+    if (!binding.replacement) return
+    const name = `${this.name(binding.environmentId)}-${binding.replacement}`
+    const handle = await this.find(name)
+    if (handle) {
+      const { labels } = z.object({ labels: z.record(z.string(), z.string()) }).parse(handle.config())
+      if (labels[REPLACEMENT_LABEL] !== binding.replacement)
+        throw new Error('microsandbox replacement environment identity changed')
+      await handle.destroy({ timeoutMs: STOP_TIMEOUT_MS })
+    }
+    await this.removeVolume(`${name}-docker`)
+    await this.removeVolume(`${name}-overlays`)
+    delete binding.replacement
+    await this.writeBinding(binding)
+  }
+
+  private async replace(
+    environment: MicrosandboxEnvironment,
+    binding: Binding,
+    imageIdentity: string
+  ): Promise<Sandbox> {
+    const token = randomUUID().replaceAll('-', '')
+    const name = `${this.name(environment.id)}-${token}`
+    binding.replacement = token
+    await this.writeBinding(binding)
+    this.options.log?.info(`microsandbox: replacing environment ${environment.id}; host workspace mounts are retained`)
+    let sandbox: Sandbox | undefined
+    let next: Binding
+    try {
+      sandbox = await this.startVm(environment.id, () =>
+        this.builder(name, environment.mounts, environment.secrets)
+          .label(REPLACEMENT_LABEL, token)
+          .vsock(this.options.sockets.mcp, 5000)
+          .vsock(this.options.sockets.gitcred, 5001)
+          .create()
+      )
+      await prepareOverlayMounts(sandbox, environment.mounts)
+      const checked = await sandbox.exec(MICROSANDBOX_NODE, [
+        '-e',
+        MOUNT_PROBE_SCRIPT,
+        JSON.stringify(environment.mounts)
+      ])
+      if (!checked.success) throw new Error(`microsandbox replacement mount check failed: ${checked.stderr().trim()}`)
+      await this.startBridge(environment.id, sandbox)
+      const persisted = await this.options.sdk.Sandbox.get(name)
+      const old: OwnedSandbox = {
+        sandboxName: binding.sandboxName,
+        sandboxId: binding.sandboxId,
+        configHash: binding.configHash,
+        dockerVolume: binding.dockerVolume,
+        overlayVolume: binding.overlayVolume
+      }
+      next = {
+        version: 1,
+        environmentId: environment.id,
+        sandboxName: name,
+        sandboxId: persisted.id,
+        configHash: hash(stableJson(persisted.config())),
+        spec: this.spec(environment),
+        imageIdentity,
+        dockerVolume: `${name}-docker`,
+        ...(overlayMounts(environment.mounts).length ? { overlayVolume: `${name}-overlays` } : {}),
+        retired: [...(binding.retired ?? []), old]
+      }
+      await this.writeBinding(next)
+    } catch (error) {
+      const bridge = this.bridges.get(environment.id)
+      this.bridges.delete(environment.id)
+      await bridge?.stop(STOP_TIMEOUT_MS).catch(() => {})
+      await sandbox?.stopWithTimeout(STOP_TIMEOUT_MS).catch(() => {})
+      await sandbox?.detach().catch(() => {})
+      await this.cleanReplacement(binding).catch((cleanup: unknown) =>
+        this.options.log?.warn(`microsandbox: replacement cleanup will retry — ${formatErr(cleanup)}`)
+      )
+      throw error
+    }
+    // The new binding is durable before the old VM or its disposable disks are removed.
+    await this.cleanRetired(next)
+    this.options.log?.info(`microsandbox: environment ${environment.id} updated; ACP remains on demand`)
+    return sandbox
   }
 
   private async writeBinding(binding: Binding): Promise<void> {
@@ -777,13 +952,18 @@ export class MicrosandboxManager {
       throw new Error(`microsandbox environment ${environment.id} transport failed; stopping before retry`)
     }
     const spec = this.spec(environment)
-    if (state && state.spec !== spec)
-      throw new Error(`microsandbox environment ${environment.id} configuration changed while active`)
+    let stopping: Promise<void> | undefined
+    if (state && state.spec !== spec) {
+      if (state.active || state.pending.size || state.processes.size)
+        throw new Error(`microsandbox environment ${environment.id} configuration changed while active`)
+      stopping = this.closeEnvironment(environment.id, false)
+      state = undefined
+    }
     if (!state) {
       state = {
         environment,
         spec,
-        sandbox: this.open(environment),
+        sandbox: stopping ? stopping.then(() => this.open(environment)) : this.open(environment),
         active: 0,
         processes: new Set(),
         pending: new Set(),
@@ -922,7 +1102,8 @@ export class MicrosandboxManager {
             (shim) => shim.stop(),
             () => {}
           )
-        const handle = await this.find(this.name(id))
+        if (binding) await this.cleanReplacement(binding)
+        const handle = await this.find(this.sandboxName(id, binding))
         if (handle) {
           if (!binding || handle.id !== binding.sandboxId)
             throw new Error(`microsandbox environment ${id} identity changed`)
@@ -935,8 +1116,9 @@ export class MicrosandboxManager {
           else await handle.stopWithTimeout(STOP_TIMEOUT_MS)
         }
         if (state) await (await state.sandbox).detach()
-        this.environments.delete(id)
+        if (this.environments.get(id) === state) this.environments.delete(id)
         if (remove) {
+          for (const owned of binding?.retired ?? []) await this.destroyOwned(id, owned)
           for (const volume of [binding?.dockerVolume, binding?.overlayVolume]) {
             if (volume) await this.removeVolume(volume)
           }

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -115,6 +115,63 @@ const DUTY_BUNDLE = {
 }
 
 describe('Daemon CP agent → memory + reconcile', () => {
+  it('activates a sandboxed agent after workspace preparation without starting ACP', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+    await seam(daemon).applyAgentDetach({ agentId: 'bot-a', moveId: MOVE_ID })
+    ;(daemon as any).cfg.sandbox.backend = 'microsandbox'
+    const preparation = vi
+      .spyOn(daemon as any, 'runAgentWorkspacePreparation')
+      .mockResolvedValue(join(root, 'agents', 'bot-a', 'ws'))
+    await expect(
+      seam(daemon).applyAgentActivate({
+        agentId: 'bot-a',
+        moveId: MOVE_ID,
+        spec: { name: 'bot-a', runtime: 'claude', runInSandbox: true },
+        integrations: [],
+        crons: []
+      })
+    ).resolves.toEqual({ ok: true })
+    expect(preparation).toHaveBeenCalled()
+    expect(hosts).toHaveLength(0)
+    expect((daemon as any).agents.has('bot-a')).toBe(true)
+    expect((daemon as any).drainingAgents.has('bot-a')).toBe(false)
+    await daemon.stop()
+  })
+
+  it('refreshes retained VMs in background prefetch and gates only their workspace preparation', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    writeAgent(root, 'bot-b')
+    const { daemon, hosts } = makeDaemon(root)
+    await daemon.start()
+    const entered = signal()
+    const release = signal()
+    const refreshing = vi.fn(async () => {
+      entered.resolve()
+      await release.promise
+    })
+    ;(daemon as any).microsandbox = {
+      refreshEnvironment: refreshing,
+      stopAll: vi.fn(async () => {}),
+      suspendIdle: vi.fn(async () => {})
+    }
+    vi.spyOn(daemon as any, 'usesMicrosandbox').mockReturnValue(true)
+    vi.spyOn(daemon as any, 'microsandboxContext').mockReturnValue({ environment: { id: 'bot-a/agent' } })
+    const agent = (daemon as any).agents.get('bot-a')
+    ;(daemon as any).prefetchClone(agent)
+    await entered.promise
+    await daemon.reconcile()
+    expect((daemon as any).workspacePreparationTails.has('bot-a')).toBe(true)
+    expect((daemon as any).workspacePreparationTails.has('bot-b')).toBe(false)
+    expect(hosts).toHaveLength(0)
+    release.resolve()
+    await (daemon as any).waitForWorkspacePreparations('bot-a')
+    await daemon.stop()
+  })
+
   it('keeps a corrupt move tombstone fail-closed without poisoning reconnect registration', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -434,6 +434,9 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
       await (daemon as any).stopHost('bot-a')
       const environments = ['bot-a/agent']
       const manager = useMicrosandbox(daemon, environments)
+      vi.spyOn(daemon as any, 'microsandboxContext').mockReturnValue({
+        environment: { id: 'bot-a/agent', mounts: [], workspaceRoot: '/workspace' }
+      })
       await (daemon as any).hydrateMicrosandboxSessions()
       await (daemon as any).dispatch('bot-a', dm('300', 'resume', 'T1'), 'int-a')
       expect((daemon as any).hosts.get(agentHostKey('bot-a'))).toBe(hosts[1])

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -108,6 +108,8 @@ function makeRoutable(daemon: Daemon): void {
 function useMicrosandbox(daemon: Daemon, environments: string[] = []) {
   const manager = {
     driverFor: vi.fn(() => ({})),
+    prepareEnvironment: vi.fn(async () => {}),
+    refreshEnvironment: vi.fn(async () => {}),
     environmentIds: vi.fn(async () => environments),
     suspend: vi.fn(async () => {}),
     suspendIdle: vi.fn(async () => {}),

--- a/packages/daemon/test/microsandbox-driver.test.ts
+++ b/packages/daemon/test/microsandbox-driver.test.ts
@@ -1,7 +1,8 @@
-import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runInNewContext } from 'node:vm'
+import { createHash } from 'node:crypto'
 import { decode, encode } from 'cborg'
 import type { ExecEvent, ModifyOptions } from 'microsandbox'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -68,7 +69,13 @@ function fakeSdk() {
   const processes: FakeExec[] = []
   let onRun: ((process: FakeExec) => void | Promise<void>) | undefined
   const images = new Map<string, number | null>([['test-image', 4_194_304]])
+  const imageDigests = new Map<string, string>()
   const imageCache = {
+    get: vi.fn(async (reference: string) => ({
+      manifestDigest: imageDigests.get(reference) ?? `sha256:${createHash('sha256').update(reference).digest('hex')}`,
+      os: 'linux',
+      architecture: 'amd64'
+    })),
     list: vi.fn(async () => [...images].map(([reference, sizeBytes]) => ({ reference, sizeBytes }))),
     remove: vi.fn(async (reference: string) => {
       if (!images.has(reference)) throw new Error(`image not found: ${reference}`)
@@ -86,6 +93,7 @@ function fakeSdk() {
     readonly processes: FakeExec[] = []
     readonly spec = {
       image: 'test-image',
+      labels: {} as Record<string, string>,
       env: [{ key: 'PATH', value: '/image/bin' }],
       secrets: {} as Record<string, { value: string; placeholder: string; host: string[] }>,
       runtime: { workdir: '/image', user: 'agent' }
@@ -141,6 +149,17 @@ function fakeSdk() {
     readonly exec = vi.fn(async (command: string, args: string[]) => {
       expect(command).toBe(MICROSANDBOX_NODE)
       expect(args[0]).toBe('-e')
+      if (args[1]!.includes('/proc/self/mountinfo')) {
+        const requested = JSON.parse(args[2]!) as MicrosandboxEnvironment['mounts']
+        const success = requested.every(
+          (mount) =>
+            mount.mode === 'overlay' ||
+            this.mounts.some(
+              (actual) => actual.target === mount.target && actual.readonly === (mount.mode === 'readonly')
+            )
+        )
+        return { success, code: success ? 0 : 1, stdout: (): string => '', stderr: (): string => 'mount mismatch' }
+      }
       let stdout = ''
       const python = vi.fn((_command: string, _args: string[]) => {})
       runInNewContext(args[1]!, {
@@ -229,10 +248,15 @@ function fakeSdk() {
         const volumeNames: string[] = []
         const mounts: FakeSandbox['mounts'] = []
         const secrets: FakeSandbox['spec']['secrets'] = {}
+        const labels: Record<string, string> = {}
         let image = 'test-image'
         const builder = {
           image(value: string) {
             image = value
+            return builder
+          },
+          label(key: string, value: string) {
+            labels[key] = value
             return builder
           },
           rootDisk() {
@@ -326,6 +350,7 @@ function fakeSdk() {
             const sandbox = new FakeSandbox(name, volumeNames, mounts)
             sandbox.spec.image = image
             sandbox.spec.secrets = secrets
+            sandbox.spec.labels = labels
             created.push(sandbox)
             sandboxes.set(name, sandbox)
             return sandbox
@@ -341,6 +366,7 @@ function fakeSdk() {
     processes,
     volumes,
     images,
+    imageDigests,
     imageCache,
     removeVolume,
     /** A VM this daemon does not know about: one an operator created, or one an interrupted start left behind. */
@@ -476,32 +502,31 @@ describe('microsandbox process and VM ownership', () => {
     }
   )
 
-  it.each([false, true])(
-    'retains VM data when its credential configuration changes (protected=%s)',
-    async (protectedVm) => {
-      const { manager, options, environment, request, created, volumes } = await fixture()
-      const env = {
-        ...environment,
-        secrets: [
-          {
-            env: 'DEEPSEEK_API_KEY',
-            placeholder: 'fixture-placeholder',
-            host: 'api.deepseek.com',
-            readValue: () => 'fixture-key'
-          }
-        ]
-      }
-      await (await manager.driverFor(protectedVm ? env : environment).launch(request)).stop(0)
-      await manager.stopAll()
-      const resumed = new MicrosandboxManager(options)
-      await expect(resumed.driverFor(protectedVm ? environment : env).launch(request)).rejects.toThrow(
-        'start a new session'
-      )
-      expect(created[0]!.status).toBe('stopped')
-      expect(volumes.size).toBe(1)
-      await resumed.discard(environment.id)
+  it.each([false, true])('replaces the VM when its credential scope changes (protected=%s)', async (protectedVm) => {
+    const { manager, options, environment, request, created, volumes } = await fixture()
+    const env = {
+      ...environment,
+      secrets: [
+        {
+          env: 'DEEPSEEK_API_KEY',
+          placeholder: 'fixture-placeholder',
+          host: 'api.deepseek.com',
+          readValue: () => 'fixture-key'
+        }
+      ]
     }
-  )
+    await (await manager.driverFor(protectedVm ? env : environment).launch(request)).stop(0)
+    await manager.stopAll()
+    const resumed = new MicrosandboxManager(options)
+    await (await resumed.driverFor(protectedVm ? environment : env).launch(request)).stop(0)
+    expect(created).toHaveLength(2)
+    expect(created[0]!.destroy).toHaveBeenCalledOnce()
+    expect(created[1]!.spec.secrets).toEqual(
+      protectedVm ? {} : expect.objectContaining({ DEEPSEEK_API_KEY: expect.anything() })
+    )
+    expect(volumes.size).toBe(1)
+    await resumed.discard(environment.id)
+  })
 
   it('shares read-only bases while retaining and cleaning up each session overlay disk', async () => {
     const { manager, options, environment, request, created, volumes, removeVolume } = await fixture()
@@ -759,36 +784,74 @@ describe('microsandbox process and VM ownership', () => {
     await manager.discard(environment.id)
   })
 
-  it('pins retained VM images while new environments use the configured image', async () => {
-    const { manager, options, environment, request, created } = await fixture()
-    await (await manager.driverFor(environment).launch(request)).stop(0)
+  it('reuses an alias with the same platform digest and refreshes a changed image without ACP', async () => {
+    const { manager, options, environment, created, imageDigests, imageCache, processes } = await fixture()
+    await manager.prepareEnvironment(environment)
     await manager.stopAll()
+    const identity = await imageCache.get('test-image')
+    imageDigests.set('next-image', identity.manifestDigest)
     const upgraded = { ...options, config: { ...options.config, image: 'next-image' } }
-    await expect(
-      new MicrosandboxManager({ ...upgraded, config: { ...upgraded.config, cpus: 4 } })
-        .driverFor(environment)
-        .launch(request)
-    ).rejects.toThrow('changed persisted configuration')
     const resumed = new MicrosandboxManager(upgraded)
-    await expect(
-      resumed
-        .driverFor({ ...environment, mounts: [{ source: '/extra', target: '/extra', mode: 'readonly' }] })
-        .launch(request)
-    ).rejects.toThrow('changed persisted configuration')
-    await (await resumed.driverFor(environment).launch(request)).stop(0)
+    await resumed.refreshEnvironment(environment)
     expect(created).toHaveLength(1)
-    expect(created[0]!.spec.image).toBe('test-image')
-    expect(created[0]!.destroy).not.toHaveBeenCalled()
-    const next = { ...environment, id: 'agent/new-session' }
-    await (await resumed.driverFor(next).launch(request)).stop(0)
-    expect(created[1]!.spec.image).toBe('next-image')
+    expect(created[0]!.status).toBe('stopped')
+    await resumed.prepareEnvironment(environment)
+    expect(created).toHaveLength(1)
     await resumed.stopAll()
-    const restarted = new MicrosandboxManager({ ...upgraded, config: { ...upgraded.config, image: 'later-image' } })
-    for (const env of [environment, next]) {
-      await (await restarted.driverFor(env).launch(request)).stop(0)
-      await restarted.discard(env.id)
-    }
+
+    imageDigests.set('next-image', 'sha256:changed')
+    const changed = new MicrosandboxManager(upgraded)
+    await changed.refreshEnvironment(environment)
     expect(created).toHaveLength(2)
+    expect(created[0]!.destroy).toHaveBeenCalledOnce()
+    expect(created[1]!.spec.image).toBe('next-image')
+    expect(processes).toHaveLength(0)
+    await changed.stopAll()
+    const restarted = new MicrosandboxManager(upgraded)
+    await restarted.prepareEnvironment(environment)
+    expect(created).toHaveLength(2)
+    await restarted.discard(environment.id)
+  })
+
+  it('refreshes a reused tag when its recorded digest changes', async () => {
+    const { manager, options, environment, created, imageDigests } = await fixture()
+    await manager.prepareEnvironment(environment)
+    await manager.stopAll()
+    imageDigests.set('test-image', 'sha256:new-content')
+    const restarted = new MicrosandboxManager(options)
+    await restarted.refreshEnvironment(environment)
+    expect(created).toHaveLength(2)
+    expect(created[0]!.destroy).toHaveBeenCalledOnce()
+    await restarted.discard(environment.id)
+  })
+
+  it('waits for VM preparation during shutdown without launching ACP', async () => {
+    const { manager, environment, created, processes } = await fixture()
+    let enter!: () => void
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve
+    })
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const start = (manager as any).startBridge.bind(manager)
+    vi.spyOn(manager as any, 'startBridge').mockImplementation(async (...args) => {
+      enter()
+      await blocked
+      await start(...args)
+    })
+    const preparation = manager.prepareEnvironment(environment)
+    await entered
+    const stopped = vi.fn()
+    const stopping = manager.stopAll().then(stopped)
+    await Promise.resolve()
+    expect(stopped).not.toHaveBeenCalled()
+    release()
+    await Promise.all([preparation, stopping])
+    expect(created[0]!.status).toBe('stopped')
+    expect(processes).toHaveLength(0)
+    await manager.discard(environment.id)
   })
 
   it('collects a retired release image and keeps the configured one before any VM boots', async () => {
@@ -850,52 +913,94 @@ describe('microsandbox process and VM ownership', () => {
     expect(imageCache.remove).not.toHaveBeenCalled()
   })
 
-  it.each([false, true])('resumes with relocated support mounts (legacy guest helper=%s)', async (withGuestHelper) => {
-    const { manager, options, environment: original, request, created } = await fixture()
-    const environment = { ...original, mounts: microsandboxSupportMounts(options.root) }
-    const helpers = join(options.root, 'microsandbox', 'helpers')
-    await mkdir(helpers, { recursive: true })
-    const legacyGit = join(helpers, 'git-credential')
-    await writeFile(legacyGit, await readFile(environment.mounts[0]!.source))
-    const helper = join(helpers, 'guest.js')
-    await writeFile(helper, 'export {}')
-    const legacy: MicrosandboxEnvironment = {
+  it('keeps active executions and replaces idle VMs when mounts change', async () => {
+    const { manager, options, environment, request, created, processes } = await fixture()
+    const workspace = join(options.root, 'workspace')
+    await mkdir(workspace)
+    await writeFile(join(workspace, 'uncommitted.txt'), 'keep')
+    const original: MicrosandboxEnvironment = {
       ...environment,
-      mounts: [
-        { ...environment.mounts[0]!, source: await realpath(legacyGit) },
-        ...(withGuestHelper
-          ? [{ source: await realpath(helper), target: '/opt/agentconnect-local/guest.js', mode: 'readonly' as const }]
-          : [])
-      ]
+      mounts: [{ source: workspace, target: '/workspace', mode: 'writable' }]
     }
-    const runtime = await manager.driverFor(environment).launch(request)
-    await runtime.stop(0)
-    await manager.stopAll()
-    // Simulate a binding written before host SDK state mounts were forbidden.
-    const bindings = join(options.root, 'microsandbox', 'bindings')
-    const path = join(bindings, (await readdir(bindings))[0]!)
-    const binding = JSON.parse(await readFile(path, 'utf8'))
-    binding.spec = (manager as any).spec(legacy)
-    await writeFile(path, JSON.stringify(binding))
-    const resumed = new MicrosandboxManager({
-      ...options,
-      config: { ...options.config, image: 'next-image' }
-    })
-    await expect(
-      resumed
-        .driverFor({
-          ...environment,
-          mounts: [{ source: '/workspace-other', target: '/workspace-other', mode: 'writable' }]
-        })
-        .launch(request)
-    ).rejects.toThrow('changed persisted configuration')
-    const changed = new MicrosandboxManager({ ...options, config: { ...options.config, cpus: 4 } })
-    await expect(changed.driverFor(environment).launch(request)).rejects.toThrow('changed persisted configuration')
-    const restored = await resumed.driverFor(environment).launch(request)
-    expect(created).toHaveLength(1)
+    const runtime = await manager.driverFor(original).launch(request)
+    const desired: MicrosandboxEnvironment = {
+      ...original,
+      mounts: [...original.mounts, { source: '/store', target: '/store', mode: 'writable' }]
+    }
+    await expect(manager.prepareEnvironment(desired)).rejects.toThrow('configuration changed while active')
     expect(created[0]!.destroy).not.toHaveBeenCalled()
-    await restored.stop(0)
-    await resumed.discard(environment.id)
+    await runtime.stop(0)
+    await Promise.all([manager.prepareEnvironment(desired), manager.prepareEnvironment(desired)])
+    expect(created).toHaveLength(2)
+    expect(created[0]!.destroy).toHaveBeenCalledOnce()
+    expect(created[1]!.mounts).toContainEqual({ source: workspace, target: '/workspace', readonly: false })
+    expect(await readFile(join(workspace, 'uncommitted.txt'), 'utf8')).toBe('keep')
+    expect(processes).toHaveLength(1)
+    await manager.discard(environment.id)
+    expect(await readFile(join(workspace, 'uncommitted.txt'), 'utf8')).toBe('keep')
+  })
+
+  it('preserves the old binding when replacement validation fails and permits a later retry', async () => {
+    const { manager, options, environment, created, volumes } = await fixture()
+    await manager.prepareEnvironment(environment)
+    await manager.stopAll()
+    const next = { ...options, config: { ...options.config, cpus: 4 } }
+    const build = options.sdk.Sandbox.builder.bind(options.sdk.Sandbox)
+    const intercept = vi.spyOn(options.sdk.Sandbox, 'builder').mockImplementation((name) => {
+      const builder = build(name)
+      const create = builder.create.bind(builder)
+      builder.create = async () => {
+        const sandbox = await create()
+        vi.mocked(sandbox.exec).mockRejectedValueOnce(new Error('mount check failed'))
+        return sandbox
+      }
+      return builder
+    })
+    const failed = new MicrosandboxManager(next)
+    await expect(failed.prepareEnvironment(environment)).rejects.toThrow('mount check failed')
+    expect(created[0]!.destroy).not.toHaveBeenCalled()
+    expect(created[1]!.destroy).toHaveBeenCalledOnce()
+    expect(volumes.size).toBe(1)
+    intercept.mockRestore()
+    const restored = new MicrosandboxManager(options)
+    await restored.prepareEnvironment(environment)
+    expect(created).toHaveLength(2)
+    await restored.stopAll()
+    const retry = new MicrosandboxManager(next)
+    await retry.prepareEnvironment(environment)
+    expect(created).toHaveLength(3)
+    expect(created[0]!.destroy).toHaveBeenCalledOnce()
+    await retry.discard(environment.id)
+  })
+
+  it('recovers an abandoned candidate before retrying and retains ownership across cleanup failures', async () => {
+    const { manager, options, environment, created, volumes } = await fixture()
+    await manager.prepareEnvironment(environment)
+    await manager.stopAll()
+    const token = 'a'.repeat(32)
+    const directory = join(options.root, 'microsandbox', 'bindings')
+    const path = join(directory, (await readdir(directory))[0]!)
+    const binding = JSON.parse(await readFile(path, 'utf8'))
+    const candidate = await options.sdk.Sandbox.builder(created[0]!.name + '-' + token)
+      .label('io.agentconnect.vm-replacement', token)
+      .create()
+    await candidate.stopWithTimeout(0)
+    await candidate.detach()
+    await writeFile(path, JSON.stringify({ ...binding, replacement: token }))
+    created[0]!.destroy.mockRejectedValueOnce(new Error('old VM busy'))
+    const upgraded = { ...options, config: { ...options.config, cpus: 4 } }
+    const resumed = new MicrosandboxManager(upgraded)
+    await resumed.prepareEnvironment(environment)
+    expect(created[1]!.destroy).toHaveBeenCalledOnce()
+    expect(JSON.parse(await readFile(path, 'utf8')).retired).toHaveLength(1)
+    await resumed.stopAll()
+    const restarted = new MicrosandboxManager(upgraded)
+    await restarted.prepareEnvironment(environment)
+    expect(created).toHaveLength(3)
+    expect(created[0]!.destroy).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(await readFile(path, 'utf8')).retired).toBeUndefined()
+    expect(volumes.size).toBe(1)
+    await restarted.discard(environment.id)
   })
 
   it('retries a failed VM lookup without retaining a rejected launch', async () => {


### PR DESCRIPTION
Retained microsandbox VMs rejected changed mount, resource, or credential settings and continued using their original image. Replace changed VMs with the desired configuration while remounting existing host workspace, HOME, and memory directories. Image tags with the same platform manifest digest reuse the VM.

Validate the candidate's mounts before committing the new binding, then remove the old VM. Failed replacements retain the previous binding, and recorded candidates and retired VMs can be cleaned up after interruption. VM root disks, Docker data, and Overlay write volumes are disposable across replacement; host-mounted files and session records are preserved.

Agent-level refresh runs in the background workspace queue without delaying daemon readiness. Session-owned VMs refresh on their next use. Activation and refresh prepare the workspace and VM without initializing ACP; runtime initialization remains on demand.

Validation:
- Daemon typecheck, focused ESLint, formatting, and publication checks passed.
- Related microsandbox, lifecycle, reconciliation, and session-host suites: 247 passed, 45 skipped under their environment conditions.
- Isolated Linux/KVM test with microsandbox 0.6.17: preserved uncommitted files, recreated the root disk, verified writable/read-only/Overlay mounts, removed the retired VM, and reused the binding after restart. Cached-image replacement took approximately 1.6 seconds.

Created by Codex . GPT-6 Astra
