### PR TITLE
refactor(relay): index hook rules by provider-qualified repository id

### DIFF
--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -1060,7 +1060,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
 
       const repoId = payload.repository?.id
       const subject = payload.issue ?? payload.pull_request
-      const rules = repoId === undefined ? [] : deps.table.getByRepoId(String(repoId))
+      const rules = repoId === undefined ? [] : deps.table.getByCodeHostRepo('github', String(repoId))
       // Thread events need a subject number; push ("commits") events need a ref; a
       // deployment needs its environment — every deployment there continues one session.
       const environment = isGithubDeploymentEvent(event) ? payload.deployment?.environment : undefined

--- a/packages/relay/src/hooks/gitlab-ingress.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.ts
@@ -461,7 +461,7 @@ export function registerGitlabIngress(app: FastifyInstance, deps: GitlabIngressD
       }
       const projectId = payload.project?.id ?? payload.project_id
       if (projectId === undefined || !Number.isSafeInteger(projectId)) return notFound(reply)
-      const rules = deps.table.getByGitlabProject(String(projectId))
+      const rules = deps.table.getByCodeHostRepo('gitlab', String(projectId))
       if (rules.length === 0) return notFound(reply)
 
       const webhookId = headerString(req.headers['webhook-id'])

--- a/packages/relay/src/hooks/hook-table.test.ts
+++ b/packages/relay/src/hooks/hook-table.test.ts
@@ -56,7 +56,7 @@ describe('HookTable', () => {
     expect(() => t.remove(HOOK_A)).not.toThrow()
   })
 
-  describe('byRepoId index (github kind)', () => {
+  describe('code-host repository index', () => {
     const HOOK_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
     const gh = (repoId: string, hookId = HOOK_A): RcHookAssign =>
       rule({
@@ -73,37 +73,54 @@ describe('HookTable', () => {
           installationIds: ['41']
         }
       })
+    const gl = (projectId: string, hookId = HOOK_A): RcHookAssign =>
+      rule({
+        hookId,
+        kind: 'gitlab',
+        sessionMode: 'perThread',
+        webhook: undefined,
+        gitlab: {
+          projectId,
+          projectPath: 'acme/infra',
+          sessionKeyPrefix: `gitlab:${projectId}`,
+          events: ['issues:opened'],
+          mentionOnly: false,
+          serviceAccountUserId: '7',
+          serviceAccountUsername: 'acme-agent',
+          signingToken: 'whsec_test'
+        }
+      })
 
-    it('indexes a github rule by repoId; one repo carries many hooks', () => {
+    it('indexes a github rule by its repository; one repo carries many hooks', () => {
       const t = new HookTable()
       t.upsert(gh('100'))
       t.upsert(gh('100', HOOK_B))
       expect(
         t
-          .getByRepoId('100')
+          .getByCodeHostRepo('github', '100')
           .map((r) => r.hookId)
           .sort()
       ).toEqual([HOOK_A, HOOK_B])
-      expect(t.getByRepoId('999')).toEqual([])
+      expect(t.getByCodeHostRepo('github', '999')).toEqual([])
     })
 
-    it('a repoId change re-indexes: the old repo stops resolving', () => {
+    it('a repository change re-indexes: the old repository stops resolving', () => {
       const t = new HookTable()
       t.upsert(gh('100'))
       t.upsert(gh('200'))
-      expect(t.getByRepoId('100')).toEqual([])
-      expect(t.getByRepoId('200')[0]?.hookId).toBe(HOOK_A)
+      expect(t.getByCodeHostRepo('github', '100')).toEqual([])
+      expect(t.getByCodeHostRepo('github', '200')[0]?.hookId).toBe(HOOK_A)
     })
 
     it('a kind flip github→webhook clears the repo index (and vice versa the token index)', () => {
       const t = new HookTable()
       t.upsert(gh('100'))
       t.upsert(rule()) // same hookId, back to webhook kind
-      expect(t.getByRepoId('100')).toEqual([])
+      expect(t.getByCodeHostRepo('github', '100')).toEqual([])
       expect(t.getByToken('wh_tok1')?.hookId).toBe(HOOK_A)
       t.upsert(gh('100'))
       expect(t.getByToken('wh_tok1')).toBeUndefined()
-      expect(t.getByRepoId('100')).toHaveLength(1)
+      expect(t.getByCodeHostRepo('github', '100')).toHaveLength(1)
     })
 
     it('remove drops only that hook from the repo bucket', () => {
@@ -111,9 +128,25 @@ describe('HookTable', () => {
       t.upsert(gh('100'))
       t.upsert(gh('100', HOOK_B))
       t.remove(HOOK_A)
-      expect(t.getByRepoId('100').map((r) => r.hookId)).toEqual([HOOK_B])
+      expect(t.getByCodeHostRepo('github', '100').map((r) => r.hookId)).toEqual([HOOK_B])
       t.remove(HOOK_B)
-      expect(t.getByRepoId('100')).toEqual([])
+      expect(t.getByCodeHostRepo('github', '100')).toEqual([])
+    })
+
+    it('qualifies the key by provider: two hosts may carry the same numeric id', () => {
+      const t = new HookTable()
+      t.upsert(gh('100'))
+      t.upsert(gl('100', HOOK_B))
+      expect(t.getByCodeHostRepo('github', '100').map((r) => r.hookId)).toEqual([HOOK_A])
+      expect(t.getByCodeHostRepo('gitlab', '100').map((r) => r.hookId)).toEqual([HOOK_B])
+    })
+
+    it('a provider flip moves the rule between keys instead of leaving both resolving', () => {
+      const t = new HookTable()
+      t.upsert(gh('100'))
+      t.upsert(gl('100'))
+      expect(t.getByCodeHostRepo('github', '100')).toEqual([])
+      expect(t.getByCodeHostRepo('gitlab', '100')[0]?.hookId).toBe(HOOK_A)
     })
   })
 })

--- a/packages/relay/src/hooks/hook-table.ts
+++ b/packages/relay/src/hooks/hook-table.ts
@@ -2,50 +2,51 @@
  * `HookTable` — the relay's in-memory hook routing table
  * (webhook-triggers-and-github-events.md, relay side). Driven entirely by the
  * CP's `rc/hook-assign` / `rc/hook-remove` EVTs: upsert-by-hookId semantics,
- * a `urlToken` index for the generic ingress lookup and a `repoId` index for
- * the GitHub endpoint (one repo → many hooks). The table is a memory copy —
- * the CP replays every enabled hook after this relay (re)registers, and a CP
- * outage leaves the copy serving (degradation matrix).
+ * a `urlToken` index for the generic ingress lookup and one
+ * `(provider, externalId)` index for every code-host endpoint (one repository →
+ * many hooks). The table is a memory copy — the CP replays every enabled hook
+ * after this relay (re)registers, and a CP outage leaves the copy serving
+ * (degradation matrix).
  *
  * Rules carry `hmacSecret` — NEVER log a rule object.
  */
-import type { RcHookAssign } from '@agentconnect.md/protocol'
+import { codeHostHookRuleOf, type CodeHostProvider, type RcHookAssign } from '@agentconnect.md/protocol'
+
+/** The code-host routing key: the provider-qualified external repository id; a display path is never a match key. */
+function repoIndexKey(provider: CodeHostProvider, externalId: string): string {
+  return `${provider}:${externalId}`
+}
+
+/** The repository key a compiled rule routes under; undefined for the generic kind. */
+function ruleRepoIndexKey(rule: RcHookAssign): string | undefined {
+  const host = codeHostHookRuleOf(rule)
+  return host && repoIndexKey(host.provider, host.repo.externalId)
+}
 
 export class HookTable {
   private byHookId = new Map<string, RcHookAssign>()
   private byToken = new Map<string, RcHookAssign>()
-  /** repoId → hookId → rule (fan-out: several hooks may watch one repo). */
-  private byRepoId = new Map<string, Map<string, RcHookAssign>>()
-  /** GitLab projectId → hookId → rule (same fan-out shape as byRepoId). */
-  private byProjectId = new Map<string, Map<string, RcHookAssign>>()
+  /** (provider, externalId) → hookId → rule (fan-out: several hooks may watch one repository). */
+  private byCodeHostRepo = new Map<string, Map<string, RcHookAssign>>()
 
   upsert(rule: RcHookAssign): void {
-    // Re-index: if the hook's token/repo changed (or the kind did), drop the old key.
+    // Re-index: if the hook's token/repository changed (or the kind did), drop the old key.
     const prior = this.byHookId.get(rule.hookId)
     if (prior?.webhook && prior.webhook.urlToken !== rule.webhook?.urlToken) {
       this.byToken.delete(prior.webhook.urlToken)
     }
-    if (prior?.github && prior.github.repoId !== rule.github?.repoId) {
-      this.dropFromRepoIndex(prior)
-    }
-    if (prior?.gitlab && prior.gitlab.projectId !== rule.gitlab?.projectId) {
-      this.dropFromProjectIndex(prior)
+    const priorRepoKey = prior && ruleRepoIndexKey(prior)
+    const repoKey = ruleRepoIndexKey(rule)
+    if (priorRepoKey !== undefined && priorRepoKey !== repoKey) {
+      this.dropFromRepoIndex(priorRepoKey, rule.hookId)
     }
     this.byHookId.set(rule.hookId, rule)
     if (rule.kind === 'webhook' && rule.webhook) this.byToken.set(rule.webhook.urlToken, rule)
-    if (rule.kind === 'github' && rule.github) {
-      let bucket = this.byRepoId.get(rule.github.repoId)
+    if (repoKey !== undefined) {
+      let bucket = this.byCodeHostRepo.get(repoKey)
       if (!bucket) {
         bucket = new Map()
-        this.byRepoId.set(rule.github.repoId, bucket)
-      }
-      bucket.set(rule.hookId, rule)
-    }
-    if (rule.kind === 'gitlab' && rule.gitlab) {
-      let bucket = this.byProjectId.get(rule.gitlab.projectId)
-      if (!bucket) {
-        bucket = new Map()
-        this.byProjectId.set(rule.gitlab.projectId, bucket)
+        this.byCodeHostRepo.set(repoKey, bucket)
       }
       bucket.set(rule.hookId, rule)
     }
@@ -56,8 +57,8 @@ export class HookTable {
     if (!rule) return
     this.byHookId.delete(hookId)
     if (rule.webhook) this.byToken.delete(rule.webhook.urlToken)
-    if (rule.github) this.dropFromRepoIndex(rule)
-    if (rule.gitlab) this.dropFromProjectIndex(rule)
+    const repoKey = ruleRepoIndexKey(rule)
+    if (repoKey !== undefined) this.dropFromRepoIndex(repoKey, hookId)
   }
 
   /** The generic-ingress lookup: URL token → rule (undefined = uniform 404). */
@@ -71,15 +72,9 @@ export class HookTable {
     return this.byHookId.get(hookId)
   }
 
-  /** The GitHub-ingress lookup: numeric repo id (as string) → every watching rule. */
-  getByRepoId(repoId: string): RcHookAssign[] {
-    const bucket = this.byRepoId.get(repoId)
-    return bucket ? [...bucket.values()] : []
-  }
-
-  /** The GitLab-ingress lookup: numeric project id (as string) → every watching rule. */
-  getByGitlabProject(projectId: string): RcHookAssign[] {
-    const bucket = this.byProjectId.get(projectId)
+  /** The code-host-ingress lookup: provider + numeric external id (as string) → every watching rule. */
+  getByCodeHostRepo(provider: CodeHostProvider, externalId: string): RcHookAssign[] {
+    const bucket = this.byCodeHostRepo.get(repoIndexKey(provider, externalId))
     return bucket ? [...bucket.values()] : []
   }
 
@@ -87,19 +82,10 @@ export class HookTable {
     return this.byHookId.size
   }
 
-  private dropFromRepoIndex(rule: RcHookAssign): void {
-    if (!rule.github) return
-    const bucket = this.byRepoId.get(rule.github.repoId)
+  private dropFromRepoIndex(repoKey: string, hookId: string): void {
+    const bucket = this.byCodeHostRepo.get(repoKey)
     if (!bucket) return
-    bucket.delete(rule.hookId)
-    if (bucket.size === 0) this.byRepoId.delete(rule.github.repoId)
-  }
-
-  private dropFromProjectIndex(rule: RcHookAssign): void {
-    if (!rule.gitlab) return
-    const bucket = this.byProjectId.get(rule.gitlab.projectId)
-    if (!bucket) return
-    bucket.delete(rule.hookId)
-    if (bucket.size === 0) this.byProjectId.delete(rule.gitlab.projectId)
+    bucket.delete(hookId)
+    if (bucket.size === 0) this.byCodeHostRepo.delete(repoKey)
   }
 }


### PR DESCRIPTION
Behavior-neutral refactor of the relay's in-memory hook routing table, one item of the seam extraction the third code host needs.

## What changed

`HookTable` carried one code-host index per provider — `byRepoId` for GitHub beside `byProjectId` for GitLab — and each copy brought its own bucket maintenance, its own re-index branch in `upsert`, its own drop helper, and its own lookup. Another code host would have added a fourth copy of the same shape.

They are now one `Map` keyed by the provider-qualified external repository id, with one lookup:

```ts
getByCodeHostRepo(provider: CodeHostProvider, externalId: string): RcHookAssign[]
```

The key a rule routes under comes from the protocol's `codeHostHookRuleOf` view, so the provider is read off the compiled rule's own member instead of being a branch in the table. `github-ingress.ts` and `gitlab-ingress.ts` each pass their provider at the one call site they already had. The generic-webhook `urlToken` index is untouched.

## Why routing is unchanged

- Keys are provider-qualified (`<provider>:<externalId>`), so two hosts sharing a numeric id never collide — both numeric ids are digits-only and a provider carries no separator.
- `upsert` still re-indexes by comparing the prior routing key to the new one, so a repository change, a kind flip to or from the generic endpoint, and a provider flip all drop the old key exactly as before.
- Fan-out (one repository → many hooks), upsert-by-`hookId`, and the table's replay-as-snapshot semantics are as they were.

One edge the single index also closes: a rule whose `kind` no longer names a code host now always leaves the repository index. The old per-member comparison looked only at the member's id, so a rule that abandoned its code-host kind while keeping that member's id could leave a stale bucket entry behind. No well-formed compiled rule reaches that state.

## Tests

`hook-table.test.ts` keeps every existing expectation; the calls that reached the old index by name now name the provider, and the `describe` is no longer GitHub-specific. Two cases were added for what the single index has to get right: two providers carrying the same numeric id resolve separately, and a provider flip moves the rule between keys rather than leaving both resolving.

## Gates

- `pnpm typecheck` — clean across all packages.
- `pnpm --filter @agentconnect.md/relay test` — 30 files, 662 tests passing, including `hook-table.test.ts` (11), `github-ingress.test.ts` (128), `gitlab-ingress.test.ts` (27), `ingress.test.ts` (28).
- `pnpm lint` — 0 errors (8 pre-existing `import-x/no-duplicates` warnings, none in the touched files).
- `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
