### PR TITLE
refactor(daemon): register code-host turn-final surfaces per provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,11 @@ with an external transport. Do not "finish the job" by forcing either into
 GitLab has now arrived and made the seam a two-implementer one
 ([`gitlab-com-integration.md`](docs/designs/gitlab-com-integration.md) §6.5,
 §8.1 `CodeHostRepository`), so its members exist: the Layer-2 turn output that
-removed the hardcoded `github` case from the dispatch path, and
+removed the hardcoded `github` case from the dispatch path,
+`daemon/src/codehost/turn-final.ts` — `CodeHostTurnFinal` registered per
+provider, owning a delivery's reply target, its effect lease and REST root, the
+final poster, the turn-start instance fence, and the lifecycle pairing that
+retires a thread's checkout — and
 `daemon/src/codehost/review-adapter.ts` — `CodeHostReviewAdapter` plus the
 router that hands provider-routed `submitCodeReview` to whichever adapter owns
 the active review turn, the GitHub review orchestrator's member or the GitLab

--- a/packages/daemon/src/codehost/ack.ts
+++ b/packages/daemon/src/codehost/ack.ts
@@ -9,8 +9,8 @@
  * subject itself fired it.
  *
  * That shared shape is why this is a seam member and not a branch. The two arms differ only
- * in path, auth header and body — each provider owns its own three, registration order is
- * resolution order, and adding a code host is adding one entry.
+ * in path, auth header and body — each provider owns its own three, the reply target's provider
+ * selects between them, and adding a code host is adding one entry.
  *
  * Best-effort by construction: nothing here throws, the turn never awaits it, and a failure
  * is one warn. A lost reaction costs a signal, never the answer. The reaction is also never
@@ -18,7 +18,7 @@
  * dies without publishing.
  */
 import type { CodeHostProvider } from '@agentconnect.md/protocol'
-import type { GithubReplyTarget } from '../github/hook-coords.js'
+import { replyTargetProvider, type CodeHostReplyTarget } from './reply-target.js'
 
 /** Bounded because it races a prompt that is already starting; an unreachable host must
  *  never hold a turn open, and a late reaction is worthless anyway. */
@@ -36,14 +36,11 @@ export interface CodeHostAckDeps {
 /** One provider's acknowledgement request. */
 interface CodeHostAckAdapter {
   readonly provider: CodeHostProvider
-  /** True when this delivery's reply target names THIS provider. */
-  claims(target: GithubReplyTarget): boolean
-  request(target: GithubReplyTarget, token: string, apiBaseUrl: string): { url: string; init: RequestInit }
+  request(target: CodeHostReplyTarget, token: string, apiBaseUrl: string): { url: string; init: RequestInit }
 }
 
 const githubAck: CodeHostAckAdapter = {
   provider: 'github',
-  claims: (target) => target.provider === undefined,
   request(target, token, apiBaseUrl) {
     // A PR review comment and a conversation comment are different GitHub resources with
     // different reaction paths; a delivery with neither was fired by the subject, and a PR
@@ -72,7 +69,6 @@ const githubAck: CodeHostAckAdapter = {
 
 const gitlabAck: CodeHostAckAdapter = {
   provider: 'gitlab',
-  claims: (target) => target.provider === 'gitlab',
   request(target, token, apiBaseUrl) {
     // `repo` is the numeric project id on a GitLab target and `number` the subject IID (§14.1).
     const subject = `/projects/${target.repo}/${target.subjectKind === 'merge_request' ? 'merge_requests' : 'issues'}/${target.number}`
@@ -91,8 +87,8 @@ const gitlabAck: CodeHostAckAdapter = {
   }
 }
 
-/** Registration order is resolution order; adding a code host is adding one entry. */
-const ACKS: readonly CodeHostAckAdapter[] = [githubAck, gitlabAck]
+/** Adding a code host is adding one entry; the record over the provider union makes a missing one a compile error. */
+const ACKS: { readonly [P in CodeHostProvider]: CodeHostAckAdapter } = { github: githubAck, gitlab: gitlabAck }
 
 /**
  * Place the "seen it" reaction on whatever fired this turn. Resolves once the request
@@ -101,9 +97,8 @@ const ACKS: readonly CodeHostAckAdapter[] = [githubAck, gitlabAck]
  * A repeat is deliberately not suppressed — both hosts treat a reaction that is already
  * present as a success, so a redelivered turn needs no state of its own to stay idempotent.
  */
-export async function acknowledgeCodeHostTrigger(target: GithubReplyTarget, deps: CodeHostAckDeps): Promise<void> {
-  const adapter = ACKS.find((candidate) => candidate.claims(target))
-  if (!adapter) return
+export async function acknowledgeCodeHostTrigger(target: CodeHostReplyTarget, deps: CodeHostAckDeps): Promise<void> {
+  const adapter = ACKS[replyTargetProvider(target)]
   const doFetch = deps.fetchImpl ?? fetch
   try {
     const { url, init } = adapter.request(target, await deps.token(), deps.apiBaseUrl())

--- a/packages/daemon/src/codehost/reply-target.ts
+++ b/packages/daemon/src/codehost/reply-target.ts
@@ -1,0 +1,36 @@
+/**
+ * Where one code-host delivery's ordinary end-of-turn reply goes
+ * (gitlab-com-integration.md §14.1, §6.5).
+ *
+ * The coordinates are shared because the durable hook row carries them: a delivery admitted
+ * before a restart is replayed from exactly these fields, so the names stay stable and each
+ * provider says what it means by them. `provider` is the discriminator every turn-final
+ * member resolves on.
+ */
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
+
+export interface CodeHostReplyTarget {
+  hookId: string
+  /** The code host whose coordinates these are, and which owns this turn's one public reply. */
+  provider: CodeHostProvider
+  /** GitLab names its subject (§14.1); GitHub reads the kind off its own trusted metadata. */
+  subjectKind?: 'issue' | 'merge_request'
+  /** GitHub: `owner/repo`. GitLab: the numeric project id — both are what the effect lease is scoped to. */
+  repo: string
+  /** GitHub: the issue/pull-request number. GitLab: the subject IID. */
+  number: number
+  /** The review-comment delivery that triggered this turn (diagnostic identity). */
+  reviewCommentId?: string
+  /** The comment that FIRED this turn, as the acknowledgement reaction targets it. Absent ⇒
+   *  the subject itself fired, so the subject is what carries the reaction. Distinct from
+   *  `reviewThreadRootCommentId`, which names where the ANSWER goes: a reply lands on the
+   *  thread root, while the acknowledgement belongs on the exact comment a human wrote. */
+  triggerComment?: { kind: 'issue_comment' | 'review_comment' | 'note'; id: string }
+  /** Stable root of the GitHub inline-review thread; replies must target this id. */
+  reviewThreadRootCommentId?: string
+}
+
+/** The provider a target names. A row persisted before the member became explicit named GitHub, and a replay must still reach its poster. */
+export function replyTargetProvider(target: Pick<CodeHostReplyTarget, 'provider'>): CodeHostProvider {
+  return target.provider ?? 'github'
+}

--- a/packages/daemon/src/codehost/turn-final.ts
+++ b/packages/daemon/src/codehost/turn-final.ts
@@ -1,0 +1,117 @@
+/**
+ * The daemon's TURN-FINAL contract member for code hosts (gitlab-com-integration.md §6.5,
+ * §14.1; integration-plugin-architecture.md §7.6, stage S2).
+ *
+ * A code-host turn publishes ONE comment at the very end, which is why its Layer-2 shape is
+ * the published turn-FINAL surface and not a streaming one. What a provider must supply to
+ * that surface is registered here: where the delivery's one reply goes, the effect lease and
+ * REST root it publishes under, the poster itself, the instance a turn is fenced to at start,
+ * and the lifecycle pairing that retires a thread's checkout without opening a turn. Core
+ * selects through the registry and compares no provider name, so adding a code host is adding
+ * one entry — never a branch on the dispatch path.
+ *
+ * Every member exists because BOTH providers implement it. GitHub-only product surfaces stay
+ * out on purpose (the workflow-approval start path, the session pull-request panel): one
+ * implementer is an interface guessed at, not a contract.
+ */
+import {
+  isCodeHostHookKind,
+  type CodeHostHookMembers,
+  type CodeHostProvider,
+  type GithubPublishedComment,
+  type PublishedHookOutput,
+  type RdMsgHook
+} from '@agentconnect.md/protocol'
+import { githubTurnFinal, type GithubTurnFinalHost } from '../github/turn-final.js'
+import { gitlabTurnFinal, type GitlabTurnFinalHost } from '../gitlab/turn-final.js'
+import type { GithubCommentAttributionSource } from '../github/poster.js'
+import type { GitlabPublishFailure } from '../gitlab/poster.js'
+import { replyTargetProvider, type CodeHostReplyTarget } from './reply-target.js'
+
+/** The one end-of-turn poster both providers implement — the published surface's `poster` slot. */
+export interface CodeHostFinalPoster {
+  publish(finalBody?: string): Promise<GithubPublishedComment | PublishedHookOutput | undefined>
+  /** Normalized reason the one comment is absent (§14.1); a provider that names none omits it. */
+  readonly failure?: GitlabPublishFailure
+}
+
+/** The action-time effect lease and REST root one delivery's public output is published under (§14.1). */
+export interface CodeHostEffectLease {
+  token: () => Promise<string>
+  /** Drop a cached token the host just rejected (401/403) so the one retry re-mints. */
+  invalidateToken: (presentedToken: string) => void
+  apiBaseUrl: () => string
+}
+
+/** What a provider's poster is built from: its lease, plus the footer facts resolved at publish time. */
+export interface CodeHostFinalPosterDeps extends CodeHostEffectLease {
+  attribution?: GithubCommentAttributionSource
+  log: { warn: (message: string) => void }
+}
+
+/** A delivery's trusted members plus the normalized event — the pair a lifecycle cleanup is fenced on. */
+export type CodeHostDelivery = CodeHostHookMembers & { event?: string }
+
+export type CodeHostThreadWorktreeCleanup = 'pull_request_merged' | 'issue_closed' | 'issue_deleted'
+
+/** What the daemon lends these members; each provider declares only the part it reads. */
+export type CodeHostTurnFinalHost = GithubTurnFinalHost & GitlabTurnFinalHost
+
+/** One code host's turn-final members. */
+export interface CodeHostTurnFinal<P extends CodeHostProvider = CodeHostProvider> {
+  readonly provider: P
+  /** This delivery's one reply target, or undefined when it owns no public reply (a push, a subject it cannot address). */
+  replyTarget(msg: RdMsgHook): CodeHostReplyTarget | undefined
+  /** The named refusal a turn-start instance disagreement takes, or undefined when this provider pins no instance. */
+  hostFence(msg: RdMsgHook, host: CodeHostTurnFinalHost): string | undefined
+  /** The lifecycle pairing that retires the per-thread checkout, read off the normalized event and trusted metadata. */
+  worktreeCleanup(delivery: CodeHostDelivery): CodeHostThreadWorktreeCleanup | undefined
+  /** The lease this target's public output publishes under, resolved per turn. */
+  effectLease(agentId: string, target: CodeHostReplyTarget, host: CodeHostTurnFinalHost): CodeHostEffectLease
+  /** The turn's one poster, tokened through that lease. */
+  finalPoster(target: CodeHostReplyTarget, deps: CodeHostFinalPosterDeps): CodeHostFinalPoster
+  /** True when this provider's poster names WHY its one comment is absent (§14.1); GitHub's reports none. */
+  readonly reportsAbsentOutput: boolean
+}
+
+/** Adding a code host is adding one entry; the record over the provider union makes a missing one a compile error. */
+const TURN_FINALS: { readonly [P in CodeHostProvider]: CodeHostTurnFinal<P> } = {
+  github: githubTurnFinal,
+  gitlab: gitlabTurnFinal
+}
+
+/** Every registered member, in provider order — the order a member that claims its own delivery resolves in. */
+const TURN_FINAL_MEMBERS: readonly CodeHostTurnFinal[] = Object.values(TURN_FINALS)
+
+/** The module owning one reply target, and therefore this turn's poster, lease and acknowledgement. */
+export function turnFinalFor(target: Pick<CodeHostReplyTarget, 'provider'>): CodeHostTurnFinal {
+  return TURN_FINALS[replyTargetProvider(target)]
+}
+
+/** The one reply target a delivery opens, built by the module its TRUSTED source names — never inferred from model-visible text. */
+export function codeHostReplyTarget(msg: RdMsgHook): CodeHostReplyTarget | undefined {
+  const source = msg.context?.source
+  if (source === undefined || !isCodeHostHookKind(source)) return undefined
+  return TURN_FINALS[source].replyTarget(msg)
+}
+
+/** The turn-start refusal this delivery takes when it names an instance the session's spec is not bound to (§24.4). */
+export function codeHostHostFence(msg: RdMsgHook, host: CodeHostTurnFinalHost): string | undefined {
+  for (const member of TURN_FINAL_MEMBERS) {
+    const refusal = member.hostFence(msg, host)
+    if (refusal !== undefined) return refusal
+  }
+  return undefined
+}
+
+/** Relay-authored lifecycle events that remove the isolated checkout without opening a model turn. */
+export function codeHostThreadWorktreeCleanup(
+  delivery: CodeHostDelivery | undefined
+): CodeHostThreadWorktreeCleanup | undefined {
+  if (!delivery) return undefined
+  for (const member of TURN_FINAL_MEMBERS) {
+    const cleanup = member.worktreeCleanup(delivery)
+    if (cleanup !== undefined) return cleanup
+  }
+  return undefined
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -582,17 +582,17 @@ import {
   githubDeletedHookEvent,
   hookOutputFallbackAllowed,
   githubReviewResultForCompletion,
-  githubThreadWorktreeCleanup,
   hookOutcomeFailure,
   MAX_HOOK_REPORT_INFLIGHT,
   type ActiveGithubReplyBatchMeta,
   type ActiveGithubTurnMeta,
-  type GithubReplyTarget,
   type HookCompletionOwner,
   type HookDispatchContext,
   type NotePublishFailure,
   type SessionWorktreeCleanupResult
 } from './github/hook-coords.js'
+import type { CodeHostReplyTarget } from './codehost/reply-target.js'
+import { codeHostThreadWorktreeCleanup, turnFinalFor } from './codehost/turn-final.js'
 import {
   FailStopError,
   LifecycleCleanupBlockedError,
@@ -10591,7 +10591,7 @@ export class Daemon {
        *  id (session-concept.md §1.1) — every consumer of this reports it onward. */
       onSessionReady?: (sessionId: string) => void
     },
-    githubReply?: GithubReplyTarget,
+    githubReply?: CodeHostReplyTarget,
     hookContext?: HookDispatchContext,
     posterPublishState: QueueEntry['posterPublishState'] = githubReply ? 'not_started' : undefined
   ): Promise<string | null> {
@@ -12042,7 +12042,7 @@ export class Daemon {
       ...(plan.githubTurnEligible && githubReply
         ? {
             github: {
-              ...this.githubReviews.makeGithubReply(agentId, githubReply, sessionId),
+              ...this.githubReviews.makeCodeHostReply(agentId, githubReply, sessionId),
               deferredFinalTranscript: false
             }
           }
@@ -13306,9 +13306,10 @@ export class Daemon {
   }
 
   /** Stamp this turn's normalized note outcome on the durable hook context (14.1) so settlement
-   *  carries it; gitlab reply targets only. Returns whether anything was recorded. */
+   *  carries it; only a host whose poster names an absent comment. Returns whether anything was recorded. */
   private markNotePublishFailure(entry: QueueEntry, code: NotePublishFailure | undefined): boolean {
-    if (!code || !entry.hookContext || entry.githubReply?.provider !== 'gitlab') return false
+    const reply = entry.githubReply
+    if (!code || !entry.hookContext || !reply || !turnFinalFor(reply).reportsAbsentOutput) return false
     entry.hookContext.notePublishFailure = code
     return true
   }
@@ -13325,10 +13326,11 @@ export class Daemon {
     if (!hookContext) return
     // The PERSISTED outcome is authoritative — it is the only one a replayed row still has. A proven
     // note identity outranks any marker: the publication happened, whatever an earlier attempt recorded.
+    const reply = entry.githubReply
     const notePublishFailure = hookContext.publishedOutput
       ? undefined
       : (hookContext.notePublishFailure ??
-        (entry.githubReply?.provider === 'gitlab' ? p.github?.poster.failure : undefined))
+        (reply && turnFinalFor(reply).reportsAbsentOutput ? p.github?.poster.failure : undefined))
     const failure = hookOutcomeFailure(
       hookContext.githubReviewBatch,
       batchPublishesItems(hookContext),
@@ -18208,7 +18210,7 @@ export class Daemon {
         await this.store.removeInbox(row.id)
         continue
       }
-      const cleanup = githubThreadWorktreeCleanup(hookContext)
+      const cleanup = codeHostThreadWorktreeCleanup(hookContext)
       const deleted = githubDeletedHookEvent(hookContext)
       if (hookContext && (cleanup || deleted)) {
         const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, row.agentId, msg.transportScope)

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -21,7 +21,8 @@ import type { SlackConnection } from '../slack/connection.js'
 import type { TelegramConnection } from '../telegram/connection.js'
 import type { DiscordConnection } from '../discord/connection.js'
 import type { FeishuConnection } from '../feishu/connection.js'
-import type { GithubReplyTarget, HookDispatchContext } from '../github/hook-coords.js'
+import type { HookDispatchContext } from '../github/hook-coords.js'
+import type { CodeHostReplyTarget } from '../codehost/reply-target.js'
 import type { WebchatTurnContext } from '../webchat/types.js'
 import type { WorkspaceFileLinkResolver } from '../messages/workspace-file-links.js'
 
@@ -283,10 +284,10 @@ export interface QueueEntry {
    *  turns, or a replayed entry re-admitted from an already-present row). Set once on
    *  admission and used to delete the row on every terminal path. */
   inboxId?: string
-  /** P3 outbound: publish the turn's completed reply on this GitHub thread. Hook
+  /** P3 outbound: publish the turn's completed reply on this code-host thread. Hook
    * deliveries duplicate this reference in their durable HookDispatchContext so
    * restart replay can recreate the poster behind its publish-state fence. */
-  githubReply?: GithubReplyTarget
+  githubReply?: CodeHostReplyTarget
   /** Selected before session/new|load so cancellation uses the exact host. */
   selectedHost?: SelectedTurnHost
   /** Session initialization must await cleanup before releasing ownership. */

--- a/packages/daemon/src/github/hook-coords.ts
+++ b/packages/daemon/src/github/hook-coords.ts
@@ -19,6 +19,7 @@ import {
 import type { GithubReviewEffect, GithubReviewEvent, GithubReviewTarget, GithubReviewVerdict } from './review.js'
 import type { SessionWorktreeRemoval } from '../workspace/workspace-manager.js'
 import type { QueueEntry } from '../daemon/turn-types.js'
+import type { CodeHostReplyTarget } from '../codehost/reply-target.js'
 import type { GitlabPublishFailure } from '../gitlab/poster.js'
 
 export function hookSnapshot(msg: RdMsgHook): HookConfigSnapshot | undefined {
@@ -64,30 +65,12 @@ export function foreignHookDispatch(report: HookReport, daemonId?: string): bool
   return report.dispatchDaemonId !== undefined && report.dispatchDaemonId !== daemonId
 }
 
-export interface GithubReplyTarget {
-  hookId: string
-  /** Provider discriminator: absent ⇒ github; 'gitlab' sets `repo` = numeric project id and `number` = the subject IID (§14.1). */
-  provider?: 'gitlab'
-  subjectKind?: 'issue' | 'merge_request'
-  repo: string
-  number: number
-  /** The review-comment delivery that triggered this turn (diagnostic identity). */
-  reviewCommentId?: string
-  /** The comment that FIRED this turn, as the acknowledgement reaction targets it. Absent ⇒
-   *  the subject itself fired, so the subject is what carries the reaction. Distinct from
-   *  `reviewThreadRootCommentId`, which names where the ANSWER goes: a reply lands on the
-   *  thread root, while the acknowledgement belongs on the exact comment a human wrote. */
-  triggerComment?: { kind: 'issue_comment' | 'review_comment' | 'note'; id: string }
-  /** Stable root of the GitHub inline-review thread; replies must target this id. */
-  reviewThreadRootCommentId?: string
-}
-
 export interface GithubReviewBatchItem {
   deliveryKey: string
   firedAt: string
   text: string
   /** The per-item reply target, present only where the provider publishes each item itself. */
-  reply?: GithubReplyTarget & { reviewThreadRootCommentId: string }
+  reply?: CodeHostReplyTarget & { reviewThreadRootCommentId: string }
   publishState?: 'not_started' | 'in_flight' | 'settled'
   publishedComment?: GithubPublishedComment
 }
@@ -143,7 +126,7 @@ export interface HookDispatchContext {
   github?: GithubHookMetadata
   /** GitLab twin of `github` — the trusted subject discriminator (§12.3). */
   gitlab?: GitlabHookMetadata
-  githubReply?: GithubReplyTarget
+  githubReply?: CodeHostReplyTarget
   githubReviewBatch?: GithubReviewBatch
   turnStartedAt?: string
   reviewAttemptId?: string
@@ -222,8 +205,6 @@ export function hookOutputFallbackAllowed(hook: HookDispatchContext | undefined)
   return githubFallbackAllowed(hook) && codeHostReviewFallbackAllowed(hook)
 }
 
-export type GithubThreadWorktreeCleanup = 'pull_request_merged' | 'issue_closed' | 'issue_deleted'
-
 const GITHUB_DELETED_HOOK_EVENTS = new Set([
   'issues:deleted',
   'pull_request:deleted',
@@ -233,27 +214,6 @@ const GITHUB_DELETED_HOOK_EVENTS = new Set([
 
 export function githubDeletedHookEvent(hook: Pick<HookDispatchContext, 'event'> | undefined): boolean {
   return hook?.event !== undefined && GITHUB_DELETED_HOOK_EVENTS.has(hook.event)
-}
-
-/** Relay-authored lifecycle events that remove the isolated checkout without
- * opening a model turn. Pair the normalized event with trusted subject metadata
- * so an old or malformed frame cannot turn an ordinary hook into maintenance. */
-export function githubThreadWorktreeCleanup(
-  hook: Pick<HookDispatchContext, 'event' | 'github' | 'gitlab'> | undefined
-): GithubThreadWorktreeCleanup | undefined {
-  if (hook?.event === 'pull_request:merged' && hook.github?.subjectKind === 'pull_request') {
-    return 'pull_request_merged'
-  }
-  if (hook?.event === 'issues:closed' && hook.github?.subjectKind === 'issue') return 'issue_closed'
-  if (hook?.event === 'issues:deleted' && hook.github?.subjectKind === 'issue') return 'issue_deleted'
-  // The GitLab counterpart (gitlab-com-integration.md §12): merged MRs and
-  // closed issues retire the per-thread checkout, fenced on the SAME pairing of
-  // normalized event + trusted subject metadata.
-  if (hook?.event === 'merge_request:merged' && hook.gitlab?.target.kind === 'merge_request') {
-    return 'pull_request_merged'
-  }
-  if (hook?.event === 'issues:closed' && hook.gitlab?.target.kind === 'issue') return 'issue_closed'
-  return undefined
 }
 
 export type SessionWorktreeCleanupResult =

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -11,7 +11,6 @@
 import { randomUUID } from 'node:crypto'
 import { WireError } from '@agentconnect.md/connection'
 import {
-  GITLAB_DEFAULT_BASE_URL,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   type GithubHookMetadata,
@@ -20,7 +19,6 @@ import {
   type RdMsgHook
 } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
-import { gitlabApiBaseUrl } from '../gitlab/api-base.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { CpClient } from '../cp/client.js'
@@ -37,15 +35,12 @@ import {
   authorizedReviewTargetMatches,
   githubDeletedHookEvent,
   githubFallbackAllowed,
-  githubThreadWorktreeCleanup,
   hookSnapshot,
   isGithubReviewCommentHook,
   reviewPolicyAllows,
   reviewResultForWire,
   type ActiveGithubReplyBatchMeta,
   type ActiveGithubTurnMeta,
-  type GithubReplyTarget,
-  type GithubThreadWorktreeCleanup,
   type HookCompletionOwner,
   type HookDispatchContext,
   type SessionWorktreeCleanupResult
@@ -54,10 +49,18 @@ import type { CallMeta, QueueEntry } from '../daemon/turn-types.js'
 import type { WebchatTurnContext } from '../webchat/types.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
 import { effectiveSessionIsolation, type PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
-import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './poster.js'
-import { GitlabFinalPoster } from '../gitlab/poster.js'
-import { GITLAB_HOST_MISMATCH_REASON } from '../gitlab/host-fence.js'
+import { GithubReplyCollector, type GithubCommentAttribution } from './poster.js'
 import { acknowledgeCodeHostTrigger } from '../codehost/ack.js'
+import type { CodeHostReplyTarget } from '../codehost/reply-target.js'
+import {
+  codeHostHostFence,
+  codeHostReplyTarget,
+  codeHostThreadWorktreeCleanup,
+  turnFinalFor,
+  type CodeHostFinalPoster,
+  type CodeHostThreadWorktreeCleanup,
+  type CodeHostTurnFinalHost
+} from '../codehost/turn-final.js'
 import { GithubReviewClient, type GithubReviewEffect } from './review.js'
 
 /** Dispatch options this seam needs; a subset of the daemon's own. */
@@ -137,7 +140,7 @@ export interface GithubReviewHost {
     webchat?: WebchatTurnContext,
     callMeta?: CallMeta,
     opts?: GithubHookDispatchOptions,
-    githubReply?: GithubReplyTarget,
+    githubReply?: CodeHostReplyTarget,
     hookContext?: HookDispatchContext
   ): Promise<string | null>
   /** Turn-finalization in dispatchOne reads these maps too, so they stay on the Daemon. */
@@ -160,6 +163,17 @@ export class GithubReviewOrchestrator {
     provider: 'github',
     owns: (key, agentId) => this.host.activeGithubTurn(key)?.hook.agentId === agentId,
     submit: (_key, req) => this.submitGithubReview(req)
+  }
+
+  /** What the §6.5 turn-final members read back here: each provider's effect mint, and the instance its spec names. */
+  private readonly turnFinalHost: CodeHostTurnFinalHost = {
+    getPostToken: (agentId, repo, hookId) => this.host.getPostToken(agentId, repo, hookId),
+    invalidatePost: (agentId, repo, presented) => this.host.invalidatePost(agentId, repo, presented),
+    getGitlabPostToken: (agentId, projectId, hookId) => this.host.getGitlabPostToken(agentId, projectId, hookId),
+    invalidateGitlabPost: (agentId, projectId, presented) =>
+      this.host.invalidateGitlabPost(agentId, projectId, presented),
+    gitlabHostFor: (agentId) => this.agents.get(agentId)?.gitlabHost,
+    log: { warn: (message: string) => this.log.warn(message) }
   }
 
   constructor(private readonly host: GithubReviewHost) {}
@@ -189,7 +203,7 @@ export class GithubReviewOrchestrator {
   async dispatchRelayHook(msg: RdMsgHook): Promise<RdAck> {
     const durable = await this.replayDurableAdmission(msg)
     if (durable) return durable
-    const cleanup = githubThreadWorktreeCleanup(msg)
+    const cleanup = codeHostThreadWorktreeCleanup(msg)
     const maintenance = cleanup !== undefined || githubDeletedHookEvent(msg)
     const agent = this.agents.get(msg.agentId)
     if (!agent) {
@@ -197,16 +211,8 @@ export class GithubReviewOrchestrator {
       return { msgId: msg.msgId, accepted: false, reason: 'no_agent' }
     }
     // §24.4: a delivery naming another instance than the spec is REFUSED, never re-targeted.
-    if (msg.gitlab !== undefined) {
-      const expected = agent.gitlabHost ?? GITLAB_DEFAULT_BASE_URL
-      const delivered = msg.gitlab.host ?? GITLAB_DEFAULT_BASE_URL
-      if (delivered !== expected) {
-        this.log.warn(
-          `hook: fire ${msg.msgId} for agent "${msg.agentId}" names gitlab instance ${delivered} but its spec is bound to ${expected} — refusing`
-        )
-        return { msgId: msg.msgId, accepted: false, reason: GITLAB_HOST_MISMATCH_REASON }
-      }
-    }
+    const hostMismatch = codeHostHostFence(msg, this.turnFinalHost)
+    if (hostMismatch) return { msgId: msg.msgId, accepted: false, reason: hostMismatch }
     if (!maintenance && this.host.paused(msg.agentId)) {
       this.log.info(`hook: agent "${msg.agentId}" is paused — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'paused' }
@@ -252,7 +258,7 @@ export class GithubReviewOrchestrator {
    * without one the fire runs headless.
    */
   async onHookFire(msg: RdMsgHook): Promise<{ accepted: boolean; reason?: string }> {
-    const cleanup = githubThreadWorktreeCleanup(msg)
+    const cleanup = codeHostThreadWorktreeCleanup(msg)
     const deleted = githubDeletedHookEvent(msg)
     // A lifecycle cleanup always addresses the stable GitHub thread session,
     // never an optional IM anchor configured for ordinary hook output.
@@ -288,55 +294,10 @@ export class GithubReviewOrchestrator {
       }
       return { accepted: true }
     }
-    // P3 outbound: github fires on a NUMBERED thread publish their completed reply as
-    // one comment (always on — design; push fires have no thread and stay silent).
-    const c = msg.context
-    const trustedInlineTarget =
-      c?.source === 'github' &&
-      msg.github?.subjectKind === 'pull_request' &&
-      msg.github.pullNumber !== undefined &&
-      msg.github.reviewThreadRootCommentId !== undefined
-        ? {
-            hookId: msg.hookId,
-            repo: msg.github.repoFullName,
-            number: msg.github.pullNumber,
-            ...(msg.github.reviewCommentId
-              ? {
-                  reviewCommentId: msg.github.reviewCommentId,
-                  triggerComment: { kind: 'review_comment' as const, id: msg.github.reviewCommentId }
-                }
-              : {}),
-            reviewThreadRootCommentId: msg.github.reviewThreadRootCommentId
-          }
-        : undefined
-    // Inline coordinates and their PR target are one body-free trusted unit.
-    // A mixed-version frame without that unit keeps the rolling-compatible
-    // ordinary issue/PR comment path derived from HookContext.
-    // GitLab (§14.1) rides the same pipe: repo = numeric project id, number = IID; pushes have no thread and stay silent.
-    const gitlabReply =
-      c?.source === 'gitlab' && msg.gitlab && msg.gitlab.target.kind !== 'push'
-        ? {
-            hookId: msg.hookId,
-            provider: 'gitlab' as const,
-            subjectKind: msg.gitlab.target.kind,
-            repo: msg.gitlab.projectId,
-            number: msg.gitlab.target.iid,
-            ...(msg.gitlab.noteId ? { triggerComment: { kind: 'note' as const, id: msg.gitlab.noteId } } : {})
-          }
-        : undefined
-    const githubReply =
-      trustedInlineTarget ??
-      gitlabReply ??
-      (c?.source === 'github' && c.repo && c.number !== undefined
-        ? {
-            hookId: msg.hookId,
-            repo: c.repo,
-            number: c.number,
-            ...(msg.github?.issueCommentId
-              ? { triggerComment: { kind: 'issue_comment' as const, id: msg.github.issueCommentId } }
-              : {})
-          }
-        : undefined)
+    // P3 outbound: a code-host fire on a NUMBERED subject publishes its completed reply as one
+    // comment (always on — design; a push has no thread and stays silent). Which coordinates
+    // that is belongs to the delivery's own turn-final member.
+    const githubReply = codeHostReplyTarget(msg)
     if (githubReply) hookContext.githubReply = githubReply
     const reviewLane = reviewSubjectLane(hookContext, hookCoordinates(msg.agentId, nmsg, msg.target?.integrationId))
     const anchor = await this.host.anchorTrigger(
@@ -390,7 +351,7 @@ export class GithubReviewOrchestrator {
   async completeGithubThreadWorktreeCleanup(
     hook: HookDispatchContext,
     key: string,
-    cleanup: GithubThreadWorktreeCleanup,
+    cleanup: CodeHostThreadWorktreeCleanup,
     owner: HookCompletionOwner
   ): Promise<void> {
     try {
@@ -971,7 +932,7 @@ export class GithubReviewOrchestrator {
       }
       item.publishState = 'in_flight'
       await this.host.persistHookState(active.entry, undefined, true)
-      const published = await this.makeGithubReply(req.agentId, reply, active.sessionId).poster.publish(
+      const published = await this.makeCodeHostReply(req.agentId, reply, active.sessionId).poster.publish(
         supplied.get(root)!
       )
       // Batch replies are a GitHub-only surface (inline review threads) — narrow away the gitlab arm of the shared poster union.
@@ -991,62 +952,32 @@ export class GithubReviewOrchestrator {
   /** Light the code host's "seen it" reaction on whatever fired this turn, through the same
    *  repo-targeted mint the turn's poster will use — reactions need no wider grant. Returns a
    *  promise only so tests can settle it; dispatch never awaits one. */
-  acknowledgeTrigger(agentId: string, ref: GithubReplyTarget): Promise<void> {
+  acknowledgeTrigger(agentId: string, ref: CodeHostReplyTarget): Promise<void> {
+    const lease = turnFinalFor(ref).effectLease(agentId, ref, this.turnFinalHost)
     return acknowledgeCodeHostTrigger(ref, {
-      token:
-        ref.provider === 'gitlab'
-          ? async () => (await this.host.getGitlabPostToken(agentId, ref.repo, ref.hookId)).token
-          : async () => (await this.host.getPostToken(agentId, ref.repo, ref.hookId)).token,
-      apiBaseUrl:
-        ref.provider === 'gitlab'
-          ? () => gitlabApiBaseUrl(this.agents.get(agentId)?.gitlabHost)
-          : () => 'https://api.github.com',
+      token: lease.token,
+      apiBaseUrl: lease.apiBaseUrl,
       log: { warn: (message: string) => this.log.warn(message) }
     })
   }
 
-  /** Build the per-turn GitHub final-answer selector and poster, tokened
-   *  via the repo-targeted gitcred mint (issues/PR write, no contents — never
-   *  enters agent env). Attribution is resolved at publish time so the completed
-   *  comment carries the session's final runtime/model selection. */
-  makeGithubReply(
+  /** Build the per-turn final-answer selector and the owning host's poster, tokened via that
+   *  host's effect lease. Attribution is resolved at publish time so the completed comment
+   *  carries the session's final runtime/model selection. */
+  makeCodeHostReply(
     agentId: string,
-    ref: GithubReplyTarget,
+    ref: CodeHostReplyTarget,
     sessionId: string
-  ): { poster: GithubFinalPoster | GitlabFinalPoster; collector: GithubReplyCollector } {
-    if (ref.provider === 'gitlab') {
-      return {
-        collector: new GithubReplyCollector(),
-        poster: new GitlabFinalPoster(
-          {
-            token: async () => (await this.host.getGitlabPostToken(agentId, ref.repo, ref.hookId)).token,
-            invalidateToken: (token) => this.host.invalidateGitlabPost(agentId, ref.repo, token),
-            // §24.4: the instance this agent's spec names, read when the note is actually posted.
-            apiBaseUrl: () => gitlabApiBaseUrl(this.agents.get(agentId)?.gitlabHost),
-            log: { warn: (m: string) => this.log.warn(m) }
-          },
-          ref.repo,
-          ref.subjectKind ?? 'issue',
-          ref.number,
-          () =>
-            this.agents.get(agentId)?.output.showFooter ? this.githubCommentAttribution(agentId, sessionId) : undefined
-        )
-      }
-    }
+  ): { poster: CodeHostFinalPoster; collector: GithubReplyCollector } {
+    const turnFinal = turnFinalFor(ref)
     return {
       collector: new GithubReplyCollector(),
-      poster: new GithubFinalPoster(
-        {
-          token: async () => (await this.host.getPostToken(agentId, ref.repo, ref.hookId)).token,
-          invalidateToken: (token) => this.host.invalidatePost(agentId, ref.repo, token),
-          log: { warn: (m: string) => this.log.warn(m) }
-        },
-        ref.repo,
-        ref.number,
-        () =>
+      poster: turnFinal.finalPoster(ref, {
+        ...turnFinal.effectLease(agentId, ref, this.turnFinalHost),
+        attribution: () =>
           this.agents.get(agentId)?.output.showFooter ? this.githubCommentAttribution(agentId, sessionId) : undefined,
-        ref.reviewThreadRootCommentId
-      )
+        log: { warn: (m: string) => this.log.warn(m) }
+      })
     }
   }
 

--- a/packages/daemon/src/github/turn-final.ts
+++ b/packages/daemon/src/github/turn-final.ts
@@ -1,0 +1,96 @@
+/** GitHub's implementation of the daemon turn-final contract (§6.5, §14.1): the issue/PR
+ *  comment target, its repo-targeted mint, and the pull-request lifecycle pairing. */
+import type { RdMsgHook } from '@agentconnect.md/protocol'
+import type {
+  CodeHostDelivery,
+  CodeHostEffectLease,
+  CodeHostFinalPoster,
+  CodeHostFinalPosterDeps,
+  CodeHostThreadWorktreeCleanup,
+  CodeHostTurnFinal
+} from '../codehost/turn-final.js'
+import type { CodeHostReplyTarget } from '../codehost/reply-target.js'
+import { GithubFinalPoster } from './poster.js'
+
+/** The deployment's App speaks to github.com alone, so this root is not a per-turn fact. */
+const GITHUB_API_BASE_URL = 'https://api.github.com'
+
+/** What GitHub's members read back on the daemon — the repo-targeted gitcred mint and nothing wider. */
+export interface GithubTurnFinalHost {
+  /** Issues/PR write for this delivery's repo, no contents; the token never enters agent env. */
+  getPostToken(agentId: string, repo: string, hookId: string): Promise<{ token: string }>
+  invalidatePost(agentId: string, repo: string, presentedToken?: string): void
+}
+
+function replyTarget(msg: RdMsgHook): CodeHostReplyTarget | undefined {
+  const github = msg.github
+  // Inline coordinates and their PR target are one body-free trusted unit.
+  if (
+    github?.subjectKind === 'pull_request' &&
+    github.pullNumber !== undefined &&
+    github.reviewThreadRootCommentId !== undefined
+  ) {
+    return {
+      hookId: msg.hookId,
+      provider: 'github',
+      repo: github.repoFullName,
+      number: github.pullNumber,
+      ...(github.reviewCommentId
+        ? {
+            reviewCommentId: github.reviewCommentId,
+            triggerComment: { kind: 'review_comment' as const, id: github.reviewCommentId }
+          }
+        : {}),
+      reviewThreadRootCommentId: github.reviewThreadRootCommentId
+    }
+  }
+  // A mixed-version frame without that unit keeps the rolling-compatible ordinary
+  // issue/PR comment path derived from HookContext.
+  const c = msg.context
+  if (!c?.repo || c.number === undefined) return undefined
+  return {
+    hookId: msg.hookId,
+    provider: 'github',
+    repo: c.repo,
+    number: c.number,
+    ...(github?.issueCommentId ? { triggerComment: { kind: 'issue_comment' as const, id: github.issueCommentId } } : {})
+  }
+}
+
+/** Pair the normalized event with trusted subject metadata so an old or malformed frame cannot turn an ordinary hook into maintenance. */
+function worktreeCleanup(delivery: CodeHostDelivery): CodeHostThreadWorktreeCleanup | undefined {
+  const github = delivery.github
+  if (delivery.event === 'pull_request:merged' && github?.subjectKind === 'pull_request') return 'pull_request_merged'
+  if (delivery.event === 'issues:closed' && github?.subjectKind === 'issue') return 'issue_closed'
+  if (delivery.event === 'issues:deleted' && github?.subjectKind === 'issue') return 'issue_deleted'
+  return undefined
+}
+
+function effectLease(agentId: string, target: CodeHostReplyTarget, host: GithubTurnFinalHost): CodeHostEffectLease {
+  return {
+    token: async () => (await host.getPostToken(agentId, target.repo, target.hookId)).token,
+    invalidateToken: (presented) => host.invalidatePost(agentId, target.repo, presented),
+    apiBaseUrl: () => GITHUB_API_BASE_URL
+  }
+}
+
+function finalPoster(target: CodeHostReplyTarget, deps: CodeHostFinalPosterDeps): CodeHostFinalPoster {
+  return new GithubFinalPoster(
+    { token: deps.token, invalidateToken: deps.invalidateToken, log: deps.log },
+    target.repo,
+    target.number,
+    deps.attribution,
+    target.reviewThreadRootCommentId
+  )
+}
+
+export const githubTurnFinal: CodeHostTurnFinal<'github'> = {
+  provider: 'github',
+  replyTarget,
+  // The App is bound to github.com, so a delivery names no instance that could disagree with the spec.
+  hostFence: () => undefined,
+  worktreeCleanup,
+  effectLease,
+  finalPoster,
+  reportsAbsentOutput: false
+}

--- a/packages/daemon/src/gitlab/host-fence.ts
+++ b/packages/daemon/src/gitlab/host-fence.ts
@@ -1,9 +1,3 @@
-/**
- * The named refusal a turn-time GitLab host disagreement takes (gitlab-com-integration.md §24.4).
- *
- * A hook may reach an ALREADY-RUNNING session whose environment cannot be retroactively edited: its
- * credential git-config block, injected helper table and `GITLAB_HOST` export were all established
- * at spawn for the instance the spec named. So a delivery whose trusted metadata names another
- * instance is refused under this reason and never re-targeted.
- */
+/** The named refusal a turn-time GitLab host disagreement takes (gitlab-com-integration.md §24.4);
+ *  the fence itself is the GitLab turn-final member that reports it. */
 export const GITLAB_HOST_MISMATCH_REASON = 'gitlab_host_mismatch'

--- a/packages/daemon/src/gitlab/turn-final.ts
+++ b/packages/daemon/src/gitlab/turn-final.ts
@@ -1,0 +1,98 @@
+/** GitLab's implementation of the daemon turn-final contract (§6.5, §14.1, §24.4): the note
+ *  target on a numbered subject, the per-instance effect lease, and the turn-start host fence. */
+import { GITLAB_DEFAULT_BASE_URL, type RdMsgHook } from '@agentconnect.md/protocol'
+import type {
+  CodeHostDelivery,
+  CodeHostEffectLease,
+  CodeHostFinalPoster,
+  CodeHostFinalPosterDeps,
+  CodeHostThreadWorktreeCleanup,
+  CodeHostTurnFinal
+} from '../codehost/turn-final.js'
+import type { CodeHostReplyTarget } from '../codehost/reply-target.js'
+import { gitlabApiBaseUrl } from './api-base.js'
+import { GITLAB_HOST_MISMATCH_REASON } from './host-fence.js'
+import { GitlabFinalPoster } from './poster.js'
+
+/** What GitLab's members read back on the daemon: the §14.1 effect lease, and the instance its spec names. */
+export interface GitlabTurnFinalHost {
+  /** The binding's effect PAT, gated by the enabled gitlab hook. */
+  getGitlabPostToken(agentId: string, projectId: string, hookId: string): Promise<{ token: string }>
+  invalidateGitlabPost(agentId: string, projectId: string, presentedToken?: string): void
+  /** The instance this agent's spec is bound to; absent means GitLab.com (§24.4). */
+  gitlabHostFor(agentId: string): string | undefined
+  log: { warn: (message: string) => void }
+}
+
+/** §14.1 rides the same pipe as GitHub: `repo` is the numeric project id and `number` the subject IID; pushes have no thread and stay silent. */
+function replyTarget(msg: RdMsgHook): CodeHostReplyTarget | undefined {
+  const gitlab = msg.gitlab
+  if (!gitlab || gitlab.target.kind === 'push') return undefined
+  return {
+    hookId: msg.hookId,
+    provider: 'gitlab',
+    subjectKind: gitlab.target.kind,
+    repo: gitlab.projectId,
+    number: gitlab.target.iid,
+    ...(gitlab.noteId ? { triggerComment: { kind: 'note' as const, id: gitlab.noteId } } : {})
+  }
+}
+
+/**
+ * §24.4: a hook may reach an ALREADY-RUNNING session whose environment cannot be retroactively
+ * edited — its credential git-config block, injected helper table and `GITLAB_HOST` export were
+ * all established at spawn for the instance the spec named. A delivery naming another instance is
+ * refused under this reason and never re-targeted.
+ */
+function hostFence(msg: RdMsgHook, host: GitlabTurnFinalHost): string | undefined {
+  if (msg.gitlab === undefined) return undefined
+  const expected = host.gitlabHostFor(msg.agentId) ?? GITLAB_DEFAULT_BASE_URL
+  const delivered = msg.gitlab.host ?? GITLAB_DEFAULT_BASE_URL
+  if (delivered === expected) return undefined
+  host.log.warn(
+    `hook: fire ${msg.msgId} for agent "${msg.agentId}" names gitlab instance ${delivered} but its spec is bound to ${expected} — refusing`
+  )
+  return GITLAB_HOST_MISMATCH_REASON
+}
+
+/** The counterpart of GitHub's pairing (§12): merged MRs and closed issues retire the per-thread checkout. */
+function worktreeCleanup(delivery: CodeHostDelivery): CodeHostThreadWorktreeCleanup | undefined {
+  const gitlab = delivery.gitlab
+  if (delivery.event === 'merge_request:merged' && gitlab?.target.kind === 'merge_request') return 'pull_request_merged'
+  if (delivery.event === 'issues:closed' && gitlab?.target.kind === 'issue') return 'issue_closed'
+  return undefined
+}
+
+function effectLease(agentId: string, target: CodeHostReplyTarget, host: GitlabTurnFinalHost): CodeHostEffectLease {
+  return {
+    token: async () => (await host.getGitlabPostToken(agentId, target.repo, target.hookId)).token,
+    invalidateToken: (presented) => host.invalidateGitlabPost(agentId, target.repo, presented),
+    // §24.4: the instance this agent's spec names, read when the note is actually posted.
+    apiBaseUrl: () => gitlabApiBaseUrl(host.gitlabHostFor(agentId))
+  }
+}
+
+function finalPoster(target: CodeHostReplyTarget, deps: CodeHostFinalPosterDeps): CodeHostFinalPoster {
+  return new GitlabFinalPoster(
+    {
+      token: deps.token,
+      invalidateToken: deps.invalidateToken,
+      apiBaseUrl: deps.apiBaseUrl,
+      log: deps.log
+    },
+    target.repo,
+    target.subjectKind ?? 'issue',
+    target.number,
+    deps.attribution
+  )
+}
+
+export const gitlabTurnFinal: CodeHostTurnFinal<'gitlab'> = {
+  provider: 'gitlab',
+  replyTarget,
+  hostFence,
+  worktreeCleanup,
+  effectLease,
+  finalPoster,
+  reportsAbsentOutput: true
+}

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -42,19 +42,15 @@
  * state and passed in as one boolean — the surface never inspects hook context.
  */
 import type { GithubPublishedComment, PublishedHookOutput } from '@agentconnect.md/protocol'
+import type { CodeHostFinalPoster } from '../../codehost/turn-final.js'
 import type { GithubReplyCollector } from '../../github/poster.js'
-import type { GitlabPublishFailure } from '../../gitlab/poster.js'
 import type { WorkspaceFileLinkResolver } from '../../messages/workspace-file-links.js'
 
 /** GitHub's per-turn state (§7.3). Held in the turn's final-surface slot, which
  *  core stores opaquely and never reads. */
 export interface GithubTurnState {
-  /** Publishes the one comment — structurally the GitHub poster or its GitLab twin (§14.1), tokened and attributed at publish time. */
-  poster: {
-    publish(finalBody?: string): Promise<GithubPublishedComment | PublishedHookOutput | undefined>
-    /** Normalized reason the one note is absent (GitLab §14.1); GitHub's poster reports none. */
-    readonly failure?: GitlabPublishFailure
-  }
+  /** Publishes the one comment: whichever code host's registered turn-final member owns this delivery (§14.1). */
+  poster: CodeHostFinalPoster
   /** Accumulates ACP updates and selects the single logical final answer. */
   collector: GithubReplyCollector
   /** Set when the runtime's explicit final chunk was withheld from the core

--- a/packages/daemon/test/codehost-ack.test.ts
+++ b/packages/daemon/test/codehost-ack.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { acknowledgeCodeHostTrigger } from '../src/codehost/ack.js'
-import type { GithubReplyTarget } from '../src/github/hook-coords.js'
+import type { CodeHostReplyTarget } from '../src/codehost/reply-target.js'
 
 const HOOK = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 
@@ -25,14 +25,15 @@ function harness(overrides: { fetchImpl?: typeof fetch; token?: () => Promise<st
   }
 }
 
-const github = (extra: Partial<GithubReplyTarget> = {}): GithubReplyTarget => ({
+const github = (extra: Partial<CodeHostReplyTarget> = {}): CodeHostReplyTarget => ({
   hookId: HOOK,
+  provider: 'github',
   repo: 'acme/infra',
   number: 42,
   ...extra
 })
 
-const gitlab = (extra: Partial<GithubReplyTarget> = {}): GithubReplyTarget => ({
+const gitlab = (extra: Partial<CodeHostReplyTarget> = {}): CodeHostReplyTarget => ({
   hookId: HOOK,
   provider: 'gitlab',
   subjectKind: 'issue',

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -235,7 +235,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
-    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -300,7 +300,7 @@ describe('Daemon rd/msg hook fires', () => {
         supportsServerFeature: (feature: string) => features.includes(feature)
       }
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
-      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
         poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
         collector: new GithubReplyCollector()
       }))
@@ -402,7 +402,7 @@ describe('Daemon rd/msg hook fires', () => {
         supportsServerFeature: (feature: string) => features.includes(feature)
       }
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
-      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
         poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
         collector: new GithubReplyCollector()
       }))
@@ -437,7 +437,7 @@ describe('Daemon rd/msg hook fires', () => {
       await daemon.start()
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
-      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
         poster: { publish: vi.fn(async () => undefined), failure },
         collector: new GithubReplyCollector()
       }))
@@ -467,7 +467,7 @@ describe('Daemon rd/msg hook fires', () => {
       await daemon.start()
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
-      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
         poster: {
           publish: vi.fn(async () => (failure ? undefined : { provider: 'gitlab', kind: 'note', externalId: '9001' })),
           ...(failure ? { failure } : {})
@@ -532,7 +532,10 @@ describe('Daemon rd/msg hook fires', () => {
     const cp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
     const poster = { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) }
-    ;(restarted as any).githubReviews.makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(restarted as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
+      poster,
+      collector: new GithubReplyCollector()
+    }))
     const settled: Array<string | undefined> = []
     const realPersist = (restarted as any).persistHookState.bind(restarted)
     ;(restarted as any).persistHookState = async (entry: any, state: any, required: any) => {
@@ -594,15 +597,15 @@ describe('Daemon rd/msg hook fires', () => {
     const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
     const cp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
-    const makeGithubReply = vi.fn(() => ({ poster: { publish: vi.fn() }, collector: new GithubReplyCollector() }))
-    ;(restarted as any).githubReviews.makeGithubReply = makeGithubReply
+    const makeCodeHostReply = vi.fn(() => ({ poster: { publish: vi.fn() }, collector: new GithubReplyCollector() }))
+    ;(restarted as any).githubReviews.makeCodeHostReply = makeCodeHostReply
 
     await restarted.start()
 
     await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
     expect(cp.hookReports[0]).toMatchObject({ status: 'failed', reason: 'note_publish_failed:post_failed' })
     // A settled row builds no poster at all, so the reason can only have come from the durable record.
-    expect(makeGithubReply).not.toHaveBeenCalled()
+    expect(makeCodeHostReply).not.toHaveBeenCalled()
     await restarted.stop()
   })
 
@@ -613,7 +616,7 @@ describe('Daemon rd/msg hook fires', () => {
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
     const poster = { publish: vi.fn(async () => undefined) }
-    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
     const realPersist = (daemon as any).persistHookState.bind(daemon)
     ;(daemon as any).persistHookState = async (entry: any, state: any, required: any) => {
       if (state === 'in_flight') throw new Error('durable inbox row is missing')
@@ -638,7 +641,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.start()
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
-    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
       collector: new GithubReplyCollector()
     }))
@@ -762,8 +765,8 @@ describe('Daemon rd/msg hook fires', () => {
     const poster = {
       publish: vi.fn(async () => ({ kind: 'review_comment' as const, commentId: '3566000000' }))
     }
-    const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-    ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
+    const makeCodeHostReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(daemon as any).githubReviews.makeCodeHostReply = makeCodeHostReply
 
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
     const ack = await (daemon as any).handleRelayMsg(
@@ -813,11 +816,12 @@ describe('Daemon rd/msg hook fires', () => {
     expect(activeReviewAuthorities).toBe(0)
     expect(submitError?.message).toContain('only available during the active PR hook turn')
     expect(cp.authorizeGithubReview).not.toHaveBeenCalled()
-    expect(makeGithubReply).toHaveBeenCalledOnce()
-    expect(makeGithubReply).toHaveBeenCalledWith(
+    expect(makeCodeHostReply).toHaveBeenCalledOnce()
+    expect(makeCodeHostReply).toHaveBeenCalledWith(
       AGENT_ID,
       {
         hookId: HOOK_ID,
+        provider: 'github',
         repo: 'acme/infra',
         number: 42,
         reviewCommentId: '3565656411',
@@ -905,7 +909,7 @@ describe('Daemon rd/msg hook fires', () => {
           setStatus: vi.fn(async () => {})
         })
       }
-      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(
+      ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(
         (_agentId: string, ref: { reviewThreadRootCommentId?: string }) => ({
           collector: new GithubReplyCollector(),
           poster: {
@@ -1696,8 +1700,8 @@ describe('Daemon rd/msg hook fires', () => {
       let releasePublish!: () => void
       const publishBarrier = new Promise<void>((resolve) => (releasePublish = resolve))
       const poster = { publish: vi.fn(() => publishBarrier) }
-      const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-      ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
+      const makeCodeHostReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+      ;(daemon as any).githubReviews.makeCodeHostReply = makeCodeHostReply
 
       const msg = fire({
         sessionKey: `acme/infra#${number}`,
@@ -1719,9 +1723,9 @@ describe('Daemon rd/msg hook fires', () => {
       expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
 
       await vi.waitFor(() => expect(poster.publish).toHaveBeenCalledTimes(1), WAIT)
-      expect(makeGithubReply).toHaveBeenCalledWith(
+      expect(makeCodeHostReply).toHaveBeenCalledWith(
         AGENT_ID,
-        { hookId: HOOK_ID, repo: 'acme/infra', number },
+        { hookId: HOOK_ID, provider: 'github', repo: 'acme/infra', number },
         `acp-${event}`
       )
       // Headless GitHub turns have no useful live destination: the turn-end
@@ -1852,8 +1856,8 @@ describe('Daemon rd/msg hook fires', () => {
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
       const poster = { publish: vi.fn(async () => {}) }
-      const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-      ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
+      const makeCodeHostReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+      ;(daemon as any).githubReviews.makeCodeHostReply = makeCodeHostReply
       const hookState = vi.spyOn((daemon as any).store, 'updateInboxHookState')
 
       await (daemon as any).handleRelayMsg(
@@ -2226,7 +2230,10 @@ describe('Daemon rd/msg hook fires', () => {
       message: 'marker is not visible yet'
     })
     const poster = { publish: vi.fn(async () => {}) }
-    ;(restarted as any).githubReviews.makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(restarted as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
+      poster,
+      collector: new GithubReplyCollector()
+    }))
 
     await restarted.start()
     await vi.waitFor(() => expect(hookReports).toHaveLength(1), WAIT)
@@ -2310,13 +2317,13 @@ describe('Daemon rd/msg hook fires', () => {
     const cp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = cp
     const poster = { publish: vi.fn(async () => {}) }
-    const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-    ;(restarted as any).githubReviews.makeGithubReply = makeGithubReply
+    const makeCodeHostReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(restarted as any).githubReviews.makeCodeHostReply = makeCodeHostReply
 
     await restarted.start()
 
     await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
-    expect(makeGithubReply).toHaveBeenCalledWith(
+    expect(makeCodeHostReply).toHaveBeenCalledWith(
       AGENT_ID,
       {
         hookId: HOOK_ID,
@@ -2509,8 +2516,8 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
     // Stub the github poster so the turn-end publish resolves without a real mint.
     const poster = { publish: vi.fn(async () => {}) }
-    const makeGithubReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
-    ;(daemon as any).githubReviews.makeGithubReply = makeGithubReply
+    const makeCodeHostReply = vi.fn(() => ({ poster, collector: new GithubReplyCollector() }))
+    ;(daemon as any).githubReviews.makeCodeHostReply = makeCodeHostReply
 
     // 1) An `opened` fire creates the session for acme/infra#42.
     await (daemon as any).handleRelayMsg(ghFire('issues', 'opened', 'd-open'), () => {})
@@ -3026,7 +3033,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).cfg.limits.shutdownDrainMs = 0
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
-    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -3140,7 +3147,7 @@ describe('Daemon rd/msg hook fires', () => {
     const restarted = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: restartedHost.factory })
     const restartedCp = fakeCpClient()
     ;(restarted as never as { cpClient: unknown }).cpClient = restartedCp
-    ;(restarted as any).githubReviews.makeGithubReply = vi.fn(() => ({
+    ;(restarted as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -3190,7 +3197,7 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).cfg.limits.shutdownDrainMs = 0
     const cp = fakeCpClient()
     ;(daemon as never as { cpClient: unknown }).cpClient = cp
-    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -3305,7 +3312,7 @@ describe('Daemon rd/msg hook fires', () => {
       postContext: vi.fn(async () => {}),
       setStatus: vi.fn(async () => {})
     })
-    ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+    ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
       poster: { publish: vi.fn(async () => {}) },
       collector: new GithubReplyCollector()
     }))
@@ -3768,7 +3775,7 @@ describe('Daemon rd/msg hook fires', () => {
       await daemon.start()
       const cp = fakeCpClient()
       ;(daemon as never as { cpClient: unknown }).cpClient = cp
-      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+      ;(daemon as any).githubReviews.makeCodeHostReply = vi.fn(() => ({
         poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
         collector: new GithubReplyCollector()
       }))

--- a/packages/daemon/test/gitlab-hook-message.test.ts
+++ b/packages/daemon/test/gitlab-hook-message.test.ts
@@ -15,7 +15,7 @@ import {
   UNTRUSTED_CONTENT_BEGIN_GITLAB,
   UNTRUSTED_CONTENT_END
 } from '../src/messages/hook-message.js'
-import { githubThreadWorktreeCleanup } from '../src/github/hook-coords.js'
+import { codeHostThreadWorktreeCleanup } from '../src/codehost/turn-final.js'
 
 const HOOK = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const AGENT = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
@@ -250,16 +250,16 @@ describe('gitlab hook normalization (§12.3)', () => {
 
   it('maps merged MRs and closed issues to the shared worktree-cleanup family, fenced on metadata', () => {
     const gitlab = { projectId: PROJECT, projectPath: 'p', target: { kind: 'merge_request' as const, iid: 77 } }
-    expect(githubThreadWorktreeCleanup({ event: 'merge_request:merged', gitlab })).toBe('pull_request_merged')
+    expect(codeHostThreadWorktreeCleanup({ event: 'merge_request:merged', gitlab })).toBe('pull_request_merged')
     expect(
-      githubThreadWorktreeCleanup({
+      codeHostThreadWorktreeCleanup({
         event: 'issues:closed',
         gitlab: { ...gitlab, target: { kind: 'issue', iid: 42 } }
       })
     ).toBe('issue_closed')
     // The event alone never authorizes maintenance (a malformed frame must run
     // as an ordinary hook, not silently delete a checkout).
-    expect(githubThreadWorktreeCleanup({ event: 'merge_request:merged' })).toBeUndefined()
-    expect(githubThreadWorktreeCleanup({ event: 'issues:closed', gitlab })).toBeUndefined()
+    expect(codeHostThreadWorktreeCleanup({ event: 'merge_request:merged' })).toBeUndefined()
+    expect(codeHostThreadWorktreeCleanup({ event: 'issues:closed', gitlab })).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Why

The daemon's turn-final wiring — the one public comment a code-host turn ends with — was still
shaped for one implementer with a second bolted on:

- `GithubReplyTarget` carried `provider?: 'gitlab'`, so "absent" meant GitHub and the GitLab
  coordinates (numeric project id, subject IID) rode fields named for GitHub's;
- `GithubReviewOrchestrator` built the GitLab reply target inline, imported `GitlabFinalPoster`
  directly, and chose mint / REST root / poster with `ref.provider === 'gitlab'` ternaries;
- the turn-start instance fence and the thread-checkout lifecycle pairing each enumerated both
  hosts in one function;
- `daemon.ts` read `githubReply?.provider === 'gitlab'` to decide whether a turn owes a
  normalized reason for a missing comment.

Each of those is a two-way branch that a third code host turns into a three-way one in core, which
is exactly what the code-host seam exists to prevent.

## What

One turn-final contract beside the review adapter and hook admission:

- `codehost/reply-target.ts` — `CodeHostReplyTarget` with a required `provider`, documenting what
  each host means by the shared (and durably persisted) coordinates.
- `codehost/turn-final.ts` — `CodeHostTurnFinal` plus the record over the provider union, so a
  missing entry is a compile error. Members: build the reply target from the delivery's own trusted
  member, the effect lease and REST root it publishes under, the final poster, the turn-start
  instance fence, the lifecycle pairing that retires a thread's checkout, and whether the poster
  names WHY its one comment is absent.
- `github/turn-final.ts`, `gitlab/turn-final.ts` — the two implementers. Each declares the narrow
  host port it reads (its own effect mint; GitLab additionally the instance its spec names), and
  the aggregate port is their intersection, so a new host adds an interface rather than widening a
  shared one.
- The orchestrator, `daemon.ts` and the acknowledgement registry now select through the registry.
  `makeGithubReply` became `makeCodeHostReply` and returns the contract's poster type;
  `acknowledgeCodeHostTrigger` keys on the target's provider instead of one adapter claiming an
  absent one. The published turn-final surface's `poster` slot is now the contract type instead of
  an inline GitHub-or-twin shape.

Deliberately left GitHub-only and outside the contract, as one implementer is an abstraction
guessed at rather than a contract: the workflow-approval start path, the session pull-request
panel, the deleted-event predicate, the review-workspace preparation, and the batched inline-thread
reply tool. Also untouched: the §14.2 broker pin and the §17.2 review start barrier (other seams),
and the credential-provider selection in workspace/gitcred code.

## Behavior

Neutral by construction; every arm keeps the condition it had.

- The reply target is built only for a delivery whose trusted context names a code host — the same
  gate all three old arms shared — and a frame that carries no trusted member still takes the
  rolling-compatible context-only path.
- The fence still reads the raw member (not the decode-time view), so a delivery naming another
  instance is refused with the same reason and the same warn text.
- The cleanup pairing keeps its evaluation order, and the event alone still never authorizes
  maintenance.
- A durable hook row persisted before the provider member became explicit carries none, and still
  resolves to GitHub — which the existing replay tests exercise.

No `gitea` identifier appears anywhere in the change.

## Gates

- `pnpm typecheck` — all packages Done.
- `pnpm --filter @agentconnect.md/daemon test` — 377 passed / 3 failed files, the three failures
  being `shim-workspace-files`, `shim-cancellation` and `acp-matrix/acp-matrix`, which are red on
  pristine `main` on this machine for environment reasons.
- `packages/daemon` eslint — 0 errors (4 pre-existing `import-x/no-duplicates` warnings in
  unrelated files).
- `pnpm format:check` — clean.

Test edits are identifier-only except three: the `CodeHostReplyTarget` fixture in
`codehost-ack.test.ts` and two `toHaveBeenCalledWith` reply targets in `daemon-hook.test.ts` now
carry the explicit `provider: 'github'` the type requires. No expectation was weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
