### PR TITLE
docs: correct when the Windows unit job runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,9 +185,9 @@ It requires Docker and runs files with four workers by default; set
 ### Windows
 
 The daemon and the CLI are supported on Windows, and CI's `Unit Test (Windows)` job runs both
-packages' unit suites on `windows-latest` — on PRs whose diff reaches those two packages or their
-workspace dependency closure, and never on the release path, which skips it as it skips the sandbox
-suite. A test case that cannot work there goes on
+packages' unit suites on `windows-latest` — on every PR except one whose diff stays entirely inside
+the packages, chart and docs that closure cannot reach, and on the release path too, which gates
+publication on the same legs review ran. A test case that cannot work there goes on
 `it.skipIf(process.platform === 'win32')`; only when _every_ case in a file is POSIX-only does the
 file join `WINDOWS_EXCLUDED` in that package's `vitest.config.ts`, which is applied on Windows
 alone so `vitest run` is green for a Windows contributor too.


### PR DESCRIPTION
## Summary

The Windows paragraph in `CLAUDE.md` says the `Unit Test (Windows)` job runs "never on the release path, which skips it as it skips the sandbox suite". Both halves are wrong.

`release.yaml` calls `test.yaml` whole as its quality gate, so every job in it runs on a release, Windows and Sandbox (Linux) included. The most recent Release run on `main` lists `Test / Unit Test (Windows) (1/2)`, `(2/2)` and `Test / Sandbox (Linux)`, all successful. The job's own comment in the workflow already records the intent: a leg the release path drops is a leg whose failure reaches main unwatched.

## Change

- Say that the job runs on the release path, and why.
- State the PR scope filter the way the workflow implements it. It is an exclusion list, not an inclusion one: only a diff that stays entirely inside the packages, chart and docs the daemon/CLI closure cannot reach skips the job. A root config, a new script or a new shared package is in scope without anyone remembering to list it, which the old wording understated.

Documentation only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
