### PR TITLE
refactor(web): select code-host marks, hosts, and pickers through provider tables

### DIFF
--- a/packages/web/src/components/console/CodeHostMark.tsx
+++ b/packages/web/src/components/console/CodeHostMark.tsx
@@ -1,0 +1,27 @@
+// No 'use client' here: reached only from the console's client trees, like `marks.tsx`'s other callers.
+
+import type { ComponentType } from 'react'
+import type { CodeHostProvider } from '@agentconnect.md/protocol/code-host'
+import { GithubMark, GitlabMark } from '@/components/marks'
+
+// One mark per code host, normalized to the GitHub mark's prop set so a selection site can render
+// whichever provider it holds. The tanuki is multi-color and ignores `color`, exactly as it does
+// where it is named directly. Total: a new host brings its own mark here.
+const CODE_HOST_MARK: Record<CodeHostProvider, ComponentType<{ color?: string; fillPct?: number }>> = {
+  github: GithubMark,
+  gitlab: GitlabMark
+}
+
+/** The brand mark of one code host — the provider-keyed reading of `GithubMark` / `GitlabMark`. */
+export function CodeHostMark({
+  provider,
+  color,
+  fillPct
+}: {
+  provider: CodeHostProvider
+  color?: string
+  fillPct?: number
+}) {
+  const Mark = CODE_HOST_MARK[provider]
+  return <Mark color={color} fillPct={fillPct} />
+}

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -26,8 +26,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
-import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
+import { isCodeHostProvider } from '@agentconnect.md/protocol/code-host'
+import { GithubMark, LoadingState } from '@/components/marks'
+import { CodeHostMark } from '@/components/console/CodeHostMark'
 import { Icon } from '@/components/ui'
+import { CODE_HOST_PROJECTION } from '@/lib/code-hosts'
 import { isPoolPlacementKind, workspaceSourceOf, type Agent, type WorkspaceStatusInfo } from '@/lib/data'
 import { creatorLabel, fetchAgentRepos, repoAuthProvider } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
@@ -122,8 +125,9 @@ export function WorkspaceCard({
   // An anonymous checkout has nothing to mint a write token from, so its
   // effective workspace access is read regardless of the stored preference.
   const workspaceAccess = ws.mode === 'git' ? (ws.provider !== undefined ? (ws.gitAccess ?? 'write') : 'read') : null
+  // A code host is named by its projection; everything else is just "remote".
   const remoteLabel =
-    header?.remoteLabel ?? (source === 'gitlab' ? 'GitLab' : source === 'github' ? 'GitHub' : 'remote')
+    header?.remoteLabel ?? (isCodeHostProvider(source) ? CODE_HOST_PROJECTION[source].label : 'remote')
 
   return (
     <div className={`card overflow-hidden max-desktop:rounded-lg ${className ?? ''}`}>
@@ -143,10 +147,8 @@ export function WorkspaceCard({
                   : undefined
             }
           >
-            {source === 'gitlab' ? (
-              <GitlabMark />
-            ) : source === 'github' ? (
-              <GithubMark color="var(--text-secondary)" />
+            {isCodeHostProvider(source) ? (
+              <CodeHostMark provider={source} color="var(--text-secondary)" />
             ) : (
               <Icon name="link-2" size={16} color="var(--text-secondary)" />
             )}
@@ -258,7 +260,7 @@ export function WorkspaceCard({
                 title={`${r.repoFullName} — ${r.access} access${poolPlaced ? '' : ', checked out alongside the workspace'}; added by ${creatorLabel(r.createdBy, me)}`}
               >
                 <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
-                  {repoAuthProvider(r) === 'gitlab' ? <GitlabMark /> : <GithubMark />}
+                  <CodeHostMark provider={repoAuthProvider(r)} />
                 </span>
                 <span className="mono text-[11.5px] text-(--text-primary)">{r.repoFullName}</span>
                 <span className={REPOSITORY_ACCESS_BADGE[r.access]}>{r.access}</span>

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
+import { CODE_HOST_PROVIDERS, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
 import { GithubMark, GitlabMark } from '@/components/marks'
+import { CodeHostMark } from '@/components/console/CodeHostMark'
 import { Button, Icon, Toggle } from '@/components/ui'
+import { CODE_HOST_PROJECTION } from '@/lib/code-hosts'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { GITLAB_PROJECT_STATE, gitlabChoiceSelectable, type GitlabProjectChoice } from '@/lib/gitlab-projects'
 import type { RepoAccess } from '@/lib/api'
@@ -10,7 +13,8 @@ import type { RepoAccess } from '@/lib/api'
 // The TILE the user types through, not what is stored (git-workspace-model.md §7):
 // every repo tile produces the same `{ mode: 'git', gitRepo }` payload, and the
 // displayed tile of an existing workspace is derived from host + credential.
-export type WorkspaceMode = 'scratch' | 'github' | 'gitlab' | 'giturl'
+// One tile per code host, so a new host is a tile rather than an edit here.
+export type WorkspaceMode = 'scratch' | CodeHostProvider | 'giturl'
 export type WorkspaceRepoAccess = 'read' | 'write'
 type RepositoryMenuStyle = { left: number; top: number; width: number; maxHeight: number }
 
@@ -41,18 +45,13 @@ const WORKSPACE_MODE_OPTIONS: {
     mark: (selected) =>
       workspaceModeMark(<Icon name="sparkles" size={16} color={selected ? 'var(--brand)' : 'var(--text-tertiary)'} />)
   },
-  {
-    value: 'github',
-    label: 'GitHub',
-    hint: 'Clone a repo on a branch.',
-    mark: () => workspaceModeMark(<GithubMark color="var(--text-primary)" fillPct={100} />)
-  },
-  {
-    value: 'gitlab',
-    label: 'GitLab',
-    hint: 'Clone a project on a branch.',
-    mark: () => workspaceModeMark(<GitlabMark fillPct={100} />)
-  },
+  // One tile per code host, named and worded by its own projection.
+  ...CODE_HOST_PROVIDERS.map((provider) => ({
+    value: provider,
+    label: CODE_HOST_PROJECTION[provider].label,
+    hint: `Clone a ${CODE_HOST_PROJECTION[provider].repoNounShort} on a branch.`,
+    mark: () => workspaceModeMark(<CodeHostMark provider={provider} color="var(--text-primary)" fillPct={100} />)
+  })),
   {
     value: 'giturl',
     label: 'Git URL',

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -46,6 +46,8 @@ import {
   type GithubRepoAccess,
   type GithubRepoDto
 } from '@/lib/api'
+import { isCodeHostProvider } from '@agentconnect.md/protocol/code-host'
+import { CODE_HOST_PROJECTION } from '@/lib/code-hosts'
 import { GithubMark, LoadingState } from '@/components/marks'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
@@ -800,14 +802,12 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   // the install button.
   const manageGithubAccess = installGithubApp
 
-  const modeHint =
-    wsMode === 'gitlab'
-      ? 'The project is cloned onto the machine; the agent runs from the directory you pick.'
-      : wsMode === 'github'
-        ? 'The repo is cloned onto the machine; the agent runs from the directory you pick.'
-        : wsMode === 'giturl'
-          ? 'Cloned with the daemon host’s own git credentials; the agent runs from the directory you pick.'
-          : 'We create a fresh working directory on the daemon — nothing is cloned.'
+  // Each code host says what it calls the thing being cloned; the two host-free tiles word themselves.
+  const modeHint = isCodeHostProvider(wsMode)
+    ? `The ${CODE_HOST_PROJECTION[wsMode].repoNounShort} is cloned onto the machine; the agent runs from the directory you pick.`
+    : wsMode === 'giturl'
+      ? 'Cloned with the daemon host’s own git credentials; the agent runs from the directory you pick.'
+      : 'We create a fresh working directory on the daemon — nothing is cloned.'
   const urlTileHint = wsMode === 'giturl' ? gitRepoUrlTileHint(urlInput) : null
 
   // What still blocks Create, per section — an amber dot on the rail item plus,

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -14,9 +14,12 @@
 // remains underneath. Escape closes only this layer (capture-phase listener),
 // so a nested open never tears down the caller.
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { CODE_HOST_PROVIDERS, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
+import { GithubMark, LoadingState } from '@/components/marks'
+import { CodeHostMark } from '@/components/console/CodeHostMark'
 import { Button, Icon } from '@/components/ui'
+import { CODE_HOST_PROJECTION } from '@/lib/code-hosts'
 import { agentLabel, type Agent } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
 import {
@@ -44,8 +47,8 @@ import {
   type RepoAccess
 } from '@/lib/api'
 
-/** Which host the picker is offering. Grants are provider-qualified (§8.1). */
-type GrantProvider = 'github' | 'gitlab'
+/** Which host the picker is offering. Grants are provider-qualified (§8.1), so the offer IS the provider axis. */
+type GrantProvider = CodeHostProvider
 
 // The two grant tiers. Read is a clone/read scope; write additionally grants
 // push access, pull_requests:write for formal reviews, and actions:write for
@@ -286,10 +289,19 @@ export default function AddAgentRepoModal({
   const typedIsListed = !!typedRepo && matches.some((r) => r.fullName.toLowerCase() === typedRepo.toLowerCase())
   const typedTaken = !!typedRepo && (isWorkspace(typedRepo) || isAuthorized(typedRepo))
 
-  const canSubmit =
-    provider === 'gitlab'
-      ? !!glPick && glTakenBy(glPick) === null && gl.provisioning === null
-      : !!pick && !isWorkspace(pick) && !isAuthorized(pick) && !uncovered && !probeDenies
+  // Each host's own footer gate and its own create payload — a grant is provider-qualified
+  // (§8.1). Total, so a new host states both instead of submitting through GitHub's.
+  const grantSubmit: Record<CodeHostProvider, { ready: boolean; input: Parameters<typeof createAgentRepo>[1] }> = {
+    github: {
+      ready: !!pick && !isWorkspace(pick) && !isAuthorized(pick) && !uncovered && !probeDenies,
+      input: { repoFullName: pick, access }
+    },
+    gitlab: {
+      ready: !!glPick && glTakenBy(glPick) === null && gl.provisioning === null,
+      input: { provider: 'gitlab', projectId: glPick, access }
+    }
+  }
+  const canSubmit = grantSubmit[provider].ready
 
   const submit = async () => {
     if (busyRef.current || !canSubmit) return
@@ -297,10 +309,7 @@ export default function AddAgentRepoModal({
     setSaving(true)
     setErr(null)
     try {
-      const row = await createAgentRepo(
-        agent.id,
-        provider === 'gitlab' ? { provider: 'gitlab', projectId: glPick, access } : { repoFullName: pick, access }
-      )
+      const row = await createAgentRepo(agent.id, grantSubmit[provider].input)
       onCreated(row)
     } catch (e) {
       if (e instanceof ApiError && e.code === 'GITHUB_IDENTITY_REQUIRED') {
@@ -319,6 +328,366 @@ export default function AddAgentRepoModal({
       setSaving(false)
       busyRef.current = false
     }
+  }
+
+  // How the picked host is named and what it calls the object being authorized.
+  const hostProjection = CODE_HOST_PROJECTION[provider]
+  // One tile per code host — the offer's row set IS the provider axis, each tile worded by its projection.
+  const hostTiles = CODE_HOST_PROVIDERS.map((v) => ({
+    v,
+    label: CODE_HOST_PROJECTION[v].label,
+    hint: `Authorize a ${CODE_HOST_PROJECTION[v].repoNoun}.`,
+    mark: <CodeHostMark provider={v} color="var(--text-primary)" />
+  }))
+
+  // Each host's own picker — GitHub's installation roster, GitLab's project list. Total over the
+  // providers, so a new code host brings its own pane instead of inheriting the first one's.
+  const grantPicker: Record<CodeHostProvider, () => ReactNode> = {
+    github: () =>
+      gh === null ? (
+        <div className="mb-4 flex items-center gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          <Icon name="loader" size={15} className="flex-none animate-spin" />
+          Checking your GitHub setup…
+        </div>
+      ) : !gh.enabled ? (
+        <div className="mb-4 flex items-start gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+          <Icon name="info" size={15} className="mt-[1px] flex-none" />
+          <span>
+            The GitHub App isn&rsquo;t configured for this deployment. Ask a deployment owner to configure it before
+            authorizing repositories.
+          </span>
+        </div>
+      ) : gh.installations.length === 0 ? (
+        <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
+          <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
+            Connect GitHub to grant repos
+          </div>
+          <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+            Install the AgentConnect GitHub app, then choose which repositories this agent can access.
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <Button size="sm" onClick={() => void openGhInstall()}>
+              <span className="flex h-4 w-4 items-center justify-center">
+                <GithubMark color="#fff" />
+              </span>
+              Install GitHub app
+            </Button>
+            <button type="button" className="lnk inline-flex items-center gap-[6px]" onClick={() => void syncGh()}>
+              <Icon
+                name={ghSyncing ? 'loader' : 'refresh-cw'}
+                size={13}
+                className={ghSyncing ? 'animate-spin' : undefined}
+              />
+              I&rsquo;ve installed it — sync
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="fld relative mb-[18px] min-w-0">
+            <span className="fldlbl">Repository</span>
+            <div
+              className={fixedRepo ? 'inp min-w-0 cursor-default gap-2' : 'inp min-w-0 cursor-pointer gap-2'}
+              onClick={() => {
+                if (fixedRepo) return
+                setQ('')
+                setPickOpen((v) => !v)
+              }}
+            >
+              <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
+                {pick ? (
+                  <>
+                    <Icon
+                      name={picked && !picked.private ? 'book-marked' : 'lock'}
+                      size={16}
+                      color="var(--text-tertiary)"
+                      className="flex-none"
+                    />
+                    <span
+                      className="min-w-0 flex-1 truncate font-mono text-[12.5px] font-medium leading-normal"
+                      title={pick}
+                    >
+                      {pick}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
+                      <GithubMark color="var(--text-secondary)" />
+                    </span>
+                    <span className="truncate text-(--text-tertiary)">
+                      {repos === null ? 'Loading repositories…' : 'Pick a repository'}
+                    </span>
+                  </>
+                )}
+              </span>
+              {!fixedRepo && <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />}
+            </div>
+            {privateReposHidden ? <GithubPrivateReposNotice profileHref={orgPath('/profile#sign-in-methods')} /> : null}
+            {!fixedRepo && pickOpen && (
+              <>
+                <div className="fscrim" onClick={() => setPickOpen(false)} />
+                <div className="fmenu left-0 right-0 z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)">
+                  <input
+                    className="fsearch h-10 rounded-md px-3 font-sans text-[13px] font-medium leading-normal"
+                    value={q}
+                    onChange={(e) => setQ(e.target.value)}
+                    placeholder="Search or type owner/repo…"
+                    autoFocus
+                  />
+                  {reposError === 'failed' && (
+                    <div className="flex items-center gap-2 px-2 py-[7px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+                      <span className="min-w-0 flex-1">
+                        Couldn’t load repositories from GitHub — the list may be incomplete.
+                      </span>
+                      <button
+                        type="button"
+                        className="lnk flex-none text-[12px]"
+                        onClick={() => {
+                          invalidateGithubRepoRosterCache()
+                          setReposError(null)
+                          setPrivateReposHidden(false)
+                          setRepos(null)
+                          setReposNonce((n) => n + 1)
+                        }}
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  )}
+                  {matches.map((r) => {
+                    const taken = isWorkspace(r.fullName) || isAuthorized(r.fullName)
+                    return (
+                      <button
+                        key={r.fullName}
+                        className={`fopt min-h-[46px] items-center gap-3 px-2 py-2 ${taken ? 'cursor-default opacity-55' : ''}`}
+                        disabled={taken}
+                        onClick={() => {
+                          setPick(r.fullName)
+                          setPickOpen(false)
+                        }}
+                      >
+                        <Icon
+                          name={r.private ? 'lock' : 'book-marked'}
+                          size={16}
+                          color="var(--text-tertiary)"
+                          className="flex-none"
+                        />
+                        <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
+                          <span
+                            className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)"
+                            title={r.fullName}
+                          >
+                            {r.fullName}
+                          </span>
+                          <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                            {isWorkspace(r.fullName)
+                              ? 'The agent’s workspace — already fully covered'
+                              : isAuthorized(r.fullName)
+                                ? 'Already authorized for this agent'
+                                : (r.description ?? 'No description')}
+                          </span>
+                        </span>
+                        {isWorkspace(r.fullName) ? (
+                          <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
+                            workspace
+                          </span>
+                        ) : isAuthorized(r.fullName) ? (
+                          <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">added</span>
+                        ) : (
+                          pick.toLowerCase() === r.fullName.toLowerCase() && (
+                            <Icon name="check" size={17} color="var(--brand)" />
+                          )
+                        )}
+                      </button>
+                    )
+                  })}
+                  {typedRepo && !typedIsListed && !typedTaken && (
+                    <button
+                      key={`typed:${typedRepo}`}
+                      className="fopt min-h-[46px] items-center gap-3 px-2 py-2"
+                      onClick={() => {
+                        setPick(typedRepo)
+                        setPickOpen(false)
+                      }}
+                    >
+                      <Icon name="book-marked" size={16} color="var(--text-tertiary)" className="flex-none" />
+                      <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
+                        <span className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)">
+                          {typedRepo}
+                        </span>
+                        <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                          Use this repository — must be covered by an installation
+                        </span>
+                      </span>
+                    </button>
+                  )}
+                  {typedRepo && typedTaken && (
+                    <div className="fnohit">
+                      {isWorkspace(typedRepo)
+                        ? `${typedRepo} is the agent’s workspace`
+                        : `${typedRepo} is already authorized`}
+                    </div>
+                  )}
+                  {repos !== null && matches.length === 0 && !typedRepo && !reposError && (
+                    <div className="fnohit">No repositories match &ldquo;{q}&rdquo;</div>
+                  )}
+                  {repos === null && (
+                    <div className="px-2 py-[7px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                      Loading repositories…
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="fldlbl mb-2">Access</div>
+          <div className="mb-4 flex flex-col gap-[9px]">
+            {TIERS.map((t) => {
+              const on = access === t.v
+              return (
+                <div
+                  key={t.v}
+                  className={`flex cursor-pointer items-center gap-[11px] rounded-[9px] border px-[13px] py-[11px] ${
+                    on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-subtle) bg-(--surface-card)'
+                  }`}
+                  onClick={() => setAccess(t.v)}
+                >
+                  <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
+                    <Icon name={t.icon} size={16} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-sans text-[13px] font-semibold leading-normal">{t.label}</div>
+                    <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                      {t.desc}
+                    </div>
+                  </div>
+                  <span
+                    className={`flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] ${
+                      on ? 'border-(--brand)' : 'border-(--border-strong)'
+                    }`}
+                  >
+                    {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+
+          {uncovered && (
+            <div className="mb-4 flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+              <Icon name="info" size={14} className="mt-[1px] flex-none" />
+              <span>
+                No GitHub App installation covers <span className="mono">{pickOwner}</span>&#32;— install (or extend)
+                the app on that account first.
+              </span>
+            </div>
+          )}
+          {!uncovered && probeNote && (
+            <div className="mb-4 flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+              <Icon name="shield-alert" size={14} className="mt-[1px] flex-none" />
+              <span>{probeNote}</span>
+            </div>
+          )}
+        </>
+      ),
+    gitlab: () =>
+      gl.error ? (
+        <div className="mb-4 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+          Couldn&rsquo;t load your GitLab projects — {gl.error}
+        </div>
+      ) : gl.loading ? (
+        <div className="mb-4">
+          <LoadingState size={20} padding={16} />
+        </div>
+      ) : glNoProjects ? (
+        <div className="mb-4">
+          <GitlabNoProjectsNotice
+            connected={gl.connected}
+            enabled={gl.enabled}
+            onConnect={() => void gl.connect()}
+            onSync={gl.reload}
+            syncing={gl.reloading}
+          />
+        </div>
+      ) : (
+        <>
+          <div className="mb-[18px]">
+            <GitlabProjectField
+              value={glPicked?.projectPath ?? ''}
+              icon="book-marked"
+              loading={false}
+              open={glPickOpen}
+              query={glQ}
+              onToggle={() => {
+                setGlQ('')
+                setGlPickOpen((value) => !value)
+              }}
+              onClose={() => setGlPickOpen(false)}
+              onQueryChange={setGlQ}
+              error={gl.provisionError ? `Couldn’t set up that project — ${gl.provisionError}` : undefined}
+            >
+              {glMatches.map((choice) => {
+                const taken = glTakenBy(choice.projectId)
+                if (taken !== null) {
+                  return (
+                    <div key={choice.projectId} className="fnohit">
+                      {choice.projectPath}
+                      {taken === 'workspace'
+                        ? ' is the agent’s workspace project'
+                        : ' is already authorized for this agent'}
+                    </div>
+                  )
+                }
+                return (
+                  <GitlabProjectOption
+                    key={choice.projectId}
+                    choice={choice}
+                    selected={glPick === choice.projectId}
+                    busy={gl.provisioning === choice.projectId}
+                    onSelect={() => void selectProject(choice)}
+                  />
+                )
+              })}
+              {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
+            </GitlabProjectField>
+          </div>
+
+          <div className="fldlbl mb-2">Access</div>
+          <div className="mb-4 flex flex-col gap-[9px]">
+            {GITLAB_TIERS.map((t) => {
+              const on = access === t.v
+              return (
+                <div
+                  key={t.v}
+                  className={`flex cursor-pointer items-center gap-[11px] rounded-[9px] border px-[13px] py-[11px] ${
+                    on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-subtle) bg-(--surface-card)'
+                  }`}
+                  onClick={() => setAccess(t.v)}
+                >
+                  <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
+                    <Icon name={t.icon} size={16} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-sans text-[13px] font-semibold leading-normal">{t.label}</div>
+                    <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                      {t.desc}
+                    </div>
+                  </div>
+                  <span
+                    className={`flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] ${
+                      on ? 'border-(--brand)' : 'border-(--border-strong)'
+                    }`}
+                  >
+                    {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </>
+      )
   }
 
   return (
@@ -342,12 +711,8 @@ export default function AddAgentRepoModal({
             </div>
             <div className="mt-[1px] truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
               {workspaceContext
-                ? provider === 'gitlab'
-                  ? 'authorize an additional project for '
-                  : 'authorize an additional repository for '
-                : provider === 'gitlab'
-                  ? 'authorize a GitLab project for '
-                  : 'authorize a GitHub repository for '}
+                ? `authorize an additional ${hostProjection.repoNoun} for `
+                : `authorize a ${hostProjection.label} ${hostProjection.repoNoun} for `}
               <span className="mono">{agentLabel(agent)}</span>
             </div>
           </div>
@@ -361,17 +726,7 @@ export default function AddAgentRepoModal({
             <div className="fld mb-[18px]">
               <span className="fldlbl">Code host</span>
               <div className="grid grid-cols-2 gap-[10px]">
-                {(
-                  [
-                    {
-                      v: 'github',
-                      label: 'GitHub',
-                      hint: 'Authorize a repository.',
-                      mark: <GithubMark color="var(--text-primary)" />
-                    },
-                    { v: 'gitlab', label: 'GitLab', hint: 'Authorize a project.', mark: <GitlabMark /> }
-                  ] as const
-                ).map((host) => (
+                {hostTiles.map((host) => (
                   <button
                     key={host.v}
                     type="button"
@@ -404,361 +759,13 @@ export default function AddAgentRepoModal({
               </div>
             </div>
           )}
-          {provider === 'gitlab' ? (
-            gl.error ? (
-              <div className="mb-4 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
-                Couldn&rsquo;t load your GitLab projects — {gl.error}
-              </div>
-            ) : gl.loading ? (
-              <div className="mb-4">
-                <LoadingState size={20} padding={16} />
-              </div>
-            ) : glNoProjects ? (
-              <div className="mb-4">
-                <GitlabNoProjectsNotice
-                  connected={gl.connected}
-                  enabled={gl.enabled}
-                  onConnect={() => void gl.connect()}
-                  onSync={gl.reload}
-                  syncing={gl.reloading}
-                />
-              </div>
-            ) : (
-              <>
-                <div className="mb-[18px]">
-                  <GitlabProjectField
-                    value={glPicked?.projectPath ?? ''}
-                    icon="book-marked"
-                    loading={false}
-                    open={glPickOpen}
-                    query={glQ}
-                    onToggle={() => {
-                      setGlQ('')
-                      setGlPickOpen((value) => !value)
-                    }}
-                    onClose={() => setGlPickOpen(false)}
-                    onQueryChange={setGlQ}
-                    error={gl.provisionError ? `Couldn’t set up that project — ${gl.provisionError}` : undefined}
-                  >
-                    {glMatches.map((choice) => {
-                      const taken = glTakenBy(choice.projectId)
-                      if (taken !== null) {
-                        return (
-                          <div key={choice.projectId} className="fnohit">
-                            {choice.projectPath}
-                            {taken === 'workspace'
-                              ? ' is the agent’s workspace project'
-                              : ' is already authorized for this agent'}
-                          </div>
-                        )
-                      }
-                      return (
-                        <GitlabProjectOption
-                          key={choice.projectId}
-                          choice={choice}
-                          selected={glPick === choice.projectId}
-                          busy={gl.provisioning === choice.projectId}
-                          onSelect={() => void selectProject(choice)}
-                        />
-                      )
-                    })}
-                    {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
-                  </GitlabProjectField>
-                </div>
-
-                <div className="fldlbl mb-2">Access</div>
-                <div className="mb-4 flex flex-col gap-[9px]">
-                  {GITLAB_TIERS.map((t) => {
-                    const on = access === t.v
-                    return (
-                      <div
-                        key={t.v}
-                        className={`flex cursor-pointer items-center gap-[11px] rounded-[9px] border px-[13px] py-[11px] ${
-                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-subtle) bg-(--surface-card)'
-                        }`}
-                        onClick={() => setAccess(t.v)}
-                      >
-                        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
-                          <Icon name={t.icon} size={16} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <div className="font-sans text-[13px] font-semibold leading-normal">{t.label}</div>
-                          <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {t.desc}
-                          </div>
-                        </div>
-                        <span
-                          className={`flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] ${
-                            on ? 'border-(--brand)' : 'border-(--border-strong)'
-                          }`}
-                        >
-                          {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
-                        </span>
-                      </div>
-                    )
-                  })}
-                </div>
-              </>
-            )
-          ) : gh === null ? (
-            <div className="mb-4 flex items-center gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-              <Icon name="loader" size={15} className="flex-none animate-spin" />
-              Checking your GitHub setup…
-            </div>
-          ) : !gh.enabled ? (
-            <div className="mb-4 flex items-start gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-              <Icon name="info" size={15} className="mt-[1px] flex-none" />
-              <span>
-                The GitHub App isn&rsquo;t configured for this deployment. Ask a deployment owner to configure it before
-                authorizing repositories.
-              </span>
-            </div>
-          ) : gh.installations.length === 0 ? (
-            <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-              <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
-                Connect GitHub to grant repos
-              </div>
-              <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
-                Install the AgentConnect GitHub app, then choose which repositories this agent can access.
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-3">
-                <Button size="sm" onClick={() => void openGhInstall()}>
-                  <span className="flex h-4 w-4 items-center justify-center">
-                    <GithubMark color="#fff" />
-                  </span>
-                  Install GitHub app
-                </Button>
-                <button type="button" className="lnk inline-flex items-center gap-[6px]" onClick={() => void syncGh()}>
-                  <Icon
-                    name={ghSyncing ? 'loader' : 'refresh-cw'}
-                    size={13}
-                    className={ghSyncing ? 'animate-spin' : undefined}
-                  />
-                  I&rsquo;ve installed it — sync
-                </button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <div className="fld relative mb-[18px] min-w-0">
-                <span className="fldlbl">Repository</span>
-                <div
-                  className={fixedRepo ? 'inp min-w-0 cursor-default gap-2' : 'inp min-w-0 cursor-pointer gap-2'}
-                  onClick={() => {
-                    if (fixedRepo) return
-                    setQ('')
-                    setPickOpen((v) => !v)
-                  }}
-                >
-                  <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
-                    {pick ? (
-                      <>
-                        <Icon
-                          name={picked && !picked.private ? 'book-marked' : 'lock'}
-                          size={16}
-                          color="var(--text-tertiary)"
-                          className="flex-none"
-                        />
-                        <span
-                          className="min-w-0 flex-1 truncate font-mono text-[12.5px] font-medium leading-normal"
-                          title={pick}
-                        >
-                          {pick}
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
-                          <GithubMark color="var(--text-secondary)" />
-                        </span>
-                        <span className="truncate text-(--text-tertiary)">
-                          {repos === null ? 'Loading repositories…' : 'Pick a repository'}
-                        </span>
-                      </>
-                    )}
-                  </span>
-                  {!fixedRepo && <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />}
-                </div>
-                {privateReposHidden ? (
-                  <GithubPrivateReposNotice profileHref={orgPath('/profile#sign-in-methods')} />
-                ) : null}
-                {!fixedRepo && pickOpen && (
-                  <>
-                    <div className="fscrim" onClick={() => setPickOpen(false)} />
-                    <div className="fmenu left-0 right-0 z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)">
-                      <input
-                        className="fsearch h-10 rounded-md px-3 font-sans text-[13px] font-medium leading-normal"
-                        value={q}
-                        onChange={(e) => setQ(e.target.value)}
-                        placeholder="Search or type owner/repo…"
-                        autoFocus
-                      />
-                      {reposError === 'failed' && (
-                        <div className="flex items-center gap-2 px-2 py-[7px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
-                          <span className="min-w-0 flex-1">
-                            Couldn’t load repositories from GitHub — the list may be incomplete.
-                          </span>
-                          <button
-                            type="button"
-                            className="lnk flex-none text-[12px]"
-                            onClick={() => {
-                              invalidateGithubRepoRosterCache()
-                              setReposError(null)
-                              setPrivateReposHidden(false)
-                              setRepos(null)
-                              setReposNonce((n) => n + 1)
-                            }}
-                          >
-                            Retry
-                          </button>
-                        </div>
-                      )}
-                      {matches.map((r) => {
-                        const taken = isWorkspace(r.fullName) || isAuthorized(r.fullName)
-                        return (
-                          <button
-                            key={r.fullName}
-                            className={`fopt min-h-[46px] items-center gap-3 px-2 py-2 ${taken ? 'cursor-default opacity-55' : ''}`}
-                            disabled={taken}
-                            onClick={() => {
-                              setPick(r.fullName)
-                              setPickOpen(false)
-                            }}
-                          >
-                            <Icon
-                              name={r.private ? 'lock' : 'book-marked'}
-                              size={16}
-                              color="var(--text-tertiary)"
-                              className="flex-none"
-                            />
-                            <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
-                              <span
-                                className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)"
-                                title={r.fullName}
-                              >
-                                {r.fullName}
-                              </span>
-                              <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                                {isWorkspace(r.fullName)
-                                  ? 'The agent’s workspace — already fully covered'
-                                  : isAuthorized(r.fullName)
-                                    ? 'Already authorized for this agent'
-                                    : (r.description ?? 'No description')}
-                              </span>
-                            </span>
-                            {isWorkspace(r.fullName) ? (
-                              <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
-                                workspace
-                              </span>
-                            ) : isAuthorized(r.fullName) ? (
-                              <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
-                                added
-                              </span>
-                            ) : (
-                              pick.toLowerCase() === r.fullName.toLowerCase() && (
-                                <Icon name="check" size={17} color="var(--brand)" />
-                              )
-                            )}
-                          </button>
-                        )
-                      })}
-                      {typedRepo && !typedIsListed && !typedTaken && (
-                        <button
-                          key={`typed:${typedRepo}`}
-                          className="fopt min-h-[46px] items-center gap-3 px-2 py-2"
-                          onClick={() => {
-                            setPick(typedRepo)
-                            setPickOpen(false)
-                          }}
-                        >
-                          <Icon name="book-marked" size={16} color="var(--text-tertiary)" className="flex-none" />
-                          <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
-                            <span className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)">
-                              {typedRepo}
-                            </span>
-                            <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                              Use this repository — must be covered by an installation
-                            </span>
-                          </span>
-                        </button>
-                      )}
-                      {typedRepo && typedTaken && (
-                        <div className="fnohit">
-                          {isWorkspace(typedRepo)
-                            ? `${typedRepo} is the agent’s workspace`
-                            : `${typedRepo} is already authorized`}
-                        </div>
-                      )}
-                      {repos !== null && matches.length === 0 && !typedRepo && !reposError && (
-                        <div className="fnohit">No repositories match &ldquo;{q}&rdquo;</div>
-                      )}
-                      {repos === null && (
-                        <div className="px-2 py-[7px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                          Loading repositories…
-                        </div>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-
-              <div className="fldlbl mb-2">Access</div>
-              <div className="mb-4 flex flex-col gap-[9px]">
-                {TIERS.map((t) => {
-                  const on = access === t.v
-                  return (
-                    <div
-                      key={t.v}
-                      className={`flex cursor-pointer items-center gap-[11px] rounded-[9px] border px-[13px] py-[11px] ${
-                        on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-subtle) bg-(--surface-card)'
-                      }`}
-                      onClick={() => setAccess(t.v)}
-                    >
-                      <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
-                        <Icon name={t.icon} size={16} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="font-sans text-[13px] font-semibold leading-normal">{t.label}</div>
-                        <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                          {t.desc}
-                        </div>
-                      </div>
-                      <span
-                        className={`flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] ${
-                          on ? 'border-(--brand)' : 'border-(--border-strong)'
-                        }`}
-                      >
-                        {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
-                      </span>
-                    </div>
-                  )
-                })}
-              </div>
-
-              {uncovered && (
-                <div className="mb-4 flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
-                  <Icon name="info" size={14} className="mt-[1px] flex-none" />
-                  <span>
-                    No GitHub App installation covers <span className="mono">{pickOwner}</span>&#32;— install (or
-                    extend) the app on that account first.
-                  </span>
-                </div>
-              )}
-              {!uncovered && probeNote && (
-                <div className="mb-4 flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
-                  <Icon name="shield-alert" size={14} className="mt-[1px] flex-none" />
-                  <span>{probeNote}</span>
-                </div>
-              )}
-            </>
-          )}
+          {/* The picked host's own picker, selected through the table above. */}
+          {grantPicker[provider]()}
           {err && <div className="font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">{err}</div>}
         </div>
         <div className="modalfoot">
           <span className="flex-1 font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-            {provider === 'gitlab'
-              ? 'Access applies only to this project and can be revoked at any time.'
-              : 'Access applies only to this repository and can be revoked at any time.'}
+            {`Access applies only to this ${hostProjection.repoNoun} and can be revoked at any time.`}
           </span>
           <Button variant="ghost" onClick={onClose}>
             Cancel

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode
 } from 'react'
 import useSWR from 'swr'
+import { isCodeHostProvider, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
 import LarkFeishuSwitcher, { type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -146,6 +147,12 @@ import {
  */
 export type Platform = string
 export type FeishuRegion = LarkFeishuTarget
+
+// What a subscription on each code host does, in that host's own subject vocabulary.
+const CODE_HOST_SUBSCRIPTION_HINT: Record<CodeHostProvider, string> = {
+  github: 'Matching events run the agent in a session and reply on the same PR, issue or commit thread.',
+  gitlab: 'Matching events run the agent in a session and reply on the same issue, merge request or push thread.'
+}
 
 type GithubRepoChoice = GithubRepoDto & { installationId: string }
 
@@ -1186,38 +1193,45 @@ export default function AddIntegrationModal({
   // whatever the active fragment published (`WizardHost.setFooter`), and the
   // fragment bakes its own busy label / disabled state into that publication.
   const identityHidden = identityView?.hidden === true
+  // Each code host subscribes through its own pane, so its footer is its own. Total over the
+  // providers, so a new host cannot inherit GitHub's submit.
+  const codeHostFooter: Record<
+    CodeHostProvider,
+    { label: string; act: () => void; enabled: boolean; hidden: boolean }
+  > = {
+    github: {
+      label: 'Connect',
+      act: () => void submitGithub(),
+      enabled: !!ghRepoPick && !ghRepoAlreadyWatched && ghSelectedFams.length > 0 && !ghReviewSettingsBlocked,
+      hidden: false
+    },
+    gitlab: {
+      label: 'Connect',
+      act: () => void submitGitlab(),
+      enabled: !!glProject && !glAlreadyWatched && glProjectAuthorized && glSelectedFams.length > 0,
+      hidden: false
+    }
+  }
   const footer =
     platform === 'webhook'
       ? createdHook
         ? { label: 'Done', act: onClose, enabled: true, hidden: false }
         : { label: 'Create webhook', act: () => void submitHook(), enabled: true, hidden: false }
-      : platform === 'github'
-        ? {
-            label: 'Connect',
-            act: () => void submitGithub(),
-            enabled: !!ghRepoPick && !ghRepoAlreadyWatched && ghSelectedFams.length > 0 && !ghReviewSettingsBlocked,
-            hidden: false
-          }
-        : platform === 'gitlab'
+      : isCodeHostProvider(platform)
+        ? codeHostFooter[platform]
+        : mode === 'existing'
           ? {
-              label: 'Connect',
-              act: () => void submitGitlab(),
-              enabled: !!glProject && !glAlreadyWatched && glProjectAuthorized && glSelectedFams.length > 0,
+              label: 'Connect & authorize',
+              act: () => void submitReuse(),
+              enabled: selectedBotId !== null,
               hidden: false
             }
-          : mode === 'existing'
-            ? {
-                label: 'Connect & authorize',
-                act: () => void submitReuse(),
-                enabled: selectedBotId !== null,
-                hidden: false
-              }
-            : {
-                label: footerView?.label ?? 'Connect & authorize',
-                act: () => footerRef.current?.onSubmit(),
-                enabled: footerView?.enabled === true,
-                hidden: footerView?.hidden === true
-              }
+          : {
+              label: footerView?.label ?? 'Connect & authorize',
+              act: () => footerRef.current?.onSubmit(),
+              enabled: footerView?.enabled === true,
+              hidden: footerView?.hidden === true
+            }
 
   return (
     <>
@@ -2097,11 +2111,9 @@ export default function AddIntegrationModal({
           <span>
             {platform === 'webhook'
               ? 'Each POST becomes a session, routed to this agent by the endpoint path. Retries are de-duplicated by the X-AC-Delivery-Key header (auto-assigned when absent).'
-              : platform === 'github'
-                ? 'Matching events run the agent in a session and reply on the same PR, issue or commit thread.'
-                : platform === 'gitlab'
-                  ? 'Matching events run the agent in a session and reply on the same issue, merge request or push thread.'
-                  : wizard?.inviteHint(region)}
+              : isCodeHostProvider(platform)
+                ? CODE_HOST_SUBSCRIPTION_HINT[platform]
+                : wizard?.inviteHint(region)}
           </span>
         </div>
         {shareToggleAvailable && !identityHidden && (

--- a/packages/web/src/components/console/modals/DeleteHookModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteHookModal.tsx
@@ -1,11 +1,33 @@
 // No 'use client' here: rendered only by ModalProvider (the client boundary).
 
 import { useState } from 'react'
+import { isCodeHostProvider, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
 import { useConsoleData } from '@/lib/data-context'
 import type { HookDto } from '@/lib/api'
+import { CODE_HOST_PROJECTION } from '@/lib/code-hosts'
 import { githubFamilyTile, githubHookFamily } from '@/lib/github-events'
 import { gitlabFamilyTile, gitlabHookFamily } from '@/lib/gitlab-events'
 import { Button, Icon } from '@/components/ui'
+
+// The subject-family pill a code-host row is named by. Total, so a new host reads as its own
+// family instead of as an unnamed row.
+const CODE_HOST_FAMILY_PILL: Record<CodeHostProvider, (hook: HookDto) => string | undefined> = {
+  github: (h) => {
+    const fam = githubHookFamily(h)
+    return fam ? githubFamilyTile(fam)?.pill : undefined
+  },
+  gitlab: (h) => {
+    const fam = gitlabHookFamily(h)
+    return fam ? gitlabFamilyTile(fam)?.pill : undefined
+  }
+}
+
+// What removing one subscription leaves behind, in each host's own terms.
+const CODE_HOST_REMOVAL_NOTE: Record<CodeHostProvider, string> = {
+  github: 'those GitHub events are ignored from now on. Past runs and their sessions stay.',
+  gitlab:
+    'those GitLab events are ignored from now on. The project itself, its bot and its webhook are untouched. Past runs and their sessions stay.'
+}
 
 // Confirm-delete a trigger. The CP drops the row and the relay pool drops its
 // rule — a webhook's inbound URL stops accepting deliveries immediately (senders
@@ -22,21 +44,11 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
   const repoNames = [...new Set(hooks.map((h) => h.repoFullName ?? h.name))]
   const group = Array.isArray(hook) && repoNames.length > 1
   // A code-host row covers ONE family, so name it: the repo's other families keep firing.
-  const familyOf = (h: HookDto) => {
-    if (h.kind === 'gitlab') {
-      const fam = gitlabHookFamily(h)
-      return fam ? gitlabFamilyTile(fam)?.pill : undefined
-    }
-    if (h.kind === 'github') {
-      const fam = githubHookFamily(h)
-      return fam ? githubFamilyTile(fam)?.pill : undefined
-    }
-    return undefined
-  }
+  const familyOf = (h: HookDto) => (isCodeHostProvider(h.kind) ? CODE_HOST_FAMILY_PILL[h.kind](h) : undefined)
   const first = hooks[0]!
-  const isGithub = first.kind === 'github'
-  const isGitlab = first.kind === 'gitlab'
-  const hostName = isGitlab ? 'GitLab' : 'GitHub'
+  const provider = isCodeHostProvider(first.kind) ? first.kind : null
+  // Only a code host's rows group, so the generic endpoint never reads this name.
+  const hostName = CODE_HOST_PROJECTION[provider ?? 'github'].label
   // Every family this confirm removes from the one repository it names.
   const familyList = [...new Set(hooks.map(familyOf).filter((pill): pill is string => !!pill))].join(', ')
   const subject = `${first.repoFullName ?? first.name}${familyList ? ` · ${familyList}` : ''}`
@@ -58,16 +70,14 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
     <>
       <div className="modalhead">
         <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
-          <Icon name={isGithub || isGitlab ? 'folder-git-2' : 'webhook'} size={16} color="var(--status-error)" />
+          <Icon name={provider ? 'folder-git-2' : 'webhook'} size={16} color="var(--status-error)" />
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">
           {group
             ? `Disconnect ${hostName}`
-            : isGithub
-              ? 'Remove repository'
-              : isGitlab
-                ? 'Remove project'
-                : 'Delete webhook'}
+            : provider
+              ? `Remove ${CODE_HOST_PROJECTION[provider].repoNoun}`
+              : 'Delete webhook'}
         </span>
         <button className="iconbtn" onClick={onClose}>
           <Icon name="x" size={16} />
@@ -81,16 +91,10 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
               <span className="mono text-(--text-primary)">{repoNames.join(', ')}</span>) — {hostName} events stop
               triggering this agent. Past runs and their sessions stay.
             </>
-          ) : isGithub ? (
+          ) : provider ? (
             <>
-              <span className="mono text-(--text-primary)">{subject}</span>&#32;stops triggering this agent — those
-              GitHub events are ignored from now on. Past runs and their sessions stay.
-            </>
-          ) : isGitlab ? (
-            <>
-              <span className="mono text-(--text-primary)">{subject}</span>&#32;stops triggering this agent — those
-              GitLab events are ignored from now on. The project itself, its bot and its webhook are untouched. Past
-              runs and their sessions stay.
+              <span className="mono text-(--text-primary)">{subject}</span>&#32;stops triggering this agent —{' '}
+              {CODE_HOST_REMOVAL_NOTE[provider]}
             </>
           ) : (
             <>

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -6,8 +6,10 @@
 // rejects edits that conflict with enabled GitHub review or Check actions.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
+import { GithubMark, LoadingState } from '@/components/marks'
+import { CodeHostMark } from '@/components/console/CodeHostMark'
 import { Button, Icon } from '@/components/ui'
+import { codeHostRecord } from '@/lib/code-hosts'
 import { agentLabel, isPoolPlacementKind, workspaceSourceOf, type Agent } from '@/lib/data'
 import { sessionIsolationLabel } from '@/lib/session-isolation'
 import { useConsoleData } from '@/lib/data-context'
@@ -105,8 +107,10 @@ export default function EditWorkspaceModal({
   // (git-workspace-model.md §7) — no source is stored.
   const currentSource = workspaceSourceOf(agent.workspace)
   const gitWorkspace = agent.workspace.mode === 'git' ? agent.workspace : null
-  const githubWorkspace = currentSource === 'github' ? gitWorkspace : null
-  const gitlabWorkspace = currentSource === 'gitlab' ? gitWorkspace : null
+  // The workspace each host's own editor sees — the checkout when this is its tile, else nothing.
+  const codeHostWorkspace = codeHostRecord((provider) => (currentSource === provider ? gitWorkspace : null))
+  const githubWorkspace = codeHostWorkspace.github
+  const gitlabWorkspace = codeHostWorkspace.gitlab
   const giturlWorkspace = currentSource === 'giturl' ? gitWorkspace : null
   const isGithubApp = githubWorkspace?.provider === 'github'
   // An anonymous checkout mints nothing, so only a credentialed workspace can hold write.
@@ -967,7 +971,7 @@ export default function EditWorkspaceModal({
                     className="flex min-w-0 items-center gap-[10px] rounded-md border border-(--border-subtle) bg-(--surface-card) px-3 py-[9px]"
                   >
                     <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
-                      {repoAuthProvider(authorization) === 'gitlab' ? <GitlabMark /> : <GithubMark />}
+                      <CodeHostMark provider={repoAuthProvider(authorization)} />
                     </span>
                     <span
                       className="mono min-w-0 flex-1 truncate text-[12.5px] font-semibold text-(--text-primary)"

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -1,8 +1,10 @@
 // No 'use client' here: reached only from the console's client trees
 // (ModalProvider and the views), exactly like `registry.ts`.
 
+import { CODE_HOST_PROVIDERS, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
 import { larkFeishuBrand, type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
 import type { BotDto } from '@/lib/api'
+import { CODE_HOST_PROJECTION } from '@/lib/code-hosts'
 import { platformLabel } from '@/lib/platform-labels'
 import { platformRegistry } from './registry'
 
@@ -60,8 +62,8 @@ export const BOT_PLATFORMS: readonly PlatformTile[] = platformTiles(platformRegi
  *  code host the deployment has not configured says so in its own pane. */
 export const PLATFORMS: readonly PlatformTile[] = [
   ...BOT_PLATFORMS,
-  { key: 'github', label: 'GitHub' },
-  { key: 'gitlab', label: 'GitLab' },
+  // One tile per code host, named by the code-host projection rather than spelled again here.
+  ...CODE_HOST_PROVIDERS.map((provider) => ({ key: provider, label: CODE_HOST_PROJECTION[provider].label })),
   // The generic trigger closes the row: chat platforms and code hosts are the named products.
   { key: 'webhook', label: 'Webhook' }
 ]
@@ -72,6 +74,12 @@ export const PLATFORMS: readonly PlatformTile[] = [
  *  capabilities gate them; every picker must treat them as always available. */
 export function isCoreTriggerKind(key: string): boolean {
   return !BOT_PLATFORMS.some((tile) => tile.key === key) && PLATFORMS.some((tile) => tile.key === key)
+}
+
+/** What watching a code host does for the agent, in that host's own subject vocabulary. */
+const CODE_HOST_BLURB: Record<CodeHostProvider, string> = {
+  github: 'React to issues & PRs',
+  gitlab: 'React to issues & MRs'
 }
 
 /**
@@ -86,8 +94,8 @@ export const INTEGRATION_BLURB: Record<string, string> = {
   discord: 'Reply in servers',
   feishu: 'Reply in groups & chats',
   linear: 'Work delegated issues',
-  github: 'React to issues & PRs',
-  gitlab: 'React to issues & MRs',
+  // The code-host rows are total over the providers, so a new host cannot reach the picker unblurbed.
+  ...CODE_HOST_BLURB,
   webhook: 'Trigger by posting a URL'
 }
 

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -134,6 +134,8 @@ import {
   type HookReviewPolicy
 } from '@/lib/github-review-settings'
 import { useDaemonDetail } from '@/lib/use-daemon-detail'
+import { isCodeHostProvider, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
+import { CODE_HOST_PROJECTION, codeHostRecord } from '@/lib/code-hosts'
 
 type DetailTab = 'config' | 'integrations' | 'workspace' | 'memory' | 'tools'
 const HOOK_REFRESH_MS = 30_000
@@ -161,9 +163,21 @@ function FeishuRegionBadge({ integration }: { integration: Pick<IntegrationRow, 
 
 interface CodeHostReviewSettingsDraft {
   hookId: string
-  kind: 'github' | 'gitlab'
+  kind: CodeHostProvider
   reviewPolicy: HookReviewPolicy
   reportingMode: HookReportingMode
+}
+
+// The review dialog's host plate on the inverse surface — each host keeps its own fill and color.
+const REVIEW_DIALOG_MARK: Record<CodeHostProvider, ReactNode> = {
+  github: <GithubMark color="#fff" />,
+  gitlab: <GitlabMark fillPct={100} />
+}
+
+// What the dialog settles, in each host's vocabulary.
+const REVIEW_DIALOG_TITLE: Record<CodeHostProvider, string> = {
+  github: 'PR review & Checks',
+  gitlab: 'MR review & run note'
 }
 
 export default function AgentDetailView() {
@@ -253,8 +267,10 @@ export default function AgentDetailView() {
   // Each code host renders as ONE group with a row per watched repository or
   // project (design); webhooks stay flat rows.
   const webhookHooks = agentHooks.filter((h) => h.kind === 'webhook')
-  const githubHooks = agentHooks.filter((h) => h.kind === 'github')
-  const gitlabHooks = agentHooks.filter((h) => h.kind === 'gitlab')
+  // Each host's own rows, keyed by provider so a lookup replaces "the other one's" branch.
+  const codeHostHooks = codeHostRecord((provider) => agentHooks.filter((h) => h.kind === provider))
+  const githubHooks = codeHostHooks.github
+  const gitlabHooks = codeHostHooks.gitlab
   // One flat row per subscription still — the grouping is only the ORDER (a repo's rows adjacent) plus its add offer.
   const githubRows = orderedGithubHookRows(githubHooks)
   const gitlabRows = orderedGitlabHookRows(gitlabHooks)
@@ -329,9 +345,9 @@ export default function AgentDetailView() {
   const [reviewSettingsDraft, setReviewSettingsDraft] = useState<CodeHostReviewSettingsDraft | null>(null)
   const [reviewSettingsSaving, setReviewSettingsSaving] = useState(false)
   const [reviewSettingsError, setReviewSettingsError] = useState<string | null>(null)
-  const isGitlabReviewDraft = reviewSettingsDraft?.kind === 'gitlab'
+  const reviewSettingsProvider = reviewSettingsDraft?.kind ?? null
   const reviewSettingsHook = reviewSettingsDraft
-    ? (isGitlabReviewDraft ? gitlabHooks : githubHooks).find((hook) => hook.id === reviewSettingsDraft.hookId)
+    ? codeHostHooks[reviewSettingsDraft.kind].find((hook) => hook.id === reviewSettingsDraft.hookId)
     : undefined
   const reviewSettingsRepoAccess = effectiveRepoAccess({
     repoId: reviewSettingsHook?.repoId,
@@ -341,10 +357,11 @@ export default function AgentDetailView() {
   })
   const reviewSettingsInstallation = installationForRepo(reviewSettingsHook?.repoFullName, githubInstallations)
   const reviewSettingsNeededAccess = reviewSettingsDraft ? requiredRepoAccess(reviewSettingsDraft) : 'none'
-  // Only the github surface has a config-time blocker; GitLab's writer is the
-  // project bot, which carries no per-agent access tier to satisfy first.
+  // Only the github surface has a config-time blocker, named positively so no other
+  // host inherits it; GitLab's writer is the project bot, which carries no per-agent
+  // access tier to satisfy first.
   const reviewSettingsBlocked =
-    !isGitlabReviewDraft &&
+    reviewSettingsProvider === 'github' &&
     (!repoAccessSatisfies(reviewSettingsRepoAccess, reviewSettingsNeededAccess) ||
       (reviewSettingsDraft?.reviewPolicy !== undefined &&
         reviewSettingsDraft.reviewPolicy !== 'off' &&
@@ -354,10 +371,12 @@ export default function AgentDetailView() {
           !hasPullRequestsReadPermission(reviewSettingsInstallation))))
 
   const openReviewSettings = (hook: HookDto) => {
+    // Opened only from a code-host row, so the row's own kind IS the draft's — never a fallback host.
+    if (!isCodeHostProvider(hook.kind)) return
     setReviewSettingsError(null)
     setReviewSettingsDraft({
       hookId: hook.id,
-      kind: hook.kind === 'gitlab' ? 'gitlab' : 'github',
+      kind: hook.kind,
       reviewPolicy: hook.reviewPolicy,
       reportingMode: hook.reportingMode
     })
@@ -377,33 +396,35 @@ export default function AgentDetailView() {
     const hook = reviewSettingsHook
     const { reviewPolicy, reportingMode } = reviewSettingsDraft
     const common = { agentId, name: hook.name, enabled: hook.enabled, events: hook.events }
-    // Each host's PUT re-sends its own whole block; only the two effect axes move.
-    const save =
-      hook.kind === 'gitlab'
-        ? hook.repoId
-          ? () =>
-              updateGitlabHook(hook.id, {
-                ...common,
-                projectId: hook.repoId!,
-                commentFamilies: gitlabCommentFamilies(hook.commentFamilies),
-                mentionOnly: hook.mentionOnly,
-                reviewPolicy,
-                reportingMode
-              })
-          : null
-        : hook.repoFullName
-          ? () =>
-              updateGithubHook(hook.id, {
-                ...common,
-                repoFullName: hook.repoFullName!,
-                commentFamilies: githubCommentFamilies(hook.commentFamilies),
-                labelFilter: hook.labelFilter,
-                mentionOnly: hook.mentionOnly,
-                reviewPolicy,
-                reportingMode,
-                gateMode: 'informational'
-              })
-          : null
+    // Each host's PUT re-sends its own whole block; only the two effect axes move. Total over
+    // the providers, so a new host writes through its own endpoint instead of GitHub's.
+    const writers: Record<CodeHostProvider, (() => Promise<HookDto>) | null> = {
+      github: hook.repoFullName
+        ? () =>
+            updateGithubHook(hook.id, {
+              ...common,
+              repoFullName: hook.repoFullName!,
+              commentFamilies: githubCommentFamilies(hook.commentFamilies),
+              labelFilter: hook.labelFilter,
+              mentionOnly: hook.mentionOnly,
+              reviewPolicy,
+              reportingMode,
+              gateMode: 'informational'
+            })
+        : null,
+      gitlab: hook.repoId
+        ? () =>
+            updateGitlabHook(hook.id, {
+              ...common,
+              projectId: hook.repoId!,
+              commentFamilies: gitlabCommentFamilies(hook.commentFamilies),
+              mentionOnly: hook.mentionOnly,
+              reviewPolicy,
+              reportingMode
+            })
+        : null
+    }
+    const save = writers[reviewSettingsDraft.kind]
     if (!save) return
     setReviewSettingsSaving(true)
     setReviewSettingsError(null)
@@ -418,6 +439,40 @@ export default function AgentDetailView() {
     } finally {
       setReviewSettingsSaving(false)
     }
+  }
+
+  // One review editor per host, chosen by a total table — a new host brings its own pane instead
+  // of inheriting GitHub's. Both arms edit the same draft, so the two handlers are shared.
+  const reviewSettingsEditor = (draft: CodeHostReviewSettingsDraft): ReactNode => {
+    const onReviewPolicyChange = (reviewPolicy: HookReviewPolicy) => {
+      setReviewSettingsError(null)
+      setReviewSettingsDraft((current) => (current ? { ...current, reviewPolicy } : current))
+    }
+    const onReportingModeChange = (reportingMode: HookReportingMode) => {
+      setReviewSettingsError(null)
+      setReviewSettingsDraft((current) => (current ? { ...current, reportingMode } : current))
+    }
+    const editors: Record<CodeHostProvider, () => ReactNode> = {
+      github: () => (
+        <GithubReviewSettings
+          value={draft}
+          onReviewPolicyChange={onReviewPolicyChange}
+          onReportingModeChange={onReportingModeChange}
+          repoAccess={reviewSettingsRepoAccess}
+          installation={reviewSettingsInstallation}
+          defaultExpanded
+        />
+      ),
+      gitlab: () => (
+        <GitlabReviewSettings
+          value={draft}
+          onReviewPolicyChange={onReviewPolicyChange}
+          onReportingModeChange={onReportingModeChange}
+          defaultExpanded
+        />
+      )
+    }
+    return editors[draft.kind]()
   }
 
   // Edit one github subscription in place (PUT re-sends the whole block); the
@@ -617,13 +672,16 @@ export default function AgentDetailView() {
   const ws = da.workspace
   // Demo agents have no daemon to read git state from, so the workspace card's
   // live half comes straight from their static mock workspace instead.
+  const mockSource = workspaceSourceOf(ws)
+  // The projection is the single source of a host's display host and name; a Git-URL mock keeps
+  // GitHub's browse host, which is what these demo rows have always shown.
+  const mockHostProjection = CODE_HOST_PROJECTION[isCodeHostProvider(mockSource) ? mockSource : 'github']
   const mockWorkspaceHeader: WorkspaceHeaderInfo = isGitWorkspace(ws)
     ? {
         status: workspaceStatus(ws),
         ...(ws.commitMsg ? { commit: { sha: ws.commit, time: ws.commitTime, title: ws.commitMsg } } : {}),
-        repoUrl: ws.repoUrl ?? `https://${workspaceSourceOf(ws) === 'gitlab' ? 'gitlab.com' : 'github.com'}/${ws.repo}`,
-        remoteLabel:
-          workspaceSourceOf(ws) === 'gitlab' ? 'GitLab' : workspaceSourceOf(ws) === 'github' ? 'GitHub' : 'remote'
+        repoUrl: ws.repoUrl ?? `https://${mockHostProjection.publicHost}/${ws.repo}`,
+        remoteLabel: isCodeHostProvider(mockSource) ? mockHostProjection.label : 'remote'
       }
     : { status: workspaceStatus(ws) }
   // Counts walk the whole mock tree (files are nested under folder children).
@@ -2281,7 +2339,7 @@ export default function AgentDetailView() {
             <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-[13px] desktop:px-5">
               <span className="flex h-8 w-8 flex-none items-center justify-center rounded-md bg-(--surface-inverse)">
                 <span className="flex h-[17px] w-[17px] items-center justify-center">
-                  {isGitlabReviewDraft ? <GitlabMark fillPct={100} /> : <GithubMark color="#fff" />}
+                  {REVIEW_DIALOG_MARK[reviewSettingsDraft.kind]}
                 </span>
               </span>
               <div className="min-w-0 flex-1">
@@ -2289,7 +2347,7 @@ export default function AgentDetailView() {
                   id="code-host-review-settings-title"
                   className="font-sans text-[14px] font-semibold leading-normal text-(--text-primary)"
                 >
-                  {isGitlabReviewDraft ? 'MR review & run note' : 'PR review & Checks'}
+                  {REVIEW_DIALOG_TITLE[reviewSettingsDraft.kind]}
                 </div>
                 <div className="mono mt-[2px] truncate text-[11.5px] text-(--text-tertiary)">
                   {reviewSettingsHook.repoFullName ?? reviewSettingsHook.name}
@@ -2300,35 +2358,7 @@ export default function AgentDetailView() {
               </button>
             </div>
             <div className="overflow-y-auto px-4 py-4 desktop:px-5">
-              {isGitlabReviewDraft ? (
-                <GitlabReviewSettings
-                  value={reviewSettingsDraft}
-                  onReviewPolicyChange={(reviewPolicy) => {
-                    setReviewSettingsError(null)
-                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reviewPolicy } : draft))
-                  }}
-                  onReportingModeChange={(reportingMode) => {
-                    setReviewSettingsError(null)
-                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reportingMode } : draft))
-                  }}
-                  defaultExpanded
-                />
-              ) : (
-                <GithubReviewSettings
-                  value={reviewSettingsDraft}
-                  onReviewPolicyChange={(reviewPolicy) => {
-                    setReviewSettingsError(null)
-                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reviewPolicy } : draft))
-                  }}
-                  onReportingModeChange={(reportingMode) => {
-                    setReviewSettingsError(null)
-                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reportingMode } : draft))
-                  }}
-                  repoAccess={reviewSettingsRepoAccess}
-                  installation={reviewSettingsInstallation}
-                  defaultExpanded
-                />
-              )}
+              {reviewSettingsEditor(reviewSettingsDraft)}
               {reviewSettingsError && (
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
                   <Icon name="triangle-alert" size={14} className="mt-[2px] flex-none" />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/lib/data'
 import { isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf, poolLabel } from '@/lib/data'
 import type { HookKind } from '@agentconnect.md/protocol'
+import type { CodeHostProvider } from '@agentconnect.md/protocol/code-host'
 import { hookKindFromIntegration, hookSourceLabel } from '@/lib/session-trigger'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
@@ -5734,7 +5735,7 @@ export type RepoAccess = 'read' | 'comment' | 'write'
 export interface AgentRepoAuthDto {
   id: string
   /** Which host numbers `repoId`. Absent on an older CP, where every grant is GitHub. */
-  provider?: 'github' | 'gitlab'
+  provider?: CodeHostProvider
   repoId?: string // rename-proof numeric repository/project id (absent on an older CP)
   repoFullName: string // owner/repo as GitHub cases it, or the GitLab project path (refreshed on rename)
   access: RepoAccess
@@ -5743,7 +5744,7 @@ export interface AgentRepoAuthDto {
 }
 
 /** Which host a grant row names — an older CP omits the field and means GitHub. */
-export function repoAuthProvider(row: AgentRepoAuthDto): 'github' | 'gitlab' {
+export function repoAuthProvider(row: AgentRepoAuthDto): CodeHostProvider {
   return row.provider ?? 'github'
 }
 

--- a/packages/web/src/lib/code-hosts.ts
+++ b/packages/web/src/lib/code-hosts.ts
@@ -1,0 +1,37 @@
+import { CODE_HOST_PROVIDERS, type CodeHostProvider } from '@agentconnect.md/protocol/code-host'
+
+/**
+ * The console's HOST PROJECTION over the code-host axis — what a provider is
+ * CALLED, where its hosted instance lives, and the word it uses for a
+ * repository. Code hosts are not platform modules (`platforms/host-projections.ts`
+ * §2 of the integration-plugin design), so the chassis projects them itself, and
+ * this table is the one place it does.
+ *
+ * Total by type: a new provider in `CODE_HOST_PROVIDERS` stops every
+ * `Record<CodeHostProvider, …>` below from compiling until it is given an entry,
+ * which is what keeps a third host from inheriting the first one's name, host or
+ * vocabulary through a two-way ternary.
+ */
+export interface CodeHostProjection {
+  /** Product name, as a tile label, a tooltip host name and a trigger-group heading. */
+  readonly label: string
+  /** Hostname of the provider's hosted instance — the display host a repository falls back to. */
+  readonly publicHost: string
+  /** What this host calls a repository, for copy that names the object ("repository", "project"). */
+  readonly repoNoun: string
+  /** The same object in the console's short register ("repo", "project"). */
+  readonly repoNounShort: string
+}
+
+export const CODE_HOST_PROJECTION: Record<CodeHostProvider, CodeHostProjection> = {
+  github: { label: 'GitHub', publicHost: 'github.com', repoNoun: 'repository', repoNounShort: 'repo' },
+  gitlab: { label: 'GitLab', publicHost: 'gitlab.com', repoNoun: 'project', repoNounShort: 'project' }
+}
+
+/** Project every provider onto one value — a total table without a second list of which hosts exist. */
+export function codeHostRecord<T>(of: (provider: CodeHostProvider) => T): Record<CodeHostProvider, T> {
+  return Object.fromEntries(CODE_HOST_PROVIDERS.map((provider) => [provider, of(provider)])) as Record<
+    CodeHostProvider,
+    T
+  >
+}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -3,7 +3,14 @@
 
 import type { AgentIcon } from '@/lib/agent-icon'
 import { gitRepoHostname, managedGitlabRepoPath } from './git-url-tile'
-import { isCodeHostHookKind, type HookKind } from '@agentconnect.md/protocol/code-host'
+import {
+  CODE_HOST_PROVIDERS,
+  isCodeHostHookKind,
+  isCodeHostProvider,
+  type CodeHostProvider,
+  type HookKind
+} from '@agentconnect.md/protocol/code-host'
+import { CODE_HOST_PROJECTION } from './code-hosts'
 import type { DaemonLifecyclePhase, McpAppCsp, McpAppDimensions, McpAppOutcome } from '@agentconnect.md/protocol'
 import type {
   DaemonSessionRetention,
@@ -435,7 +442,7 @@ export interface GitWorkspace {
   mode: 'git'
   worktree?: boolean
   /** Who vouches for the repository (persisted credential); absent ⇒ anonymous clone. */
-  provider?: 'github' | 'gitlab'
+  provider?: CodeHostProvider
   /** Rename-proof numeric repository/project id, when the credential carries one. */
   repoId?: string
   gitAccess?: 'read' | 'write'
@@ -466,15 +473,15 @@ export type Workspace = GitWorkspace | ScratchWorkspace
 // Which provider tile a workspace displays as (§7) — DERIVED from host + credential,
 // never stored: a provider names its tile; anonymous on a managed host shows that
 // tile with a public badge; anonymous anywhere else is the Git URL tile.
-export type WorkspaceSource = 'scratch' | 'github' | 'gitlab' | 'giturl'
+export type WorkspaceSource = 'scratch' | CodeHostProvider | 'giturl'
 
 export function workspaceSourceOf(
   ws: Pick<Workspace, 'mode'> & Partial<Pick<GitWorkspace, 'provider' | 'gitRepo'>>
 ): WorkspaceSource {
   if (ws.mode === 'scratch') return 'scratch'
-  if (ws.provider === 'github' || ws.provider === 'gitlab') return ws.provider
+  if (isCodeHostProvider(ws.provider)) return ws.provider
   const host = ws.gitRepo !== undefined ? gitRepoHostname(ws.gitRepo) : undefined
-  if (host === 'github.com') return 'github'
+  if (host === CODE_HOST_PROJECTION.github.publicHost) return 'github'
   // Same host+port+prefix semantics as the CP classifier; gitlab.com only as fallback.
   if (ws.gitRepo !== undefined && managedGitlabRepoPath(ws.gitRepo) !== null) return 'gitlab'
   // Bare `owner/repo` shorthand (legacy rows) is GitHub-only sugar.
@@ -2388,8 +2395,10 @@ export const MEMBERS: Member[] = [
 export function platName(p: string): string {
   const x = (p || '').toLowerCase()
   if (x.includes('sched')) return 'Schedule'
-  if (x.includes('github')) return 'GitHub'
-  if (x.includes('gitlab')) return 'GitLab'
+  // Each code host, named by its own projection — the id carries the provider, so no host needs its own arm.
+  for (const provider of CODE_HOST_PROVIDERS) {
+    if (x.includes(provider)) return CODE_HOST_PROJECTION[provider].label
+  }
   if (x.includes('dream')) return 'Memory dream'
   if (x.includes('hook')) return 'Webhook'
   // 'playground' (live sandbox) and 'webchat' (its persisted CP session) are the same

--- a/packages/web/src/lib/github-review-settings.ts
+++ b/packages/web/src/lib/github-review-settings.ts
@@ -3,6 +3,7 @@
 // The host-neutral half lives in `code-host-review-settings.ts`; what stays is GitHub's own
 // App-installation permissions and the per-repository access tier an effect is clamped against.
 
+import type { CodeHostProvider } from '@agentconnect.md/protocol/code-host'
 import {
   codeHostReviewCapabilities,
   codeHostReviewSettingsFromCapabilities,
@@ -84,7 +85,7 @@ interface WorkspaceRepoMatchInput {
   repoFullName: string | null | undefined
   workspace: {
     mode: 'git' | 'scratch'
-    provider?: 'github' | 'gitlab'
+    provider?: CodeHostProvider
     repoId?: string
     repo?: string
   }
@@ -110,7 +111,7 @@ export function effectiveRepoAccess(input: {
   repoFullName: string | null | undefined
   workspace: {
     mode: 'git' | 'scratch'
-    provider?: 'github' | 'gitlab'
+    provider?: CodeHostProvider
     repoId?: string
     repo?: string
     gitAccess?: 'read' | 'write'

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -4,6 +4,7 @@ import {
   isCodeHostProvider,
   type HookKind
 } from '@agentconnect.md/protocol/code-host'
+import { CODE_HOST_PROJECTION, codeHostRecord } from './code-hosts'
 import { isSelfSender } from './data'
 
 /**
@@ -19,17 +20,19 @@ export type SessionTriggerKind = 'agent' | 'person' | 'schedule' | HookKind
 /** Hook kinds in console display order — every code host first, the generic endpoint last. */
 export const HOOK_TRIGGER_KINDS = [...CODE_HOST_PROVIDERS, GENERIC_HOOK_KIND] as const
 
+// A code host is named by its own projection, never re-spelled per table, so the product
+// name has one authority on this surface too.
+const CODE_HOST_LABEL = codeHostRecord((provider) => CODE_HOST_PROJECTION[provider].label)
+
 /** Trigger filter-group heading per hook kind. Total: a new kind gets its own group. */
 export const HOOK_KIND_GROUP_LABEL: Record<HookKind, string> = {
-  github: 'GitHub',
-  gitlab: 'GitLab',
+  ...CODE_HOST_LABEL,
   webhook: 'Webhooks'
 }
 
 /** Display name for a hook source the daemon left unnamed. Total, so no code host reads as "Webhook". */
 export const HOOK_KIND_LABEL: Record<HookKind, string> = {
-  github: 'GitHub',
-  gitlab: 'GitLab',
+  ...CODE_HOST_LABEL,
   webhook: 'Webhook'
 }
 


### PR DESCRIPTION
Step 1 of the third-implementer seam extraction (`docs/designs/gitea-integration.md` §13, item 7): a behavior-neutral refactor so that a third code host is a compile-time event in the console instead of a hunt for two-way `github`/`gitlab` ternaries.

**No rendered change.** Same text, same marks, same DOM, same requests — every edit replaces a two-way provider comparison with a lookup whose value is the one the comparison produced. No test expectation was touched.

## What changed

New, following the tables the console already has (`platforms/host-projections.ts`, `IntegrationMarks`'s `HOOK_KIND_MARK`, `lib/session-trigger.ts` deriving from `CODE_HOST_PROVIDERS`):

- `lib/code-hosts.ts` — `CODE_HOST_PROJECTION`, one entry per provider: product name, the hosted instance's hostname (the single source of a provider's display host), and the word that host uses for a repository (long and short). Plus `codeHostRecord`, which projects every provider onto one value so a derived table needs no per-provider edit.
- `components/console/CodeHostMark.tsx` — the provider-keyed reading of the existing `GithubMark` / `GitlabMark`, normalized to one prop set. The mark components themselves are untouched.

Sites that now read a table instead of comparing a provider two ways:

| File | What was decided by a ternary |
| --- | --- |
| `lib/session-trigger.ts` | the hook-kind label tables re-spelled "GitHub"/"GitLab"; they derive from the projection now |
| `platforms/host-projections.ts` | the install picker's code-host tiles and their blurbs were a hand-written two-row list |
| `lib/data.ts` | workspace credential + `WorkspaceSource` unions, the source classifier's literal host, `platName`'s two arms |
| `lib/api.ts`, `lib/github-review-settings.ts` | `provider?: 'github' \| 'gitlab'` on the grant row and the workspace shapes |
| `WorkspaceFormFields.tsx` | `WorkspaceMode` keeps its shape (`'scratch' \| CodeHostProvider \| 'giturl'`); the code-host tiles derive label, hint and mark |
| `WorkspaceCard.tsx` | source mark, remote label, grant-row marks |
| `modals/EditWorkspaceModal.tsx` | grant-row mark; the per-host workspace binding |
| `modals/AddAgentModal.tsx` | the clone hint's "repo"/"project" |
| `modals/DeleteHookModal.tsx` | family pill, host name, title noun, the removal sentence |
| `modals/AddAgentRepoModal.tsx` | host tiles, subtitle and footer nouns, the grant picker, the footer gate and the create payload |
| `modals/AddIntegrationModal.tsx` | the code-host footer and the subscription hint |
| `views/AgentDetailView.tsx` | the `gitlab.com`/`github.com` host guess and remote label, hooks-by-provider, review dialog mark/title/editor, the settings PUT |

Where a modal genuinely renders a provider-specific picker, the picker keeps its components and markup and is selected through the table — which is why `AddAgentRepoModal`'s diff is mostly re-indentation (`git diff -w` shows the content as unchanged apart from the listed edits).

Deliberately left alone, with reasons:

- `components/marks.tsx` — `PlatformMark`'s substring dispatch is a mark component, not a selection site.
- `lib/git-url-tile.ts` — the Git-URL tile refuses a managed host through per-provider address matchers (hostname equality vs. the configured-instance path parser). That is §13 item 2's registry shape, not a display table; generalizing it here would be guessing.
- The per-host panes in `AddIntegrationModal` and the per-host group cards in `AgentDetailView` — single `&&` guards on the open platform axis, not two-way ternaries; a third host adds its own pane there.
- `AgentWorkspaceCredentialDto` and `createAgentRepo`'s input union keep their per-provider arms: those are wire shapes that genuinely differ.

Nothing outside `packages/web` changed — no protocol export was needed.

## Verification that a third provider now fails to compile

Temporarily adding one entry to `CODE_HOST_PROVIDERS` (then reverted — no such string is in this branch) makes `pnpm --filter @agentconnect.md/web typecheck` report **16 missing entries**, in: `lib/code-hosts.ts`, `CodeHostMark.tsx`, `IntegrationMarks.tsx`, `platforms/host-projections.ts`, `views/AgentsView.tsx`, `views/SessionsView.tsx`, `views/AgentDetailView.tsx` (4), `modals/DeleteHookModal.tsx` (2), `modals/AddAgentRepoModal.tsx` (2), `modals/AddIntegrationModal.tsx` (2). The derived surfaces (workspace tiles, hook-kind labels, picker tiles) pick the new host up without an edit.

## Gates

- `pnpm typecheck` — pass (every package).
- `pnpm --filter @agentconnect.md/web test` — 222 of 223 files pass, 2566 of 2567 tests pass. The one failure is `src/protocol-imports.leaf.test.ts`, which fails identically on `main` before this branch: `components/console/McpAppCard.tsx` value-imports the protocol barrel instead of a leaf subpath (landed in #2021). Untouched here, and unrelated to this refactor. The `*.gitlab.test.tsx` and `*.codehost.test.tsx` suites all pass.
- `pnpm --filter @agentconnect.md/web lint` — 0 errors; the 2 `import-x/no-duplicates` warnings are pre-existing in `views/SessionDetailView.tsx`, which this branch does not touch.
- `pnpm format:check` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
