### PR TITLE
ci(web): run the console unit tests in the Unit Test job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,6 +177,7 @@ jobs:
             'daemon=@agentconnect.md/daemon' \
             'cli=@agentconnect.md/cli' \
             'setup=@agentconnect.md/setup' \
+            'web=@agentconnect.md/web' \
             'k8s-client=@agentconnect.md/k8s-client'
       - name: Publish unit test summary
         if: ${{ !cancelled() && !inputs.defer_summaries }}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint .",
     "start": "next start",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vitest/config'
+import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js'
 
 export default defineConfig({
   oxc: { jsx: { runtime: 'automatic' } },
@@ -9,6 +10,7 @@ export default defineConfig({
     }
   },
   test: {
-    environment: 'node'
+    environment: 'node',
+    reporters: githubActionsReporters('web.md')
   }
 })


### PR DESCRIPTION
## Summary

The Unit Test job runs `pnpm test:unit`, which recurses into each package's `test:unit` script. `packages/web` only defined `test`, so pnpm skipped it and none of the console's 223 test files have ever run in CI. The job logs for recent PRs list twelve packages and no `web`. That is how the protocol-imports leaf guard could sit red on `main` behind a green Unit Test check until #2047.

## Change

- Add `test:unit` to `packages/web/package.json`, the same `vitest run` the other packages use.
- Wire `githubActionsReporters('web.md')` into the web vitest config so results land in the job summary like every other package.
- List `web` in the Unit Test summary merge step.

## Verification

- `GITHUB_ACTIONS=true VITEST_JOB_SUMMARY_DIR=… pnpm --filter @agentconnect.md/web test:unit` runs the suite and writes `web.md` (223 files, 2567 tests, all passing on top of #2047).
- Locally the web suite takes about 16 seconds, well under the daemon and control-plane suites already in the job.
- `node --test scripts/*.test.mjs` passes; Prettier is clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
