### PR TITLE
fix(web): value-import the MCP Apps constants from a leaf protocol subpath

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -29,6 +29,12 @@
       "import": "./dist/slack-app-manifest.js",
       "default": "./dist/slack-app-manifest.js"
     },
+    "./mcp-app": {
+      "development": "./src/mcp-app.ts",
+      "types": "./dist/mcp-app.d.ts",
+      "import": "./dist/mcp-app.js",
+      "default": "./dist/mcp-app.js"
+    },
     "./package.json": "./package.json",
     "./runtime-command": {
       "development": "./src/frames/runtime-command.ts",

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod'
+import { MCP_APP_CONTEXT_MAX_CHARS } from '../mcp-app.js'
+
+// The MCP Apps constants live in the `./mcp-app` leaf so the console can value-import them; the barrel still re-exports them.
+export * from '../mcp-app.js'
 
 // webchat's content plane is the RELAY, not the daemon↔CP control WS:
 // a browser dials the relay pool with a CP-minted token and the relay bridges the
@@ -332,25 +336,6 @@ export type McpAppCard = z.infer<typeof McpAppCard>
  *  session that no longer exists (§8). */
 export const McpAppOutcome = z.enum(['closed', 'superseded', 'expired'])
 export type McpAppOutcome = z.infer<typeof McpAppOutcome>
-
-/**
- * The MCP Apps extension version this host implements, sent as `protocolVersion` in the
- * `ui/initialize` result and as the host's own version beside it.
- *
- * Stated rather than derived: the official SDK's `App.connect()` validates the initialize result
- * and rejects one without it, so a view built on the SDK never finishes initializing if this is
- * missing or wrong. SEP-1865 Final, 2026-01-26.
- */
-export const MCP_APPS_PROTOCOL_VERSION = '2026-01-26'
-
-/** The most text one `ui/message` may carry into the conversation, matching the wire field's own
- *  bound so a decoded content-block list is clamped before it is refused. */
-export const MCP_APP_MESSAGE_MAX_CHARS = 4000
-
-/** The most model context one app may hold (`ui/update-model-context`). An app's context is a
- *  note for the next turn, not a store: the session carries it, and the reader who opened the
- *  frame is the one it speaks for. */
-export const MCP_APP_CONTEXT_MAX_CHARS = 4000
 
 /**
  * What a view may ASK THE DAEMON for — the four host methods of SEP-1865 that cannot be served

--- a/packages/protocol/src/mcp-app.ts
+++ b/packages/protocol/src/mcp-app.ts
@@ -1,0 +1,10 @@
+// ⚠️ NO RELATIVE IMPORTS — a bundler compiles this from source; web's protocol-imports.leaf.test.ts enforces it.
+
+// Sent as `protocolVersion` in the `ui/initialize` result; the official SDK's `App.connect()` rejects a result without it (SEP-1865 Final).
+export const MCP_APPS_PROTOCOL_VERSION = '2026-01-26'
+
+// The most text one `ui/message` may carry into the conversation; matches the wire field's bound so a decoded list is clamped before it is refused.
+export const MCP_APP_MESSAGE_MAX_CHARS = 4000
+
+// The most model context one app may hold via `ui/update-model-context`; a note for the next turn carried on the session, not a store.
+export const MCP_APP_CONTEXT_MAX_CHARS = 4000

--- a/packages/web/src/components/console/McpAppCard.tsx
+++ b/packages/web/src/components/console/McpAppCard.tsx
@@ -15,12 +15,12 @@
  * against its own record of the card rather than against anything the frame said.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { McpAppRpc } from '@agentconnect.md/protocol'
 import {
   MCP_APPS_PROTOCOL_VERSION,
   MCP_APP_CONTEXT_MAX_CHARS,
-  MCP_APP_MESSAGE_MAX_CHARS,
-  type McpAppRpc
-} from '@agentconnect.md/protocol'
+  MCP_APP_MESSAGE_MAX_CHARS
+} from '@agentconnect.md/protocol/mcp-app'
 import { Icon } from '@/components/ui'
 import type { SessionStep } from '@/lib/data'
 import {


### PR DESCRIPTION
## Summary

`src/protocol-imports.leaf.test.ts` in `packages/web` has been red on `main` since #2021: `McpAppCard.tsx` value-imports `MCP_APPS_PROTOCOL_VERSION`, `MCP_APP_CONTEXT_MAX_CHARS` and `MCP_APP_MESSAGE_MAX_CHARS` from the `@agentconnect.md/protocol` barrel. Turbopack does not implement TypeScript's `.js` -> `.ts` substitution, so a barrel value-import 500s every console route at runtime while `typecheck` and `next build` stay green. The guard exists to catch exactly this.

## Change

- Move the three constants into a new relative-import-free module, `packages/protocol/src/mcp-app.ts`, carrying the same "NO RELATIVE IMPORTS" note as the other leaves.
- Expose it as the `./mcp-app` subpath in `packages/protocol/package.json#exports` with a `development` condition, matching the existing `./code-host` entry.
- `frames/webchat.ts` imports the bound it needs from the leaf and re-exports the module, so the barrel's surface is unchanged for the daemon and every other consumer.
- `McpAppCard.tsx` value-imports from `@agentconnect.md/protocol/mcp-app` and takes `McpAppRpc` as a type-only import.

## Verification

- `pnpm --filter @agentconnect.md/web test src/protocol-imports.leaf.test.ts` passes.
- `pnpm typecheck` is green across all packages.
- `pnpm --filter @agentconnect.md/web test` passes (223 files, 2567 tests).
- `pnpm --filter @agentconnect.md/protocol test` passes (534 tests).
- ESLint is clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
