### PR TITLE
refactor(dream): drop the 64-topic cap on a dream's rebuilt store

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -102,10 +102,10 @@ Three invariants:
    successful adoption.
 3. **The model proposes; the daemon disposes.** The model's writes reach disk
    only through the daemon's own memory tools, bound to the staged store: the
-   same path validation, topic-name rule, and byte caps a turn gets, plus the
-   dream's own bounded file count. The daemon still performs every filesystem
-   write itself and generates the index. `.history` is never part of the
-   proposal — it is carried over verbatim and appended to.
+   same path validation, topic-name rule, and byte caps a turn gets. The daemon
+   still performs every filesystem write itself and generates the index.
+   `.history` is never part of the proposal — it is carried over verbatim and
+   appended to.
 
 Invariant 3 bounds only what the dream _output_ can do: a bad proposal can
 change only the managed-memory store, and only after staging and validation.
@@ -252,8 +252,9 @@ interface DreamRecord {
    session's `writeMemory`/`readMemory` are bound to `memory-dreams/<dreamId>/`
    as their store, so every topic file went through the same write path a turn
    uses (header normalize + stamp, byte cap, `.history`) — the binding also
-   carries the two limits the old JSON format enforced, the topic regex
-   `^[a-z0-9][a-z0-9-]{0,62}\.md$` and the bounded file count. Staging then
+   carries the topic regex `^[a-z0-9][a-z0-9-]{0,62}\.md$` the old JSON format
+   enforced; a rebuild is never capped on file count, since the live store it
+   must be able to keep in full is not. Staging then
    generates the index from those files' `description` headers, so the index a
    human reviews is byte-for-byte the one adoption installs. Parse the returned
    JSON (§5) for the review queue only — skills and organization suggestions,

--- a/docs/designs/unified-memory-interface.md
+++ b/docs/designs/unified-memory-interface.md
@@ -398,8 +398,8 @@ and the trusted source turn internally. Every mutation goes through the existing
 write-access/approval gate, and the entry service rechecks access before resolving
 the live provider. A one-call approval permits that payload while a subsequent
 policy denial still wins. Synthetic extraction and Dream bindings retain their
-constrained legacy writer; entry mutations are forbidden there so topic limits,
-staged-root provenance, and adoption checks cannot be bypassed.
+constrained legacy writer; entry mutations are forbidden there so the topic-name
+rule, staged-root provenance, and adoption checks cannot be bypassed.
 
 Admin HTTP mutation transport and UI remain separate follow-up work. This MCP
 projection does not send large mutation bodies in the bounded daemon/CP read frame;

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -195,7 +195,7 @@ import { AppSurface, newAppId, type AppTurn } from './mcp/apps/surface.js'
 import { APP_RPC_REFUSALS, CLOSED, EXPIRED, LiveAppRegistry, SUPERSEDED, appContextBlock } from './mcp/apps/cards.js'
 import { toolsForIntegrations, CODE_HOST_EFFECT_TOOLS, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
 import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
-import { DREAM_TOPIC_RE, MAX_DREAM_FILES } from './dream/dreamer.js'
+import { DREAM_TOPIC_RE } from './dream/dreamer.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
 import { CLAUDE_HEADLESS_DISALLOWED_TOOLS } from './runtime-defs/claude-runtime.js'
 import {
@@ -6039,8 +6039,8 @@ export class Daemon {
     // The token is unregistered in finally so a leaked token cannot outlive the
     // one-off dream host.
     // The dream writes its proposal through the SAME memory tools an agent uses,
-    // bound to the dream's staged store rather than the live one (#41). The two
-    // constraints its old JSON format enforced ride along on the binding.
+    // bound to the dream's staged store rather than the live one (#41). The topic-name
+    // rule its old JSON format enforced rides along on the binding.
     const mcpToken = this.mcp.register({
       agentId,
       platform: 'dream',
@@ -6051,8 +6051,7 @@ export class Daemon {
       memoryBinding: {
         source: 'dream',
         scope: { agentId, root: context.stagedStore },
-        topicPattern: DREAM_TOPIC_RE,
-        maxTopics: MAX_DREAM_FILES
+        topicPattern: DREAM_TOPIC_RE
       }
     })
     const mcpServers = this.mcpToolServerSpec(mcpToken, this.agents.get(agentId))

--- a/packages/daemon/src/dream/dreamer.ts
+++ b/packages/daemon/src/dream/dreamer.ts
@@ -103,8 +103,6 @@ export interface DreamExplorationPromptInput {
 /** Same topic discipline as the distiller, enforced on the dream's memory-tool binding. */
 export const DREAM_TOPIC_RE = /^[a-z0-9][a-z0-9-]{0,62}\.md$/
 
-/** Bounded proposal: a store rebuild, not a dump. */
-export const MAX_DREAM_FILES = 64
 /** Skill candidates are REVIEWED BY A HUMAN one by one, so the cap is about
  *  what a person will actually read, not what the model can produce. */
 export const MAX_DREAM_SKILLS = 5

--- a/packages/daemon/src/mcp/ops/context.ts
+++ b/packages/daemon/src/mcp/ops/context.ts
@@ -207,9 +207,6 @@ export interface SessionContext {
     /** Constrain topic filenames beyond the store's own path rules. A dream keeps the
      *  lowercase-kebab shape its proposal format always enforced. */
     topicPattern?: RegExp
-    /** Cap distinct topics this session may create, mirroring the bound the proposal
-     *  format used to apply. Absent ⇒ uncapped, as for an ordinary turn. */
-    maxTopics?: number
   }
   /** Snapshot of the agent's integrations (id + platform) at session/new. Lets the
    *  platform-neutral `sendMessage` tool route to ANY connected platform,

--- a/packages/daemon/src/mcp/ops/memory.ts
+++ b/packages/daemon/src/mcp/ops/memory.ts
@@ -169,9 +169,7 @@ export function memoryScopeFor(ctx: SessionContext, deps: MemoryOpsDeps): Memory
 /** Provenance for a write made through the shared tool surface. The ordinary
  *  conversational case is `tool`; a distillation- or dream-bound session keeps its own
  *  source so the write ledger — and dream adoption's distill-only rebase — stay honest. */
-/** Topics a bound session has SUCCESSFULLY written, so `maxTopics` counts DISTINCT files
- *  rather than writes — appending to one topic repeatedly is not new content. It doubles
- *  as the provenance record a dream checks its staged store against. */
+/** Topics a bound session has SUCCESSFULLY written — the provenance record a dream checks its staged store against. */
 const boundTopics = new WeakMap<SessionContext, Set<string>>()
 
 /** Every topic this bound session wrote through the tool. A staged file that is NOT
@@ -180,9 +178,7 @@ export function boundWrittenTopics(ctx: SessionContext): string[] {
   return [...(boundTopics.get(ctx) ?? [])]
 }
 
-/** Apply the binding's own limits before a write reaches the store. These carry the
- *  constraints the dream's JSON proposal format used to enforce; the store still
- *  applies path containment and the byte cap underneath. */
+/** Apply the binding's topic-name rule before a write reaches the store; the store still applies path containment and the byte cap underneath. */
 function enforceBindingPolicy(ctx: SessionContext, path: string): void {
   const binding = ctx.memoryBinding
   if (!binding) return
@@ -190,16 +186,11 @@ function enforceBindingPolicy(ctx: SessionContext, path: string): void {
   if (binding.topicPattern && !binding.topicPattern.test(name)) {
     throw new Error(`invalid memory path: "${name}" must match ${String(binding.topicPattern)}`)
   }
-  const seen = boundTopics.get(ctx)
-  if (binding.maxTopics !== undefined && !seen?.has(name) && (seen?.size ?? 0) >= binding.maxTopics) {
-    throw new Error(`memory topic limit reached (${binding.maxTopics}) for this session`)
-  }
 }
 
 /** Record the topic only once the write is DURABLE. A refused write — a subdirectory
  *  path, an oversized body, a bad mode pair — must not vouch for that name, or a dream
- *  could name a topic here and then smuggle its content in some other way. It also
- *  keeps a rejected call from consuming a `maxTopics` slot. */
+ *  could name a topic here and then smuggle its content in some other way. */
 function recordBoundTopic(ctx: SessionContext, path: string): void {
   if (!ctx.memoryBinding) return
   const seen = boundTopics.get(ctx) ?? new Set<string>()

--- a/packages/daemon/test/managed-memory-crud.test.ts
+++ b/packages/daemon/test/managed-memory-crud.test.ts
@@ -349,7 +349,7 @@ it('executes conditional MCP writes with trusted scope, approvals and synthetic-
   decision = 'allow'
   await expect(
     executeTool(
-      { ...ctx, memoryBinding: { source: 'distill', scope: { agentId: 'agent' }, maxTopics: 0 } },
+      { ...ctx, memoryBinding: { source: 'distill', scope: { agentId: 'agent' } } },
       'createMemoryEntry',
       { text: 'bypass' },
       deps

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -301,7 +301,6 @@ describe('a dream-bound session writing its staged store', () => {
       source: 'dream',
       scope: { agentId: 'bot-a', root: { key: 'staged' } as never },
       topicPattern: /^[a-z0-9][a-z0-9-]{0,62}\.md$/,
-      maxTopics: 2,
       ...over
     }
   })
@@ -322,16 +321,14 @@ describe('a dream-bound session writing its staged store', () => {
     expect(d.memory.write).not.toHaveBeenCalled()
   })
 
-  it('caps DISTINCT topics, while letting one topic be rewritten freely', async () => {
+  it('never caps the number of distinct topics — a rebuild must be able to keep every live one', async () => {
     const d = deps('allow')
     const ctx = dreamCtx()
-    await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a' }, d)
-    await executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'a2' }, d) // same topic, fine
-    await executeTool(ctx, 'writeMemory', { path: 'two.md', content: 'b' }, d)
-    await expect(executeTool(ctx, 'writeMemory', { path: 'three.md', content: 'c' }, d)).rejects.toThrow(
-      /topic limit reached/
-    )
-    expect((d.memory.write as unknown as WriteCalls).mock.calls).toHaveLength(3)
+    for (let i = 0; i < 200; i++) {
+      await executeTool(ctx, 'writeMemory', { path: `topic-${i}.md`, content: `entry ${i}` }, d)
+    }
+    expect((d.memory.write as unknown as WriteCalls).mock.calls).toHaveLength(200)
+    expect(boundWrittenTopics(ctx)).toHaveLength(200)
   })
 
   it('reports the topics it wrote, which is what the dream stages against', async () => {
@@ -342,7 +339,7 @@ describe('a dream-bound session writing its staged store', () => {
     expect(boundWrittenTopics(ctx)).toEqual(['one.md'])
   })
 
-  it('does not let a REFUSED write vouch for its topic or spend a topic slot', async () => {
+  it('does not let a REFUSED write vouch for its topic', async () => {
     // The store rejects the write (a subdirectory path, an oversized body). The name must
     // not enter the provenance record, or a dream could claim a topic through the tool and
     // then put the actual bytes there with the runtime's own file tool.
@@ -354,7 +351,7 @@ describe('a dream-bound session writing its staged store', () => {
     await expect(executeTool(ctx, 'writeMemory', { path: 'one.md', content: 'x' }, d)).rejects.toThrow()
     expect(boundWrittenTopics(ctx)).toEqual([])
 
-    // ...and the refusal did not consume one of the two allowed topics.
+    // ...and it stays out of the record once later writes succeed.
     await executeTool(ctx, 'writeMemory', { path: 'two.md', content: 'x' }, d)
     await executeTool(ctx, 'writeMemory', { path: 'three.md', content: 'x' }, d)
     expect(boundWrittenTopics(ctx).sort()).toEqual(['three.md', 'two.md'])


### PR DESCRIPTION
## Why

A dream writes its rebuilt store through the memory tools into an empty staging area that **replaces** the live store on adoption — the system prompt says so explicitly: a file the model never writes is deleted. The dream's memory binding also carried `maxTopics: MAX_DREAM_FILES` (64), so once a live store held more than 64 topics, no dream could ever be adopted without pruning it down to 64. Worse, the prompt never mentioned the cap: the model only found out when the 65th `writeMemory` was refused with `memory topic limit reached (64)`, by which point the extraction was usually wrecked (`unparseable_proposal`) or, if it finished, the staged store was missing topics.

The number came from the original JSON-reply proposal format, where it bounded the size of one reply. Since #1298 the dream writes one file per tool call, and everything else that bounds a dream is still in place:

- the per-file byte cap (`MAX_MEMORY_FILE_BYTES`) and path containment in the store,
- the lowercase-kebab topic rule (`DREAM_TOPIC_RE`) on the binding,
- the staging provenance check (a staged file no bound write produced fails the dream),
- the human review / adoption gate.

A count cap on the rebuild has no analogue on the live store it must be able to keep in full, so it is removed rather than raised.

## What changed

- `MAX_DREAM_FILES` and the `maxTopics` binding field are gone; `enforceBindingPolicy` keeps only the topic-name rule. The written-topic set stays, since it is the provenance record the dream stages against.
- `memory-write-gate.test.ts`: the cap test becomes a regression test that a dream-bound session can write 200 distinct topics; the refused-write test keeps its provenance assertion and drops the "topic slot" half.
- `managed-memory-crud.test.ts`: the bound-session fixture no longer sets the removed field (its assertion — entry mutations are forbidden under a binding — is unchanged).
- `docs/designs/memory-dreaming.md` and `unified-memory-interface.md`: drop the "bounded file count" from the binding's guarantees and state why a rebuild is not count-capped.

## Tests

- `pnpm --filter @agentconnect.md/daemon typecheck` clean.
- `vitest run test/memory-write-gate.test.ts test/dream-runner.test.ts test/memory-dreamer.test.ts test/managed-memory-crud.test.ts`: 138 passed.
- eslint + prettier clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
