### PR TITLE
refactor(control-plane): route code-host decisions through a provider registry

### DIFF
--- a/packages/control-plane/src/codehost/provider.ts
+++ b/packages/control-plane/src/codehost/provider.ts
@@ -1,0 +1,224 @@
+/**
+ * The control plane's **code-host provider contract**
+ * (gitlab-com-integration.md §6.5, gitea-integration.md §13.5/§13.8).
+ *
+ * Code hosts are not chat platforms: they have no bot connection, no chat
+ * ingress, no read port and no wizard identity, so they do not adopt the
+ * four-contract platform-module shape. What the two hosts share is narrower, and
+ * every member below is here because BOTH providers implement it today — the
+ * same "extracted at the moment of the second implementer" rule the daemon's
+ * turn-final surface and the relay's ingress contract followed. The shape that
+ * earned the extraction is the two-way `kind === 'gitlab' ? … : …` ternary, which
+ * a third host turns into a `switch` in core code.
+ *
+ * WHAT STAYS OUT, on purpose (§6.5, §13):
+ *  - the bot identity and claim lifecycle — a GitHub App installation versus a
+ *    per-project binding with per-agent service accounts (`provisionAgentAccount`
+ *    brackets in the agent and hook writes have no GitHub counterpart at all);
+ *  - webhook-secret distribution and credential minting (one deployment-wide App
+ *    secret versus a per-binding signing token; App JWTs versus OAuth);
+ *  - GitHub-only product surfaces (the workflow-approval start path, the session
+ *    merge-request panel) and the GitLab-only console rerun;
+ *  - the per-provider spec host field (`gitlabHost`): both hosts' instance axes
+ *    are one-axis values with a default, and a table of hosts would be guessing
+ *    at a multi-instance design that does not exist yet. A provider reads its own
+ *    field through {@link CodeHostProviderFeatures.specHost}.
+ *  - the base-URL immutability lock's STATE COUNT, which lives in
+ *    `persistence/repositories/deployment-config.repo.ts` keyed by provider:
+ *    Prisma models are persistence's knowledge, not a provider module's.
+ *
+ * THE INSTANCE MODEL. An entry is a stateless strategy object: everything it
+ * needs at call time arrives as an argument, so the registry is a plain record
+ * and not a late-bound façade. `container.ts` publishes it on `HttpDeps` for the
+ * routes; the pure projections no container reaches (the DTO and wire arms, the
+ * feature predicates) read the same record through `codehost/registry.ts`.
+ */
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import type {
+  AgentSpec,
+  AgentWorkspaceCredential as SpecWorkspaceCredential,
+  CodeHostHookRule,
+  CodeHostProvider
+} from '@agentconnect.md/protocol'
+import type {
+  AgentRecord,
+  AgentRepoAuthorizationRecord,
+  AgentWorkspaceCredential,
+  HookRecord,
+  RepoAccess
+} from '../persistence/ports.js'
+import type { AgentRepoAuthDtoT, AgentWorkspaceCredentialDtoT } from '../http/dto/index.js'
+import type { HttpDeps } from '../http/deps.js'
+import type { OrgId } from '../domain/ids.js'
+
+/** The bundle a provider member reads its deployment's own services from. */
+export type CodeHostDeps = HttpDeps
+
+/** The effect axes a code-host hook write proposes; an axis this host has no surface for is absent. */
+export interface CodeHostHookEffectBody {
+  reviewPolicy?: HookRecord['reviewPolicy']
+  reportingMode?: HookRecord['reportingMode']
+  gateMode?: HookRecord['gateMode']
+}
+
+/** The same axes, resolved — a host without a surface for one reads its inert default. */
+export interface CodeHostHookEffects {
+  reviewPolicy: HookRecord['reviewPolicy']
+  reportingMode: HookRecord['reportingMode']
+  gateMode: HookRecord['gateMode']
+}
+
+/** The derived provenance of one cloneable address, for the acting caller (git-workspace-model.md §6). */
+export type DerivedWorkspace =
+  | {
+      kind: 'github'
+      /** The covering live installation (provenance hint persisted on the row). */
+      installationId: string
+      repoId: bigint
+      gitRepo: string // canonical address from the installation lookup, never caller input
+      defaultBranch: string
+      access: 'read' | 'write'
+    }
+  | {
+      kind: 'gitlab'
+      projectId: bigint
+      gitRepo: string // the catalog row's provider-authored clone URL (§24.1)
+      defaultBranch: string
+      access: 'read' | 'write'
+    }
+  | {
+      kind: 'anonymous'
+      gitRepo: string
+      defaultBranch?: string
+      access: 'read'
+      /** Which managed host the anonymous target sits on, for display derivation (§7). */
+      host: 'github' | 'gitlab' | 'other'
+    }
+
+/** Actionable refusal (§6 table) — the routes answer it as a 409. */
+export class WorkspaceCredentialRefused extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkspaceCredentialRefused'
+  }
+}
+
+/** Throw the §6 table's refusal for an address this host owns. */
+export function refuseWorkspaceCredential(message: string): never {
+  throw new WorkspaceCredentialRefused(message)
+}
+
+/** One derivation attempt: provenance from the address, eligibility from the acting caller. */
+export interface CodeHostWorkspaceDerivation {
+  deps: CodeHostDeps
+  orgId: string
+  /** Absent ⇒ actorless caller; a configured identity gate fails CLOSED on one. */
+  actorUserId?: string
+  gitRepo: string
+  /** Unstated ⇒ the highest tier the target carries. */
+  requestedAccess?: 'read' | 'write'
+}
+
+/** The persisted workspace fields one of this host's derivations writes. */
+export interface CodeHostWorkspaceWrite {
+  credential: AgentWorkspaceCredential
+  workspaceRepoId: bigint
+}
+
+/** The host-shaped fields the legacy (pre-`workspace-git-v1`) spec arms share. */
+export interface LegacySpecWorkspaceShared {
+  isolation: Extract<AgentSpec['workspace'], { mode: 'git' }>['isolation']
+  gitRepo: string
+  branch: string
+  agentDir?: string
+  additionalRepos: Extract<AgentSpec['workspace'], { mode: 'git' }>['additionalRepos']
+}
+
+/** A projected spec, read for the §24.4 instance axis its host put there. */
+export interface CodeHostShapedSpec {
+  gitlabHost?: string
+}
+
+/** The route context an additional-repository grant mutation runs in. */
+export interface CodeHostRepoAuthorizationContext {
+  deps: CodeHostDeps
+  req: FastifyRequest
+  reply: FastifyReply
+  /** The caller's active organization, resolved by the route. */
+  orgId: OrgId
+  agent: AgentRecord
+  /** The grant row being raised; `row.provider` is what selected this entry. */
+  row: AgentRepoAuthorizationRecord
+  /** The tier the caller asked for — already checked to be strictly stronger. */
+  access: RepoAccess
+  /** The route's shared grant projection, so both arms answer one body shape. */
+  toDto(row: AgentRepoAuthorizationRecord): AgentRepoAuthDtoT
+}
+
+/** §17.3/§24.4 feature negotiation for values this host shapes. */
+export interface CodeHostProviderFeatures {
+  /** The instance axis this deployment configures for this host, if it has one. */
+  deploymentHost(deps: CodeHostDeps): string | undefined
+  /** The instance axis a projected spec carries for this host, if it carries one. */
+  specHost(spec: CodeHostShapedSpec): string | undefined
+  /** The instance axis a compiled hook rule carries for this host, if it carries one. */
+  ruleHost(rule: CodeHostHookRule): string | undefined
+  /** Features a peer must advertise before a value this host shaped on `host` can decode there. */
+  required(host: string | undefined): readonly string[]
+  /** The §24.4 addition ALONE — for a gate that must not start requiring §17.3's bit as well. */
+  requiredForInstance(host: string | undefined): readonly string[]
+}
+
+/** The workspace-provenance arms, one per host (git-workspace-model.md §5/§6). */
+export interface CodeHostProviderWorkspace {
+  /** Derive provenance for an address this host owns; null ⇒ the address is not its. */
+  derive(derivation: CodeHostWorkspaceDerivation): Promise<DerivedWorkspace | null>
+  /** The persisted credential + numeric repo id one of this host's derivations writes; null ⇒ not its derivation. */
+  writeFromDerived(derived: DerivedWorkspace): CodeHostWorkspaceWrite | null
+  /** The read DTO of a persisted credential of this host; null ⇒ not its credential. */
+  toDto(credential: AgentWorkspaceCredential, workspaceRepoId?: bigint): AgentWorkspaceCredentialDtoT | null
+  /** The wire credential of a persisted credential of this host; null ⇒ not its credential. */
+  toSpec(credential: AgentWorkspaceCredential, workspaceRepoId?: bigint): SpecWorkspaceCredential | null
+  /** This host's legacy spec arm for a peer without `workspace-git-v1`; null ⇒ it has no arm of its own. */
+  legacySpecArm(shared: LegacySpecWorkspaceShared, credential: SpecWorkspaceCredential): AgentSpec['workspace'] | null
+}
+
+/** The code-host hook axes and the convergence a hook write owes this host. */
+export interface CodeHostProviderHooks {
+  /** The effect axes this host's hook body carries, with its inert defaults for the axes it lacks. */
+  effects(body: CodeHostHookEffectBody): CodeHostHookEffects
+  /**
+   * Re-converge this host's managed ingress for one repository after a hook or
+   * grant write. A no-op where the host's webhook is deployment-wide (a GitHub
+   * App delivers for every covered repository, so no write can change it).
+   * Fire-and-forget: `onError` reports, and the convergence never fails CRUD.
+   */
+  convergeManagedRepository(
+    deps: CodeHostDeps,
+    orgId: OrgId,
+    repoId: bigint | null,
+    onError: (err: unknown) => void
+  ): void
+}
+
+/** One code host's control-plane module. */
+export interface CodeHostProviderModule {
+  readonly provider: CodeHostProvider
+  /** How operator-facing refusals name this host. */
+  readonly displayName: string
+  /** What this host calls one of its repositories, for refusals that name the subject. */
+  readonly repositorySubject: string
+  readonly features: CodeHostProviderFeatures
+  readonly workspace: CodeHostProviderWorkspace
+  readonly hooks: CodeHostProviderHooks
+  /** Raise one additional-repository grant to a stronger tier (§8.3). */
+  upgradeRepoAuthorization(ctx: CodeHostRepoAuthorizationContext): Promise<AgentRepoAuthDtoT | undefined>
+}
+
+/**
+ * The provider set, keyed by provider. A `Record` and not a lookup façade: every
+ * `Record<CodeHostProvider, …>` over it stops type-checking until a new host is
+ * given an entry, which is what makes adding one a compile-time event instead of
+ * a silently-inherited default.
+ */
+export type CodeHostProviderRegistry = Readonly<Record<CodeHostProvider, CodeHostProviderModule>>

--- a/packages/control-plane/src/codehost/registry.ts
+++ b/packages/control-plane/src/codehost/registry.ts
@@ -1,0 +1,25 @@
+/**
+ * The code-host provider set (`codehost/provider.ts`) — one entry per host, and
+ * the ONE place a third host is registered.
+ *
+ * `container.ts` publishes this record on `HttpDeps`, and a route resolves it with
+ * {@link codeHostsOf}. It is a module const rather than something the composition
+ * root constructs because an entry is a stateless strategy object: it captures
+ * nothing and takes its deployment's services as call-time arguments. So the pure
+ * projections that no container reaches — the DTO and wire workspace arms, the
+ * §17.3/§24.4 feature predicates evaluated at transmit time — read the same record
+ * directly instead of growing a parameter through every transmit site.
+ */
+import type { CodeHostProviderRegistry } from './provider.js'
+import { githubCodeHostProvider } from '../github/provider.js'
+import { gitlabCodeHostProvider } from '../gitlab/provider.js'
+
+export const codeHostProviders: CodeHostProviderRegistry = Object.freeze({
+  github: githubCodeHostProvider,
+  gitlab: gitlabCodeHostProvider
+})
+
+/** The registry a consumer should read: the one the composition root published, else this record. */
+export function codeHostsOf(deps: { codeHosts?: CodeHostProviderRegistry }): CodeHostProviderRegistry {
+  return deps.codeHosts ?? codeHostProviders
+}

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -237,6 +237,7 @@ import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/disc
 import { createDiscordBotProfileSyncer } from './http/discord-bot-profile.js'
 import type { CpPlatformRegistry } from './platforms/provider.js'
 import { buildCpPlatformRegistry } from './platforms/registry.js'
+import { codeHostProviders } from './codehost/registry.js'
 import { botIdentityProjector } from './platforms/bot-identity.js'
 import { buildPendingInstallReapers, platformBackgroundLoops } from './platforms/lifecycle.js'
 import { createTelegramCpProvider } from './platforms/telegram/provider.js'
@@ -1473,6 +1474,9 @@ export function buildContainer(
     // registry cannot exist before this object does. Every reader runs at
     // Fastify `ready()` time or later, by which point it has been assigned.
     platforms,
+    // The §6.5 code-host provider set, published here so routes take their
+    // per-host decisions through the bundle (gitea-integration.md §13.5).
+    codeHosts: codeHostProviders,
     repos: {
       agent: repos.agent,
       assignment: repos.assignment,

--- a/packages/control-plane/src/domain/daemon-features.test.ts
+++ b/packages/control-plane/src/domain/daemon-features.test.ts
@@ -10,10 +10,9 @@ import {
   daemonSupportsAgent,
   encodeSpecWorkspaceForPeer,
   isSelfManagedGitlabHost,
-  requiredDaemonFeatures,
-  requiredGitlabFeatures,
-  requiredGitlabInstanceFeatures
+  requiredDaemonFeatures
 } from './daemon-features.js'
+import { codeHostProviders } from '../codehost/registry.js'
 import type { AgentRecord } from '../persistence/ports.js'
 
 const SELF_MANAGED = 'https://gitlab.example.test'
@@ -76,12 +75,13 @@ describe('§17.3 snapshot projection gate predicate', () => {
   it('keeps the two host-keyed feature lists apart', () => {
     // The hook's dispatch target was never gated on gitlab-com-v1, so §24.4 must not
     // start requiring it there.
-    expect(requiredGitlabInstanceFeatures(SELF_MANAGED)).toEqual([GITLAB_INSTANCE_V1_FEATURE])
-    expect(requiredGitlabInstanceFeatures(GITLAB_DEFAULT_BASE_URL)).toEqual([])
-    expect(requiredGitlabInstanceFeatures(undefined)).toEqual([])
-    expect(requiredGitlabFeatures(SELF_MANAGED)).toEqual([GITLAB_COM_V1_FEATURE, GITLAB_INSTANCE_V1_FEATURE])
-    expect(requiredGitlabFeatures(GITLAB_DEFAULT_BASE_URL)).toEqual([GITLAB_COM_V1_FEATURE])
-    expect(requiredGitlabFeatures(undefined)).toEqual([GITLAB_COM_V1_FEATURE])
+    const gitlab = codeHostProviders.gitlab.features
+    expect(gitlab.requiredForInstance(SELF_MANAGED)).toEqual([GITLAB_INSTANCE_V1_FEATURE])
+    expect(gitlab.requiredForInstance(GITLAB_DEFAULT_BASE_URL)).toEqual([])
+    expect(gitlab.requiredForInstance(undefined)).toEqual([])
+    expect(gitlab.required(SELF_MANAGED)).toEqual([GITLAB_COM_V1_FEATURE, GITLAB_INSTANCE_V1_FEATURE])
+    expect(gitlab.required(GITLAB_DEFAULT_BASE_URL)).toEqual([GITLAB_COM_V1_FEATURE])
+    expect(gitlab.required(undefined)).toEqual([GITLAB_COM_V1_FEATURE])
     expect(isSelfManagedGitlabHost(SELF_MANAGED)).toBe(true)
     expect(isSelfManagedGitlabHost(GITLAB_DEFAULT_BASE_URL)).toBe(false)
     expect(isSelfManagedGitlabHost(undefined)).toBe(false)

--- a/packages/control-plane/src/domain/daemon-features.ts
+++ b/packages/control-plane/src/domain/daemon-features.ts
@@ -3,28 +3,30 @@
  *
  * The daemon reads CP-authored frames tolerantly, but tolerance covers unknown
  * KEYS only — a new union arm or enum value inside `register/ok` or
- * `agent/upsert` makes the whole frame undecodable on a pre-GitLab daemon,
- * killing its GitHub work too. So the CP must never project a GitLab-shaped
- * spec (or place such an agent) onto a daemon that has not advertised
- * `gitlab-com-v1`. This module is the one predicate every projection and
- * placement site asks; it lands before any GitLab-shaped value can exist, so
- * the first one to exist is born gated.
+ * `agent/upsert` makes the whole frame undecodable on a peer that predates it,
+ * killing its work for every other host too. So the CP must never project a
+ * spec shaped by a host (or place such an agent) onto a daemon that has not
+ * advertised that host's feature. This module is the one predicate every
+ * projection and placement site asks; which features a host needs, and which
+ * field carries its instance axis, are that host's registry entry's answers
+ * (`codehost/provider.ts`).
  *
- * §24.4 adds a second axis on the same predicate: when the deployment's GitLab
- * host is not GitLab.com, the same values additionally require
- * `gitlab-instance-v1`, so a daemon that cannot carry a host per agent never
- * sees self-managed work and cannot fall back to GitLab.com for it.
+ * §24.4 adds a second axis on the same predicate: when the deployment's instance
+ * is not the host's default, the same values additionally require the per-agent
+ * host bit, so a daemon that cannot carry a host per agent never sees
+ * self-managed work and cannot fall back to the default instance for it.
  */
 import {
-  GITLAB_COM_V1_FEATURE,
-  GITLAB_INSTANCE_V1_FEATURE,
+  CODE_HOST_PROVIDERS,
   WORKSPACE_GIT_V1_FEATURE,
   isSelfManagedGitlabHost,
   type AgentSpec
 } from '@agentconnect.md/protocol'
+import type { CodeHostProviderRegistry } from '../codehost/provider.js'
+import { codeHostProviders } from '../codehost/registry.js'
 
 // Structural on purpose: the predicate reads the workspace discriminant + credential
-// axis, the assembled additional-repository list, and the assembled host axis — so
+// axis, the assembled additional-repository list, and the assembled host axes — so
 // DOMAIN records and WIRE AgentSpec bundles both fit. The sender-level activation gate
 // checks the exact spec it is about to transmit, which is the only place the
 // grant and hook sources are visible: neither lives on the agent row.
@@ -37,18 +39,6 @@ type WorkspaceShapedAgent = {
   gitlabHost?: string
 }
 
-/** The §24.4 addition ALONE — for a gate that must not start requiring §17.3's bit as well.
- *  The hook's dispatch-target daemon is one: it was never gated on `gitlab-com-v1`, and
- *  widening it here would change GitLab.com fleets. */
-export function requiredGitlabInstanceFeatures(host: string | undefined): readonly string[] {
-  return isSelfManagedGitlabHost(host) ? [GITLAB_INSTANCE_V1_FEATURE] : []
-}
-
-/** Features a peer must advertise before a GitLab-shaped value on `host` can decode there. */
-export function requiredGitlabFeatures(host: string | undefined): readonly string[] {
-  return [GITLAB_COM_V1_FEATURE, ...requiredGitlabInstanceFeatures(host)]
-}
-
 export { isSelfManagedGitlabHost }
 
 /** Fail-closed: unknown/absent advertised features support only feature-free values. */
@@ -58,25 +48,36 @@ export function advertises(advertisedFeatures: readonly string[] | undefined, re
   return required.every((feature) => advertised.has(feature))
 }
 
+/** Whether any of this agent's workspace, grants, or legacy wire mode is vouched by `provider`. */
+function consumes(agent: WorkspaceShapedAgent, provider: string): boolean {
+  return (
+    agent.workspace?.mode === provider ||
+    agent.workspace?.credential?.provider === provider ||
+    (agent.workspace?.additionalRepos ?? []).some((repo) => repo.provider === provider)
+  )
+}
+
 /** Features a daemon must advertise before this agent's spec can decode there. */
-export function requiredDaemonFeatures(agent: WorkspaceShapedAgent): readonly string[] {
-  // Three sources, not one. A gitlab-vouched workspace (git-workspace-model.md §2:
-  // `credential.provider === 'gitlab'`, or the legacy wire arm's mode) is
-  // frame-fatal on a pre-GitLab daemon; a gitlab ADDITIONAL repository is quieter
-  // and worse — the old schema strips the unknown `provider` key, so a two-segment
-  // project path reads as an `owner/repo` GitHub entry and would be cloned from
-  // github.com. Comparisons stay strings so a new host lights the gate up without
-  // touching this file again.
-  const gitlab =
-    agent.workspace?.mode === 'gitlab' ||
-    agent.workspace?.credential?.provider === 'gitlab' ||
-    (agent.workspace?.additionalRepos ?? []).some((repo) => repo.provider === 'gitlab')
-  const features = gitlab ? [GITLAB_COM_V1_FEATURE] : []
-  // §24.4: GitLab-shaped is any spec carrying a non-default host, whichever consumer
-  // put it there — an enabled hook alone qualifies, and that consumer is invisible in
-  // the workspace above. A default (or absent) host gates nothing, so GitLab.com fleets
-  // stay exactly as they are.
-  if (isSelfManagedGitlabHost(agent.gitlabHost)) features.push(GITLAB_INSTANCE_V1_FEATURE)
+export function requiredDaemonFeatures(
+  agent: WorkspaceShapedAgent,
+  codeHosts: CodeHostProviderRegistry = codeHostProviders
+): readonly string[] {
+  const features: string[] = []
+  for (const provider of CODE_HOST_PROVIDERS) {
+    const host = codeHosts[provider].features
+    // Three sources of a consumer, not one. A vouched workspace (git-workspace-model.md
+    // §2: `credential.provider`, or the legacy wire arm's mode) is frame-fatal on a peer
+    // that predates the host; an ADDITIONAL repository of its is quieter and worse — the
+    // old schema strips the unknown `provider` key, so a two-segment project path reads
+    // as an `owner/repo` GitHub entry and would be cloned from github.com.
+    //
+    // §24.4: a spec carrying a non-default instance is host-shaped whichever consumer put
+    // it there — an enabled hook alone qualifies, and that consumer is invisible in the
+    // workspace above. A default (or absent) instance gates nothing, so default-instance
+    // fleets stay exactly as they are.
+    const instance = host.specHost(agent)
+    features.push(...(consumes(agent, provider) ? host.required(instance) : host.requiredForInstance(instance)))
+  }
   return features
 }
 
@@ -94,7 +95,8 @@ export function daemonSupportsAgent(
 // agent/upsert, agent/activate, duty/fetch — because the peer is only known there.
 export function encodeSpecWorkspaceForPeer<S extends Pick<AgentSpec, 'workspace'>>(
   spec: S,
-  advertisedFeatures: readonly string[] | undefined
+  advertisedFeatures: readonly string[] | undefined,
+  codeHosts: CodeHostProviderRegistry = codeHostProviders
 ): S {
   const workspace = spec.workspace
   if (workspace?.mode !== 'git' || advertises(advertisedFeatures, [WORKSPACE_GIT_V1_FEATURE])) return spec
@@ -105,15 +107,10 @@ export function encodeSpecWorkspaceForPeer<S extends Pick<AgentSpec, 'workspace'
     ...(workspace.agentDir !== undefined ? { agentDir: workspace.agentDir } : {}),
     additionalRepos: workspace.additionalRepos
   }
-  // The legacy `github` arm's gitRepo is deliberately host-agnostic, so an
-  // anonymous workspace on any host rides it exactly as it always did.
-  const legacy: AgentSpec['workspace'] =
-    workspace.credential?.provider === 'gitlab'
-      ? { mode: 'gitlab', ...shared, projectId: workspace.credential.projectId }
-      : {
-          mode: 'github',
-          ...shared,
-          ...(workspace.credential?.provider === 'github' ? { gitCredential: 'github-app' as const } : {})
-        }
+  const credential = workspace.credential
+  const hostArm = credential ? codeHosts[credential.provider].workspace.legacySpecArm(shared, credential) : null
+  // The legacy `github` arm is deliberately host-agnostic, so an anonymous
+  // workspace on any host rides it exactly as it always did.
+  const legacy: AgentSpec['workspace'] = hostArm ?? { mode: 'github', ...shared }
   return { ...spec, workspace: legacy }
 }

--- a/packages/control-plane/src/github/provider.ts
+++ b/packages/control-plane/src/github/provider.ts
@@ -1,0 +1,222 @@
+/**
+ * The GitHub entry of the code-host provider registry (`codehost/provider.ts`).
+ *
+ * Every member here is one half of a `kind === 'gitlab' ? … : …` ternary core
+ * used to carry. GitHub's halves are the quiet ones: its App webhook is
+ * deployment-wide (so no hook write converges an ingress), it has no instance
+ * axis (so it negotiates no feature), and its gate axis is the one both hosts'
+ * hook rows store. What is NOT here is everything the two hosts genuinely
+ * disagree about — the App installation claim, App-JWT credential minting, and
+ * the GitHub-only workflow-approval and review surfaces.
+ */
+import { gitRepoLabel, normalizeGitUrl } from '@agentconnect.md/protocol'
+import {
+  refuseWorkspaceCredential,
+  type CodeHostDeps,
+  type CodeHostProviderModule,
+  type CodeHostWorkspaceDerivation,
+  type DerivedWorkspace
+} from '../codehost/provider.js'
+import type { AgentWorkspaceCredentialDtoT } from '../http/dto/index.js'
+import type { GithubInstallationRecord } from '../persistence/ports.js'
+import { isCanonicalGithubAddress } from '../domain/git-host.js'
+import { OrgId } from '../domain/ids.js'
+import { GithubApiError } from './api.js'
+import { UserAuthzDeniedError } from './user-authz.js'
+import { LogtoApiError } from './logto-identity.js'
+
+/** owner/repo when the address selects canonical github.com; null otherwise. */
+function githubTarget(gitRepo: string): { owner: string; repo: string } | null {
+  if (!isCanonicalGithubAddress(gitRepo)) return null
+  const parts = gitRepoLabel(gitRepo).split('/')
+  const [owner, repo] = parts
+  if (parts.length !== 2 || !owner || !repo) refuseWorkspaceCredential('workspace gitRepo is not a github repository')
+  return { owner, repo }
+}
+
+/** Resolve the covering App installation, converge the catalog row, and hold the
+ *  acting human to the access the agent will run with. Null ⇒ not granted. */
+async function bindGithubWorkspaceRepo(
+  deps: CodeHostDeps,
+  orgId: string,
+  ins: GithubInstallationRecord,
+  owner: string,
+  repo: string,
+  access: 'read' | 'write',
+  userId: string | undefined
+): Promise<{ repoId: bigint; fullName: string; defaultBranch: string } | null> {
+  const ref = await deps.github!.repoRefFor(ins, owner, repo)
+  if (!ref) return null
+  await deps.repos.codeHostRepository.upsert({
+    orgId,
+    provider: 'github',
+    externalId: ref.repoId,
+    displayPath: ref.fullName,
+    cloneUrl: `https://github.com/${ref.fullName}`,
+    defaultBranch: ref.defaultBranch
+  })
+  // The identity gate inside the derivation IS the security check (§6), on the
+  // CANONICAL spelling so one repository holds one authz cache entry. Where the
+  // gate is configured, an actorless caller fails CLOSED — never a silent allow.
+  const [canonicalOwner, canonicalRepo] = ref.fullName.split('/')
+  if (deps.githubUserAuthz) {
+    if (userId === undefined) refuseWorkspaceCredential('a signed-in identity is required to bind this repository')
+    await deps.githubUserAuthz.assertAccess(userId, ins, canonicalOwner ?? owner, canonicalRepo ?? repo, access)
+  }
+  return ref
+}
+
+/** The github arm of the §6 outcome table: App installation, else an anonymous public read. */
+async function deriveGithubWorkspace(derivation: CodeHostWorkspaceDerivation): Promise<DerivedWorkspace | null> {
+  const { deps, orgId, actorUserId, gitRepo, requestedAccess } = derivation
+  const gh = githubTarget(gitRepo)
+  if (!gh) return null
+  const covering = deps.github ? await deps.repos.githubInstallation.liveByOrgAndAccount(OrgId(orgId), gh.owner) : null
+  const installation = covering && !covering.suspendedAt ? covering : null
+  if (installation) {
+    const access = requestedAccess ?? 'write'
+    const ref = await bindGithubWorkspaceRepo(deps, orgId, installation, gh.owner, gh.repo, access, actorUserId)
+    // An installation token reads any PUBLIC repository, so a miss here means
+    // private-and-ungranted (or absent) — an anonymous clone cannot serve it,
+    // and the actionable answer is to grant it rather than to degrade silently.
+    if (!ref) {
+      refuseWorkspaceCredential(
+        `${gh.owner}/${gh.repo} is not granted to the GitHub installation — re-select it on GitHub`
+      )
+    }
+    return {
+      kind: 'github',
+      installationId: installation.id,
+      repoId: ref.repoId,
+      gitRepo: normalizeGitUrl(ref.fullName),
+      defaultBranch: ref.defaultBranch,
+      access
+    }
+  }
+  if (requestedAccess === 'write') refuseWorkspaceCredential('github write access requires a GitHub App installation')
+  // Anonymous public read. `unreachable` (rate limit, outage) deliberately does
+  // NOT refuse — creation never preflighted at all, and a GitHub blip must not
+  // block a checkout the daemon's clone boundary will verify anyway.
+  const lookup = deps.resolvePublicRepo ? await deps.resolvePublicRepo(gh.owner, gh.repo) : 'unreachable'
+  if (lookup === 'not-found') {
+    refuseWorkspaceCredential(
+      `${gh.owner}/${gh.repo} is not a public repository — install the GitHub App for access to private ones`
+    )
+  }
+  return {
+    kind: 'anonymous',
+    gitRepo: normalizeGitUrl(lookup === 'unreachable' ? gitRepo : lookup.fullName),
+    ...(lookup !== 'unreachable' ? { defaultBranch: lookup.defaultBranch } : {}),
+    access: 'read',
+    host: 'github'
+  }
+}
+
+export const githubCodeHostProvider: CodeHostProviderModule = {
+  provider: 'github',
+  displayName: 'GitHub',
+  repositorySubject: 'repository',
+  features: {
+    // github.com is the only instance this App model addresses, so neither the
+    // deployment nor a projected spec carries a host and nothing is negotiated.
+    deploymentHost: () => undefined,
+    specHost: () => undefined,
+    ruleHost: () => undefined,
+    required: () => [],
+    requiredForInstance: () => []
+  },
+  workspace: {
+    derive: deriveGithubWorkspace,
+    writeFromDerived: (derived) =>
+      derived.kind === 'github'
+        ? {
+            credential: { provider: 'github', installationId: derived.installationId, access: derived.access },
+            workspaceRepoId: derived.repoId
+          }
+        : null,
+    // installationId stays server-side; the DTO names the provider and the tier.
+    toDto: (credential): AgentWorkspaceCredentialDtoT | null =>
+      credential.provider === 'github' ? { provider: 'github', access: credential.access } : null,
+    // installationId and access stay off the wire: minting re-resolves the live
+    // installation by owner, and the CP clamps minted tokens server-side.
+    toSpec: (credential) => (credential.provider === 'github' ? { provider: 'github' } : null),
+    legacySpecArm: (shared, credential) =>
+      credential.provider === 'github' ? { mode: 'github', ...shared, gitCredential: 'github-app' as const } : null
+  },
+  hooks: {
+    effects: (body) => ({
+      reviewPolicy: body.reviewPolicy ?? 'off',
+      reportingMode: body.reportingMode ?? 'off',
+      gateMode: body.gateMode ?? 'informational'
+    }),
+    // The App's webhook is deployment-wide: no hook or grant write can change
+    // what it delivers, so there is nothing to converge.
+    convergeManagedRepository: () => {}
+  },
+
+  /** Raising the tier re-checks the CALLER's own GitHub permission on the repository. */
+  async upgradeRepoAuthorization({ deps, req, reply, orgId, agent, row, access, toDto }) {
+    const [owner, repo] = row.repoFullName.split('/')
+    const installation = owner ? await deps.repos.githubInstallation.liveByOrgAndAccount(orgId, owner) : null
+    if (!owner || !repo || !installation || installation.suspendedAt) {
+      void reply.code(409).send({
+        error: 'Conflict',
+        statusCode: 409,
+        message: 'repository is not covered by a live GitHub App installation'
+      })
+      return undefined
+    }
+    try {
+      if (deps.githubUserAuthz) {
+        await deps.githubUserAuthz.assertAccess(
+          req.principal!.userId,
+          installation,
+          owner,
+          repo,
+          access === 'write' ? 'write' : 'read'
+        )
+      }
+      const updated = await deps.repos.agentRepoAuth.updateAccess(row.id, access)
+      if (!updated) {
+        void reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'authorization not found' })
+        return undefined
+      }
+      void deps.repos.audit
+        .append({
+          kind: 'agent_repo_change',
+          orgId,
+          agentId: agent.id,
+          ...(req.principal ? { actorUserId: req.principal.userId } : {}),
+          frameType: 'gitcred/grant',
+          message: `repo ${updated.repoFullName} authorization upgraded (${row.access} → ${updated.access})`,
+          details: {
+            repoAuthId: updated.id,
+            repoFullName: updated.repoFullName,
+            previousAccess: row.access,
+            access: updated.access
+          }
+        })
+        .catch(() => {})
+      return toDto(updated)
+    } catch (e) {
+      if (e instanceof UserAuthzDeniedError) {
+        void reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: e.message, code: e.code })
+        return undefined
+      }
+      if (e instanceof GithubApiError) {
+        const status = e.code === 'RATE_LIMITED' ? 429 : 502
+        void reply.code(status).send({
+          error: status === 429 ? 'Too Many Requests' : 'Bad Gateway',
+          statusCode: status,
+          message: `github: ${e.message}`
+        })
+        return undefined
+      }
+      if (e instanceof LogtoApiError) {
+        void reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: e.message })
+        return undefined
+      }
+      throw e
+    }
+  }
+}

--- a/packages/control-plane/src/gitlab/provider.ts
+++ b/packages/control-plane/src/gitlab/provider.ts
@@ -1,0 +1,178 @@
+/**
+ * The GitLab entry of the code-host provider registry (`codehost/provider.ts`).
+ *
+ * GitLab is the half that made each member a member: a managed project binding
+ * vouches for a workspace, every hook write re-converges the project's webhook
+ * and §7.2 memberships, a self-managed instance adds a negotiated feature, and a
+ * grant tier is also a project role. The binding lifecycle itself — OAuth
+ * administration, service accounts, PAT rotation, the rerun authorizer — stays in
+ * its own services: it has no GitHub counterpart to share a shape with.
+ */
+import {
+  GITLAB_COM_V1_FEATURE,
+  GITLAB_INSTANCE_V1_FEATURE,
+  GitCloneUrlError,
+  isSelfManagedGitlabHost,
+  normalizeGitCloneUrl,
+  normalizeGitUrl
+} from '@agentconnect.md/protocol'
+import {
+  refuseWorkspaceCredential,
+  type CodeHostProviderModule,
+  type CodeHostWorkspaceDerivation,
+  type DerivedWorkspace
+} from '../codehost/provider.js'
+import type { AgentWorkspaceCredentialDtoT } from '../http/dto/index.js'
+import { gitlabManagedProjectPath } from '../domain/git-host.js'
+import { gitlabAuthorizationAccessLevel, gitlabPublicProject } from './api.js'
+import { gitlabAccountUnavailableMessage } from './account.service.js'
+
+/** The gitlab arm of the §6 outcome table: a managed binding, else an anonymous public project. */
+async function deriveGitlabWorkspace(derivation: CodeHostWorkspaceDerivation): Promise<DerivedWorkspace | null> {
+  const { deps, orgId, gitRepo, requestedAccess } = derivation
+  const gitlab = deps.gitlab
+  const gitlabPath = gitlab ? gitlabManagedProjectPath(gitRepo, gitlab.api.baseUrl) : null
+  if (!gitlabPath || !gitlab) return null
+  const binding = await deps.repos.gitlabProjectBinding.byProjectPath(orgId, gitlabPath)
+  if (binding) {
+    // A binding mid-removal must refuse, never demote to an anonymous clone of
+    // the same path — the managed identity still exists until cleanup finishes.
+    if (binding.state === 'cleanup_pending') {
+      refuseWorkspaceCredential(`${gitlabPath} is being removed from this organization — wait for cleanup to finish`)
+    }
+    // The persisted catalog row, not caller input and never a composed URL, is
+    // the authority for the clone URL (§24.1).
+    const catalogRow = await deps.repos.codeHostRepository.byExternalId(orgId, 'gitlab', binding.projectId)
+    if (!catalogRow?.cloneUrl) {
+      refuseWorkspaceCredential('the GitLab project binding has no clone URL yet — repair the project first')
+    }
+    return {
+      kind: 'gitlab',
+      projectId: binding.projectId,
+      gitRepo: catalogRow.cloneUrl,
+      defaultBranch: binding.defaultBranch ?? 'main',
+      // A managed binding always mints, so an unstated tier is write.
+      access: requestedAccess ?? 'write'
+    }
+  }
+  if (requestedAccess === 'write') {
+    refuseWorkspaceCredential(
+      'gitlab write access requires a managed project — add the project to the organization first'
+    )
+  }
+  const project = await gitlabPublicProject(gitlabPath, gitlab.api)
+  if (!project) {
+    refuseWorkspaceCredential(
+      `${gitlabPath} is not a managed GitLab project in this organization — add the project first`
+    )
+  }
+  // The provider's own clone URL, held to the same codec every stored address
+  // passes; a malformed answer falls back to the caller's normalized input.
+  let cloneUrl: string
+  try {
+    cloneUrl = normalizeGitCloneUrl(project.http_url_to_repo ?? gitRepo)
+  } catch (e) {
+    if (!(e instanceof GitCloneUrlError)) throw e
+    cloneUrl = normalizeGitUrl(gitRepo)
+  }
+  return {
+    kind: 'anonymous',
+    gitRepo: cloneUrl,
+    ...(typeof project.default_branch === 'string' ? { defaultBranch: project.default_branch } : {}),
+    access: 'read',
+    host: 'gitlab'
+  }
+}
+
+export const gitlabCodeHostProvider: CodeHostProviderModule = {
+  provider: 'gitlab',
+  displayName: 'GitLab',
+  repositorySubject: 'project',
+  features: {
+    deploymentHost: (deps) => deps.gitlab?.api.baseUrl,
+    specHost: (spec) => spec.gitlabHost,
+    ruleHost: (rule) => (rule.provider === 'gitlab' ? rule.rule.host : undefined),
+    // §17.3: a GitLab-shaped value is frame-fatal on a pre-GitLab peer. §24.4: a
+    // value on a self-managed instance additionally needs the per-agent host bit.
+    required: (host) => [GITLAB_COM_V1_FEATURE, ...(isSelfManagedGitlabHost(host) ? [GITLAB_INSTANCE_V1_FEATURE] : [])],
+    requiredForInstance: (host) => (isSelfManagedGitlabHost(host) ? [GITLAB_INSTANCE_V1_FEATURE] : [])
+  },
+  workspace: {
+    derive: deriveGitlabWorkspace,
+    writeFromDerived: (derived) =>
+      derived.kind === 'gitlab'
+        ? { credential: { provider: 'gitlab', access: derived.access }, workspaceRepoId: derived.projectId }
+        : null,
+    toDto: (credential, workspaceRepoId): AgentWorkspaceCredentialDtoT | null =>
+      credential.provider === 'gitlab'
+        ? { provider: 'gitlab', access: credential.access, projectId: (workspaceRepoId ?? 0n).toString() }
+        : null,
+    // A gitlab-vouched workspace is frame-fatal on a pre-GitLab daemon; every
+    // projection path gates on daemonSupportsAgent before sending it.
+    toSpec: (credential, workspaceRepoId) =>
+      credential.provider === 'gitlab' ? { provider: 'gitlab', projectId: (workspaceRepoId ?? 0n).toString() } : null,
+    legacySpecArm: (shared, credential) =>
+      credential.provider === 'gitlab' ? { mode: 'gitlab', ...shared, projectId: credential.projectId } : null
+  },
+  hooks: {
+    // `check` is the §16 run note. No gateMode: GitLab has no required-gate
+    // surface, so a row of this kind stays informational.
+    effects: (body) => ({
+      reviewPolicy: body.reviewPolicy ?? 'off',
+      reportingMode: body.reportingMode ?? 'off',
+      gateMode: 'informational'
+    }),
+    // §11.1: the saga recomputes the project's desired event union, gives each
+    // consumer its own §7.2 account and membership, and its onConverged
+    // rebroadcasts the compiled rules. The saga itself outwaits a peer's lease.
+    convergeManagedRepository: (deps, orgId, repoId, onError) => {
+      const gitlab = deps.gitlab
+      if (!gitlab || repoId === null) return
+      void gitlab.provisioner.convergeProject(orgId, repoId).catch(onError)
+    }
+  },
+
+  /** Raising the tier raises the account's project role, so it re-runs the same ensure the grant took. */
+  async upgradeRepoAuthorization({ deps, req, reply, orgId, agent, row, access, toDto }) {
+    const conflict = (message: string): undefined => {
+      void reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
+    }
+    const gitlab = deps.gitlab
+    if (!gitlab) return conflict('GitLab is not configured on this deployment')
+    const binding = await deps.repos.gitlabProjectBinding.byProject(orgId, row.repoId)
+    if (!binding || binding.state === 'cleanup_pending') {
+      return conflict('the project is not a managed GitLab project in this organization')
+    }
+    const applied = await gitlab.provisioner.provisionAgentAccount(
+      orgId,
+      row.repoId,
+      { agentId: agent.id, accessLevel: gitlabAuthorizationAccessLevel(access) },
+      // Access-only: the row's path is converged by the same lease's fact sync.
+      () => deps.repos.agentRepoAuth.updateAccess(row.id, access)
+    )
+    if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))
+    const updated = applied.result
+    if (!updated) {
+      void reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'authorization not found' })
+      return undefined
+    }
+    void deps.repos.audit
+      .append({
+        kind: 'agent_repo_change',
+        orgId,
+        agentId: agent.id,
+        ...(req.principal ? { actorUserId: req.principal.userId } : {}),
+        frameType: 'gitcred/grant',
+        message: `gitlab project ${updated.repoFullName} authorization upgraded (${row.access} → ${updated.access})`,
+        details: {
+          repoAuthId: updated.id,
+          provider: 'gitlab',
+          repoFullName: updated.repoFullName,
+          previousAccess: row.access,
+          access: updated.access
+        }
+      })
+      .catch(() => {})
+    return toDto(updated)
+  }
+}

--- a/packages/control-plane/src/hooks/hook-family.ts
+++ b/packages/control-plane/src/hooks/hook-family.ts
@@ -8,7 +8,9 @@
  * (agent, kind, repo, family) uniqueness owns the duplicate rule.
  */
 
-/** Every subject family the two code hosts between them subscribe to. */
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
+
+/** Every subject family the code hosts between them subscribe to. */
 export type HookFamily = 'issues' | 'pull_request' | 'merge_request' | 'push' | 'deployment'
 
 /** The families a row of each kind may declare. */
@@ -45,7 +47,7 @@ export function familyOfEventPattern(pattern: string): HookFamily | null {
 }
 
 /** Whether one stored pattern belongs on a row of this kind and family. */
-export function eventPatternFitsFamily(kind: 'github' | 'gitlab', family: HookFamily, pattern: string): boolean {
+export function eventPatternFitsFamily(kind: CodeHostProvider, family: HookFamily, pattern: string): boolean {
   const prefix = pattern.split(':', 1)[0]
   if (prefix === 'issue_comment') {
     return kind === 'github' && (family === 'issues' || family === 'pull_request')
@@ -63,7 +65,7 @@ export function hasSharedCommentPattern(events: readonly string[]): boolean {
 
 /** The per-row subscription block a write proposes. */
 export interface HookFamilyShape {
-  kind: 'github' | 'gitlab'
+  kind: CodeHostProvider
   family: HookFamily
   events: readonly string[]
   commentFamilies: readonly string[]

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -17,7 +17,8 @@
  * NEVER log.
  */
 import { codeHostHookRuleOf, type RcHookAssign } from '@agentconnect.md/protocol'
-import { advertises, requiredGitlabFeatures } from '../domain/daemon-features.js'
+import { advertises } from '../domain/daemon-features.js'
+import { codeHostProviders } from '../codehost/registry.js'
 import type { AgentId, OrgId } from '../domain/ids.js'
 import type {
   AgentRecord,
@@ -283,7 +284,8 @@ export class HookService {
         const rule = await this.compile(hook)
         // The §17.3/§24.4 negotiation gate, per channel (mirrors RelayControlSender).
         const host = rule && codeHostHookRuleOf(rule)
-        if (host?.provider === 'gitlab' && !advertises(ch.features, requiredGitlabFeatures(host.rule.host))) continue
+        const features = host && codeHostProviders[host.provider].features
+        if (features && !advertises(ch.features, features.required(features.ruleHost(host)))) continue
         if (rule) ch.send('rc/hook-assign', rule)
       } catch (err) {
         this.log?.warn({ hookId: hook.id, err }, 'hook replay: compile/send failed — skipped')

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -74,6 +74,7 @@ import type { LogtoIdentityService } from '../github/logto-identity.js'
 import type { HookService } from '../hooks/hook.service.js'
 import type { DaemonRegistry, DaemonAuth, ApiKeyAdmin, DaemonLiveness, ClusterWorkloadIdentity } from '../ports.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
+import type { CodeHostProviderRegistry } from '../codehost/provider.js'
 import type { DaemonReleaseResolver } from '../registry/daemonRelease.js'
 import type { WebchatTokenService } from '../registry/webchatToken.js'
 import type { OrgInviteLinkService } from '../registry/orgInviteLinkService.js'
@@ -296,6 +297,18 @@ export interface HttpDeps {
    * late (a provider is built FROM this very bundle).
    */
   platforms: CpPlatformRegistry
+  /**
+   * The §6.5 code-host provider registry — the one authority for a per-host
+   * decision a route used to take with `kind === 'gitlab' ? … : …`: the hook
+   * effect axes of a kind, the managed-ingress convergence a write owes, the
+   * additional-repository grant upgrade, workspace provenance and its DTO
+   * projection, and §17.3/§24.4 feature negotiation. Reading it here (never a
+   * per-host field on this bundle) is what keeps a new host out of core files.
+   *
+   * Optional only so a focused harness may omit it: an entry is stateless, so
+   * `codeHostsOf` falls back to the very record the composition root publishes.
+   */
+  codeHosts?: CodeHostProviderRegistry
   /** The ONE assembler of CP→daemon AgentSpecs (owns secret loading + icon bases) —
    *  every spec emission (upsert replicate, icon refresh, move activation) uses it. */
   agentSpecs: AgentSpecAssembler

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -387,6 +387,7 @@ export const AgentWorkspaceCredentialDto = z.discriminatedUnion('provider', [
     projectId: z.string() // rename-stable numeric project id (workspaceRepoId)
   })
 ])
+export type AgentWorkspaceCredentialDtoT = z.infer<typeof AgentWorkspaceCredentialDto>
 
 /** Where the agent runs (inline; path is daemon-generated). Mirrors the domain
  *  AgentWorkspace (git-workspace-model.md §5). Reused as the response shape inside

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -17,7 +17,7 @@
  * runs the same inline account/membership ensure the workspace and hook arms run,
  * and revoking converges the membership away.
  */
-import { gitRepoLabel } from '@agentconnect.md/protocol'
+import { gitRepoLabel, type CodeHostProvider } from '@agentconnect.md/protocol'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
@@ -38,6 +38,7 @@ import { AgentId, OrgId } from '../../domain/ids.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView } from '../../authorization/policy.js'
+import { codeHostsOf } from '../../codehost/registry.js'
 import { Tag } from '../plugins/openapi.js'
 import { isCanonicalGithubAddress } from '../../domain/git-host.js'
 import {
@@ -65,6 +66,7 @@ function toDto(r: AgentRepoAuthorizationRecord): AgentRepoAuthDtoT {
 export function agentRepoRoutes(deps: HttpDeps) {
   return async function agentRepoRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    const codeHosts = codeHostsOf(deps)
 
     // Same no-oracle rule as `GET /agents/:agentId/hooks`: cross-org, unknown,
     // and not-viewable agents all read 404.
@@ -126,15 +128,14 @@ export function agentRepoRoutes(deps: HttpDeps) {
       })
     }
 
-    // Authorization changed who consumes the project, so the §7.2 accounts and
-    // memberships must reconverge — the same kick a gitlab workspace or hook write
-    // does. Fire-and-forget: the saga outwaits a peer's lease on its own.
-    const convergeGitlabProject = (orgId: string, projectId: bigint): void => {
-      const gitlab = deps.gitlab
-      if (!gitlab) return
-      void gitlab.provisioner
-        .convergeProject(OrgId(orgId), projectId)
-        .catch((err) => app.log.warn({ err, projectId: projectId.toString() }, 'gitlab authorization converge failed'))
+    // Authorization changed who consumes the repository, so whatever the host binds
+    // per consumer must reconverge — the same kick a workspace or hook write does
+    // (a no-op where the host binds nothing). Fire-and-forget: a host's own saga
+    // outwaits a peer's lease.
+    const convergeManagedRepository = (provider: CodeHostProvider, orgId: string, repoId: bigint): void => {
+      codeHosts[provider].hooks.convergeManagedRepository(deps, OrgId(orgId), repoId, (err) =>
+        app.log.warn({ err, projectId: repoId.toString() }, `${provider} authorization converge failed`)
+      )
     }
 
     /** The gitlab arm of `POST /agents/:agentId/repos` (§8.3). */
@@ -197,7 +198,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
       } catch (err) {
         // The grant rolled back, so the membership just bound belongs to an agent
         // that does not consume the project: converge it away.
-        convergeGitlabProject(orgId, projectId)
+        convergeManagedRepository('gitlab', orgId, projectId)
         throw err
       }
       if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))
@@ -215,58 +216,6 @@ export function agentRepoRoutes(deps: HttpDeps) {
         .catch(() => {})
       await replicateUpsert(agent)
       return toDto(row)
-    }
-
-    /** The gitlab arm of `PATCH /agents/:agentId/repos/:repoAuthId`: raising the tier
-     *  raises the account's project role, so it re-runs the same ensure the grant took. */
-    const upgradeGitlabAuthorization = async (
-      req: FastifyRequest,
-      reply: FastifyReply,
-      agent: AgentRecord,
-      row: AgentRepoAuthorizationRecord,
-      access: RepoAccess
-    ): Promise<AgentRepoAuthDtoT | undefined> => {
-      const conflict = (message: string): undefined => {
-        void reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
-      }
-      const gitlab = deps.gitlab
-      if (!gitlab) return conflict('GitLab is not configured on this deployment')
-      const orgId = orgOf(req)
-      const binding = await deps.repos.gitlabProjectBinding.byProject(orgId, row.repoId)
-      if (!binding || binding.state === 'cleanup_pending') {
-        return conflict('the project is not a managed GitLab project in this organization')
-      }
-      const applied = await gitlab.provisioner.provisionAgentAccount(
-        orgId,
-        row.repoId,
-        { agentId: agent.id, accessLevel: gitlabAuthorizationAccessLevel(access) },
-        // Access-only: the row's path is converged by the same lease's fact sync.
-        () => deps.repos.agentRepoAuth.updateAccess(row.id, access)
-      )
-      if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))
-      const updated = applied.result
-      if (!updated) {
-        void reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'authorization not found' })
-        return undefined
-      }
-      void deps.repos.audit
-        .append({
-          kind: 'agent_repo_change',
-          orgId,
-          agentId: agent.id,
-          ...(req.principal ? { actorUserId: req.principal.userId } : {}),
-          frameType: 'gitcred/grant',
-          message: `gitlab project ${updated.repoFullName} authorization upgraded (${row.access} → ${updated.access})`,
-          details: {
-            repoAuthId: updated.id,
-            provider: 'gitlab',
-            repoFullName: updated.repoFullName,
-            previousAccess: row.access,
-            access: updated.access
-          }
-        })
-        .catch(() => {})
-      return toDto(updated)
     }
 
     r.get(
@@ -496,67 +445,18 @@ export function agentRepoRoutes(deps: HttpDeps) {
           })
         }
         if (req.body.access === row.access) return toDto(row)
-        if (row.provider === 'gitlab') return upgradeGitlabAuthorization(req, reply, agent, row, req.body.access)
-
-        const [owner, repo] = row.repoFullName.split('/')
-        const installation = owner
-          ? await deps.repos.githubInstallation.liveByOrgAndAccount(OrgId(orgOf(req)), owner)
-          : null
-        if (!owner || !repo || !installation || installation.suspendedAt) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'repository is not covered by a live GitHub App installation'
-          })
-        }
-        try {
-          if (deps.githubUserAuthz) {
-            await deps.githubUserAuthz.assertAccess(
-              req.principal!.userId,
-              installation,
-              owner,
-              repo,
-              req.body.access === 'write' ? 'write' : 'read'
-            )
-          }
-          const updated = await deps.repos.agentRepoAuth.updateAccess(row.id, req.body.access)
-          if (!updated) {
-            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'authorization not found' })
-          }
-          void deps.repos.audit
-            .append({
-              kind: 'agent_repo_change',
-              orgId: orgOf(req),
-              agentId: agent.id,
-              ...(req.principal ? { actorUserId: req.principal.userId } : {}),
-              frameType: 'gitcred/grant',
-              message: `repo ${updated.repoFullName} authorization upgraded (${row.access} → ${updated.access})`,
-              details: {
-                repoAuthId: updated.id,
-                repoFullName: updated.repoFullName,
-                previousAccess: row.access,
-                access: updated.access
-              }
-            })
-            .catch(() => {})
-          return toDto(updated)
-        } catch (e) {
-          if (e instanceof UserAuthzDeniedError) {
-            return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: e.message, code: e.code })
-          }
-          if (e instanceof GithubApiError) {
-            const status = e.code === 'RATE_LIMITED' ? 429 : 502
-            return reply.code(status).send({
-              error: status === 429 ? 'Too Many Requests' : 'Bad Gateway',
-              statusCode: status,
-              message: `github: ${e.message}`
-            })
-          }
-          if (e instanceof LogtoApiError) {
-            return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: e.message })
-          }
-          throw e
-        }
+        // What raising a tier means is the host's: a re-checked GitHub permission,
+        // or a raised project role on the grant's own §7.2 account.
+        return codeHosts[row.provider].upgradeRepoAuthorization({
+          deps,
+          req,
+          reply,
+          orgId: orgOf(req),
+          agent,
+          row,
+          access: req.body.access,
+          toDto
+        })
       }
     )
 
@@ -633,7 +533,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
           .catch(() => {})
         // Revoked authorization ⇒ the agent is no longer a consumer, so the §7.2
         // membership must go — and with nothing left in its root, the account retires.
-        if (row.provider === 'gitlab' && !redundantWorkspaceGrant) convergeGitlabProject(orgOf(req), row.repoId)
+        if (!redundantWorkspaceGrant) convergeManagedRepository(row.provider, orgOf(req), row.repoId)
         await replicateUpsert(agent)
         return reply.code(204).send(null)
       }

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -83,7 +83,8 @@ import {
 } from './workspace-credential.js'
 import type { DaemonView } from '../../ports.js'
 import { AgentId, DaemonId, OrgId, SessionId } from '../../domain/ids.js'
-import { advertises, requiredGitlabFeatures } from '../../domain/daemon-features.js'
+import { advertises } from '../../domain/daemon-features.js'
+import { codeHostProviders, codeHostsOf } from '../../codehost/registry.js'
 import {
   dutyEligibility,
   onSet,
@@ -297,23 +298,17 @@ function workspaceToDto(workspace: AgentWorkspace, workspaceRepoId?: bigint): Ag
   if (workspace.mode === 'scratch') return { mode: 'scratch' }
   // The DTO mirrors PERSISTED provenance (git-workspace-model.md §5) — never a live
   // re-derivation. installationId stays server-side; the credential names the provider.
+  const credential = workspace.credential
+    ? codeHostProviders[workspace.credential.provider].workspace.toDto(workspace.credential, workspaceRepoId)
+    : null
   return {
     mode: 'git',
     worktree: workspace.isolation === 'session',
     gitRepo: workspace.gitRepo,
     ...(workspace.gitBranch !== undefined ? { gitBranch: workspace.gitBranch } : {}),
     ...(workspace.agentDir !== undefined ? { agentDir: workspace.agentDir } : {}),
-    ...(workspace.credential?.provider === 'github'
-      ? { credential: { provider: 'github' as const, access: workspace.credential.access } }
-      : workspace.credential?.provider === 'gitlab'
-        ? {
-            credential: {
-              provider: 'gitlab' as const,
-              access: workspace.credential.access,
-              projectId: (workspaceRepoId ?? 0n).toString()
-            }
-          }
-        : {})
+    // The vouching host owns its own read shape; an anonymous workspace has none.
+    ...(credential ? { credential } : {})
   }
 }
 
@@ -914,6 +909,7 @@ function memoryAdminFailure(err: unknown): {
 export function agentRoutes(deps: HttpDeps) {
   return async function agentRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    const codeHosts = codeHostsOf(deps)
 
     // Fetch an agent AND verify it belongs to the caller's active org AND is visible
     // to them — a cross-org id OR a restricted agent they can't see both read as
@@ -1818,15 +1814,19 @@ export function agentRoutes(deps: HttpDeps) {
           // §17.3/§24.4: a DIRECT placement must advertise the features NOW — the
           // delivery/reconcile gates would otherwise strand a 201'd agent
           // assigned to a daemon that can never materialize it.
-          if (derived.kind === 'gitlab' && req.body.daemonId !== undefined) {
+          const vouching = derived.kind === 'anonymous' ? null : codeHosts[derived.kind]
+          const vouchingFeatures = vouching ? vouching.features.required(vouching.features.deploymentHost(deps)) : []
+          if (vouching && vouchingFeatures.length > 0 && req.body.daemonId !== undefined) {
             const daemon = await deps.registry.getAvailable(orgOf(req), DaemonId(req.body.daemonId))
-            if (!advertises(daemon?.capabilities.features, requiredGitlabFeatures(deps.gitlab?.api.baseUrl))) {
-              return conflict('the selected daemon does not support GitLab workspaces yet — upgrade it first')
+            if (!advertises(daemon?.capabilities.features, vouchingFeatures)) {
+              return conflict(
+                `the selected daemon does not support ${vouching.displayName} workspaces yet — upgrade it first`
+              )
             }
           }
           // The derivation's canonical address and default branch — never the
           // caller's clone host/path — are the authority for a credentialed workspace.
-          const built = workspaceFromDerived(derived, {
+          const built = workspaceFromDerived(codeHosts, derived, {
             isolation: ws.worktree === false ? 'shared' : 'session',
             ...(ws.gitBranch !== undefined ? { gitBranch: ws.gitBranch } : {}),
             ...(ws.agentDir !== undefined ? { agentDir: ws.agentDir } : {})
@@ -2639,22 +2639,26 @@ export function agentRoutes(deps: HttpDeps) {
               if (e instanceof WorkspaceCredentialRefused) return conflict(e.message)
               throw e // provider/identity errors map in the shared catch below
             }
-            // §17.3: the daemon that will re-activate a gitlab-vouched workspace must
+            // §17.3: the daemon that will re-activate a host-vouched workspace must
             // decode its credential — direct placement or a pool/duty incumbent alike
             // (the earlier check only proves workspace-edit-v2).
-            if (derived.kind === 'gitlab') {
+            const vouching = derived.kind === 'anonymous' ? null : codeHosts[derived.kind]
+            const vouchingFeatures = vouching ? vouching.features.required(vouching.features.deploymentHost(deps)) : []
+            if (vouching && vouchingFeatures.length > 0) {
               const servingId = (await deps.placementResolver.servingDaemon(existing)) ?? existing.daemonId
               if (servingId) {
                 const serving = await deps.registry.getAvailable(existing.orgId, servingId)
-                if (!advertises(serving?.capabilities.features, requiredGitlabFeatures(deps.gitlab?.api.baseUrl))) {
-                  return conflict('the serving daemon does not support GitLab workspaces yet — upgrade it first')
+                if (!advertises(serving?.capabilities.features, vouchingFeatures)) {
+                  return conflict(
+                    `the serving daemon does not support ${vouching.displayName} workspaces yet — upgrade it first`
+                  )
                 }
               }
             }
             const worktree =
               req.body.worktree ??
               (existing.workspace.mode !== 'scratch' ? existing.workspace.isolation === 'session' : true)
-            const built = workspaceFromDerived(derived, {
+            const built = workspaceFromDerived(codeHosts, derived, {
               isolation: worktree ? 'session' : 'shared',
               ...(req.body.gitBranch !== undefined ? { gitBranch: req.body.gitBranch } : {}),
               ...(req.body.agentDir ? { agentDir: req.body.agentDir } : {})

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -11,7 +11,7 @@
  * echoed EXACTLY ONCE in the create response and never retrievable after.
  */
 import { randomBytes, randomUUID } from 'node:crypto'
-import { gitRepoLabel, type CodeHostProvider } from '@agentconnect.md/protocol'
+import { gitRepoLabel, isCodeHostHookKind, type CodeHostProvider } from '@agentconnect.md/protocol'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
@@ -35,6 +35,7 @@ import { toDbPlatform, type DbPlatform } from '../../persistence/platform.js'
 import { AgentWorkspaceIntegrationConflict } from '../../persistence/errors.js'
 import { isCanonicalGithubAddress } from '../../domain/git-host.js'
 import { hookFamilyShapeError, hookSiblingShapeError, type HookFamily } from '../../hooks/hook-family.js'
+import { codeHostsOf } from '../../codehost/registry.js'
 import { Tag } from '../plugins/openapi.js'
 import {
   CreateHookBody,
@@ -120,6 +121,7 @@ function toDto(h: HookRecord, publicRelayUrl?: string): HookDtoT {
 export function hookRoutes(deps: HttpDeps) {
   return async function hookRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    const codeHosts = codeHostsOf(deps)
 
     // A hook is reachable iff its OWNING AGENT is viewable (no per-hook visibility;
     // the agent is the access boundary, like an Integration). Cross-org ids, an
@@ -202,16 +204,14 @@ export function hookRoutes(deps: HttpDeps) {
       return { ok: true, result: done.result }
     }
 
-    // gitlab-kind writes also (re)converge the project (§11.1): the saga
-    // recomputes the desired event union, gives the hook's agent its own §7.2
-    // account and membership, and its onConverged rebroadcasts the compiled
-    // rules. Fire-and-forget; the saga itself outwaits a peer's lease.
-    const convergeGitlabWebhook = (orgId: OrgId, projectId: bigint | null): void => {
-      const gitlab = deps.gitlab
-      if (!gitlab || projectId === null) return
-      void gitlab.provisioner
-        .convergeProject(orgId, projectId)
-        .catch((err) => app.log.warn({ projectId: projectId.toString(), err }, 'gitlab webhook converge failed'))
+    // A code-host write also re-converges the managed ingress its host owns: what
+    // that means is the provider's (a no-op where the webhook is deployment-wide).
+    // Fire-and-forget; a host's own saga outwaits a peer's lease.
+    const convergeManagedRepository = (kind: HookRecord['kind'], orgId: OrgId, repoId: bigint | null): void => {
+      if (!isCodeHostHookKind(kind)) return
+      codeHosts[kind].hooks.convergeManagedRepository(deps, orgId, repoId, (err) =>
+        app.log.warn({ projectId: repoId?.toString(), err }, `${kind} webhook converge failed`)
+      )
     }
 
     // The repository repeats the workspace-access invariant under its shared
@@ -236,7 +236,7 @@ export function hookRoutes(deps: HttpDeps) {
     // family, comments are scoped to it, and only a change-proposal family may
     // carry the review/reporting axes. Runs before any upstream call.
     const familyShapeError = (body: {
-      kind: 'github' | 'gitlab'
+      kind: CodeHostProvider
       family: HookFamily
       events: string[]
       commentFamilies?: string[]
@@ -349,7 +349,7 @@ export function hookRoutes(deps: HttpDeps) {
       repoId: bigint,
       repoFullName: string
     ): Promise<WatchRepoAuthz> => {
-      const subject = provider === 'gitlab' ? 'project' : 'repository'
+      const subject = codeHosts[provider].repositorySubject
       const denied = {
         ok: false,
         status: 409,
@@ -532,15 +532,17 @@ export function hookRoutes(deps: HttpDeps) {
             message: 'targetIntegrationId is not an integration of this agent'
           })
         }
+        // Each host's own effect axes, with its inert default for an axis it has no
+        // surface for. Resolved up front: the per-kind arms below run inside closures,
+        // where the body's own narrowing no longer holds.
+        const effects = req.body.kind === 'webhook' ? null : codeHosts[req.body.kind].hooks.effects(req.body)
         if (req.body.kind !== 'webhook') {
           const shapeError = familyShapeError({
             kind: req.body.kind,
             family: req.body.family,
             events: req.body.events,
             commentFamilies: req.body.commentFamilies,
-            reviewPolicy: req.body.reviewPolicy,
-            reportingMode: req.body.reportingMode,
-            gateMode: req.body.kind === 'github' ? req.body.gateMode : 'informational'
+            ...effects!
           })
           if (shapeError) {
             return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: shapeError })
@@ -591,10 +593,7 @@ export function hookRoutes(deps: HttpDeps) {
                   // ALREADY be the workspace or an explicit additional authorization.
                   const authz = await watchRepoAuthorized(agent, 'gitlab', projectId, binding.projectPath)
                   if (!authz.ok) return authz
-                  const effectError = validateGitlabEffects(binding, {
-                    reviewPolicy: req.body.kind === 'gitlab' ? req.body.reviewPolicy : 'off',
-                    reportingMode: req.body.kind === 'gitlab' ? req.body.reportingMode : 'off'
-                  })
+                  const effectError = validateGitlabEffects(binding, effects!)
                   if (effectError) return { ok: false as const, ...effectError }
                   return {
                     // gitlab is perThread by definition, like github (§12.3).
@@ -625,11 +624,7 @@ export function hookRoutes(deps: HttpDeps) {
                   }
                   const authz = await watchRepoAuthorized(agent, 'github', repo.repoId, repo.repoFullName)
                   if (!authz.ok) return authz
-                  const configError = await validateGithubEffects(agent, repo.repoId, repo.repoFullName, {
-                    reviewPolicy: req.body.kind === 'github' ? req.body.reviewPolicy : 'off',
-                    reportingMode: req.body.kind === 'github' ? req.body.reportingMode : 'off',
-                    gateMode: req.body.kind === 'github' ? req.body.gateMode : 'informational'
-                  })
+                  const configError = await validateGithubEffects(agent, repo.repoId, repo.repoFullName, effects!)
                   if (configError) {
                     return { ok: false as const, ...configError }
                   }
@@ -728,7 +723,7 @@ export function hookRoutes(deps: HttpDeps) {
         // Re-read so hmacConfigured reflects the secret written above.
         const fresh = (await deps.repos.hook.get(orgId, hookId)) ?? hook
         converge(fresh)
-        if (fresh.kind === 'gitlab') convergeGitlabWebhook(orgId, fresh.repoId)
+        convergeManagedRepository(fresh.kind, orgId, fresh.repoId)
         return { ...toDto(fresh, deps.config.PUBLIC_RELAY_URL), hmacSecret }
       }
     )
@@ -1081,13 +1076,11 @@ export function hookRoutes(deps: HttpDeps) {
         // dropping its host first would have a delivery in that window refused.
         const retargetedFrom = existing.agentId && existing.agentId !== agent.id ? existing.agentId : null
         converge(hook, retargetedFrom ? () => replicateUpsert(orgOf(req), retargetedFrom) : undefined)
-        if (hook.kind === 'gitlab') {
-          convergeGitlabWebhook(orgOf(req), hook.repoId)
-          // A retarget moved this hook off `existing.repoId`: the source
-          // binding's union shrank too, so converge BOTH distinct projects.
-          if (existing.repoId !== null && existing.repoId !== hook.repoId) {
-            convergeGitlabWebhook(orgOf(req), existing.repoId)
-          }
+        convergeManagedRepository(hook.kind, orgOf(req), hook.repoId)
+        // A retarget moved this hook off `existing.repoId`: the source binding's
+        // union shrank too, so converge BOTH distinct repositories.
+        if (existing.repoId !== null && existing.repoId !== hook.repoId) {
+          convergeManagedRepository(hook.kind, orgOf(req), existing.repoId)
         }
         return toDto(hook, deps.config.PUBLIC_RELAY_URL)
       }
@@ -1129,7 +1122,7 @@ export function hookRoutes(deps: HttpDeps) {
         // Losing: no rule can fire any more, so dropping the host now cannot orphan a
         // delivery that still quotes it.
         await replicateUpsert(orgOf(req), existing.agentId)
-        if (existing.kind === 'gitlab') convergeGitlabWebhook(orgOf(req), existing.repoId)
+        convergeManagedRepository(existing.kind, orgOf(req), existing.repoId)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/http/routes/workspace-credential.test.ts
+++ b/packages/control-plane/src/http/routes/workspace-credential.test.ts
@@ -9,6 +9,7 @@ import type { GithubInstallationRecord } from '../../persistence/ports.js'
 import type { PublicRepoLookup } from '../../github/public-repo.js'
 import { deriveWorkspaceCredential, WorkspaceCredentialRefused } from './workspace-credential.js'
 import { gitlabManagedProjectPath } from '../../domain/git-host.js'
+import { codeHostProviders } from '../../codehost/registry.js'
 
 const ORG = 'org-1'
 const ACTOR = 'user-1'
@@ -43,6 +44,8 @@ type Parts = {
 function makeDeps(parts: Parts = {}) {
   const calls = { upserts: [] as Array<Record<string, unknown>>, publicLookups: 0, assertions: [] as string[] }
   const deps = {
+    // The per-host arms are registry entries; this suite stubs what they read.
+    codeHosts: codeHostProviders,
     github: {
       repoRefFor: async () => parts.repoRef ?? null
     },

--- a/packages/control-plane/src/http/routes/workspace-credential.ts
+++ b/packages/control-plane/src/http/routes/workspace-credential.ts
@@ -2,96 +2,27 @@
  * `deriveWorkspaceCredential` — one function, three callers (git-workspace-model.md §6):
  * the agent create route, the workspace replace route, and the resolve endpoint.
  * No other code decides workspace provenance. Provenance depends only on
- * `(orgId, gitRepo)`; eligibility and tier depend on the actor — the GitHub
- * identity gate runs INSIDE this derivation on purpose, so a route can never
+ * `(orgId, gitRepo)`; eligibility and tier depend on the actor — the identity
+ * gate runs INSIDE each host's derivation on purpose, so a route can never
  * re-introduce the per-route divergence the design removes (#1561, #1567).
+ *
+ * The per-host arms live in the code-host provider registry (`codehost/provider.ts`):
+ * this function owns the ORDER they are asked in and the terminal "any other host"
+ * outcome, and nothing else here names a host.
  */
-import { GitCloneUrlError, gitRepoLabel, normalizeGitCloneUrl, normalizeGitUrl } from '@agentconnect.md/protocol'
-import { gitlabPublicProject } from '../../gitlab/api.js'
+import { normalizeGitUrl, CODE_HOST_PROVIDERS } from '@agentconnect.md/protocol'
 import type { HttpDeps } from '../deps.js'
-import type { AgentWorkspace, GithubInstallationRecord } from '../../persistence/ports.js'
-import { gitlabManagedProjectPath, isCanonicalGithubAddress } from '../../domain/git-host.js'
-import { OrgId } from '../../domain/ids.js'
+import type { AgentWorkspace } from '../../persistence/ports.js'
+import { codeHostsOf } from '../../codehost/registry.js'
+import {
+  refuseWorkspaceCredential,
+  WorkspaceCredentialRefused,
+  type CodeHostProviderRegistry,
+  type DerivedWorkspace
+} from '../../codehost/provider.js'
 
-/** Actionable refusal (§6 table) — the routes answer it as a 409. */
-export class WorkspaceCredentialRefused extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'WorkspaceCredentialRefused'
-  }
-}
-
-/** The derived provenance of one cloneable address, for the acting caller. */
-export type DerivedWorkspace =
-  | {
-      kind: 'github'
-      /** The covering live installation (provenance hint persisted on the row). */
-      installationId: string
-      repoId: bigint
-      gitRepo: string // canonical address from the installation lookup, never caller input
-      defaultBranch: string
-      access: 'read' | 'write'
-    }
-  | {
-      kind: 'gitlab'
-      projectId: bigint
-      gitRepo: string // the catalog row's provider-authored clone URL (§24.1)
-      defaultBranch: string
-      access: 'read' | 'write'
-    }
-  | {
-      kind: 'anonymous'
-      gitRepo: string
-      defaultBranch?: string
-      access: 'read'
-      /** Which managed host the anonymous target sits on, for display derivation (§7). */
-      host: 'github' | 'gitlab' | 'other'
-    }
-
-function refuse(message: string): never {
-  throw new WorkspaceCredentialRefused(message)
-}
-
-/** owner/repo when the address selects canonical github.com; null otherwise. */
-function githubTarget(gitRepo: string): { owner: string; repo: string } | null {
-  if (!isCanonicalGithubAddress(gitRepo)) return null
-  const parts = gitRepoLabel(gitRepo).split('/')
-  const [owner, repo] = parts
-  if (parts.length !== 2 || !owner || !repo) refuse('workspace gitRepo is not a github repository')
-  return { owner, repo }
-}
-
-/** Resolve the covering App installation, converge the catalog row, and hold the
- *  acting human to the access the agent will run with. Null ⇒ not granted. */
-async function bindGithubWorkspaceRepo(
-  deps: HttpDeps,
-  orgId: string,
-  ins: GithubInstallationRecord,
-  owner: string,
-  repo: string,
-  access: 'read' | 'write',
-  userId: string | undefined
-): Promise<{ repoId: bigint; fullName: string; defaultBranch: string } | null> {
-  const ref = await deps.github!.repoRefFor(ins, owner, repo)
-  if (!ref) return null
-  await deps.repos.codeHostRepository.upsert({
-    orgId,
-    provider: 'github',
-    externalId: ref.repoId,
-    displayPath: ref.fullName,
-    cloneUrl: `https://github.com/${ref.fullName}`,
-    defaultBranch: ref.defaultBranch
-  })
-  // The identity gate inside the derivation IS the security check (§6), on the
-  // CANONICAL spelling so one repository holds one authz cache entry. Where the
-  // gate is configured, an actorless caller fails CLOSED — never a silent allow.
-  const [canonicalOwner, canonicalRepo] = ref.fullName.split('/')
-  if (deps.githubUserAuthz) {
-    if (userId === undefined) refuse('a signed-in identity is required to bind this repository')
-    await deps.githubUserAuthz.assertAccess(userId, ins, canonicalOwner ?? owner, canonicalRepo ?? repo, access)
-  }
-  return ref
-}
+export { WorkspaceCredentialRefused }
+export type { DerivedWorkspace }
 
 /**
  * Derive who vouches for `gitRepo` (§6 outcome table) for the acting caller.
@@ -110,98 +41,27 @@ export async function deriveWorkspaceCredential(
   gitRepo: string,
   requestedAccess?: 'read' | 'write'
 ): Promise<DerivedWorkspace> {
-  const gh = githubTarget(gitRepo)
-  if (gh) {
-    const covering = deps.github
-      ? await deps.repos.githubInstallation.liveByOrgAndAccount(OrgId(orgId), gh.owner)
-      : null
-    const installation = covering && !covering.suspendedAt ? covering : null
-    if (installation) {
-      const access = requestedAccess ?? 'write'
-      const ref = await bindGithubWorkspaceRepo(deps, orgId, installation, gh.owner, gh.repo, access, actorUserId)
-      // An installation token reads any PUBLIC repository, so a miss here means
-      // private-and-ungranted (or absent) — an anonymous clone cannot serve it,
-      // and the actionable answer is to grant it rather than to degrade silently.
-      if (!ref) refuse(`${gh.owner}/${gh.repo} is not granted to the GitHub installation — re-select it on GitHub`)
-      return {
-        kind: 'github',
-        installationId: installation.id,
-        repoId: ref.repoId,
-        gitRepo: normalizeGitUrl(ref.fullName),
-        defaultBranch: ref.defaultBranch,
-        access
-      }
-    }
-    if (requestedAccess === 'write') refuse('github write access requires a GitHub App installation')
-    // Anonymous public read. `unreachable` (rate limit, outage) deliberately does
-    // NOT refuse — creation never preflighted at all, and a GitHub blip must not
-    // block a checkout the daemon's clone boundary will verify anyway.
-    const lookup = deps.resolvePublicRepo ? await deps.resolvePublicRepo(gh.owner, gh.repo) : 'unreachable'
-    if (lookup === 'not-found') {
-      refuse(`${gh.owner}/${gh.repo} is not a public repository — install the GitHub App for access to private ones`)
-    }
-    return {
-      kind: 'anonymous',
-      gitRepo: normalizeGitUrl(lookup === 'unreachable' ? gitRepo : lookup.fullName),
-      ...(lookup !== 'unreachable' ? { defaultBranch: lookup.defaultBranch } : {}),
-      access: 'read',
-      host: 'github'
-    }
-  }
-
-  const gitlabPath = deps.gitlab ? gitlabManagedProjectPath(gitRepo, deps.gitlab.api.baseUrl) : null
-  if (gitlabPath && deps.gitlab) {
-    const binding = await deps.repos.gitlabProjectBinding.byProjectPath(orgId, gitlabPath)
-    if (binding) {
-      // A binding mid-removal must refuse, never demote to an anonymous clone of
-      // the same path — the managed identity still exists until cleanup finishes.
-      if (binding.state === 'cleanup_pending') {
-        refuse(`${gitlabPath} is being removed from this organization — wait for cleanup to finish`)
-      }
-      // The persisted catalog row, not caller input and never a composed URL, is
-      // the authority for the clone URL (§24.1).
-      const catalogRow = await deps.repos.codeHostRepository.byExternalId(orgId, 'gitlab', binding.projectId)
-      if (!catalogRow?.cloneUrl) {
-        refuse('the GitLab project binding has no clone URL yet — repair the project first')
-      }
-      return {
-        kind: 'gitlab',
-        projectId: binding.projectId,
-        gitRepo: catalogRow.cloneUrl,
-        defaultBranch: binding.defaultBranch ?? 'main',
-        // A managed binding always mints, so an unstated tier is write.
-        access: requestedAccess ?? 'write'
-      }
-    }
-    if (requestedAccess === 'write') {
-      refuse('gitlab write access requires a managed project — add the project to the organization first')
-    }
-    const project = await gitlabPublicProject(gitlabPath, deps.gitlab.api)
-    if (!project) {
-      refuse(`${gitlabPath} is not a managed GitLab project in this organization — add the project first`)
-    }
-    // The provider's own clone URL, held to the same codec every stored address
-    // passes; a malformed answer falls back to the caller's normalized input.
-    let cloneUrl: string
-    try {
-      cloneUrl = normalizeGitCloneUrl(project.http_url_to_repo ?? gitRepo)
-    } catch (e) {
-      if (!(e instanceof GitCloneUrlError)) throw e
-      cloneUrl = normalizeGitUrl(gitRepo)
-    }
-    return {
-      kind: 'anonymous',
-      gitRepo: cloneUrl,
-      ...(typeof project.default_branch === 'string' ? { defaultBranch: project.default_branch } : {}),
-      access: 'read',
-      host: 'gitlab'
-    }
+  // Asked in the registry's own order, which is the order these arms have always
+  // run in: the first host that RECOGNIZES the address owns the outcome, refusals
+  // included — a host declines only when the address is not its.
+  const codeHosts = codeHostsOf(deps)
+  for (const provider of CODE_HOST_PROVIDERS) {
+    const derived = await codeHosts[provider].workspace.derive({
+      deps,
+      orgId,
+      ...(actorUserId !== undefined ? { actorUserId } : {}),
+      gitRepo,
+      ...(requestedAccess !== undefined ? { requestedAccess } : {})
+    })
+    if (derived) return derived
   }
 
   // Any other host (bare Git, an unmanaged GitLab instance, GHE, …): anonymous,
   // no preflight — the daemon's clone boundary reports failure, exactly as
   // creation behaves today. Its operator-owned origin policy still applies.
-  if (requestedAccess === 'write') refuse('write access requires managed credentials — this host is cloned anonymously')
+  if (requestedAccess === 'write') {
+    refuseWorkspaceCredential('write access requires managed credentials — this host is cloned anonymously')
+  }
   return { kind: 'anonymous', gitRepo: normalizeGitUrl(gitRepo), access: 'read', host: 'other' }
 }
 
@@ -210,9 +70,12 @@ export async function deriveWorkspaceCredential(
  * create and replace routes so their consumption of a derivation cannot drift.
  */
 export function workspaceFromDerived(
+  codeHosts: CodeHostProviderRegistry,
   derived: DerivedWorkspace,
   opts: { isolation: 'shared' | 'session'; gitBranch?: string; agentDir?: string }
 ): { workspace: Extract<AgentWorkspace, { mode: 'git' }>; workspaceRepoId?: bigint } {
+  // An anonymous outcome has no vouching host, so it writes neither field.
+  const write = derived.kind === 'anonymous' ? null : codeHosts[derived.kind].workspace.writeFromDerived(derived)
   return {
     workspace: {
       mode: 'git',
@@ -220,16 +83,8 @@ export function workspaceFromDerived(
       gitRepo: derived.gitRepo,
       gitBranch: opts.gitBranch ?? derived.defaultBranch ?? 'main',
       ...(opts.agentDir !== undefined ? { agentDir: opts.agentDir } : {}),
-      ...(derived.kind === 'github'
-        ? { credential: { provider: 'github', installationId: derived.installationId, access: derived.access } }
-        : derived.kind === 'gitlab'
-          ? { credential: { provider: 'gitlab', access: derived.access } }
-          : {})
+      ...(write ? { credential: write.credential } : {})
     },
-    ...(derived.kind === 'github'
-      ? { workspaceRepoId: derived.repoId }
-      : derived.kind === 'gitlab'
-        ? { workspaceRepoId: derived.projectId }
-        : {})
+    ...(write ? { workspaceRepoId: write.workspaceRepoId } : {})
   }
 }

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -35,6 +35,7 @@ import type {
 } from '../persistence/ports.js'
 import { AgentId } from '../domain/ids.js'
 import { gitlabManagedProjectPath } from '../domain/git-host.js'
+import { codeHostProviders } from '../codehost/registry.js'
 import { resolveAgentIconUrl, type IconUrlBases } from '../agents/agent-icon.js'
 import { resolveAgentSkillEntries, type InvalidSkillSourceProjection } from './skillSource.js'
 import {
@@ -271,6 +272,10 @@ export function agentRecordToSpec(
   // dual encoding to the legacy arms (git-workspace-model.md §8) happens at the
   // transmit sites through encodeSpecWorkspaceForPeer. Credential derivation and
   // the allowlist both stay CP-side.
+  const specCredential =
+    a.workspace.mode === 'git' && a.workspace.credential
+      ? codeHostProviders[a.workspace.credential.provider].workspace.toSpec(a.workspace.credential, a.workspaceRepoId)
+      : null
   const workspace: AgentSpec['workspace'] =
     a.workspace.mode === 'git'
       ? {
@@ -284,15 +289,8 @@ export function agentRecordToSpec(
               : normalizeGitCloneUrl(redactGitUrlSecrets(a.workspace.gitRepo)),
           branch: a.workspace.gitBranch ?? 'main',
           ...(a.workspace.agentDir !== undefined ? { agentDir: a.workspace.agentDir } : {}),
-          // installationId and access stay off the wire: minting re-resolves the live
-          // installation by owner, and the CP clamps minted tokens server-side.
-          ...(a.workspace.credential?.provider === 'github'
-            ? { credential: { provider: 'github' as const } }
-            : a.workspace.credential?.provider === 'gitlab'
-              ? // A gitlab-vouched workspace is frame-fatal on a pre-GitLab daemon;
-                // every projection path gates on daemonSupportsAgent before sending it.
-                { credential: { provider: 'gitlab' as const, projectId: (a.workspaceRepoId ?? 0n).toString() } }
-              : {}),
+          // The vouching host owns its own wire shape; absent ⇒ anonymous clone.
+          ...(specCredential ? { credential: specCredential } : {}),
           additionalRepos
         }
       : {

--- a/packages/control-plane/src/orchestrator/relayControl.ts
+++ b/packages/control-plane/src/orchestrator/relayControl.ts
@@ -24,7 +24,8 @@ import type {
   RcMemoryConnectionUnassign
 } from '@agentconnect.md/protocol'
 import { codeHostHookRuleOf, GITLAB_RERUN_V1_FEATURE, RcHookRerunResult } from '@agentconnect.md/protocol'
-import { advertises, requiredGitlabFeatures, requiredGitlabInstanceFeatures } from '../domain/daemon-features.js'
+import { advertises } from '../domain/daemon-features.js'
+import { codeHostProviders } from '../codehost/registry.js'
 
 /** What one Console rerun attempt achieved across the eligible relay pool. */
 export type RelayRerunOutcome =
@@ -60,7 +61,9 @@ export class RelayControlSender {
   hookAssign(rule: RcHookAssign): void {
     const host = codeHostHookRuleOf(rule)
     this.broadcast((ch) => {
-      if (host?.provider === 'gitlab' && !advertises(ch.features, requiredGitlabFeatures(host.rule.host))) return
+      if (!host) return ch.send('rc/hook-assign', rule)
+      const features = codeHostProviders[host.provider].features
+      if (!advertises(ch.features, features.required(features.ruleHost(host)))) return
       ch.send('rc/hook-assign', rule)
     })
   }
@@ -93,7 +96,11 @@ export class RelayControlSender {
    * eligible peer was ever asked.
    */
   async hookRerun(rerun: RcHookRerun): Promise<RelayRerunOutcome> {
-    const required = [GITLAB_RERUN_V1_FEATURE, ...requiredGitlabInstanceFeatures(rerun.gitlab.host)]
+    // The rerun frame is GitLab's own surface (§16.1), so its instance bit is that entry's.
+    const required = [
+      GITLAB_RERUN_V1_FEATURE,
+      ...codeHostProviders.gitlab.features.requiredForInstance(rerun.gitlab.host)
+    ]
     for (const ch of this.relays.all()) {
       if (!advertises(ch.features, required) || typeof ch.request !== 'function') continue
       let result: RcHookRerunResult

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -3,7 +3,12 @@
  */
 import { Prisma } from '../../generated/prisma/client.js'
 import type { Agent, PrismaClient, User } from '../../generated/prisma/client.js'
-import { AgentMemoryBinding, redactGitUrlSecrets } from '@agentconnect.md/protocol'
+import {
+  AgentMemoryBinding,
+  isCodeHostProvider,
+  redactGitUrlSecrets,
+  type CodeHostProvider
+} from '@agentconnect.md/protocol'
 import type { PrismaLike } from '../prisma.js'
 import type {
   AgentCallPolicy,
@@ -215,18 +220,22 @@ async function settlePresetPlacement(tx: Prisma.TransactionClient, agentId: stri
   })
 }
 
+// Each host also needs the column holding the identity that makes its credential
+// mintable — the github provenance-hint installation, the gitlab rename-stable
+// project id. A row missing it reads as anonymous rather than minting against nothing.
+const CREDENTIAL_OF: Record<CodeHostProvider, (a: Agent) => AgentWorkspaceCredential | undefined> = {
+  github: (a) =>
+    a.installationId !== null
+      ? { provider: 'github', installationId: a.installationId, access: a.gitAccess }
+      : undefined,
+  gitlab: (a) => (a.workspaceRepoId !== null ? { provider: 'gitlab', access: a.gitAccess } : undefined)
+}
+
 function credentialOf(a: Agent): AgentWorkspaceCredential | undefined {
-  // Provider is the explicit column (git-workspace-model.md §4); each arm also
-  // needs the identity that makes its credential mintable — the github
-  // provenance-hint installation, the gitlab rename-stable project id. A legacy
-  // row missing either reads as anonymous rather than minting against nothing.
-  if (a.gitCredentialProvider === 'github' && a.installationId !== null) {
-    return { provider: 'github', installationId: a.installationId, access: a.gitAccess }
-  }
-  if (a.gitCredentialProvider === 'gitlab' && a.workspaceRepoId !== null) {
-    return { provider: 'gitlab', access: a.gitAccess }
-  }
-  return undefined
+  // Provider is the explicit column (git-workspace-model.md §4); a value no host
+  // claims reads as anonymous, never as another host's credential.
+  const provider = a.gitCredentialProvider
+  return provider !== null && isCodeHostProvider(provider) ? CREDENTIAL_OF[provider](a) : undefined
 }
 
 function workspaceOf(a: Agent): AgentWorkspace {

--- a/packages/control-plane/src/persistence/repositories/deployment-config.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/deployment-config.repo.ts
@@ -6,6 +6,7 @@
  * Replacement locks one deployment-global advisory key and commits the typed
  * JSON document, monotonic revision, and secret patch in one transaction.
  */
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { SecretCipher } from '../../secrets/cipher.js'
 import { withTx } from '../prisma.js'
@@ -75,19 +76,32 @@ function toRuntime(row: RuntimeRow): StoredDeploymentConfigRuntime {
   }
 }
 
-/** Does any GitLab state still bind this deployment to its instance (§24.1)? A
- *  `disconnected` connection is credential-free history and does not; a binding
- *  (`cleanup_pending` included), an account, a hook, or a claim carrying a
- *  tombstone or an unfinished cleanup obligation does. */
-async function gitlabStateExists(tx: Prisma.TransactionClient): Promise<boolean> {
-  const [connections, bindings, accounts, hooks, claims] = await Promise.all([
-    tx.gitlabConnection.count({ where: { NOT: { state: 'disconnected' } } }),
-    tx.gitlabProjectBinding.count(),
-    tx.gitlabAgentAccount.count(),
-    tx.hookDef.count({ where: { kind: 'gitlab' } }),
-    tx.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })
-  ])
-  return connections + bindings + accounts + hooks + claims > 0
+/**
+ * Does any of one host's state still bind this deployment to its instance (§24.1)?
+ * Keyed by provider here rather than in the code-host provider registry: the count
+ * is a statement about Prisma models, which are persistence's knowledge.
+ */
+const CODE_HOST_STATE_EXISTS: Record<CodeHostProvider, (tx: Prisma.TransactionClient) => Promise<boolean>> = {
+  // A GitHub App addresses github.com only: the deployment has no instance axis
+  // for this host, so no state of its can pin one.
+  github: async () => false,
+  // A `disconnected` connection is credential-free history and does not bind; a
+  // binding (`cleanup_pending` included), an account, a hook, or a claim carrying
+  // a tombstone or an unfinished cleanup obligation does.
+  gitlab: async (tx) => {
+    const [connections, bindings, accounts, hooks, claims] = await Promise.all([
+      tx.gitlabConnection.count({ where: { NOT: { state: 'disconnected' } } }),
+      tx.gitlabProjectBinding.count(),
+      tx.gitlabAgentAccount.count(),
+      tx.hookDef.count({ where: { kind: 'gitlab' } }),
+      tx.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })
+    ])
+    return connections + bindings + accounts + hooks + claims > 0
+  }
+}
+
+function codeHostStateExists(tx: Prisma.TransactionClient, provider: CodeHostProvider): Promise<boolean> {
+  return CODE_HOST_STATE_EXISTS[provider](tx)
 }
 
 export class PgDeploymentConfigRepository implements DeploymentConfigPersistence {
@@ -142,7 +156,7 @@ export class PgDeploymentConfigRepository implements DeploymentConfigPersistence
       // which for the first persisted document is the environment fallback.
       const previousBaseUrl = previousValues ? effectiveGitlabBaseUrl(previousValues) : this.envGitlabBaseUrl
       const nextBaseUrl = effectiveGitlabBaseUrl(input.values)
-      if (previousBaseUrl !== nextBaseUrl && (await gitlabStateExists(tx))) {
+      if (previousBaseUrl !== nextBaseUrl && (await codeHostStateExists(tx, 'gitlab'))) {
         throw new DeploymentConfigGitlabBaseUrlLockedError(previousBaseUrl, nextBaseUrl)
       }
       const refreshKeys = previousValues ? deploymentSecretsRequiringRefresh(previousValues, input.values) : []

--- a/packages/control-plane/src/ws/handlers/gitcred.ts
+++ b/packages/control-plane/src/ws/handlers/gitcred.ts
@@ -17,7 +17,7 @@
  * The grant payload carries the token MATERIAL — never log it.
  */
 import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
-import { isFrame } from '@agentconnect.md/protocol'
+import { isCodeHostProvider, isFrame } from '@agentconnect.md/protocol'
 import { AgentId, HookId } from '../../domain/ids.js'
 import { GitCredDeniedError } from '../../github/service.js'
 import { frameOrgId } from './frame-org.js'
@@ -60,8 +60,8 @@ export const handleGitCredRequest: Handler = async (frame, conn, deps) => {
     requestedAccess
   } = frame.payload
 
-  // v2 provider fail-per-value (§17.1): only gitlab has a non-GitHub arm here.
-  if (provider !== undefined && provider !== 'github' && provider !== 'gitlab') {
+  // v2 provider fail-per-value (§17.1): an open wire string, checked against the host set.
+  if (provider !== undefined && !isCodeHostProvider(provider)) {
     conn.sendError(frame.id, 'SCOPE_DENIED', `unknown git credential provider ${provider}`, false)
     return
   }


### PR DESCRIPTION
Behavior-neutral refactor: the Control Plane's two-way `kind === 'gitlab' ? … : …`
branches become lookups in one code-host provider registry, so a third code host
is a registry entry rather than a third arm in every core file. This is step 1 of
the seam extraction the Gitea design asks for (§13, items 5 and 8); no behavior,
no HTTP response, and no OpenAPI schema, tag, summary or operation id changes.

## The contract

`packages/control-plane/src/codehost/provider.ts` declares `CodeHostProviderModule`
with the members both hosts implement **today** — the same "extracted at the moment
of the second implementer" rule the daemon's turn-final surface and the relay's
ingress contract followed:

| Member | Replaced |
| --- | --- |
| `displayName`, `repositorySubject` | the subject noun and host name inside refusals |
| `hooks.effects(body)` | the create path's three per-kind effect-axis ternaries |
| `hooks.convergeManagedRepository(…)` | the `kind === 'gitlab'`-guarded post-write convergence in the hook and grant routes (a no-op for GitHub, whose App webhook is deployment-wide) |
| `upgradeRepoAuthorization(ctx)` | `PATCH /agents/:agentId/repos/:repoAuthId` dispatching on the grant row's provider |
| `workspace.derive(…)` | the two inline arms of `deriveWorkspaceCredential` |
| `workspace.writeFromDerived/toDto/toSpec/legacySpecArm` | the persisted, read-DTO, wire, and legacy-wire projections of a credential (the `gitCredential: 'github-app'` label included) |
| `features.required/requiredForInstance/deploymentHost/specHost/ruleHost` | the hardcoded host feature pair and instance field in the projection gate, the two workspace daemon gates, and the rule-frame gates |

Entries live in `src/github/provider.ts` and `src/gitlab/provider.ts`. An entry is a
stateless strategy object — it captures nothing and takes its deployment's services
as call-time arguments — so the registry is a plain `Record<CodeHostProvider, …>`:
every mapping over it stops type-checking until a new host is given an entry, which
is what makes adding one a compile-time event. `container.ts` publishes it on the
route bundle; a route resolves it with `codeHostsOf(deps)`, and the pure projections
no container reaches (the DTO and wire arms, the transmit-time feature predicates)
read the same record.

## Deliberately outside the registry

- **Bot identity and claim lifecycle.** A GitHub App installation claim versus a
  project binding with per-agent service accounts. The `provisionAgentAccount`
  brackets around the agent, hook and grant writes have no GitHub counterpart at
  all, so there is nothing to share a shape with.
- **Credential minting and webhook-secret distribution.** App JWTs versus OAuth;
  one deployment-wide App secret versus a per-binding signing token in the
  compiled rule.
- **Host-only product surfaces.** The workflow-approval start path, the session
  merge-request panel, the console rerun, and each host's effect validation
  (installation permissions versus binding state), which run inside arms the
  request body has already narrowed.
- **The per-host instance axis field** (`gitlabHost`, the §24.1 write fence, the
  base-URL lock's own comparison): both are one-axis values with a default, and a
  table of hosts would be guessing at a multi-instance design that does not exist.
  A provider reads its own field through `features.specHost` / `features.ruleHost`.
- **The `POST /agents/:agentId/repos` create arm.** The two hosts name a repository
  differently in the request body, so a member over that union would hand each arm
  a body it must re-narrow. The third host's body shape is the fact that decides
  that member's signature, and it does not exist yet.
- **The base-URL lock's state count**, which stays in
  `persistence/repositories/deployment-config.repo.ts` keyed by provider: the count
  is a statement about Prisma models, which a provider module has no business
  knowing. Same for the persisted-credential read in `agent.repo.ts`.
- `note-projection.service.ts`'s provider constant and `review-lease.service.ts`,
  which the design leaves alone, and the frame-level reads a previous step already
  moved onto the protocol's decode-time view.

## Behavior notes

- The effect axes resolve to exactly the values each body's own zod defaults gave;
  the two ternaries that existed only because a closure lost the body's narrowing
  are gone, not reinterpreted.
- Every refusal string is unchanged. The two workspace daemon gates now name the
  vouching host instead of hardcoding one, which reproduces today's text; a host
  that requires no feature skips the daemon lookup it never made, so no path gains
  a read.
- The feature lists come back in the same order, including the two deliberately
  separate ones — the dispatch-target gate still requires only the instance bit.
- The convergence runs for exactly the writes it ran for (GitHub's entry is a
  no-op), and its warning text is now derived from the provider, so it is
  byte-identical for the host that has one.

## Tests

No test expectation changed. Two test-side edits: the derivation suite's fake deps
gains the registry, and the feature-list assertions call the registry entry that
now owns those two functions — same expected values, verbatim.

- `pnpm typecheck` — clean (every package).
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 196 files, 2318 tests passed.
- `pnpm --filter @agentconnect.md/control-plane test:int` — 126 files, 2009 tests passed.
- `pnpm lint` — 0 errors (the 8 remaining warnings are pre-existing elsewhere).
- `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
