### PR TITLE
refactor(daemon): resolve code-host credentials and managed hosts through a provider registry

### DIFF
--- a/packages/daemon/src/codehost/credentials.ts
+++ b/packages/daemon/src/codehost/credentials.ts
@@ -1,0 +1,103 @@
+/**
+ * The daemon's code-host credential contract (gitlab-com-integration.md §13.2, §24.4).
+ *
+ * Where a managed credential reaches, how its host is addressed, and where an authorized repository
+ * lands on disk are provider knowledge; core asks this seam for them and never compares a provider
+ * name. Every member below exists because BOTH hosts implement it today. What genuinely diverges
+ * stays inside the implementing module — GitHub mints an App installation token for a repository it
+ * already covers, GitLab resolves a per-project grant and carries its own instance — and so does the
+ * spec's host field, which is one axis per provider by design, not a table of hosts.
+ *
+ * The credential helper cannot read this registry: it ships in the runtime image and may import
+ * nothing but node builtins, so the path grammars live in the `gitcred/repo-path.ts` leaf and each
+ * entry points at its own.
+ */
+import { CODE_HOST_PROVIDERS, isCodeHostProvider, type CodeHostProvider } from '@agentconnect.md/protocol'
+import { IMPLICIT_CREDENTIAL_PROVIDER, type ManagedCredentialHost } from '../gitcred/managed-hosts.js'
+import type { CredentialRepoPathParser } from '../gitcred/repo-path.js'
+import type { ManagedCredentialScope } from '../workspace/git-injection.js'
+import { githubCredentials } from '../github/credentials.js'
+import { gitlabCredentials } from '../gitlab/credentials.js'
+
+/** The provider a credential request carries only when it is not the implicit one (the empty cache-key segment). */
+export type QualifiedCodeHostProvider = Exclude<CodeHostProvider, typeof IMPLICIT_CREDENTIAL_PROVIDER>
+
+/** The host-carrying fields of one replicated agent spec — one axis per provider (§24.4). */
+export interface CodeHostSpecHosts {
+  /** The GitLab instance this spec's GitLab consumers address; absent ⇒ GitLab.com. */
+  gitlabHost?: string
+}
+
+/** Where one authorized additional repository's subtree hangs under `repos/` (multi-repository-workspaces.md). */
+export interface SecondaryRootPlacement {
+  provider: CodeHostProvider
+  repoFullName: string
+  subtreeName: string
+}
+
+/** One code host's credential and placement behavior behind the seam. */
+export interface CodeHostCredentialModule {
+  readonly provider: CodeHostProvider
+  /** The spec's `gitCredential` value that names this host's managed credential. */
+  readonly specGitCredential: string
+  /** True when the instance comes off the spec rather than being this host's one fixed address (§24.4). */
+  readonly hostFromSpec: boolean
+  /** The host this provider's consumers address for one spec. */
+  managedHost(spec: CodeHostSpecHosts): ManagedCredentialHost
+  /** git's credential `path` as this host's repository path — the leaf grammar both ends share. */
+  readonly credentialRepoPath: CredentialRepoPathParser
+  /** An already-normalized clone URL under this host's own address conventions. */
+  canonicalCloneUrl(normalized: string): string
+  /** The clone address a MANAGED remote resolves to from the spec's repository label. */
+  managedRemoteUrl(repository: string): string
+  /** Credential purposes this host re-resolves live, so a refusal is never durable (§14.1, §14.2). */
+  readonly liveCredentialPurposes: readonly string[]
+  /** Where one additional repository lands, or undefined when the row is not a placeable name. */
+  placeSecondaryRoot(row: { repoFullName: string; repoId: string }): SecondaryRootPlacement | undefined
+  /** The authorized clone URL of one additional repository on this host. */
+  secondaryCloneUrl(repoFullName: string, spec: CodeHostSpecHosts): string
+  /** The credential scope one additional repository on this host rides. */
+  secondaryCredentialScope(spec: CodeHostSpecHosts): ManagedCredentialScope
+}
+
+/** Adding a code host is adding one entry; the record over the provider union makes a missing one a compile error. */
+const MODULES: { readonly [P in CodeHostProvider]: CodeHostCredentialModule } = {
+  github: githubCredentials,
+  gitlab: gitlabCredentials
+}
+
+/** The module owning one provider — undefined for an anonymous remote and for a name this build does not carry. */
+export function codeHostCredentials(provider: string | undefined): CodeHostCredentialModule | undefined {
+  return provider !== undefined && isCodeHostProvider(provider) ? MODULES[provider] : undefined
+}
+
+/** Every module, in the provider order the injected host table and its env encoding are written in. */
+export function codeHostCredentialModules(): readonly CodeHostCredentialModule[] {
+  return CODE_HOST_PROVIDERS.map((provider) => MODULES[provider])
+}
+
+/** The host table one agent's git classifies against: one entry per provider, resolved from the spec (§24.4). */
+export function managedHostTable(spec: CodeHostSpecHosts): ManagedCredentialHost[] {
+  return codeHostCredentialModules().map((module) => module.managedHost(spec))
+}
+
+/** The provider a spec's `gitCredential` names, whatever the workspace mode; undefined ⇒ anonymous. */
+export function credentialProviderOf(gitCredential: string | undefined): CodeHostProvider | undefined {
+  if (gitCredential === undefined) return undefined
+  return codeHostCredentialModules().find((module) => module.specGitCredential === gitCredential)?.provider
+}
+
+/** The hosts whose instance a spec carries — the only ones an anonymous remote can be attributed to. */
+export function specHostCodeHosts(): readonly CodeHostCredentialModule[] {
+  return codeHostCredentialModules().filter((module) => module.hostFromSpec)
+}
+
+/** Every purpose whose credential is re-resolved live, so its refusal is never cached as durable. */
+const LIVE_CREDENTIAL_PURPOSES: ReadonlySet<string> = new Set(
+  codeHostCredentialModules().flatMap((module) => [...module.liveCredentialPurposes])
+)
+
+/** True when a refusal of this purpose must not outlive the call that discovered it. */
+export function isLiveCredentialPurpose(purpose: string | undefined): boolean {
+  return purpose !== undefined && LIVE_CREDENTIAL_PURPOSES.has(purpose)
+}

--- a/packages/daemon/src/codehost/credentials.ts
+++ b/packages/daemon/src/codehost/credentials.ts
@@ -72,29 +72,33 @@ export function codeHostCredentials(provider: string | undefined): CodeHostCrede
 }
 
 /** Every module, in the provider order the injected host table and its env encoding are written in. */
+const MODULE_LIST: readonly CodeHostCredentialModule[] = CODE_HOST_PROVIDERS.map((provider) => MODULES[provider])
+
 export function codeHostCredentialModules(): readonly CodeHostCredentialModule[] {
-  return CODE_HOST_PROVIDERS.map((provider) => MODULES[provider])
+  return MODULE_LIST
 }
 
 /** The host table one agent's git classifies against: one entry per provider, resolved from the spec (§24.4). */
 export function managedHostTable(spec: CodeHostSpecHosts): ManagedCredentialHost[] {
-  return codeHostCredentialModules().map((module) => module.managedHost(spec))
+  return MODULE_LIST.map((module) => module.managedHost(spec))
 }
 
 /** The provider a spec's `gitCredential` names, whatever the workspace mode; undefined ⇒ anonymous. */
 export function credentialProviderOf(gitCredential: string | undefined): CodeHostProvider | undefined {
   if (gitCredential === undefined) return undefined
-  return codeHostCredentialModules().find((module) => module.specGitCredential === gitCredential)?.provider
+  return MODULE_LIST.find((module) => module.specGitCredential === gitCredential)?.provider
 }
+
+const SPEC_HOST_MODULES: readonly CodeHostCredentialModule[] = MODULE_LIST.filter((module) => module.hostFromSpec)
 
 /** The hosts whose instance a spec carries — the only ones an anonymous remote can be attributed to. */
 export function specHostCodeHosts(): readonly CodeHostCredentialModule[] {
-  return codeHostCredentialModules().filter((module) => module.hostFromSpec)
+  return SPEC_HOST_MODULES
 }
 
 /** Every purpose whose credential is re-resolved live, so its refusal is never cached as durable. */
 const LIVE_CREDENTIAL_PURPOSES: ReadonlySet<string> = new Set(
-  codeHostCredentialModules().flatMap((module) => [...module.liveCredentialPurposes])
+  MODULE_LIST.flatMap((module) => [...module.liveCredentialPurposes])
 )
 
 /** True when a refusal of this purpose must not outlive the call that discovered it. */

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -31,16 +31,19 @@
  * and an UNEXPIRED cached token keeps serving — CP downtime only breaks remote
  * git once the hour runs out.
  */
-import { GITLAB_DEFAULT_BASE_URL, type GitCredCapability, type GitCredGrant } from '@agentconnect.md/protocol'
+import {
+  GITLAB_DEFAULT_BASE_URL,
+  type CodeHostProvider,
+  type GitCredCapability,
+  type GitCredGrant
+} from '@agentconnect.md/protocol'
+import { isLiveCredentialPurpose, type QualifiedCodeHostProvider } from '../codehost/credentials.js'
 
 /** Hand out only while more than this remains (nests under the CP's 15min floor). */
 const HANDOUT_MIN_MS = 10 * 60 * 1000
 
 /** Repo-level denials are retried after this — the console-authorization lag. */
 const REPO_DENIAL_TTL_MS = 60 * 1000
-
-/** Daemon-owned GitLab writers: project-keyed, re-resolved live per call, so a refusal is never durable. */
-const GITLAB_EFFECT_PURPOSES = new Set(['gitlab_hook_reply', 'gitlab_effect'])
 
 /** The baseline scope set behind `GH_TOKEN` (P2.5 write-back): git contents plus the
  *  issue/PR scopes `gh issue comment` / `gh pr comment` need. The CP clamps
@@ -58,7 +61,7 @@ type CachePlane = CredPlane | 'gh-actions'
  *  (the GH_KEY precedent). GitHub is the EMPTY provider segment whether the request went out
  *  v1-shaped or github-qualified: one logical credential must stay one entry across a CP up- or
  *  downgrade, and the request shape is a wire negotiation, not part of the credential's identity. */
-const keyOf = (agentId: string, plane: CachePlane, repo?: string, provider?: 'gitlab'): string =>
+const keyOf = (agentId: string, plane: CachePlane, repo?: string, provider?: QualifiedCodeHostProvider): string =>
   `${plane}\u0000${agentId}\u0000${repo?.toLowerCase() ?? ''}\u0000${provider ?? ''}`
 
 /** Cache key for a repo-targeted COMMENT token (the GithubPoster's — issues/PR
@@ -105,7 +108,7 @@ export interface GitCredentialCacheDeps {
     purpose?: 'github_hook_reply' | 'gitlab_hook_reply' | 'gitlab_effect'
     hookId?: string
     forceRefresh?: boolean
-    provider?: 'github' | 'gitlab'
+    provider?: CodeHostProvider
     externalRepoId?: string
     requestedAccess?: 'read' | 'write'
   }) => Promise<GitCredGrant>
@@ -164,15 +167,16 @@ export class GitCredentialCache {
     opts: {
       plane?: CredPlane
       repo?: string
-      provider?: 'gitlab'
+      provider?: QualifiedCodeHostProvider
       externalRepoId?: string
       requestedAccess?: 'read' | 'write'
     } = {}
   ): Promise<Entry> {
     const plane = opts.plane ?? 'git'
-    if (opts.provider === 'gitlab' && this.deps.providerV2Supported?.() !== true) {
+    // §17.1: any provider but the implicit one may be named only after the CP advertises the field.
+    if (opts.provider !== undefined && this.deps.providerV2Supported?.() !== true) {
       throw new GitCredUnavailableError(
-        'the control plane is too old for gitlab credentials (gitcred-provider-v2 not advertised)',
+        `the control plane is too old for ${opts.provider} credentials (gitcred-provider-v2 not advertised)`,
         false
       )
     }
@@ -348,7 +352,7 @@ export class GitCredentialCache {
   invalidate(
     agentId: string,
     presentedPassword?: string,
-    opts: { plane?: CredPlane; repo?: string; provider?: 'gitlab' } = {}
+    opts: { plane?: CredPlane; repo?: string; provider?: QualifiedCodeHostProvider } = {}
   ): void {
     const plane = opts.plane ?? 'git'
     const cachePlane = plane === 'gh' && this.deps.actionsSupported?.() === true ? 'gh-actions' : plane
@@ -375,9 +379,9 @@ export class GitCredentialCache {
     } catch (e) {
       const code = (e as { code?: string }).code
       if (code === 'SCOPE_DENIED') {
-        // §14.1/§14.2: these leases are re-resolved live and hook/binding lifecycle changes never
-        // replicate an agent spec, so a refusal is never durable — the next turn asks the CP again.
-        if (payload.purpose !== undefined && GITLAB_EFFECT_PURPOSES.has(payload.purpose)) {
+        // §14.1/§14.2: a purpose its host re-resolves live — hook/binding lifecycle changes never
+        // replicate an agent spec, so a refusal is never durable and the next turn asks the CP again.
+        if (isLiveCredentialPurpose(payload.purpose)) {
           this.entries.delete(key)
           throw new GitCredUnavailableError((e as Error).message, false)
         }

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -33,6 +33,9 @@ import { createRequire } from 'node:module'
 import { createServer, type Server, type Socket } from 'node:net'
 import { dirname, join } from 'node:path'
 import { GitCredentialCache, GitCredUnavailableError, type CredPlane } from './git-credential.js'
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
+import type { QualifiedCodeHostProvider } from '../codehost/credentials.js'
+import { IMPLICIT_CREDENTIAL_PROVIDER } from '../gitcred/managed-hosts.js'
 import { isWindowsNamedPipe, localIpcPath } from '../paths.js'
 
 // Declared in `gitcred/env.ts` and re-exported here, where every daemon-side caller already looks
@@ -65,8 +68,8 @@ interface GitCredIpcRequest {
   repoFullName?: string
   /** 'gh' ⇒ the widened GH_TOKEN capability set; absent/'git' ⇒ contents-only. */
   plane?: string
-  /** Host-derived hint from the helper ('gitlab' when git asked for gitlab.com).
-   *  ROUTING ONLY: the daemon's own replicated spec decides the real provider. */
+  /** Host-derived hint from the helper — the provider whose managed host git asked for, absent for
+   *  the implicit one. ROUTING ONLY: the daemon's own replicated spec decides the real provider. */
   provider?: string
 }
 
@@ -78,14 +81,17 @@ export interface GitCredServerDeps {
   workspaceRepoOf?: (agentId: string) => string | undefined
   /** The agent's managed credential provider from its REPLICATED SPEC — never
    *  the helper's claim (§13.2). Absent/undefined ⇒ github (the v1 behavior). */
-  providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
-  /** The gitlab workspace's numeric project id from the REPLICATED SPEC — the
+  providerOf?: (agentId: string) => CodeHostProvider | undefined
+  /** The workspace repository's own numeric id from the REPLICATED SPEC — the
    *  §17.1 request identity the grant echo is verified against. */
-  projectIdOf?: (agentId: string) => string | undefined
-  /** The numeric project id of a NAMED gitlab project the spec lists as an additional
-   *  authorization (§8.3), or undefined when the path is not one. Also from the
-   *  replicated spec, so a named project never introduces a provider the spec lacks. */
-  gitlabProjectOf?: (agentId: string, repoFullName: string) => string | undefined
+  workspaceRepoIdOf?: (agentId: string) => string | undefined
+  /** A NAMED repository the spec lists as an additional authorization (§8.3) on a host that must be
+   *  named on the wire, with its numeric id; undefined when the path is not one. Also from the
+   *  replicated spec, so a named repository never introduces a provider the spec lacks. */
+  qualifiedRepoOf?: (
+    agentId: string,
+    repoFullName: string
+  ) => { provider: QualifiedCodeHostProvider; externalId: string } | undefined
 }
 
 export class GitCredServer {
@@ -93,9 +99,9 @@ export class GitCredServer {
   private readonly capabilities = new Map<string, string>()
   private readonly log: GitCredServerDeps['log']
   private readonly workspaceRepoOf?: (agentId: string) => string | undefined
-  private readonly providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
-  private readonly projectIdOf?: (agentId: string) => string | undefined
-  private readonly gitlabProjectOf?: (agentId: string, repoFullName: string) => string | undefined
+  private readonly providerOf?: GitCredServerDeps['providerOf']
+  private readonly workspaceRepoIdOf?: GitCredServerDeps['workspaceRepoIdOf']
+  private readonly qualifiedRepoOf?: GitCredServerDeps['qualifiedRepoOf']
 
   constructor(
     private readonly cache: GitCredentialCache,
@@ -105,8 +111,8 @@ export class GitCredServer {
     this.log = deps.log
     if (deps.workspaceRepoOf) this.workspaceRepoOf = deps.workspaceRepoOf
     if (deps.providerOf) this.providerOf = deps.providerOf
-    if (deps.projectIdOf) this.projectIdOf = deps.projectIdOf
-    if (deps.gitlabProjectOf) this.gitlabProjectOf = deps.gitlabProjectOf
+    if (deps.workspaceRepoIdOf) this.workspaceRepoIdOf = deps.workspaceRepoIdOf
+    if (deps.qualifiedRepoOf) this.qualifiedRepoOf = deps.qualifiedRepoOf
   }
 
   async start(): Promise<void> {
@@ -202,27 +208,29 @@ export class GitCredServer {
     }
     // The SPEC decides the provider; a helper whose host hint disagrees is
     // asking for another host's credential and gets a clean denial (§13.2).
-    // A named project the spec lists as a gitlab additional authorization (§8.3) is
-    // the second spec-derived gitlab authority; the host hint only disambiguates
-    // between authorities the spec already carries, it never introduces one.
+    // A named repository the spec lists as an additional authorization on another host (§8.3) is the
+    // second spec-derived authority; the host hint only disambiguates between authorities the spec
+    // already carries, it never introduces one.
     //
-    // Resolved BEFORE the op split: erase has to reach the key get stored, and a
-    // gitlab additional project on a scratch or github workspace is keyed gitlab
-    // while the workspace alone says github. Deriving erase from the workspace
-    // would invalidate the wrong entry and leave the rejected token live to TTL.
-    const workspaceProvider = this.providerOf?.(req.agentId) ?? 'github'
-    const gitlabProject = repo !== undefined ? this.gitlabProjectOf?.(req.agentId, repo) : undefined
-    const provider: 'github' | 'gitlab' =
-      gitlabProject !== undefined && (req.provider === 'gitlab' || workspaceProvider === 'gitlab')
-        ? 'gitlab'
+    // Resolved BEFORE the op split: erase has to reach the key get stored, and an additional
+    // repository on another host rides a scratch or github workspace whose spec alone says github.
+    // Deriving erase from the workspace would invalidate the wrong entry and leave the rejected
+    // token live to TTL.
+    const workspaceProvider = this.providerOf?.(req.agentId) ?? IMPLICIT_CREDENTIAL_PROVIDER
+    const named = repo !== undefined ? this.qualifiedRepoOf?.(req.agentId, repo) : undefined
+    const provider: CodeHostProvider =
+      named !== undefined && (req.provider === named.provider || workspaceProvider === named.provider)
+        ? named.provider
         : workspaceProvider
+    // Only a provider that is not the implicit one is named on the wire (the empty cache-key segment).
+    const qualifier = provider === IMPLICIT_CREDENTIAL_PROVIDER ? {} : { provider }
     if (req.op === 'erase') {
       // Git presents the rejected credential — the provider revokes instantly on
       // uninstall/suspend/rotation, and this is how the daemon cache learns.
       this.cache.invalidate(req.agentId, req.password, {
         plane,
         ...(repo !== undefined ? { repo } : {}),
-        ...(provider === 'gitlab' ? { provider: 'gitlab' as const } : {})
+        ...qualifier
       })
       this.audit('erased', req.agentId, plane, repo)
       return reply({ ok: true })
@@ -239,19 +247,21 @@ export class GitCredServer {
       return reply({ ok: false, error: 'glab credentials require a managed GitLab workspace' })
     }
     try {
-      // §17.1: every gitlab ask names the rename-stable numeric identity so the
-      // consumer can reject a wrong-project grant echo — the workspace project for
-      // the repo-less ask, the authorized project for a named one. Without it a
-      // named project resolves to the workspace grant and the echo check rejects it.
-      const projectId =
-        provider !== 'gitlab'
-          ? undefined
-          : (gitlabProject ?? (repo === undefined ? this.projectIdOf?.(req.agentId) : undefined))
+      // §17.1: every qualified ask names the rename-stable numeric identity so the consumer can
+      // reject a wrong-repository grant echo — the authorized repository for a named ask, the
+      // workspace's own for the repo-less one. Without it a named repository resolves to the
+      // workspace grant and the echo check rejects it.
+      const externalId =
+        named?.provider === provider
+          ? named.externalId
+          : repo === undefined
+            ? this.workspaceRepoIdOf?.(req.agentId)
+            : undefined
       const cred = await this.cache.get(req.agentId, 'helper', {
         plane,
         ...(repo !== undefined ? { repo } : {}),
-        ...(provider === 'gitlab' ? { provider: 'gitlab' as const } : {}),
-        ...(projectId !== undefined ? { externalRepoId: projectId } : {}),
+        ...qualifier,
+        ...(externalId !== undefined ? { externalRepoId: externalId } : {}),
         // §13.3: the CLI wrapper is read-only BY DESIGN — a mutating glab
         // command never receives effect authority and fails at GitLab.
         ...(plane === 'glab' ? { requestedAccess: 'read' as const } : {})

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -36,7 +36,7 @@ import { promises as fs } from 'node:fs'
 import * as path from 'node:path'
 import { join } from 'node:path'
 import {
-  normalizeGithubRepoUrl,
+  type CodeHostProvider,
   type GitCommitIdentity,
   type WorkspaceGitStatus,
   type WorkspaceGitDiffReq,
@@ -55,6 +55,8 @@ import {
   type WorkspaceGitMessageReq,
   type WorkspaceGitMessageResult
 } from '@agentconnect.md/protocol'
+import { codeHostCredentials } from '../codehost/credentials.js'
+import { IMPLICIT_CREDENTIAL_PROVIDER } from '../gitcred/managed-hosts.js'
 import {
   assertSafeWorkspaceGitConfig,
   canonicalWorkspaceGitUrl,
@@ -210,8 +212,8 @@ export interface WorkspaceGitTarget {
   githubApp: boolean
   /** The managed host this scope's credential channel pins, resolved from the spec (§24.4). */
   managed?: ManagedCredentialScope
-  /** Whose URL conventions this remote follows; absent ⇒ neither provider's (§24.4). */
-  remoteProvider?: 'github' | 'gitlab'
+  /** Whose URL conventions this remote follows; absent ⇒ no managed host's (§24.4). */
+  remoteProvider?: CodeHostProvider
 }
 
 export function createWorkspaceGit(
@@ -296,13 +298,13 @@ export function createWorkspaceGit(
     try {
       if (!target) throw new Error('workspace target is unavailable')
       currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']), target.managed?.gitlabHost)
-      // Canonicalization follows the remote's PROVIDER: only a gitlab project keeps its subgroups.
+      // Canonicalization follows the remote's PROVIDER — each host's own address conventions, and a
+      // managed remote additionally resolves through the host that issues its credential.
       const provider = target.remoteProvider
-      const github = target.githubApp && provider !== 'gitlab'
-      expectedOrigin = authorizeWorkspaceGitUrl(
-        canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo, provider),
-        target.managed?.gitlabHost
-      )
+      // A managed target that names no provider is the pre-GitLab shape: the implicit host owns it.
+      const host = target.githubApp ? codeHostCredentials(provider ?? IMPLICIT_CREDENTIAL_PROVIDER) : undefined
+      const address = host !== undefined ? host.managedRemoteUrl(target.repo) : target.repo
+      expectedOrigin = authorizeWorkspaceGitUrl(canonicalWorkspaceGitUrl(address, provider), target.managed?.gitlabHost)
     } catch {
       return undefined
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -78,6 +78,8 @@ import { MICROSANDBOX_TUNNEL_PATHS } from './microsandbox/socket-bridge.js'
 import { MicrosandboxWorkspaceFs } from './microsandbox/workspace-fs.js'
 import { microsandboxSupportMounts } from './microsandbox/support.js'
 import { GITCRED_SOCKET_ENV } from './gitcred/env.js'
+import { IMPLICIT_CREDENTIAL_PROVIDER } from './gitcred/managed-hosts.js'
+import { codeHostCredentials, credentialProviderOf } from './codehost/credentials.js'
 import { tmpdir } from 'node:os'
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
@@ -2175,16 +2177,18 @@ export class Daemon {
         const agent = this.agents.get(agentId)
         return agent ? this.workspaces.managedCredentialProvider(agent) : undefined
       },
-      projectIdOf: (agentId: string) => {
-        const ws = this.agents.get(agentId)?.workspace
-        return ws?.mode === 'git-repo' ? ws.gitlabProjectId : undefined
-      },
-      // The §8.3 allowlist, matched case-insensitively on the project path.
-      gitlabProjectOf: (agentId: string, repoFullName: string) => {
+      // Only a host whose grants are numerically qualified carries a workspace id on the spec (§17.1).
+      workspaceRepoIdOf: (agentId: string) => this.gitlabWorkspaceProject(agentId),
+      // The §8.3 allowlist, matched case-insensitively on the repository path.
+      qualifiedRepoOf: (agentId: string, repoFullName: string) => {
         const wanted = repoFullName.toLowerCase()
-        return (this.agents.get(agentId)?.workspace.additionalRepos ?? []).find(
-          (row) => row.provider === 'gitlab' && row.repoFullName.toLowerCase() === wanted
-        )?.repoId
+        for (const row of this.agents.get(agentId)?.workspace.additionalRepos ?? []) {
+          if (row.repoFullName.toLowerCase() !== wanted) continue
+          const provider = codeHostCredentials(row.provider)?.provider
+          if (provider === undefined || provider === IMPLICIT_CREDENTIAL_PROVIDER) continue
+          return { provider, externalId: row.repoId }
+        }
+        return undefined
       }
     })
     const daemonCredentialTarget = daemonGitCredentialTarget({
@@ -2201,11 +2205,13 @@ export class Daemon {
       preWarm: async (agentId, reason) => {
         const agent = this.agents.get(agentId)
         const provider = agent ? this.workspaces.managedCredentialProvider(agent) : undefined
-        if (provider === 'gitlab') {
-          const projectId = agent?.workspace.mode === 'git-repo' ? agent.workspace.gitlabProjectId : undefined
+        // A provider named on the wire pre-warms under its own numeric identity (§17.1); the
+        // implicit one keeps the v1 ask, which carries neither field.
+        if (provider !== undefined && provider !== IMPLICIT_CREDENTIAL_PROVIDER) {
+          const externalRepoId = this.gitlabWorkspaceProject(agentId)
           await this.gitCreds.get(agentId, reason, {
-            provider: 'gitlab',
-            ...(projectId !== undefined ? { externalRepoId: projectId } : {})
+            provider,
+            ...(externalRepoId !== undefined ? { externalRepoId } : {})
           })
         } else await this.gitCreds.get(agentId, reason)
       }
@@ -3838,19 +3844,22 @@ export class Daemon {
     const runtime = runtimeEntry?.runtime
     if (!runtime) throw new Error(`runtime "${agent.runtime}" is not provided by the microsandbox image`)
     const placement = this.microsandboxPlacement(agent, cwd, key)
-    const github = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
-    const gitlab = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'gitlab'
+    // The provider whose managed credential this spec names; a dream host gets none at all.
+    const credentialProvider = excludeAgentToolCredentials
+      ? undefined
+      : credentialProviderOf(agent.workspace.gitCredential)
+    const managedCredentials = credentialProvider !== undefined
     const scope = managedCredentialScope(
-      gitlab ? 'gitlab' : github ? 'github' : undefined,
+      credentialProvider,
       agent.gitlabHost,
       !excludeAgentToolCredentials && this.workspaces.gitlabRepoBearing(agent)
     )
     const git =
-      github || gitlab || agent.workspace.mode === 'git-repo'
+      managedCredentials || agent.workspace.mode === 'git-repo'
         ? sessionGitEnv(
             agent.id,
-            github || gitlab ? this.gitCommitIdentity : undefined,
-            github || gitlab ? scope : null
+            managedCredentials ? this.gitCommitIdentity : undefined,
+            managedCredentials ? scope : null
           )
         : undefined
     const launch = prepareMicrosandboxLaunch({
@@ -4831,13 +4840,18 @@ export class Daemon {
     const excludeAgentToolCredentials = opts.excludeAgentToolCredentials === true
     // A GitHub workspace uses this channel for its implicit repo; scratch uses
     // it only for explicitly authorized repos named by git/gh.
-    const githubAppCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
-    const gitlabCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'gitlab'
-    const managedCredentials = githubAppCredentials || gitlabCredentials
+    const credentialProvider = excludeAgentToolCredentials
+      ? undefined
+      : credentialProviderOf(agent.workspace.gitCredential)
+    const managedCredentials = credentialProvider !== undefined
+    // The two CLI wrappers are per-provider facts, not a seam member: `gh` and `glab` exist because
+    // those hosts ship one, and a third host shipping none adds no entry (gitea-integration.md §9).
+    const githubAppCredentials = credentialProvider === 'github'
+    const gitlabCredentials = credentialProvider === 'gitlab'
     // §24.4: the pinned host comes from the SPEC, and a repo-bearing GitLab consumer that is not
     // the workspace pins its instance beside it. A dream host gets no tool credentials at all.
     const managedScope = managedCredentialScope(
-      gitlabCredentials ? 'gitlab' : githubAppCredentials ? 'github' : undefined,
+      credentialProvider,
       agent.gitlabHost,
       !excludeAgentToolCredentials && this.workspaces.gitlabRepoBearing(agent)
     )

--- a/packages/daemon/src/gitcred/helper.ts
+++ b/packages/daemon/src/gitcred/helper.ts
@@ -26,12 +26,22 @@
  *
  * WHICH socket to dial is the caller's business, and that is the whole reason this is a leaf: the
  * daemon CLI derives it from its own root, while in a sandbox pod the same code dials the path the
- * shim serves the daemon's socket on. Its only imports are node builtins and the env names, because
- * the in-sandbox bundle is asserted to import nothing else.
+ * shim serves the daemon's socket on. Its only imports are node builtins and the credential-channel
+ * leaves beside it, because the in-sandbox bundle is asserted to import nothing else.
  */
 import { createConnection } from 'node:net'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from './env.js'
-import { decodeManagedHostTable, GITCRED_HOSTS_ENV, matchManagedHost } from './managed-hosts.js'
+import {
+  decodeManagedHostTable,
+  GITCRED_HOSTS_ENV,
+  IMPLICIT_CREDENTIAL_PROVIDER,
+  matchManagedHost
+} from './managed-hosts.js'
+import { credentialRepoPathParser } from './repo-path.js'
+
+// The path grammars live in the parser table; re-exported because the daemon CLI and the helper's
+// own tests have always reached them through this module.
+export { projectFromPath, repoFromPath } from './repo-path.js'
 
 interface HelperInput {
   protocol?: string
@@ -59,12 +69,15 @@ export async function runGitCredential(action: string, agentId: string, socketPa
 
   const input = parseStdin(await readStdin())
   const match = matchManagedHost(decodeManagedHostTable(process.env[GITCRED_HOSTS_ENV]), input)
-  // GitLab keeps full subgroup depth from the instance's path prefix (§13.2); github stays owner/repo.
-  const gitlab = match?.entry.provider === 'gitlab'
-  const repo = match?.path === undefined ? undefined : gitlab ? projectFromPath(match.path) : repoFromPath(match.path)
+  // Each host spells its own path (§13.2): GitLab keeps full subgroup depth, GitHub stays owner/repo.
+  const parseRepoPath = match === undefined ? undefined : credentialRepoPathParser(match.entry.provider)
+  // A provider the injected table names but this build has no grammar for is not ours either.
+  const provider = parseRepoPath === undefined ? undefined : match?.entry.provider
+  const qualifier = provider !== undefined && provider !== IMPLICIT_CREDENTIAL_PROVIDER ? { provider } : {}
+  const repo = parseRepoPath === undefined || match?.path === undefined ? undefined : parseRepoPath(match.path)
 
   // Not ours — stay silent so git can try other helpers; an absent host still means the workspace.
-  if (input.host !== undefined && match === undefined) return
+  if (input.host !== undefined && provider === undefined) return
 
   if (action === 'erase') {
     // Route the invalidation to the same (agent, repo) key the get used.
@@ -74,7 +87,7 @@ export async function runGitCredential(action: string, agentId: string, socketPa
       capability: process.env[GITCRED_CAPABILITY_ENV],
       password: input.password,
       repoFullName: repo,
-      ...(gitlab ? { provider: 'gitlab' } : {})
+      ...qualifier
     }).catch(() => undefined) // best-effort
     return
   }
@@ -85,7 +98,7 @@ export async function runGitCredential(action: string, agentId: string, socketPa
     agentId,
     capability: process.env[GITCRED_CAPABILITY_ENV],
     repoFullName: repo,
-    ...(gitlab ? { provider: 'gitlab' } : {})
+    ...qualifier
   })
   if (!res.ok || !res.username || !res.password) {
     process.stderr.write(
@@ -115,26 +128,6 @@ function normalizeRepoPath(p: string): string {
     .replace(/^\/+/, '')
     .replace(/\.git$/i, '')
     .toLowerCase()
-}
-
-/** The full namespaced GitLab project path from git's credential `path` —
- *  arbitrary subgroup depth, tolerating a leading slash, a `.git` suffix, and
- *  LFS-ish subpaths (`group/sub/project.git/info/lfs`). */
-export function projectFromPath(p: string): string | undefined {
-  const cleaned = p.replace(/^\/+/, '')
-  const gitSuffix = cleaned.search(/\.git(?:\/|$)/i)
-  const path = (gitSuffix >= 0 ? cleaned.slice(0, gitSuffix) : cleaned).replace(/\/+$/, '')
-  return path.includes('/') ? path.toLowerCase() : undefined
-}
-
-/** "owner/repo" from git's credential `path` — tolerates a leading slash, a
- *  `.git` suffix, and LFS-ish subpaths (`owner/repo.git/info/lfs`). */
-export function repoFromPath(p: string): string | undefined {
-  const segs = p.replace(/^\/+/, '').split('/')
-  const owner = segs[0]
-  const repo = segs[1]?.replace(/\.git$/i, '')
-  if (!owner || !repo) return undefined
-  return `${owner}/${repo}`.toLowerCase()
 }
 
 function parseStdin(text: string): HelperInput {

--- a/packages/daemon/src/gitcred/managed-hosts.ts
+++ b/packages/daemon/src/gitcred/managed-hosts.ts
@@ -9,7 +9,18 @@
  * credential `path` that starts with that prefix, and a bare hostname could not strip it.
  */
 
-export type ManagedCredentialProvider = 'github' | 'gitlab'
+/**
+ * Wire form for the provider a table entry names: an OPEN string, like protocol's
+ * `CodeHostProviderString`. The table is INJECTED, so an entry for a provider this build knows
+ * nothing about must degrade per value rather than make the whole table undecodable; the daemon's
+ * code-host credential registry and the helper's parser table are where a provider is narrowed, and
+ * each fails closed on a name it does not carry. The narrowed union cannot live here: both ends of
+ * the channel share this leaf, and the in-sandbox bundle may import nothing but node builtins.
+ */
+export type ManagedCredentialProvider = string
+
+/** The provider every v1 credential request means implicitly — the only one never named on the wire. */
+export const IMPLICIT_CREDENTIAL_PROVIDER = 'github'
 
 /** One managed code host: the provider plus the normalized base URL its consumers address. */
 export interface ManagedCredentialHost {
@@ -21,7 +32,10 @@ export interface ManagedCredentialHost {
 /** The env name the table travels on, minted beside the capability and agent identity. */
 export const GITCRED_HOSTS_ENV = 'AC_GITCRED_HOSTS'
 
-export const GITHUB_MANAGED_HOST: ManagedCredentialHost = { provider: 'github', baseUrl: 'https://github.com' }
+export const GITHUB_MANAGED_HOST: ManagedCredentialHost = {
+  provider: IMPLICIT_CREDENTIAL_PROVIDER,
+  baseUrl: 'https://github.com'
+}
 
 /** The default value of the GitLab host axis (§24.1) — absent is GitLab.com, never a second mode. */
 export const GITLAB_COM_BASE_URL = 'https://gitlab.com'
@@ -38,13 +52,20 @@ function trimSurroundingSlashes(value: string): string {
   return trimTrailingSlashes(value.slice(start))
 }
 
-/** The GitLab instance a spec's GitLab consumers address; an absent host means GitLab.com (§24.1). */
-export function gitlabManagedHost(gitlabHost?: string): ManagedCredentialHost {
-  const trimmed = trimTrailingSlashes((gitlabHost ?? '').trim())
-  return { provider: 'gitlab', baseUrl: trimmed === '' ? GITLAB_COM_BASE_URL : trimmed }
+/** A spec-carried host as a base URL — trimmed, no trailing slash; undefined when the spec names none. */
+export function normalizeManagedBaseUrl(host?: string): string | undefined {
+  const trimmed = trimTrailingSlashes((host ?? '').trim())
+  return trimmed === '' ? undefined : trimmed
 }
 
-/** The table one agent's git classifies against: GitHub plus the one GitLab instance its spec names. */
+/** The GitLab instance a spec's GitLab consumers address; an absent host means GitLab.com (§24.1). */
+export function gitlabManagedHost(gitlabHost?: string): ManagedCredentialHost {
+  return { provider: 'gitlab', baseUrl: normalizeManagedBaseUrl(gitlabHost) ?? GITLAB_COM_BASE_URL }
+}
+
+/** The default table — GitHub plus the one GitLab instance a spec names — and what an absent or
+ *  unparseable env falls back to. An injected table is composed per provider by the daemon's
+ *  code-host credential registry, which this leaf cannot reach. */
 export function managedHostTableFor(gitlabHost?: string): ManagedCredentialHost[] {
   return [GITHUB_MANAGED_HOST, gitlabManagedHost(gitlabHost)]
 }
@@ -55,7 +76,9 @@ export function encodeManagedHostTable(hosts: readonly ManagedCredentialHost[]):
   return hosts.map((entry) => `${entry.provider}=${entry.baseUrl}`).join(' ')
 }
 
-/** Absent or unparseable ⇒ the default table, which is what a deployment on GitLab.com means. */
+/** Absent or unparseable ⇒ the default table, which is what a deployment on GitLab.com means. An
+ *  entry keeps whatever provider it names: the consumer that cannot place the name is the one that
+ *  refuses it, so a newer daemon's table never reads as a table of nothing. */
 export function decodeManagedHostTable(raw: string | undefined): ManagedCredentialHost[] {
   const entries: ManagedCredentialHost[] = []
   for (const token of (raw ?? '').split(/\s+/)) {
@@ -63,7 +86,6 @@ export function decodeManagedHostTable(raw: string | undefined): ManagedCredenti
     if (eq <= 0) continue
     const provider = token.slice(0, eq)
     const baseUrl = trimTrailingSlashes(token.slice(eq + 1))
-    if (provider !== 'github' && provider !== 'gitlab') continue
     if (parseManagedBaseUrl(baseUrl) === undefined) continue
     entries.push({ provider, baseUrl })
   }

--- a/packages/daemon/src/gitcred/repo-path.ts
+++ b/packages/daemon/src/gitcred/repo-path.ts
@@ -1,0 +1,42 @@
+/**
+ * The repository path one managed code host spells in a git credential request, for both ends of the
+ * credential channel (gitlab-com-integration.md §13.2, §24.4).
+ *
+ * A leaf beside the host table and for the same reason: the credential helper is bundled for the
+ * sandbox image and may import nothing but node builtins, so it cannot reach the daemon-side
+ * provider registry. The registry's entry for a provider points at the parser registered here, so a
+ * host has ONE path grammar whichever side of the channel asks for it.
+ */
+
+/** git's credential `path` as this host's repository path, or undefined when it names no repository. */
+export type CredentialRepoPathParser = (path: string) => string | undefined
+
+/** The full namespaced GitLab project path — arbitrary subgroup depth, tolerating a leading slash, a
+ *  `.git` suffix, and LFS-ish subpaths (`group/sub/project.git/info/lfs`). */
+export function projectFromPath(p: string): string | undefined {
+  const cleaned = p.replace(/^\/+/, '')
+  const gitSuffix = cleaned.search(/\.git(?:\/|$)/i)
+  const path = (gitSuffix >= 0 ? cleaned.slice(0, gitSuffix) : cleaned).replace(/\/+$/, '')
+  return path.includes('/') ? path.toLowerCase() : undefined
+}
+
+/** "owner/repo" — tolerates a leading slash, a `.git` suffix, and LFS-ish subpaths
+ *  (`owner/repo.git/info/lfs`). */
+export function repoFromPath(p: string): string | undefined {
+  const segs = p.replace(/^\/+/, '').split('/')
+  const owner = segs[0]
+  const repo = segs[1]?.replace(/\.git$/i, '')
+  if (!owner || !repo) return undefined
+  return `${owner}/${repo}`.toLowerCase()
+}
+
+/** Keyed by the table's OPEN provider string: a host this side cannot parse is never ours. */
+const PARSERS: Record<string, CredentialRepoPathParser> = {
+  github: repoFromPath,
+  gitlab: projectFromPath
+}
+
+/** The grammar this provider's credential paths follow; undefined ⇒ a provider this build knows nothing about. */
+export function credentialRepoPathParser(provider: string): CredentialRepoPathParser | undefined {
+  return PARSERS[provider]
+}

--- a/packages/daemon/src/github/credentials.ts
+++ b/packages/daemon/src/github/credentials.ts
@@ -1,0 +1,35 @@
+// GitHub's entry in the daemon's code-host credential seam (codehost/credentials.ts): one fixed
+// host, owner/repo addresses, and an App installation token the CP mints for a covered repository.
+import { normalizeGithubRepoUrl } from '@agentconnect.md/protocol'
+import { GITHUB_MANAGED_HOST, type ManagedCredentialHost } from '../gitcred/managed-hosts.js'
+import { repoFromPath } from '../gitcred/repo-path.js'
+import { isRepoSegment, RESERVED_SECONDARY_ROOT_DIRS } from '../workspace/secondary-layout.js'
+import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
+import type { CodeHostCredentialModule, SecondaryRootPlacement } from '../codehost/credentials.js'
+import type { ManagedCredentialScope } from '../workspace/git-injection.js'
+
+/** Anonymous and github-app operations both pin github.com; only a spec-carried host moves the axis. */
+const GITHUB_SCOPE: ManagedCredentialScope = { host: GITHUB_MANAGED_HOST }
+
+export const githubCredentials: CodeHostCredentialModule = {
+  provider: 'github',
+  specGitCredential: 'github-app',
+  hostFromSpec: false,
+  managedHost: (): ManagedCredentialHost => GITHUB_MANAGED_HOST,
+  credentialRepoPath: repoFromPath,
+  // github.com serves the suffix-less HTTPS address, so a normalized URL is already canonical.
+  canonicalCloneUrl: (normalized) => normalized,
+  managedRemoteUrl: (repository) => normalizeGithubRepoUrl(repository),
+  // An App installation token is re-minted per repository, so a scope denial is the repo-level one.
+  liveCredentialPurposes: [],
+  placeSecondaryRoot: (row): SecondaryRootPlacement | undefined => {
+    // `repos/<owner>/<repo>`; undefined when its text is not two plain segments, which would place the subtree by that text.
+    const [owner, repo, ...rest] = row.repoFullName.split('/')
+    if (rest.length > 0 || !isRepoSegment(owner) || !isRepoSegment(repo)) return undefined
+    if (RESERVED_SECONDARY_ROOT_DIRS.has(owner)) return undefined
+    return { provider: 'github', repoFullName: `${owner}/${repo}`, subtreeName: `${owner}/${repo}` }
+  },
+  secondaryCloneUrl: (repoFullName) =>
+    authorizeWorkspaceGitUrl(normalizeGithubRepoUrl(`https://github.com/${repoFullName}`)),
+  secondaryCredentialScope: () => GITHUB_SCOPE
+}

--- a/packages/daemon/src/gitlab/credentials.ts
+++ b/packages/daemon/src/gitlab/credentials.ts
@@ -1,0 +1,46 @@
+// GitLab's entry in the daemon's code-host credential seam (codehost/credentials.ts): the one
+// instance the spec names (§24.4), namespaced project paths, and per-project grants the CP resolves
+// live — so this host's hook-reply and effect leases are re-asked rather than negatively cached.
+import { normalizeGitCloneUrl } from '@agentconnect.md/protocol'
+import { gitlabManagedHost } from '../gitcred/managed-hosts.js'
+import { projectFromPath } from '../gitcred/repo-path.js'
+import { gitlabSubtreeName, isRepoSegment } from '../workspace/secondary-layout.js'
+import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
+import type { CodeHostCredentialModule, CodeHostSpecHosts, SecondaryRootPlacement } from '../codehost/credentials.js'
+import type { ManagedCredentialScope } from '../workspace/git-injection.js'
+
+export const gitlabCredentials: CodeHostCredentialModule = {
+  provider: 'gitlab',
+  specGitCredential: 'gitlab',
+  hostFromSpec: true,
+  managedHost: (spec) => gitlabManagedHost(spec.gitlabHost),
+  credentialRepoPath: projectFromPath,
+  // GitLab 301s the suffix-less HTTPS probe and we refuse redirects, so a gitlab remote carries `.git`.
+  canonicalCloneUrl: (normalized) => {
+    if (!/^https:/i.test(normalized) || /\.git$/i.test(normalized)) return normalized
+    return `${normalized}.git`
+  },
+  // A GitLab workspace's spec repository is already the project's address on its instance.
+  managedRemoteUrl: (repository) => repository,
+  liveCredentialPurposes: ['gitlab_hook_reply', 'gitlab_effect'],
+  placeSecondaryRoot: (row): SecondaryRootPlacement | undefined => {
+    // `repos/_gitlab/<project id>` — the id, because a project path is namespaced to any depth and a rename moves it.
+    const segments = row.repoFullName.split('/')
+    if (!/^[1-9]\d*$/.test(row.repoId) || segments.length < 2 || !segments.every(isRepoSegment)) return undefined
+    return { provider: 'gitlab', repoFullName: segments.join('/'), subtreeName: gitlabSubtreeName(row.repoId) }
+  },
+  // The project on the spec's own instance, under GitLab's `.git` rule — the address a gitlab primary resolves to.
+  secondaryCloneUrl: (repoFullName, spec) => {
+    const instance = gitlabManagedHost(spec.gitlabHost).baseUrl
+    return authorizeWorkspaceGitUrl(
+      gitlabCredentials.canonicalCloneUrl(normalizeGitCloneUrl(`${instance}/${repoFullName}`)),
+      spec.gitlabHost
+    )
+  },
+  // A gitlab row is repo-bearing by construction (§24.4), so its scope pins the instance's credential path.
+  secondaryCredentialScope: (spec: CodeHostSpecHosts): ManagedCredentialScope => ({
+    host: gitlabManagedHost(spec.gitlabHost),
+    ...(spec.gitlabHost !== undefined ? { gitlabHost: spec.gitlabHost } : {}),
+    gitlabRepoBearing: true
+  })
+}

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -37,14 +37,14 @@ import { dirname, join } from 'node:path'
 import { tlsTrustEnv } from '../config/tls-trust-env.js'
 import type { GitPullSummary, GitRunner } from './git-runner.js'
 import { simpleGit, type SimpleGit } from 'simple-git'
-import { normalizeGitCloneUrl, type GitCommitIdentity } from '@agentconnect.md/protocol'
+import { normalizeGitCloneUrl, type CodeHostProvider, type GitCommitIdentity } from '@agentconnect.md/protocol'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, GITCRED_SOCKET_ENV } from '../cp/gitcred-server.js'
+import { codeHostCredentials, managedHostTable } from '../codehost/credentials.js'
 import {
   encodeManagedHostTable,
   gitlabManagedHost,
   GITCRED_HOSTS_ENV,
   GITHUB_MANAGED_HOST,
-  managedHostTableFor,
   parseManagedBaseUrl,
   stripHostPathPrefix,
   type ManagedCredentialHost
@@ -366,21 +366,23 @@ export const GITHUB_CREDENTIAL_SCOPE: ManagedCredentialScope = { host: GITHUB_MA
 export { GITHUB_MANAGED_HOST, gitlabManagedHost }
 export type { ManagedCredentialHost }
 
-/** The classifier table an injection carries: GitHub plus the one GitLab instance the scope names. */
+/** The classifier table an injection carries: one entry per provider, the operation's own host included. */
 function scopeHostTable(scope: ManagedCredentialScope): ManagedCredentialHost[] {
-  return managedHostTableFor(scope.gitlabHost ?? (scope.host.provider === 'gitlab' ? scope.host.baseUrl : undefined))
+  const spec = scope.gitlabHost !== undefined ? { gitlabHost: scope.gitlabHost } : {}
+  return managedHostTable(spec).map((entry) => (entry.provider === scope.host.provider ? scope.host : entry))
 }
 
 export function managedCredentialScope(
-  provider: 'github' | 'gitlab' | undefined,
+  provider: CodeHostProvider | undefined,
   gitlabHost?: string,
   gitlabRepoBearing = false
 ): ManagedCredentialScope {
-  const host = provider === 'gitlab' ? gitlabManagedHost(gitlabHost) : GITHUB_MANAGED_HOST
+  const host = codeHostCredentials(provider)?.managedHost({ gitlabHost }) ?? GITHUB_MANAGED_HOST
   return {
     host,
     ...(gitlabHost !== undefined ? { gitlabHost } : {}),
-    // A gitlab workspace is repo-bearing by construction; the flag only adds the other consumer.
+    // A gitlab workspace is repo-bearing by construction; the flag only adds the other consumer. It
+    // names its provider because the field is the GitLab host axis itself (gitea-integration.md §13).
     ...(gitlabRepoBearing || provider === 'gitlab' ? { gitlabRepoBearing: true } : {})
   }
 }
@@ -422,12 +424,11 @@ export function originOnManagedHost(input: string, host: ManagedCredentialHost):
   }
 }
 
-// GitLab 301s the suffix-less HTTPS probe and we refuse redirects, so a gitlab remote carries `.git`.
-export function canonicalWorkspaceGitUrl(repository: string, provider?: 'github' | 'gitlab'): string {
+/** A workspace remote under its own host's address conventions; an anonymous remote keeps the
+ *  normalized form, which is what every host that needs no suffix rule answers with. */
+export function canonicalWorkspaceGitUrl(repository: string, provider?: CodeHostProvider): string {
   const normalized = normalizeGitCloneUrl(repository)
-  if (provider !== 'gitlab') return normalized
-  if (!/^https:/i.test(normalized) || /\.git$/i.test(normalized)) return normalized
-  return `${normalized}.git`
+  return codeHostCredentials(provider)?.canonicalCloneUrl(normalized) ?? normalized
 }
 
 /**

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -5,7 +5,7 @@ import {
   workspaceGitOriginOf,
   WORKSPACE_GIT_ANY_ORIGIN
 } from '@agentconnect.md/protocol'
-import { gitlabManagedHost } from '../gitcred/managed-hosts.js'
+import { normalizeManagedBaseUrl } from '../gitcred/managed-hosts.js'
 
 // One daemon runs per process. Keep the operator-owned policy beside the
 // functional workspace helpers, like git-injection's process-local state.
@@ -15,12 +15,12 @@ export function configureWorkspaceGitOrigins(origins: readonly string[]): void {
   allowedOrigins = origins.map(normalizeWorkspaceGitOrigin)
 }
 
-/** The origin form of a GitLab base URL, which may carry a path prefix (§24.1) an origin may not. */
-function codeHostOrigin(gitlabHost: string | undefined): string | undefined {
-  const host = gitlabHost?.trim()
+/** The origin form of a code host's base URL, which may carry a path prefix (§24.1) an origin may not. */
+function codeHostOrigin(codeHost: string | undefined): string | undefined {
+  const host = normalizeManagedBaseUrl(codeHost)
   if (!host) return undefined
   try {
-    const url = new URL(gitlabManagedHost(host).baseUrl)
+    const url = new URL(host)
     return normalizeWorkspaceGitOrigin(`${url.protocol}//${url.host}`)
   } catch {
     return undefined // not addressable as a clone origin; the caller's own boundary reports that

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -12,6 +12,9 @@ export const PRIMARY_CHECKOUT_DIR = 'workspace'
 export const SECONDARY_ROOTS_DIR = 'repos'
 /** GitLab roots sit under one reserved owner keyed by numeric project id: `repos/_gitlab/<id>`. A GitHub login admits neither `_` nor a leading one, so no GitHub row can name this directory. */
 export const GITLAB_ROOTS_DIR = '_gitlab'
+/** Owner directories under `repos/` a provider reserves for its own id-keyed subtrees: a row whose
+ *  own text would place a subtree there is refused rather than allowed to collide with one. */
+export const RESERVED_SECONDARY_ROOT_DIRS: ReadonlySet<string> = new Set([GITLAB_ROOTS_DIR])
 /** Every root's per-session worktrees hang off this leaf of it — the agent root for the primary, the subtree for a secondary. */
 export const WORKTREES_DIR = 'worktrees'
 /** What a secondary root's subtree records about the checkout beside it. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -15,14 +15,21 @@ import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import {
   type AgentSkillEntry,
+  type CodeHostProvider,
   gitRepoLabel,
   normalizeGitCloneUrl,
-  normalizeGithubRepoUrl,
   normalizeGitUrl,
   normalizeRepoSubdir,
-  redactGitUrlSecrets
+  redactGitUrlSecrets,
+  isCodeHostProvider
 } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
+import {
+  codeHostCredentials,
+  credentialProviderOf,
+  specHostCodeHosts,
+  type CodeHostSpecHosts
+} from '../codehost/credentials.js'
 import { formatErr } from '../daemon/text.js'
 import { makeLogger } from '../log.js'
 import { installSkills, type LocalSkillSource } from '../skills/install-skills.js'
@@ -40,7 +47,6 @@ import {
   workspaceGitRemoteTarget,
   writeRepoHelperConfig,
   GITHUB_CREDENTIAL_SCOPE,
-  gitlabManagedHost,
   managedCredentialScope,
   originOnManagedHost,
   type ManagedCredentialScope
@@ -49,9 +55,6 @@ import { GitTransportError, LocalGitRunner, type GitRunner } from './git-runner.
 import { localWorkspaceFs, type WorkspaceFs, type WorkspacePlacement } from './workspace-fs.js'
 import { githubSubmoduleRepo, gitmoduleRepos } from './gitmodules.js'
 import {
-  GITLAB_ROOTS_DIR,
-  gitlabSubtreeName,
-  isRepoSegment,
   PRIMARY_CHECKOUT_DIR,
   secondaryRootsDirIn,
   secondarySubtreesIn,
@@ -137,8 +140,8 @@ export type SessionRootLocator = Pick<WorkspaceRoot, 'path' | 'worktreesPath' | 
 export interface SecondaryWorkspaceRoot extends WorkspaceRoot {
   repoFullName: string
   subtreeName: string
-  /** The host that numbers `repoId` — the two number theirs independently (gitlab-com-integration.md §8.1). */
-  provider: 'github' | 'gitlab'
+  /** The host that numbers `repoId` — each numbers its own independently (gitlab-com-integration.md §8.1). */
+  provider: CodeHostProvider
   /** The host's numeric repository or project id — the identity a rename cannot change. */
   repoId: string
   /** Empty until `prepareSecondaryRoot` resolves the remote's default; nothing may clone before that. */
@@ -181,7 +184,7 @@ export type ClusterSessionScope = Pick<PrepareSessionWorkspaceRequest, 'isolatio
 /** What a secondary root's `.materialization.json` records about the checkout beside it. */
 interface SecondaryMaterialization {
   /** Absent in a marker written before GitLab roots existed, which means github. */
-  provider: 'github' | 'gitlab'
+  provider: CodeHostProvider
   repoId: string
   repoFullName: string
   branch: string
@@ -366,11 +369,9 @@ export class WorkspaceManager {
   }
 
   /** Which managed credential backs this workspace's remote git; undefined ⇒ anonymous. */
-  managedCredentialProvider(agent: Agent): 'github' | 'gitlab' | undefined {
+  managedCredentialProvider(agent: Agent): CodeHostProvider | undefined {
     if (agent.workspace.mode !== 'git-repo') return undefined
-    if (agent.workspace.gitCredential === 'github-app') return 'github'
-    if (agent.workspace.gitCredential === 'gitlab') return 'gitlab'
-    return undefined
+    return credentialProviderOf(agent.workspace.gitCredential)
   }
 
   usesManagedCredential(agent: Agent): boolean {
@@ -408,23 +409,30 @@ export class WorkspaceManager {
    * the deployment's GitLab instance (§24.4) — a public clone from that instance still needs
    * GitLab's `.git` suffix rule, and checking is not the same as sniffing a host out of the URL.
    */
-  remoteProviderOf(agent: Agent, repository: string): 'github' | 'gitlab' | undefined {
+  remoteProviderOf(agent: Agent, repository: string): CodeHostProvider | undefined {
     const managed = this.managedCredentialProvider(agent)
     if (managed !== undefined) return managed
-    return originOnManagedHost(repository, gitlabManagedHost(agent.gitlabHost)) ? 'gitlab' : undefined
+    const spec = this.specHostsOf(agent)
+    return specHostCodeHosts().find((host) => originOnManagedHost(repository, host.managedHost(spec)))?.provider
+  }
+
+  /** The host-carrying fields of this agent's replicated spec — one axis per provider (§24.4). */
+  private specHostsOf(agent: Agent): CodeHostSpecHosts {
+    return agent.gitlabHost !== undefined ? { gitlabHost: agent.gitlabHost } : {}
   }
 
   gitRepoOf(agent: Agent): string {
     if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
       throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
     }
-    return authorizeWorkspaceGitUrl(
-      canonicalWorkspaceGitUrl(
-        this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo,
-        this.remoteProviderOf(agent, agent.workspace.gitRepo)
-      ),
-      agent.gitlabHost
-    )
+    const provider = this.remoteProviderOf(agent, agent.workspace.gitRepo)
+    const host = codeHostCredentials(provider)
+    // A MANAGED remote follows its own host's address conventions; an anonymous one is taken as given.
+    const address =
+      host !== undefined && this.usesManagedCredential(agent)
+        ? host.managedRemoteUrl(agent.workspace.gitRepo)
+        : agent.workspace.gitRepo
+    return authorizeWorkspaceGitUrl(canonicalWorkspaceGitUrl(address, provider), agent.gitlabHost)
   }
 
   /** The agent's primary checkout as a root, in the coordinates of whichever filesystem holds it.
@@ -485,8 +493,10 @@ export class WorkspaceManager {
     const parent = this.secondaryRootsDirAt(agent, mount)
     const roots: SecondaryWorkspaceRoot[] = []
     for (const row of agent.workspace.additionalRepos ?? []) {
-      const placed = (row.provider ?? 'github') === 'gitlab' ? this.gitlabRootRow(row) : this.githubRootRow(row)
-      if (placed === undefined) {
+      const host = codeHostCredentials(row.provider ?? 'github')
+      const placed = host?.placeSecondaryRoot(row)
+      if (host === undefined || placed === undefined) {
+        // No module for the row's host, or a name its module cannot place: fail closed per row.
         workspaceLog.warn(
           `workspace: agent "${agent.id}" additional repository "${row.repoFullName}" (${row.provider ?? 'github'}) is not a placeable name — skipping it`
         )
@@ -499,18 +509,12 @@ export class WorkspaceManager {
           repoId: row.repoId,
           // Rows exist only for App-covered repositories, so credentials ride the same helper a managed
           // primary does; the branch is the remote's default, resolved at materialization.
-          cloneUrl:
-            placed.provider === 'gitlab'
-              ? this.gitlabCloneUrl(agent, placed.repoFullName)
-              : this.githubCloneUrl(placed.repoFullName),
+          cloneUrl: host.secondaryCloneUrl(placed.repoFullName, this.specHostsOf(agent)),
           branch: '',
           path: join(base, 'checkout'),
           worktreesPath: join(base, 'worktrees'),
           githubApp: true,
-          managed:
-            placed.provider === 'gitlab'
-              ? managedCredentialScope('gitlab', agent.gitlabHost, true)
-              : GITHUB_CREDENTIAL_SCOPE
+          managed: host.secondaryCredentialScope(this.specHostsOf(agent))
         })
       } catch (err) {
         workspaceLog.warn(
@@ -519,35 +523,6 @@ export class WorkspaceManager {
       }
     }
     return roots.sort((a, b) => (a.repoFullName < b.repoFullName ? -1 : a.repoFullName > b.repoFullName ? 1 : 0))
-  }
-
-  /** A GitHub row placed at `repos/<owner>/<repo>`; undefined when its text is not two plain segments, which would place the subtree by that text. */
-  private githubRootRow(row: {
-    repoFullName: string
-  }): Pick<SecondaryWorkspaceRoot, 'provider' | 'repoFullName' | 'subtreeName'> | undefined {
-    const [owner, repo, ...rest] = row.repoFullName.split('/')
-    if (rest.length > 0 || !isRepoSegment(owner) || !isRepoSegment(repo) || owner === GITLAB_ROOTS_DIR) return undefined
-    return { provider: 'github', repoFullName: `${owner}/${repo}`, subtreeName: `${owner}/${repo}` }
-  }
-
-  /** A GitLab row placed at `repos/_gitlab/<project id>` — the id, because a project path is namespaced to any depth and a rename moves it. */
-  private gitlabRootRow(row: {
-    repoFullName: string
-    repoId: string
-  }): Pick<SecondaryWorkspaceRoot, 'provider' | 'repoFullName' | 'subtreeName'> | undefined {
-    const segments = row.repoFullName.split('/')
-    if (!/^[1-9]\d*$/.test(row.repoId) || segments.length < 2 || !segments.every(isRepoSegment)) return undefined
-    return { provider: 'gitlab', repoFullName: segments.join('/'), subtreeName: gitlabSubtreeName(row.repoId) }
-  }
-
-  private githubCloneUrl(repoFullName: string): string {
-    return authorizeWorkspaceGitUrl(normalizeGithubRepoUrl(`https://github.com/${repoFullName}`))
-  }
-
-  /** The project on the spec's own instance (§24.4), under GitLab's `.git` rule — the same address a gitlab primary resolves to. */
-  private gitlabCloneUrl(agent: Agent, repoFullName: string): string {
-    const instance = gitlabManagedHost(agent.gitlabHost).baseUrl
-    return authorizeWorkspaceGitUrl(canonicalWorkspaceGitUrl(`${instance}/${repoFullName}`, 'gitlab'), agent.gitlabHost)
   }
 
   /**
@@ -2997,7 +2972,7 @@ function parseSecondaryMaterialization(text: string | undefined): SecondaryMater
     if (typeof value.repoId !== 'string' || !value.repoId) return undefined
     if (typeof value.branch !== 'string' || !value.branch) return undefined
     if (typeof value.repoFullName !== 'string' || !value.repoFullName) return undefined
-    if (value.provider !== undefined && value.provider !== 'github' && value.provider !== 'gitlab') return undefined
+    if (value.provider !== undefined && !isCodeHostProvider(value.provider)) return undefined
     return {
       provider: value.provider ?? 'github',
       repoId: value.repoId,
@@ -3010,7 +2985,7 @@ function parseSecondaryMaterialization(text: string | undefined): SecondaryMater
 }
 
 /** The identity a root is compared to an attestation by: the numeric id under the host that issued it. */
-function repoIdentity(entry: { provider: 'github' | 'gitlab'; repoId: string }): string {
+function repoIdentity(entry: { provider: CodeHostProvider; repoId: string }): string {
   return `${entry.provider}:${entry.repoId}`
 }
 

--- a/packages/daemon/test/cp/gitcred-routing.test.ts
+++ b/packages/daemon/test/cp/gitcred-routing.test.ts
@@ -169,8 +169,10 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     // what leaves an exact checkout of an authorized project credential-less.
     const { sockPath, gets, capability } = await boot('example-group/example-project', {
       providerOf: () => 'gitlab',
-      gitlabProjectOf: (_agentId, repoFullName) =>
-        repoFullName === 'example-group/example-second' ? '4455668' : undefined
+      qualifiedRepoOf: (_agentId: string, repoFullName: string) =>
+        repoFullName === 'example-group/example-second'
+          ? ({ provider: 'gitlab', externalId: '4455668' } as const)
+          : undefined
     })
     const res = await roundtrip(sockPath, {
       op: 'get',
@@ -191,7 +193,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
   it('denies a gitlab project the replicated spec does not authorize', async () => {
     const { sockPath, gets, capability } = await boot(undefined, {
       providerOf: () => 'github',
-      gitlabProjectOf: () => undefined
+      qualifiedRepoOf: () => undefined
     })
     const res = await roundtrip(sockPath, {
       op: 'get',
@@ -223,8 +225,10 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     // GitLab token live until its TTL.
     const { sockPath, erases, capability } = await boot(undefined, {
       providerOf: () => 'github',
-      gitlabProjectOf: (_agentId, repoFullName) =>
-        repoFullName === 'example-group/example-second' ? '4455668' : undefined
+      qualifiedRepoOf: (_agentId: string, repoFullName: string) =>
+        repoFullName === 'example-group/example-second'
+          ? ({ provider: 'gitlab', externalId: '4455668' } as const)
+          : undefined
     })
     const res = await roundtrip(sockPath, {
       op: 'erase',


### PR DESCRIPTION
Behavior-neutral refactor of the daemon's Git-credential and managed-host code, so that a third code
host is a registry entry rather than a hunt for `provider === 'gitlab' ? … : …`. No new host is
added here and no test expectation changes.

This is the second change of the seam-extraction sequence in
`docs/designs/gitea-integration.md` §13 (item 2, plus the managed-host and workspace parts of items
5 and 7 that live on the daemon). It builds on the decode-time code-host view that landed in #2040.

## The seam

`packages/daemon/src/codehost/credentials.ts` is one more member of the existing `src/codehost/`
contract family, in the same shape as `hook-admission.ts` and `review-adapter.ts`: a
`Record<CodeHostProvider, CodeHostCredentialModule>`, so a missing entry is a compile error, with
each host's entry owned by its own module — `src/github/credentials.ts`, `src/gitlab/credentials.ts`.

Members are the ones both hosts implement today:

| Member | GitHub | GitLab |
| --- | --- | --- |
| `managedHost(spec)` | the one fixed address | the instance the spec carries (§24.4) |
| `credentialRepoPath` | `owner/repo` | namespaced project path |
| `canonicalCloneUrl` | the normalized URL | the normalized URL plus `.git` |
| `managedRemoteUrl` | expands a repository label | the spec value is already the address |
| `specGitCredential` | `github-app` | `gitlab` |
| `liveCredentialPurposes` | none | the hook-reply and effect leases |
| `placeSecondaryRoot` | `repos/<owner>/<repo>` | `repos/<reserved>/<numeric id>` |
| `secondaryCloneUrl` / `secondaryCredentialScope` | the fixed host, no spec host | the instance, pinned as repo-bearing |

Core reads the registry: git injection resolves a scope's host and composes the injected
`AC_GITCRED_HOSTS` table from one entry per provider; the workspace manager places, addresses and
scopes every additional repository through it; console git derives a remote's canonical origin from
its host instead of from a `github-app` flag paired with a not-GitLab test; the credential cache
takes its live-purpose set from it.

The table's provider becomes the open wire string protocol already uses for provider fields, and the
hand-written decoder no longer drops an entry whose provider it does not recognize — the consumer
that cannot place the name is the one that refuses it. The env encoding, the default table, the
`glab` shim, `GITLAB_HOST` and every `AC_GITCRED_*` name are untouched, and the existing table tests
pin the encoding byte for byte.

Everywhere a credential request carried `provider?: 'gitlab'` as a type, it now carries "any provider
but the implicit one" (`QualifiedCodeHostProvider`). GitHub stays the empty cache-key segment, so no
cache key moves.

## Left outside the registry, on purpose

- **The spec's host field.** One axis per provider (`gitlabHost`), as §13 records: a table of hosts
  would be guessing at a shape no multi-instance design has asked for yet. The registry takes the
  spec's host-carrying fields as one argument and each entry reads its own.
- **The scope's `gitlabRepoBearing` flag and the session-config widening behind it.** That field *is*
  the GitLab host axis; a third host with its own axis gets its own, not a shared boolean.
- **How a credential is obtained.** GitHub mints an App installation token for a repository the
  installation already covers; GitLab resolves a per-project grant, qualifies it by numeric id and
  verifies an instance echo. Two disagreeing data points are not an interface, so the GitLab poster
  and broker token methods, the grant host echo and its `gitlabHostFor` dependency stay where they
  are.
- **Feature negotiation strings and the `glab` plane.** A wire negotiation is per-feature, and the
  read-only CLI plane exists because GitLab ships a CLI; §9 of the Gitea design records that the next
  host ships none. The `gh` and `glab` PATH wrappers stay keyed on their own hosts for the same
  reason.
- **The spec's workspace arms** (`mode: 'gitlab'`, `gitCredential`, `gitlabProjectId`) and the hook,
  reply and note-projection paths — wire members and later items of the §13 sequence.
- **The credential-path grammars themselves** live in a new `gitcred/repo-path.ts` leaf rather than in
  the registry modules: the helper ships in the runtime image and its bundle is asserted to import
  nothing but node builtins, so it cannot reach a module that imports protocol. Each registry entry
  points at the same parser, so a host still has one grammar.

## One deliberate behavior difference

An additional-repository row whose provider string this build does not carry used to be read as the
implicit host's and placed under `repos/<owner>/<repo>` with a github.com clone URL. It is now
skipped with the warning an unplaceable name already gets. No control plane sends such a row today,
and failing closed per value is what the protocol's open provider string asks consumers to do.

## Gates

- `pnpm typecheck` — clean (daemon, control-plane, relay, setup, web).
- `pnpm --filter @agentconnect.md/daemon test` — credential suites first
  (`test/cp/git-credential.test.ts`, `test/git-injection.test.ts`,
  `test/sandbox-credential-helper.test.ts`, `test/gitlab-self-managed-host.test.ts`,
  `test/cp/gitcred-routing.test.ts`, `test/cp/gitlab-gitcred.test.ts`,
  `test/gitlab-self-managed-git.test.ts`, `test/daemon-hook.test.ts`): 255 passed. Full suite: green
  apart from `test/shim-workspace-files.test.ts`, `test/shim-cancellation.test.ts` and
  `test/acp-matrix/acp-matrix.test.ts`, which are red on this machine on an untouched `origin/main`
  too (they need a Linux sandbox and live local runtimes).
- `eslint packages/daemon` — no errors; the four `import-x/no-duplicates` warnings are pre-existing in
  files this change does not touch.
- `prettier --check .` — clean.

The only test file touched is `test/cp/gitcred-routing.test.ts`, where three fake dependencies follow
the renamed server dependency. No assertion changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
