### PR TITLE
docs(web): cite the design that keeps code hosts off the platform axis

### DIFF
--- a/packages/web/src/lib/code-hosts.ts
+++ b/packages/web/src/lib/code-hosts.ts
@@ -2,10 +2,10 @@ import { CODE_HOST_PROVIDERS, type CodeHostProvider } from '@agentconnect.md/pro
 
 /**
  * The console's HOST PROJECTION over the code-host axis — what a provider is
- * CALLED, where its hosted instance lives, and the word it uses for a
- * repository. Code hosts are not platform modules (`platforms/host-projections.ts`
- * §2 of the integration-plugin design), so the chassis projects them itself, and
- * this table is the one place it does.
+ * CALLED, where its hosted instance lives, and the word it uses for a repository.
+ * Code hosts are deliberately not platform modules
+ * (integration-plugin-architecture.md §2), so the chassis projects them itself,
+ * the way `platforms/host-projections.ts` projects the platform axis.
  *
  * Total by type: a new provider in `CODE_HOST_PROVIDERS` stops every
  * `Record<CodeHostProvider, …>` below from compiling until it is given an entry,


### PR DESCRIPTION
Comment-only follow-up to #2042. The new code-host projection's doc block folded a design section number into a source path — "(`platforms/host-projections.ts` §2 of the integration-plugin design)" — which sends a reader looking for a §2 inside a TypeScript file. It now names `integration-plugin-architecture.md` §2 for the rule and `platforms/host-projections.ts` for the pattern it mirrors.

No code, no behavior, no test change. It was ready while #2042 was still open, but the PR merged first.

Gates: `pnpm format:check` passes; nothing executable changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
