### PR TITLE
feat(relay): verify and route Gitea webhook deliveries

### DIFF
--- a/charts/agentconnect/templates/httproute.yaml
+++ b/charts/agentconnect/templates/httproute.yaml
@@ -181,6 +181,7 @@ the relay host (relay.host, else apiHost, else the website host):
   /webhooks/in                  → relay pool (generic inbound webhook HTTP POST)
   /webhooks/github              → relay pool (GitHub App webhook)
   /webhooks/gitlab              → relay pool (GitLab project webhook, Standard Webhooks)
+  /webhooks/gitea               → relay pool (Gitea repository webhook, hex HMAC-SHA256)
   /slack/events                 → relay pool (Slack Events API, http transport)
   /slack/interactions           → relay pool (Slack interactivity + block_suggestion)
   /feishu/events                → relay pool (Feishu/Lark HTTP event callback)
@@ -244,6 +245,9 @@ spec:
         - path:
             type: PathPrefix
             value: /webhooks/gitlab
+        - path:
+            type: PathPrefix
+            value: /webhooks/gitea
         - path:
             type: PathPrefix
             value: /slack/events

--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -293,22 +293,35 @@ display, the connection's bot user id as the veto set, the signing key inline.
 
 ## 8. Event Mapping and Routing
 
-| Product family                     | Gitea source                                                                                                                          |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `issues:opened` / `:edited` / …    | `issues` with the matching `action`                                                                                                   |
-| issue conversation comment         | `issue_comment`, `is_pull: false`, `action: created`                                                                                  |
-| pull-request conversation comment  | `pull_request_comment`, `is_pull: true`, `action: created`                                                                            |
-| pull-request diff comment          | `pull_request_review_comment`, `action: reviewed` — one delivery per review submission, carrying only the summary in `review.content` |
-| `merge_request:opened`             | `pull_request` `opened`                                                                                                               |
-| `merge_request:synchronize`        | `pull_request_sync` `synchronized`                                                                                                    |
-| `merge_request:reviewer_requested` | `pull_request_review_request` `review_requested` naming the bot                                                                       |
-| `merge_request:reopened`           | `pull_request` `reopened`                                                                                                             |
-| maintenance cleanup family         | `pull_request` `closed` with `merged: true`; `issues` `closed`                                                                        |
-| `push:*`                           | `push`                                                                                                                                |
+| Product family                    | Gitea source                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `issues:opened` / `:edited` / …   | `issues` with the matching `action`                                                                                                   |
+| issue conversation comment        | `issue_comment`, `is_pull: false`, `action: created`                                                                                  |
+| pull-request conversation comment | `pull_request_comment`, `is_pull: true`, `action: created`                                                                            |
+| pull-request diff comment         | `pull_request_review_comment`, `action: reviewed` — one delivery per review submission, carrying only the summary in `review.content` |
+| `merge_request:opened`            | `pull_request` `opened`                                                                                                               |
+| `merge_request:synchronize`       | `pull_request_sync` `synchronized`                                                                                                    |
+| `merge_request:review_requested`  | `pull_request_review_request` `review_requested` naming the bot                                                                       |
+| `merge_request:reopened`          | `pull_request` `reopened`                                                                                                             |
+| maintenance cleanup family        | `pull_request` `closed` with `merged: true`; `issues` `closed`                                                                        |
+| `push:*`                          | `push`                                                                                                                                |
 
 Edited-comment noise, draft toggles, label churn, and assignment events are
-vetoed exactly as in §12. `pull_request.head.sha` and `base.sha` are present
-on every pull-request payload and become the head fence.
+vetoed exactly as in §12; Gitea delivers label, assignment, and milestone churn
+under its own `issue_label`/`issue_assign`/`issue_milestone` event types, which
+the table above simply does not name, and a draft toggle rides `pull_request`
+`edited`, which is inert for the same reason. `pull_request.head.sha` and
+`base.sha` are present on every pull-request payload and become the head fence.
+
+The normalized event names are GitLab's, so a stored pattern stays
+provider-neutral: `issues:opened`, `merge_request:opened`,
+`merge_request:synchronize`, `merge_request:review_requested`, `note:created`,
+`push`, and the maintenance pair `issues:closed` / `merge_request:merged`. A
+review submission is the one delivery GitLab has no counterpart for, and its
+verdict is the only thing the relay can carry into the correlation below, so it
+normalizes to `review:commented`, `review:approved`, or
+`review:changes_requested` — one per review event type, gated by the
+pull-request comment family rather than by an event pattern.
 
 A review delivery is lossy in a way the diff-comment trigger has to absorb
 (§16): it carries the summary body and nothing about the inline comments — no

--- a/packages/relay/src/hooks/gitea/events.ts
+++ b/packages/relay/src/hooks/gitea/events.ts
@@ -24,12 +24,13 @@ export const GITEA_EVENT_PULL_REQUEST_SYNC = 'pull_request_sync'
 export const GITEA_EVENT_PULL_REQUEST_REVIEW_REQUEST = 'pull_request_review_request'
 export const GITEA_EVENT_PUSH = 'push'
 
-/** The three review event types (§16): one delivery per review submission, verdict in the type. */
-const GITEA_REVIEW_EVENT_ACTIONS: Readonly<Record<string, string>> = {
-  pull_request_review_comment: 'review:commented',
-  pull_request_review_approved: 'review:approved',
-  pull_request_review_rejected: 'review:changes_requested'
-}
+/** The three review event types (§16): one delivery per review submission, verdict in the type. A
+ *  Map, not an object: the key is a request header, which must never reach Object.prototype. */
+const GITEA_REVIEW_EVENT_ACTIONS = new Map<string, string>([
+  ['pull_request_review_comment', 'review:commented'],
+  ['pull_request_review_approved', 'review:approved'],
+  ['pull_request_review_rejected', 'review:changes_requested']
+])
 
 interface GiteaUserRef {
   id?: number
@@ -228,7 +229,7 @@ export function normalizeGiteaEvent(eventType: string, payload: GiteaPayload): G
         : {})
     }
   }
-  const reviewAction = GITEA_REVIEW_EVENT_ACTIONS[eventType]
+  const reviewAction = GITEA_REVIEW_EVENT_ACTIONS.get(eventType)
   if (reviewAction !== undefined) {
     const pull = payload.pull_request
     const index = positiveIndex(pull?.number)

--- a/packages/relay/src/hooks/gitea/events.ts
+++ b/packages/relay/src/hooks/gitea/events.ts
@@ -1,0 +1,429 @@
+/**
+ * Gitea delivery normalization (gitea-integration.md §8) — the pure half of the
+ * ingress: the payload slice the matcher reads, the event-type table, the §12
+ * vetoes, the loop-prevention exception, the session key, and the trusted
+ * metadata and model-visible envelope a verified delivery produces.
+ *
+ * Every decision keys on `X-Gitea-Event-Type`, never `X-Gitea-Event`: the latter
+ * collapses `pull_request_sync` and `pull_request_review_request` into
+ * `pull_request`, and names an inline review comment `pull_request_comment`,
+ * which is also the exact type of an ordinary pull-request comment (§7, §16).
+ *
+ * Nothing here is trusted beyond filter input: authorization is the signature
+ * plus the Control Plane's live membership resolution.
+ */
+import type { GiteaHookMetadata, GiteaHookTarget, HookContext, RcHookAssign } from '@agentconnect.md/protocol'
+import { mentionsGithubHandle, truncateUtf8, GITHUB_BODY_EXCERPT_MAX } from '../github-ingress.js'
+
+/** The Gitea webhook event types this ingress maps; every other type is silently unmapped. */
+export const GITEA_EVENT_ISSUES = 'issues'
+export const GITEA_EVENT_ISSUE_COMMENT = 'issue_comment'
+export const GITEA_EVENT_PULL_REQUEST = 'pull_request'
+export const GITEA_EVENT_PULL_REQUEST_COMMENT = 'pull_request_comment'
+export const GITEA_EVENT_PULL_REQUEST_SYNC = 'pull_request_sync'
+export const GITEA_EVENT_PULL_REQUEST_REVIEW_REQUEST = 'pull_request_review_request'
+export const GITEA_EVENT_PUSH = 'push'
+
+/** The three review event types (§16): one delivery per review submission, verdict in the type. */
+const GITEA_REVIEW_EVENT_ACTIONS: Readonly<Record<string, string>> = {
+  pull_request_review_comment: 'review:commented',
+  pull_request_review_approved: 'review:approved',
+  pull_request_review_rejected: 'review:changes_requested'
+}
+
+interface GiteaUserRef {
+  id?: number
+  login?: string
+  username?: string
+  avatar_url?: string
+}
+
+interface GiteaBranchRef {
+  ref?: string
+  sha?: string
+  repo_id?: number
+}
+
+interface GiteaIssueRef {
+  id?: number
+  number?: number
+  title?: string
+  body?: string | null
+  html_url?: string
+  user?: GiteaUserRef
+  labels?: Array<{ name?: string }>
+}
+
+interface GiteaPullRequestRef extends GiteaIssueRef {
+  head?: GiteaBranchRef
+  base?: GiteaBranchRef
+  draft?: boolean
+  merged?: boolean
+}
+
+/** The slice of a Gitea webhook payload the matcher and envelope read. */
+export interface GiteaPayload {
+  action?: string
+  /** Comment deliveries only: whether the commented subject is a pull request. */
+  is_pull?: boolean
+  repository?: { id?: number; full_name?: string }
+  sender?: GiteaUserRef
+  issue?: GiteaIssueRef
+  pull_request?: GiteaPullRequestRef
+  comment?: { id?: number; body?: string; html_url?: string }
+  /** Review submissions carry the summary and nothing about the inline comments (§16). */
+  review?: { type?: string; content?: string | null }
+  /** Meaningful ONLY on `pull_request_review_request`; on a review delivery it names the review's author. */
+  requested_reviewer?: GiteaUserRef
+  // push
+  ref?: string
+  commits?: Array<{ message?: string | null }>
+}
+
+/** One delivery's normalized facts (extracted once; pure filter input). */
+export interface GiteaMatchCtx {
+  /** Normalized `family:action` (or bare `push`) — the stored-pattern universe. */
+  eventAction: string
+  family: 'issues' | 'merge_request' | 'push' | 'note' | 'review'
+  /** Comment and review deliveries: the subject family the text hangs off. */
+  commentSubjectFamily?: 'issues' | 'pull_request'
+  actorId?: string
+  actorLogin?: string
+  subjectAuthorId?: string
+  subjectAuthorLogin?: string
+  labels: string[]
+  mentionText: string | undefined
+  /** Pull-request facts (loop prevention + the §8 external gate + metadata). */
+  sourceRepoId?: string
+  targetRepoId?: string
+  /** §8 explicit start path: set only on `pull_request_review_request`, where the field means what its name says. */
+  requestedReviewerId?: string
+  /** Positive issue/pull index — one index space, so the subject kind discriminates. */
+  index?: number
+  ref?: string
+}
+
+/** Gitea's issue and pull-request event patterns share GitLab's product families, so the
+ *  comment-family value (`pull_request`) needs mapping onto the event family it subscribes to. */
+function eventFamilyOfCommentSubject(subject: 'issues' | 'pull_request'): 'issues' | 'merge_request' {
+  return subject === 'issues' ? 'issues' : 'merge_request'
+}
+
+function userId(user: GiteaUserRef | undefined): string | undefined {
+  return user?.id !== undefined ? String(user.id) : undefined
+}
+
+function labelNames(subject: GiteaIssueRef | undefined): string[] {
+  return (subject?.labels ?? []).map((label) => label.name ?? '').filter(Boolean)
+}
+
+function positiveIndex(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isSafeInteger(value) && value > 0 ? value : undefined
+}
+
+/** Lifecycle deliveries that close a Gitea thread's daemon-owned workspace (§8):
+ *  merged pull requests and closed issues; an unmerged closed pull request may reopen. */
+export interface GiteaCleanupDelivery {
+  event: string
+  kind: 'issue' | 'pull'
+  index: number
+}
+
+export function giteaThreadWorktreeCleanup(eventType: string, payload: GiteaPayload): GiteaCleanupDelivery | undefined {
+  if (payload.action !== 'closed') return undefined
+  if (eventType === GITEA_EVENT_ISSUES) {
+    const index = positiveIndex(payload.issue?.number)
+    return index === undefined ? undefined : { event: 'issues:closed', kind: 'issue', index }
+  }
+  if (eventType === GITEA_EVENT_PULL_REQUEST && payload.pull_request?.merged === true) {
+    const index = positiveIndex(payload.pull_request.number)
+    return index === undefined ? undefined : { event: 'merge_request:merged', kind: 'pull', index }
+  }
+  return undefined
+}
+
+function pullRequestCtxBase(payload: GiteaPayload, pull: GiteaPullRequestRef, index: number) {
+  return {
+    family: 'merge_request' as const,
+    ...(userId(payload.sender) !== undefined ? { actorId: userId(payload.sender) } : {}),
+    ...(payload.sender?.login ? { actorLogin: payload.sender.login } : {}),
+    ...(userId(pull.user) !== undefined ? { subjectAuthorId: userId(pull.user) } : {}),
+    ...(pull.user?.login ? { subjectAuthorLogin: pull.user.login } : {}),
+    labels: labelNames(pull),
+    mentionText: pull.body ?? undefined,
+    ...(pull.head?.repo_id !== undefined ? { sourceRepoId: String(pull.head.repo_id) } : {}),
+    ...(payload.repository?.id !== undefined ? { targetRepoId: String(payload.repository.id) } : {}),
+    index
+  }
+}
+
+/**
+ * Normalize one verified delivery to the stored-pattern event universe, or
+ * undefined when the delivery is lifecycle noise (§8 vetoes) or an event type
+ * this ingress does not map. Exported for unit tests.
+ *
+ * Label, assignment, and milestone churn arrive under their own event types
+ * (`issue_label`, `issue_assign`, `issue_milestone`, and the pull-request
+ * equivalents), which the table below never names — the Gitea form of GitLab's
+ * label/assignment veto. Draft toggles and target-branch edits ride
+ * `pull_request` `edited`, which is inert here for the same reason.
+ */
+export function normalizeGiteaEvent(eventType: string, payload: GiteaPayload): GiteaMatchCtx | undefined {
+  if (eventType === GITEA_EVENT_PUSH) {
+    if (!payload.ref) return undefined
+    return {
+      eventAction: 'push',
+      family: 'push',
+      ...(userId(payload.sender) !== undefined ? { actorId: userId(payload.sender) } : {}),
+      ...(payload.sender?.login ? { actorLogin: payload.sender.login } : {}),
+      labels: [],
+      mentionText:
+        (payload.commits ?? [])
+          .map((commit) => commit.message)
+          .filter(Boolean)
+          .join('\n') || undefined,
+      ref: payload.ref
+    }
+  }
+  if (eventType === GITEA_EVENT_ISSUES) {
+    const issue = payload.issue
+    const index = positiveIndex(issue?.number)
+    if (!issue || index === undefined) return undefined
+    // `closed` fires separately as maintenance cleanup; `edited` and `reopened` are lifecycle noise.
+    if (payload.action !== 'opened') return undefined
+    return {
+      eventAction: 'issues:opened',
+      family: 'issues',
+      ...(userId(payload.sender) !== undefined ? { actorId: userId(payload.sender) } : {}),
+      ...(payload.sender?.login ? { actorLogin: payload.sender.login } : {}),
+      ...(userId(issue.user) !== undefined ? { subjectAuthorId: userId(issue.user) } : {}),
+      ...(issue.user?.login ? { subjectAuthorLogin: issue.user.login } : {}),
+      labels: labelNames(issue),
+      mentionText: issue.body ?? undefined,
+      index
+    }
+  }
+  if (eventType === GITEA_EVENT_PULL_REQUEST || eventType === GITEA_EVENT_PULL_REQUEST_SYNC) {
+    const pull = payload.pull_request
+    const index = positiveIndex(pull?.number)
+    if (!pull || index === undefined) return undefined
+    const base = pullRequestCtxBase(payload, pull, index)
+    if (eventType === GITEA_EVENT_PULL_REQUEST_SYNC) {
+      return payload.action === 'synchronized' ? { ...base, eventAction: 'merge_request:synchronize' } : undefined
+    }
+    // `closed` with `merged` fires separately as maintenance cleanup; an unmerged close, a
+    // reopen, and `edited` (which carries draft toggles and target-branch changes) are noise.
+    return payload.action === 'opened' ? { ...base, eventAction: 'merge_request:opened' } : undefined
+  }
+  if (eventType === GITEA_EVENT_PULL_REQUEST_REVIEW_REQUEST) {
+    const pull = payload.pull_request
+    const index = positiveIndex(pull?.number)
+    if (!pull || index === undefined || payload.action !== 'review_requested') return undefined
+    return {
+      ...pullRequestCtxBase(payload, pull, index),
+      eventAction: 'merge_request:review_requested',
+      // The one event type where `requested_reviewer` names a requested reviewer (§8).
+      ...(userId(payload.requested_reviewer) !== undefined
+        ? { requestedReviewerId: userId(payload.requested_reviewer) }
+        : {})
+    }
+  }
+  const reviewAction = GITEA_REVIEW_EVENT_ACTIONS[eventType]
+  if (reviewAction !== undefined) {
+    const pull = payload.pull_request
+    const index = positiveIndex(pull?.number)
+    if (!pull || index === undefined || payload.action !== 'reviewed') return undefined
+    return {
+      ...pullRequestCtxBase(payload, pull, index),
+      eventAction: reviewAction,
+      family: 'review',
+      commentSubjectFamily: 'pull_request',
+      // The summary body is all a review delivery carries; the daemon lists the reviews and
+      // correlates by author, state, and body to read the inline comments (§8).
+      mentionText: payload.review?.content ?? undefined
+    }
+  }
+  if (eventType === GITEA_EVENT_ISSUE_COMMENT || eventType === GITEA_EVENT_PULL_REQUEST_COMMENT) {
+    // §8 edit veto: a comment EDIT or DELETE re-fires the same type with a fresh delivery id.
+    if (payload.action !== 'created') return undefined
+    const isPull = eventType === GITEA_EVENT_PULL_REQUEST_COMMENT
+    // The event type already names the subject family; a payload disagreeing with it fails closed.
+    if (payload.is_pull !== isPull) return undefined
+    const subject = isPull ? payload.pull_request : payload.issue
+    const index = positiveIndex(payload.issue?.number ?? subject?.number)
+    if (!subject || index === undefined) return undefined
+    const pull = isPull ? payload.pull_request : undefined
+    return {
+      eventAction: 'note:created',
+      family: 'note',
+      commentSubjectFamily: isPull ? 'pull_request' : 'issues',
+      ...(userId(payload.sender) !== undefined ? { actorId: userId(payload.sender) } : {}),
+      ...(payload.sender?.login ? { actorLogin: payload.sender.login } : {}),
+      ...(userId(subject.user) !== undefined ? { subjectAuthorId: userId(subject.user) } : {}),
+      ...(subject.user?.login ? { subjectAuthorLogin: subject.user.login } : {}),
+      labels: labelNames(subject),
+      mentionText: payload.comment?.body ?? undefined,
+      ...(pull?.head?.repo_id !== undefined ? { sourceRepoId: String(pull.head.repo_id) } : {}),
+      ...(payload.repository?.id !== undefined ? { targetRepoId: String(payload.repository.id) } : {}),
+      index
+    }
+  }
+  return undefined
+}
+
+export function giteaRuleIsSummoned(rule: RcHookAssign, ctx: GiteaMatchCtx): boolean {
+  return (
+    mentionsGithubHandle(ctx.mentionText, rule.gitea?.botUsername) ||
+    mentionsGithubHandle(ctx.mentionText, rule.gitea?.agentName)
+  )
+}
+
+/** Explicit agent handles narrow a repository fan-out; the connection's bot handle is the broadcast form. */
+export function giteaMentionCandidates(rules: RcHookAssign[], body: string | undefined): RcHookAssign[] {
+  if (rules.some((rule) => mentionsGithubHandle(body, rule.gitea?.botUsername))) return rules
+  const targeted = new Set(
+    rules.filter((rule) => mentionsGithubHandle(body, rule.gitea?.agentName)).map((rule) => rule.agentId)
+  )
+  return targeted.size === 0 ? rules : rules.filter((rule) => targeted.has(rule.agentId))
+}
+
+export type GiteaRuleVerdict = 'no-match' | 'trusted' | 'needs-authz'
+
+/** §8 internal lane: only a same-repository pull-request revision the bot itself authored enters review. */
+function isInternalBotRevision(rule: RcHookAssign, ctx: GiteaMatchCtx): boolean {
+  return (
+    (ctx.eventAction === 'merge_request:opened' || ctx.eventAction === 'merge_request:synchronize') &&
+    ctx.subjectAuthorId !== undefined &&
+    ctx.subjectAuthorId === rule.gitea?.botUserId &&
+    ctx.sourceRepoId !== undefined &&
+    ctx.sourceRepoId === ctx.targetRepoId
+  )
+}
+
+/**
+ * One rule's verdict for one verified delivery (pure; exported for unit tests).
+ * Order: loop-prevention veto → reviewer-request path → cadence/additive summon
+ * match → comment scope → mention-only gate → live-authz classification.
+ */
+export function giteaRuleVerdict(rule: RcHookAssign, ctx: GiteaMatchCtx): GiteaRuleVerdict {
+  const gitea = rule.gitea
+  if (rule.kind !== 'gitea' || !gitea) return 'no-match'
+  // §8 loop prevention: the connection's single bot user never re-triggers, except its own
+  // same-repository pull-request revisions. A comment it authors is always rejected.
+  const botAuthored = ctx.actorId !== undefined && ctx.actorId === gitea.botUserId
+  const internalRevision = botAuthored && isInternalBotRevision(rule, ctx)
+  if (botAuthored && !internalRevision) return 'no-match'
+  // §8 explicit start path: requesting the bot as reviewer bypasses cadence and mention filters,
+  // but only for THIS rule's bot and only after the live membership gate authorizes the requester.
+  if (ctx.eventAction === 'merge_request:review_requested') {
+    const supportsPulls =
+      gitea.events.some((event) => event.startsWith('merge_request:')) ||
+      (gitea.commentFamilies ?? []).includes('pull_request')
+    return ctx.requestedReviewerId === gitea.botUserId && supportsPulls ? 'needs-authz' : 'no-match'
+  }
+  const action = ctx.eventAction.includes(':') ? ctx.eventAction.slice(ctx.eventAction.indexOf(':')) : ''
+  const matchesPattern = (family: string): boolean =>
+    (action !== '' && gitea.events.includes(`${family}${action}`)) || gitea.events.includes(`${family}:*`)
+  const summoned = giteaRuleIsSummoned(rule, ctx)
+  let eventMatched: boolean
+  if (ctx.family === 'note' || ctx.family === 'review') {
+    // Comments and review submissions are both scoped by the console-selected comment families;
+    // a summon in a created-cadence thread family fires additively (§8).
+    const families = gitea.commentFamilies ?? []
+    const familySelected = ctx.commentSubjectFamily !== undefined && families.includes(ctx.commentSubjectFamily)
+    const createdCadenceSummon =
+      summoned &&
+      ctx.commentSubjectFamily !== undefined &&
+      gitea.events.includes(`${eventFamilyOfCommentSubject(ctx.commentSubjectFamily)}:opened`)
+    eventMatched = familySelected || createdCadenceSummon
+  } else {
+    const createdCadenceSummon =
+      summoned &&
+      (ctx.family === 'issues' || ctx.family === 'merge_request') &&
+      gitea.events.includes(`${ctx.family}:opened`)
+    eventMatched = matchesPattern(ctx.family) || createdCadenceSummon
+  }
+  if (!eventMatched) return 'no-match'
+  if (gitea.mentionOnly && !summoned) return 'no-match'
+  // §8: pushes and the bot's own same-repository revisions stay relay-trusted; every issue and
+  // pull-request lifecycle event, comment, and review submission resolves live membership.
+  if (ctx.family === 'push') return 'trusted'
+  if (internalRevision) return 'trusted'
+  return 'needs-authz'
+}
+
+/** The §8 rename-stable session key: exact subject discriminator, positive index
+ *  (or the payload's canonical ref) — never a display path or delivery id. */
+export function giteaSessionKey(rule: RcHookAssign, target: GiteaHookTarget): string {
+  const prefix = rule.gitea!.sessionKeyPrefix
+  return target.kind === 'push' ? `${prefix}:push:${target.ref}` : `${prefix}:${target.kind}:${target.index}`
+}
+
+/** The signed-payload subject → the trusted `RdMsgHook.gitea` discriminator.
+ *  Undefined identity is rejected before any dispatch — never substituted. */
+export function buildTrustedGiteaMetadata(
+  payload: GiteaPayload,
+  ctx: GiteaMatchCtx,
+  rule: RcHookAssign
+): GiteaHookMetadata | undefined {
+  const gitea = rule.gitea
+  if (!gitea) return undefined
+  const repoId = payload.repository?.id
+  if (repoId === undefined || String(repoId) !== gitea.repoId) return undefined
+  let target: GiteaHookTarget
+  if (ctx.family === 'push') {
+    if (!ctx.ref) return undefined
+    target = { kind: 'push', ref: ctx.ref }
+  } else if (ctx.family === 'issues' || ctx.commentSubjectFamily === 'issues') {
+    if (ctx.index === undefined || ctx.index <= 0) return undefined
+    target = { kind: 'issue', index: ctx.index }
+  } else {
+    if (ctx.index === undefined || ctx.index <= 0) return undefined
+    const pull = payload.pull_request
+    target = {
+      kind: 'pull',
+      index: ctx.index,
+      ...(ctx.sourceRepoId !== undefined ? { sourceRepoId: ctx.sourceRepoId } : {}),
+      // Both sides of the head fence are on every pull-request payload (§8).
+      ...(pull?.head?.sha ? { headSha: pull.head.sha } : {}),
+      ...(pull?.base?.sha ? { baseSha: pull.base.sha } : {}),
+      ...(pull?.draft !== undefined ? { isDraft: pull.draft } : {}),
+      ...(ctx.eventAction === 'merge_request:review_requested' ? { explicitReviewRequest: true } : {})
+    }
+  }
+  const commentId = ctx.family === 'note' ? positiveIndex(payload.comment?.id) : undefined
+  return {
+    repoId: gitea.repoId,
+    // §3: opaque pass-through. The relay never dials Gitea and never parses this — the daemon
+    // fences the turn on it against the session's spec-carried host.
+    ...(gitea.host !== undefined ? { host: gitea.host } : {}),
+    repoPath: payload.repository?.full_name ?? gitea.repoPath,
+    target,
+    // The comment that fired this delivery — the acknowledgement reaction's exact target. A review
+    // submission carries no comment id at all (§16), so it never gets one.
+    ...(commentId !== undefined ? { commentId: String(commentId) } : {})
+  }
+}
+
+/** The trimmed model-visible envelope shared by the delivery's fan-out. */
+export function buildGiteaContext(payload: GiteaPayload, ctx: GiteaMatchCtx): HookContext {
+  const subject = payload.pull_request ?? payload.issue
+  const bodySource = payload.comment?.body ?? ctx.mentionText ?? ''
+  const excerpt = truncateUtf8(bodySource, GITHUB_BODY_EXCERPT_MAX)
+  const flatTitle = subject?.title ? subject.title.replace(/\s+/g, ' ').trim() : undefined
+  const htmlUrl = payload.comment?.html_url ?? subject?.html_url
+  return {
+    source: 'gitea',
+    event: ctx.family,
+    ...(ctx.eventAction.includes(':') ? { action: ctx.eventAction.slice(ctx.eventAction.indexOf(':') + 1) } : {}),
+    ...(payload.repository?.full_name ? { repo: payload.repository.full_name } : {}),
+    ...(ctx.index !== undefined ? { number: ctx.index } : {}),
+    ...(flatTitle ? { title: flatTitle.length > 200 ? `${flatTitle.slice(0, 199)}…` : flatTitle } : {}),
+    ...(ctx.actorLogin ? { senderLogin: ctx.actorLogin } : {}),
+    ...(payload.sender?.avatar_url ? { senderAvatarUrl: payload.sender.avatar_url } : {}),
+    ...(ctx.labels.length > 0 ? { labels: ctx.labels } : {}),
+    ...(htmlUrl ? { htmlUrl } : {}),
+    ...(excerpt.text ? { bodyExcerpt: excerpt.text } : {}),
+    truncated: excerpt.truncated
+  }
+}

--- a/packages/relay/src/hooks/gitea/ingress.test.ts
+++ b/packages/relay/src/hooks/gitea/ingress.test.ts
@@ -1,0 +1,836 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { createHmac, randomBytes } from 'node:crypto'
+import { FakeClock } from '@agentconnect.md/connection'
+import {
+  GITEA_V1_FEATURE,
+  HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED,
+  type RcCodeHostMembershipAuthz,
+  type RcHookAssign,
+  type RcHookRerun,
+  type RcRunReport,
+  type RdAck,
+  type RdMsg,
+  type RdMsgHook
+} from '@agentconnect.md/protocol'
+import { HookTable } from '../hook-table.js'
+import { HookRateLimiter } from '../rate-limit.js'
+import { dispatchGiteaRerun, registerGiteaIngress, type GiteaRerunDeps } from './ingress.js'
+import { giteaRuleVerdict, normalizeGiteaEvent, type GiteaPayload } from './events.js'
+
+// Every identifier below is synthetic. The probe captures that shaped these fixtures carried real
+// repository, user, and delivery identities; none of them appear here (publication policy).
+const HOOK = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const HOOK_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const AGENT = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const AGENT_B = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const DAEMON = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const REPO = 7701234
+const FORK_REPO = 7709999
+const BOT_USER = 424242
+const BOT_LOGIN = 'example-bot'
+const HUMAN = 515151
+const OUTSIDER = 606060
+const REPO_PATH = 'example-org/example-repo'
+const HEAD_SHA = 'a'.repeat(40)
+const BASE_SHA = 'b'.repeat(40)
+const KEY = randomBytes(32).toString('hex')
+const NEXT_KEY = randomBytes(32).toString('hex')
+const DELIVERY = '11111111-2222-4333-8444-555555555555'
+
+const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function rule(
+  overrides: Partial<RcHookAssign> = {},
+  gitea: Partial<NonNullable<RcHookAssign['gitea']>> = {}
+): RcHookAssign {
+  return {
+    hookId: HOOK,
+    kind: 'gitea',
+    agentId: AGENT,
+    daemonId: DAEMON,
+    configRevision: '3',
+    dispatchRevision: '5',
+    dispatchDaemonId: DAEMON,
+    reviewPolicy: 'off',
+    reportingMode: 'off',
+    gateMode: 'informational',
+    sessionMode: 'perThread',
+    gitea: {
+      repoId: String(REPO),
+      repoPath: REPO_PATH,
+      sessionKeyPrefix: `gitea:${REPO}`,
+      events: ['issues:opened'],
+      mentionOnly: false,
+      botUserId: String(BOT_USER),
+      botUsername: BOT_LOGIN,
+      signingKey: KEY,
+      ...gitea
+    },
+    ...overrides
+  }
+}
+
+function sender(id = HUMAN, login = 'alice'): Record<string, unknown> {
+  return { id, login, username: login, avatar_url: `https://gitea.example.test/avatars/${id}` }
+}
+
+function repository(): Record<string, unknown> {
+  return { id: REPO, full_name: REPO_PATH }
+}
+
+function issuePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'opened',
+    repository: repository(),
+    sender: sender(),
+    issue: {
+      id: 900001,
+      number: 42,
+      title: 'db down',
+      body: 'the primary is unreachable',
+      html_url: `https://gitea.example.test/${REPO_PATH}/issues/42`,
+      user: sender(),
+      labels: [{ name: 'bug' }],
+      ...((overrides.issue as Record<string, unknown> | undefined) ?? {})
+    },
+    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== 'issue'))
+  }
+}
+
+function pullRequest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 900002,
+    number: 77,
+    title: 'tighten retry',
+    body: 'please review',
+    html_url: `https://gitea.example.test/${REPO_PATH}/pulls/77`,
+    user: sender(),
+    labels: [],
+    draft: false,
+    merged: false,
+    head: { ref: 'topic', sha: HEAD_SHA, repo_id: REPO },
+    base: { ref: 'main', sha: BASE_SHA, repo_id: REPO },
+    ...overrides
+  }
+}
+
+function pullPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'opened',
+    number: 77,
+    commit_id: '',
+    repository: repository(),
+    sender: sender(),
+    requested_reviewer: null,
+    review: null,
+    pull_request: pullRequest((overrides.pull_request as Record<string, unknown> | undefined) ?? {}),
+    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== 'pull_request'))
+  }
+}
+
+/** An issue-timeline comment: Gitea sends `is_pull: false` under event type `issue_comment`. */
+function issueCommentPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'created',
+    is_pull: false,
+    repository: repository(),
+    sender: sender(),
+    issue: { ...(issuePayload().issue as Record<string, unknown>), user: sender(OUTSIDER, 'mallory') },
+    comment: {
+      id: 1692903,
+      body: 'what is the rollout plan?',
+      html_url: `https://gitea.example.test/${REPO_PATH}/issues/42#issuecomment-1692903`
+    },
+    ...overrides
+  }
+}
+
+/** A pull-request TIMELINE comment: event type `pull_request_comment`, `is_pull: true`. */
+function pullCommentPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'created',
+    is_pull: true,
+    repository: repository(),
+    sender: sender(),
+    issue: { number: 77, title: 'tighten retry', user: sender() },
+    pull_request: pullRequest(),
+    comment: {
+      id: 1692904,
+      body: 'plain timeline comment',
+      html_url: `https://gitea.example.test/${REPO_PATH}/pulls/77#issuecomment-1692904`
+    },
+    ...overrides
+  }
+}
+
+/** A review submission: one delivery, `action: reviewed`, only the summary in `review.content`,
+ *  and a top-level `commit_id` Gitea never assigns on review events (§16). */
+function reviewPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'reviewed',
+    number: 77,
+    commit_id: '',
+    repository: repository(),
+    sender: sender(),
+    // On a review delivery this names the review's AUTHOR, not a requested reviewer (§8).
+    requested_reviewer: sender(),
+    review: { type: 'pull_request_review_comment', content: 'review body' },
+    pull_request: pullRequest(),
+    ...overrides
+  }
+}
+
+function reviewRequestPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'review_requested',
+    number: 77,
+    commit_id: '',
+    repository: repository(),
+    sender: sender(),
+    requested_reviewer: sender(BOT_USER, BOT_LOGIN),
+    review: null,
+    pull_request: pullRequest({ user: sender(OUTSIDER, 'mallory') }),
+    ...overrides
+  }
+}
+
+function pushPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ref: 'refs/heads/main',
+    before: '0'.repeat(40),
+    after: HEAD_SHA,
+    repository: repository(),
+    sender: sender(),
+    pusher: sender(),
+    commits: [{ message: 'fix: retry\n' }],
+    ...overrides
+  }
+}
+
+interface Harness {
+  app: FastifyInstance
+  table: HookTable
+  clock: FakeClock
+  sent: RdMsg[]
+  reports: RcRunReport[]
+  authzRequests: RcCodeHostMembershipAuthz[]
+  authzResult: boolean | ((request: RcCodeHostMembershipAuthz) => boolean | Promise<boolean>)
+  ack: RdAck
+  offline: boolean
+  giteaSupported: boolean
+  /** The same deps the ingress runs on — the rerun path reuses them verbatim. */
+  deps: GiteaRerunDeps
+}
+
+function makeHarness(): Harness {
+  const clock = new FakeClock()
+  const h: Partial<Harness> & Pick<Harness, 'sent' | 'reports' | 'authzRequests'> = {
+    sent: [],
+    reports: [],
+    authzRequests: [],
+    authzResult: true,
+    ack: { msgId: 'x', accepted: true },
+    offline: false,
+    giteaSupported: true
+  }
+  const app = Fastify()
+  const table = new HookTable()
+  const deps = {
+    table,
+    daemons: () => ({
+      get: () => {
+        if (h.offline) return undefined
+        return {
+          supports: (capability: string) => {
+            if (capability === GITEA_V1_FEATURE) return h.giteaSupported === true
+            return true
+          },
+          sendMsg: async (msg: RdMsg) => {
+            h.sent.push(msg)
+            return h.ack!
+          }
+        } as never
+      }
+    }),
+    report: (r: RcRunReport) => h.reports.push(r),
+    authorizeMembership: async (request: RcCodeHostMembershipAuthz) => {
+      h.authzRequests.push(request)
+      return typeof h.authzResult === 'function' ? h.authzResult(request) : h.authzResult!
+    },
+    authzLimiter: new HookRateLimiter(clock, { capacity: 20, refillPerSec: 0 }),
+    limiter: new HookRateLimiter(clock, { capacity: 5, refillPerSec: 0 }),
+    clock,
+    log
+  }
+  registerGiteaIngress(app, deps)
+  h.app = app
+  h.table = table
+  h.clock = clock
+  h.deps = deps
+  return h as Harness
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0))
+}
+
+interface PostOptions {
+  /** `X-Gitea-Event-Type` — the only header any decision keys on. */
+  eventType: string
+  /** `X-Gitea-Event` — the lossy legacy header, deliberately set to a COLLIDING value by default. */
+  event?: string
+  delivery?: string | null
+  signature?: string | null
+  signingKey?: string
+}
+
+function post(h: Harness, payload: Record<string, unknown>, opts: PostOptions) {
+  const body = JSON.stringify(payload)
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (opts.event !== undefined) headers['x-gitea-event'] = opts.event
+  headers['x-gitea-event-type'] = opts.eventType
+  const delivery = opts.delivery === undefined ? DELIVERY : opts.delivery
+  if (delivery !== null) headers['x-gitea-delivery'] = delivery
+  const signature =
+    opts.signature === undefined
+      ? createHmac('sha256', opts.signingKey ?? KEY)
+          .update(body)
+          .digest('hex')
+      : opts.signature
+  if (signature !== null) headers['x-gitea-signature'] = signature
+  return h.app.inject({ method: 'POST', url: '/webhooks/gitea', headers, payload: body })
+}
+
+describe('gitea ingress', () => {
+  let h: Harness
+  beforeEach(() => {
+    h = makeHarness()
+  })
+  afterEach(async () => {
+    await h.app.close()
+  })
+
+  it('verified issue open → membership authz (id AND login) → dispatch with the §8 key', async () => {
+    h.table.upsert(rule())
+    const res = await post(h, issuePayload(), { eventType: 'issues', event: 'issues' })
+    expect(res.statusCode).toBe(202)
+    expect(res.json()).toEqual({ deliveryKey: DELIVERY })
+    await flush()
+    // Gitea's permission lookup is by username, so the login travels beside the numeric id.
+    expect(h.authzRequests).toEqual([
+      expect.objectContaining({
+        provider: 'gitea',
+        repoExternalId: String(REPO),
+        actorExternalId: String(HUMAN),
+        actorUsername: 'alice',
+        configRevision: '3',
+        dispatchRevision: '5'
+      })
+    ])
+    expect(h.sent).toHaveLength(1)
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.sessionKey).toBe(`gitea:${REPO}:issue:42`)
+    expect(msg.msgId).toBe(`${HOOK}:${DELIVERY}`)
+    expect(msg.deliveryKey).toBe(DELIVERY)
+    expect(msg.event).toBe('issues:opened')
+    expect(msg.gitea).toEqual({ repoId: String(REPO), repoPath: REPO_PATH, target: { kind: 'issue', index: 42 } })
+    expect(msg.context?.source).toBe('gitea')
+    expect(msg.context?.bodyExcerpt).toBe('the primary is unreachable')
+    expect(msg.context?.labels).toEqual(['bug'])
+    expect(h.reports.map((r) => r.status)).toEqual(['accepted'])
+  })
+
+  it('uniform 404: wrong key, tampered body, unknown repository, malformed body, missing headers', async () => {
+    h.table.upsert(rule())
+    const wrongKey = await post(h, issuePayload(), { eventType: 'issues', signingKey: NEXT_KEY })
+    expect(wrongKey.statusCode).toBe(404)
+    // The digest covers the EXACT raw bytes: a body edited in flight cannot keep its signature.
+    const body = JSON.stringify(issuePayload())
+    const tampered = await h.app.inject({
+      method: 'POST',
+      url: '/webhooks/gitea',
+      headers: {
+        'content-type': 'application/json',
+        'x-gitea-event-type': 'issues',
+        'x-gitea-delivery': DELIVERY,
+        'x-gitea-signature': createHmac('sha256', KEY).update(body).digest('hex')
+      },
+      payload: body.replace('"number":42', '"number":43')
+    })
+    expect(tampered.statusCode).toBe(404)
+    const unknownRepo = await post(h, issuePayload({ repository: { id: 9, full_name: 'other/repo' } }), {
+      eventType: 'issues'
+    })
+    expect(unknownRepo.statusCode).toBe(404)
+    const malformed = await h.app.inject({
+      method: 'POST',
+      url: '/webhooks/gitea',
+      headers: { 'content-type': 'application/json', 'x-gitea-event-type': 'issues' },
+      payload: 'not-json'
+    })
+    expect(malformed.statusCode).toBe(404)
+    expect((await post(h, issuePayload(), { eventType: 'issues', delivery: null })).statusCode).toBe(404)
+    expect((await post(h, issuePayload(), { eventType: 'issues', signature: null })).statusCode).toBe(404)
+    // A non-hex signature of the right shape decodes short and fails the length check.
+    expect((await post(h, issuePayload(), { eventType: 'issues', signature: 'z'.repeat(64) })).statusCode).toBe(404)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('accepts the NEXT signing key while a rotation leaves the table mixed (§7)', async () => {
+    // Rotation distributes both keys; one repository's rules may carry either until promotion.
+    h.table.upsert(rule())
+    h.table.upsert(rule({ hookId: HOOK_B, agentId: AGENT_B }, { signingKey: NEXT_KEY }))
+    expect((await post(h, issuePayload(), { eventType: 'issues', signingKey: NEXT_KEY })).statusCode).toBe(202)
+    await flush()
+    // Either key verifies the delivery for EVERY rule on the repository, so nothing is dropped.
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId).sort()).toEqual([HOOK, HOOK_B].sort())
+  })
+
+  it('keys on X-Gitea-Event-Type, never the lossy X-Gitea-Event', async () => {
+    h.table.upsert(rule({}, { events: ['merge_request:*'], commentFamilies: ['pull_request'] }))
+    // A pull-request TIMELINE comment: the legacy header says `issue_comment`.
+    expect(
+      (await post(h, pullCommentPayload(), { eventType: 'pull_request_comment', event: 'issue_comment' })).statusCode
+    ).toBe(202)
+    // A REVIEW submission: the legacy header says `pull_request_comment` — the exact value the
+    // timeline comment's own event type uses, which is why it can never be the match key.
+    expect(
+      (
+        await post(h, reviewPayload(), {
+          eventType: 'pull_request_review_comment',
+          event: 'pull_request_comment',
+          delivery: 'delivery-review'
+        })
+      ).statusCode
+    ).toBe(202)
+    // And a revision: the legacy header collapses `pull_request_sync` into `pull_request`.
+    expect(
+      (
+        await post(h, pullPayload({ action: 'synchronized', before: BASE_SHA, after: HEAD_SHA }), {
+          eventType: 'pull_request_sync',
+          event: 'pull_request',
+          delivery: 'delivery-sync'
+        })
+      ).statusCode
+    ).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).event)).toEqual([
+      'note:created',
+      'review:commented',
+      'merge_request:synchronize'
+    ])
+  })
+
+  it('maps every event-type row and vetoes the rest', () => {
+    const row = (eventType: string, payload: Record<string, unknown>): string | undefined =>
+      normalizeGiteaEvent(eventType, payload as GiteaPayload)?.eventAction
+    expect(row('issues', issuePayload())).toBe('issues:opened')
+    expect(row('issue_comment', issueCommentPayload())).toBe('note:created')
+    expect(row('pull_request_comment', pullCommentPayload())).toBe('note:created')
+    expect(row('pull_request', pullPayload())).toBe('merge_request:opened')
+    expect(row('pull_request_sync', pullPayload({ action: 'synchronized' }))).toBe('merge_request:synchronize')
+    expect(row('pull_request_review_request', reviewRequestPayload())).toBe('merge_request:review_requested')
+    expect(row('pull_request_review_comment', reviewPayload())).toBe('review:commented')
+    expect(row('pull_request_review_approved', reviewPayload({ review: { type: 'x', content: 'ok' } }))).toBe(
+      'review:approved'
+    )
+    expect(row('pull_request_review_rejected', reviewPayload())).toBe('review:changes_requested')
+    expect(row('push', pushPayload())).toBe('push')
+
+    // Lifecycle noise: edits, reopens, unmerged closes, and the draft toggle that rides `edited`.
+    expect(row('issues', issuePayload({ action: 'edited' }))).toBeUndefined()
+    expect(row('issues', issuePayload({ action: 'reopened' }))).toBeUndefined()
+    expect(row('pull_request', pullPayload({ action: 'reopened' }))).toBeUndefined()
+    expect(row('pull_request', pullPayload({ action: 'edited' }))).toBeUndefined()
+    expect(row('pull_request', pullPayload({ action: 'closed' }))).toBeUndefined()
+    // Comment edits and deletions re-fire the same type with a fresh delivery id — never a turn.
+    expect(row('issue_comment', issueCommentPayload({ action: 'edited' }))).toBeUndefined()
+    expect(row('pull_request_comment', pullCommentPayload({ action: 'deleted' }))).toBeUndefined()
+    // Label, assignment, and milestone churn arrive under event types the table never names.
+    expect(row('issue_label', issuePayload({ action: 'label_updated' }))).toBeUndefined()
+    expect(row('issue_assign', issuePayload({ action: 'assigned' }))).toBeUndefined()
+    expect(row('pull_request_label', pullPayload({ action: 'label_updated' }))).toBeUndefined()
+    expect(row('pull_request_assign', pullPayload({ action: 'assigned' }))).toBeUndefined()
+    expect(
+      row('pull_request_review_request', reviewRequestPayload({ action: 'review_request_removed' }))
+    ).toBeUndefined()
+    expect(row('release', { repository: repository(), action: 'published' })).toBeUndefined()
+    // The subject discriminator is required: a comment whose payload disagrees with its event
+    // type, and a subject without a positive index, are both rejected before any session key.
+    expect(row('pull_request_comment', pullCommentPayload({ is_pull: false }))).toBeUndefined()
+    expect(row('issue_comment', issueCommentPayload({ is_pull: true }))).toBeUndefined()
+    expect(row('issues', issuePayload({ issue: { number: 0 } }))).toBeUndefined()
+    expect(row('push', pushPayload({ ref: undefined }))).toBeUndefined()
+  })
+
+  it('a pull-request comment carries the comment id and the head fence; a review carries neither', async () => {
+    h.table.upsert(rule({}, { events: ['merge_request:*'], commentFamilies: ['pull_request'] }))
+    expect((await post(h, pullCommentPayload(), { eventType: 'pull_request_comment' })).statusCode).toBe(202)
+    await flush()
+    const comment = h.sent[0] as RdMsgHook
+    expect(comment.sessionKey).toBe(`gitea:${REPO}:pull:77`)
+    expect(comment.gitea).toMatchObject({
+      commentId: '1692904',
+      target: { kind: 'pull', index: 77, headSha: HEAD_SHA, baseSha: BASE_SHA, sourceRepoId: String(REPO) }
+    })
+
+    h.sent.length = 0
+    expect(
+      (await post(h, reviewPayload(), { eventType: 'pull_request_review_approved', delivery: 'delivery-2' })).statusCode
+    ).toBe(202)
+    await flush()
+    const review = h.sent[0] as RdMsgHook
+    expect(review.event).toBe('review:approved')
+    // §16: the delivery carries the summary and no comment, path, line, or review id at all.
+    expect(review.gitea?.commentId).toBeUndefined()
+    expect(review.context?.bodyExcerpt).toBe('review body')
+    expect(review.gitea?.target).toMatchObject({ kind: 'pull', index: 77, headSha: HEAD_SHA })
+  })
+
+  it('§8 loop prevention: the bot is vetoed, except its own same-repository revision', async () => {
+    h.table.upsert(rule({}, { events: ['issues:opened', 'merge_request:*'], commentFamilies: ['pull_request'] }))
+    const botIssue = issuePayload({ sender: sender(BOT_USER, BOT_LOGIN), issue: { user: sender(BOT_USER, BOT_LOGIN) } })
+    expect((await post(h, botIssue, { eventType: 'issues' })).statusCode).toBe(202)
+    const botComment = pullCommentPayload({ sender: sender(BOT_USER, BOT_LOGIN) })
+    expect((await post(h, botComment, { eventType: 'pull_request_comment', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.authzRequests).toHaveLength(0)
+
+    // The internal lane: a same-repository revision the bot authored is TRUSTED — no membership
+    // call, straight to dispatch, so the bot's own pull requests stay reviewable.
+    const ownRevision = pullPayload({
+      action: 'synchronized',
+      sender: sender(BOT_USER, BOT_LOGIN),
+      pull_request: { user: sender(BOT_USER, BOT_LOGIN) }
+    })
+    expect((await post(h, ownRevision, { eventType: 'pull_request_sync', delivery: 'd3' })).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:synchronize')
+
+    // A bot revision from a FORK is not the internal lane and stays vetoed.
+    h.sent.length = 0
+    const forkedBotRevision = pullPayload({
+      action: 'synchronized',
+      sender: sender(BOT_USER, BOT_LOGIN),
+      pull_request: { user: sender(BOT_USER, BOT_LOGIN), head: { ref: 'topic', sha: HEAD_SHA, repo_id: FORK_REPO } }
+    })
+    expect((await post(h, forkedBotRevision, { eventType: 'pull_request_sync', delivery: 'd4' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('an external pull request never starts automatically (§8)', async () => {
+    h.authzResult = false
+    h.table.upsert(rule({}, { events: ['merge_request:*'] }))
+    const external = pullPayload({
+      sender: sender(OUTSIDER, 'mallory'),
+      pull_request: { user: sender(OUTSIDER, 'mallory'), head: { ref: 'topic', sha: HEAD_SHA, repo_id: FORK_REPO } }
+    })
+    expect((await post(h, external, { eventType: 'pull_request' })).statusCode).toBe(202)
+    await flush()
+    // The gate resolves the PULL REQUEST'S AUTHOR, not the delivery's sender claim.
+    expect(h.authzRequests).toEqual([
+      expect.objectContaining({ actorExternalId: String(OUTSIDER), actorUsername: 'mallory' })
+    ])
+    expect(h.sent).toHaveLength(0)
+    // A denied revision leaves the durable, actionable row instead of silence.
+    expect(h.reports).toEqual([
+      expect.objectContaining({ status: 'failed', reason: HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED })
+    ])
+  })
+
+  it('requesting the bot as reviewer is the explicit start path, and only on its own event type', async () => {
+    h.table.upsert(rule({}, { events: ['merge_request:opened'] }))
+    expect((await post(h, reviewRequestPayload(), { eventType: 'pull_request_review_request' })).statusCode).toBe(202)
+    await flush()
+    // The REQUESTING actor is authorized — never the (untrusted) external pull-request author.
+    expect(h.authzRequests).toHaveLength(1)
+    expect(h.authzRequests[0]?.actorExternalId).toBe(String(HUMAN))
+    expect(h.authzRequests[0]?.subjectAuthorExternalId).toBeUndefined()
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.event).toBe('merge_request:review_requested')
+    expect(msg.gitea?.target).toMatchObject({ kind: 'pull', index: 77, explicitReviewRequest: true })
+
+    // Requesting SOMEONE ELSE is inert.
+    h.sent.length = 0
+    h.authzRequests.length = 0
+    const other = reviewRequestPayload({ requested_reviewer: sender(OUTSIDER, 'mallory') })
+    expect((await post(h, other, { eventType: 'pull_request_review_request', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+
+    // And `requested_reviewer` on a REVIEW delivery names the review's author (§8), so a review
+    // the bot submitted must never read as a request for the bot to review.
+    const botReview = reviewPayload({ sender: sender(HUMAN, 'alice'), requested_reviewer: sender(BOT_USER, BOT_LOGIN) })
+    expect((await post(h, botReview, { eventType: 'pull_request_review_comment', delivery: 'd3' })).statusCode).toBe(
+      202
+    )
+    await flush()
+    // The rule selects no comment family, so the review matched nothing at all.
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('push is relay-trusted, matches only push:*, and keys the session by ref', async () => {
+    h.table.upsert(rule({}, { events: ['push:*'] }))
+    h.table.upsert(rule({ hookId: HOOK_B, agentId: AGENT_B }, { events: ['issues:opened'] }))
+    expect((await post(h, pushPayload(), { eventType: 'push' })).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.hookId).toBe(HOOK)
+    expect(msg.sessionKey).toBe(`gitea:${REPO}:push:refs/heads/main`)
+    expect(msg.gitea?.target).toEqual({ kind: 'push', ref: 'refs/heads/main' })
+  })
+
+  it('merged pull requests and closed issues fan out as maintenance cleanup, bypassing the gate', async () => {
+    h.authzResult = false // the gate would deny — cleanup must not care
+    h.table.upsert(rule({}, { events: ['merge_request:*'] }))
+    const merged = pullPayload({ action: 'closed', pull_request: { merged: true } })
+    expect((await post(h, merged, { eventType: 'pull_request' })).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:merged')
+    expect((h.sent[0] as RdMsgHook).sessionKey).toBe(`gitea:${REPO}:pull:77`)
+
+    h.sent.length = 0
+    const closed = issuePayload({ action: 'closed' })
+    expect((await post(h, closed, { eventType: 'issues', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect((h.sent[0] as RdMsgHook).event).toBe('issues:closed')
+    expect((h.sent[0] as RdMsgHook).sessionKey).toBe(`gitea:${REPO}:issue:42`)
+
+    // An UNMERGED close may still reopen, so it is neither cleanup nor a turn.
+    h.sent.length = 0
+    expect(
+      (await post(h, pullPayload({ action: 'closed' }), { eventType: 'pull_request', delivery: 'd3' })).statusCode
+    ).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('comment families scope comments and reviews; a summon narrows the fan-out', async () => {
+    h.table.upsert(rule({}, { commentFamilies: ['issues'], agentName: 'oncall' }))
+    h.table.upsert(rule({ hookId: HOOK_B, agentId: AGENT_B }, { agentName: 'deploy' }))
+    // HOOK matches via its selected family; HOOK_B selects none and is not summoned.
+    expect((await post(h, issueCommentPayload(), { eventType: 'issue_comment' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId)).toEqual([HOOK])
+    // An unmentioned continuation fences the thread author as well as the commenter (§8).
+    expect(h.authzRequests).toEqual([
+      expect.objectContaining({
+        actorExternalId: String(HUMAN),
+        actorUsername: 'alice',
+        subjectAuthorExternalId: String(OUTSIDER),
+        subjectAuthorUsername: 'mallory'
+      })
+    ])
+
+    h.sent.length = 0
+    h.authzRequests.length = 0
+    const mention = issueCommentPayload({ comment: { id: 2, body: '@oncall please look' } })
+    expect((await post(h, mention, { eventType: 'issue_comment', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId)).toEqual([HOOK])
+    // A summoning comment authorizes only its author.
+    expect(h.authzRequests[0]?.subjectAuthorExternalId).toBeUndefined()
+  })
+
+  it('mention-only rules stay silent without a summon, on comments and on reviews alike', async () => {
+    h.table.upsert(rule({}, { mentionOnly: true, commentFamilies: ['issues', 'pull_request'], agentName: 'oncall' }))
+    expect((await post(h, issueCommentPayload(), { eventType: 'issue_comment' })).statusCode).toBe(202)
+    expect(
+      (await post(h, reviewPayload(), { eventType: 'pull_request_review_comment', delivery: 'd2' })).statusCode
+    ).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    // The bot handle is the repository-wide broadcast form; the agent handle targets one rule.
+    const summoned = reviewPayload({ review: { type: 'x', content: `@${BOT_LOGIN} what about the retry?` } })
+    expect((await post(h, summoned, { eventType: 'pull_request_review_comment', delivery: 'd3' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('review:commented')
+  })
+
+  it('copies the rule host onto the trusted metadata as opaque data (§3)', async () => {
+    const SELF_HOSTED = 'https://gitea.example.test/gitea'
+    h.table.upsert(rule({}, { host: SELF_HOSTED }))
+    expect((await post(h, issuePayload(), { eventType: 'issues' })).statusCode).toBe(202)
+    await flush()
+    // Copied from the RULE, never read off the payload, and never parsed here: the relay does not
+    // dial Gitea, and the daemon fences the turn on this value.
+    expect((h.sent[0] as RdMsgHook).gitea?.host).toBe(SELF_HOSTED)
+
+    h.sent.length = 0
+    h.table.upsert(rule())
+    expect((await post(h, issuePayload(), { eventType: 'issues', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect((h.sent[0] as RdMsgHook).gitea?.host).toBeUndefined()
+  })
+
+  it('a daemon without gitea-v1 fails the dispatch closed, and heals when it gains the bit', async () => {
+    h.giteaSupported = false
+    h.table.upsert(rule({}, { events: ['push:*'] }))
+    expect((await post(h, pushPayload(), { eventType: 'push' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toEqual([expect.objectContaining({ status: 'failed', reason: 'rejected:unsupported' })])
+
+    // The fence is re-read per attempt, so no convergence pass is needed.
+    h.reports.length = 0
+    h.giteaSupported = true
+    expect((await post(h, pushPayload(), { eventType: 'push', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(1)
+  })
+
+  it('membership denial skips silently for issues and comments; nothing reaches the daemon', async () => {
+    h.authzResult = false
+    h.table.upsert(rule({}, { commentFamilies: ['issues'] }))
+    expect((await post(h, issuePayload(), { eventType: 'issues' })).statusCode).toBe(202)
+    expect((await post(h, issueCommentPayload(), { eventType: 'issue_comment', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toHaveLength(0)
+  })
+
+  it('verdict is pure: patterns gate before authz, and a foreign kind never matches', () => {
+    const ctx = normalizeGiteaEvent('issues', issuePayload() as GiteaPayload)!
+    expect(giteaRuleVerdict(rule(), ctx)).toBe('needs-authz')
+    expect(giteaRuleVerdict(rule({}, { events: ['issues:*'] }), ctx)).toBe('needs-authz')
+    expect(giteaRuleVerdict(rule({}, { events: ['merge_request:*'] }), ctx)).toBe('no-match')
+    expect(giteaRuleVerdict(rule({ kind: 'gitlab' }), ctx)).toBe('no-match')
+    // A created-cadence rule fires additively on a later summon in the same thread family.
+    const summon = normalizeGiteaEvent(
+      'issue_comment',
+      issueCommentPayload({ comment: { id: 3, body: '@oncall ping' } }) as GiteaPayload
+    )!
+    expect(giteaRuleVerdict(rule({}, { events: ['issues:opened'], agentName: 'oncall' }), summon)).toBe('needs-authz')
+    expect(giteaRuleVerdict(rule({}, { events: ['issues:opened'] }), summon)).toBe('no-match')
+    // A review submission is gated by the pull-request comment family, never by an event pattern.
+    const review = normalizeGiteaEvent('pull_request_review_rejected', reviewPayload() as GiteaPayload)!
+    expect(giteaRuleVerdict(rule({}, { events: ['merge_request:*'] }), review)).toBe('no-match')
+    expect(giteaRuleVerdict(rule({}, { commentFamilies: ['pull_request'] }), review)).toBe('needs-authz')
+  })
+})
+
+describe('gitea rerun dispatch (§10.4 "Run again")', () => {
+  let h: Harness
+  beforeEach(() => {
+    h = makeHarness()
+  })
+  afterEach(async () => {
+    await h.app.close()
+  })
+
+  const frame = (over: Partial<RcHookRerun> = {}): RcHookRerun => ({
+    hookId: HOOK,
+    agentId: AGENT,
+    deliveryKey: 'rerun_1',
+    configRevision: '3',
+    dispatchRevision: '5',
+    event: 'merge_request:rerun',
+    gitea: {
+      repoId: String(REPO),
+      repoPath: REPO_PATH,
+      target: { kind: 'pull', index: 77, headSha: HEAD_SHA, explicitReviewRequest: true }
+    },
+    ...over
+  })
+
+  it('re-enters the ordinary dispatch path with the §8 key and the frame head', async () => {
+    h.table.upsert(rule())
+    expect(dispatchGiteaRerun(h.deps, frame())).toEqual({ admitted: true, deliveryKey: 'rerun_1' })
+    await flush()
+    const msg = h.sent[0] as RdMsgHook
+    expect(msg.source).toBe('hook')
+    expect(msg.hookId).toBe(HOOK)
+    expect(msg.agentId).toBe(AGENT)
+    expect(msg.sessionKey).toBe(`gitea:${REPO}:pull:77`)
+    expect(msg.msgId).toBe(`${HOOK}:rerun_1`)
+    expect(msg.event).toBe('merge_request:rerun')
+    expect(msg.gitea?.target).toMatchObject({ kind: 'pull', index: 77, headSha: HEAD_SHA })
+    // A control-authored envelope: no third-party excerpt rides it.
+    expect(msg.context).toMatchObject({ source: 'gitea', event: 'merge_request', action: 'rerun', number: 77 })
+    expect(msg.context?.bodyExcerpt).toBeUndefined()
+    expect(h.reports.map((report) => report.status)).toEqual(['accepted'])
+    expect(h.reports[0]?.deliveryKey).toBe('rerun_1')
+  })
+
+  it('lands an issue rerun on the same thread key as the issue events', async () => {
+    h.table.upsert(rule())
+    dispatchGiteaRerun(
+      h.deps,
+      frame({ event: 'issues:rerun', gitea: { ...frame().gitea!, target: { kind: 'issue', index: 42 } } })
+    )
+    await flush()
+    expect((h.sent[0] as RdMsgHook).sessionKey).toBe(`gitea:${REPO}:issue:42`)
+  })
+
+  it('answers rule_mismatch for a frame whose fence no longer matches the compiled rule', async () => {
+    h.table.upsert(rule())
+    const mismatch = { admitted: false, code: 'rule_mismatch' }
+    expect(dispatchGiteaRerun(h.deps, frame({ configRevision: '4' }))).toEqual(mismatch)
+    expect(dispatchGiteaRerun(h.deps, frame({ dispatchRevision: '6' }))).toEqual(mismatch)
+    expect(dispatchGiteaRerun(h.deps, frame({ agentId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }))).toEqual(mismatch)
+    expect(dispatchGiteaRerun(h.deps, frame({ gitea: { ...frame().gitea!, repoId: '999' } }))).toEqual(mismatch)
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toHaveLength(0)
+  })
+
+  it('refuses a rerun whose provider member is not its own', async () => {
+    h.table.upsert(rule())
+    const gitlabRerun: RcHookRerun = {
+      hookId: HOOK,
+      agentId: AGENT,
+      deliveryKey: 'rerun_2',
+      configRevision: '3',
+      dispatchRevision: '5',
+      event: 'merge_request:rerun',
+      gitlab: { projectId: String(REPO), projectPath: REPO_PATH, target: { kind: 'merge_request', iid: 77 } }
+    }
+    expect(dispatchGiteaRerun(h.deps, gitlabRerun)).toEqual({ admitted: false, code: 'rule_mismatch' })
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toHaveLength(0)
+  })
+
+  it('answers replay_pending while its table holds no rule for the hook', async () => {
+    expect(dispatchGiteaRerun(h.deps, frame())).toEqual({ admitted: false, code: 'replay_pending' })
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toHaveLength(0)
+  })
+
+  it('ADMITS a fire the daemon then refuses — the run row is the report, not the verdict', async () => {
+    h.table.upsert(rule())
+    h.giteaSupported = false
+    expect(dispatchGiteaRerun(h.deps, frame({ deliveryKey: 'rerun_2' }))).toEqual({
+      admitted: true,
+      deliveryKey: 'rerun_2'
+    })
+    await flush()
+    expect(h.sent).toHaveLength(0)
+    expect(h.reports).toEqual([expect.objectContaining({ status: 'failed', reason: 'rejected:unsupported' })])
+  })
+
+  it('answers limiter_exhausted once the shared per-hook run budget is spent', async () => {
+    h.table.upsert(rule())
+    const verdicts = Array.from({ length: 7 }, (_, i) => dispatchGiteaRerun(h.deps, frame({ deliveryKey: `r_${i}` })))
+    await flush()
+    // The harness limiter holds five tokens and does not refill.
+    expect(verdicts.filter((v) => v.admitted)).toHaveLength(5)
+    expect(verdicts.slice(5)).toEqual([
+      { admitted: false, code: 'limiter_exhausted' },
+      { admitted: false, code: 'limiter_exhausted' }
+    ])
+    expect(h.sent).toHaveLength(5)
+  })
+})

--- a/packages/relay/src/hooks/gitea/ingress.ts
+++ b/packages/relay/src/hooks/gitea/ingress.ts
@@ -1,0 +1,411 @@
+/**
+ * Gitea ingress — `POST /webhooks/gitea`, the relay's per-repository webhook
+ * endpoint (gitea-integration.md §7, §8). Verification is per-rule: the compiled
+ * rule carries the repository's signing key inline, so the bounded first parse
+ * only extracts the numeric repository id, `X-Gitea-Signature` is checked
+ * against the matching rules' keys, and only then is the payload trusted as
+ * filter input. Uniform 404 for invalid signatures, unknown repositories,
+ * missing headers, and malformed bodies — no connected-repository oracle.
+ * Verified unmatched deliveries answer 202.
+ *
+ * Gitea sends no timestamp header, so there is no replay window — the same
+ * position GitHub is in. `X-Gitea-Delivery` is the delivery key, `msgId` is
+ * `${hookId}:${deliveryKey}`, and the daemon's durable `(sessionKey, msgId)`
+ * inbox plus the Control Plane's unique `(hookId, deliveryKey)` `HookRun`
+ * absorb every provider retry.
+ *
+ * Deployment supplies the HTTPS termination this endpoint requires (§7), exactly
+ * as it does for the GitHub and GitLab endpoints.
+ *
+ * The payload is NEVER logged; rules carry secret material.
+ */
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import type { Clock } from '@agentconnect.md/connection'
+import {
+  HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED,
+  type GiteaHookMetadata,
+  type RcCodeHostMembershipAuthz,
+  type RcHookAssign,
+  type RcHookRerun,
+  type RcHookRerunResult,
+  type RcRunReport,
+  type RdMsgHook
+} from '@agentconnect.md/protocol'
+import type { RelayDaemonServer } from '../../relay-daemon-server.js'
+import type { HookTable } from '../hook-table.js'
+import type { HookRateLimiter } from '../rate-limit.js'
+import { dispatchHookFire } from '../ingress.js'
+import { hookSnapshotForDelivery } from '../hook-snapshot.js'
+import { verifyHexHmacSha256 } from '../signature.js'
+import type { Logger } from '../../log.js'
+import {
+  buildGiteaContext,
+  buildTrustedGiteaMetadata,
+  giteaMentionCandidates,
+  giteaRuleIsSummoned,
+  giteaRuleVerdict,
+  giteaSessionKey,
+  giteaThreadWorktreeCleanup,
+  normalizeGiteaEvent,
+  type GiteaPayload
+} from './events.js'
+
+/** Raw-body cap (§7: 1 MiB). */
+export const GITEA_BODY_LIMIT = 1024 * 1024
+
+export interface GiteaIngressDeps {
+  table: HookTable
+  /** Late-bound: the rd/* server exists only after `listen()` (routes register before). */
+  daemons: () => Pick<RelayDaemonServer, 'get'> | undefined
+  /** Emit one delivery-stage `rc/run-report` EVT to the CP (fire-and-forget). */
+  report: (report: RcRunReport) => void
+  /** §8 live effective-membership gate — metadata only, resolved by the CP. */
+  authorizeMembership: (request: RcCodeHostMembershipAuthz) => Promise<boolean>
+  /** Dedicated upstream-call budget, shared by every hook on one repository. */
+  authzLimiter: HookRateLimiter
+  limiter: HookRateLimiter
+  clock: Clock
+  log: Logger
+}
+
+function headerString(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function notFound(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({ error: 'Not Found', statusCode: 404 })
+}
+
+export function registerGiteaIngress(app: FastifyInstance, deps: GiteaIngressDeps): void {
+  // Own plugin scope: the buffer content parser (raw bytes for the signature)
+  // must not leak onto the relay's other JSON surfaces.
+  void app.register(async (scope) => {
+    scope.addContentTypeParser(
+      'application/json',
+      { parseAs: 'buffer', bodyLimit: GITEA_BODY_LIMIT },
+      (_req, body, done) => done(null, body)
+    )
+
+    scope.post('/webhooks/gitea', { bodyLimit: GITEA_BODY_LIMIT }, async (req, reply) => {
+      const raw = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0)
+      // §7 order: bounded parse for the repository id FIRST, then the rules'
+      // signing key verifies the delivery, and only then is anything matched.
+      let payload: GiteaPayload
+      try {
+        payload = JSON.parse(raw.toString('utf8')) as GiteaPayload
+      } catch {
+        return notFound(reply)
+      }
+      const repoId = payload.repository?.id
+      if (repoId === undefined || !Number.isSafeInteger(repoId)) return notFound(reply)
+      const rules = deps.table.getByCodeHostRepo('gitea', String(repoId))
+      if (rules.length === 0) return notFound(reply)
+
+      const deliveryHeader = headerString(req.headers['x-gitea-delivery'])
+      const signature = headerString(req.headers['x-gitea-signature'])
+      if (!deliveryHeader || !signature) return notFound(reply)
+      // `X-Gitea-Signature` is bare hex HMAC-SHA256 over the exact raw body (§16); accepting any
+      // rule's key is what keeps a mid-rotation table holding current AND next lossless (§7).
+      const verified = rules.some((rule) => rule.gitea && verifyHexHmacSha256(rule.gitea.signingKey, raw, signature))
+      if (!verified) return notFound(reply)
+
+      const deliveryKey = deliveryHeader.slice(0, 200)
+      const firedAt = new Date(deps.clock.now()).toISOString()
+      // Never `X-Gitea-Event`: it collapses the sync and reviewer-request types into
+      // `pull_request`, and names a review `pull_request_comment` — a timeline comment's type (§7).
+      const eventType = headerString(req.headers['x-gitea-event-type'])
+      if (!eventType) return reply.code(202).send({ deliveryKey })
+
+      const cleanup = giteaThreadWorktreeCleanup(eventType, payload)
+      if (cleanup) {
+        // Maintenance cleanup (§8): relay-authored, never a model turn, and it
+        // bypasses the actor gate — a low-role closer must not leak a worktree.
+        const { event: cleanupEvent, kind, index: cleanupIndex } = cleanup
+        for (const rule of rules) {
+          if (rule.kind !== 'gitea' || !rule.gitea) continue
+          const gitea: GiteaHookMetadata = {
+            repoId: rule.gitea.repoId,
+            ...(rule.gitea.host !== undefined ? { host: rule.gitea.host } : {}),
+            repoPath: payload.repository?.full_name ?? rule.gitea.repoPath,
+            target: { kind, index: cleanupIndex }
+          }
+          const msg: RdMsgHook = {
+            source: 'hook',
+            agentId: rule.agentId,
+            sessionKey: giteaSessionKey(rule, gitea.target),
+            msgId: `${rule.hookId}:${deliveryKey}`,
+            hookId: rule.hookId,
+            deliveryKey,
+            firedAt,
+            ...hookSnapshotForDelivery(rule),
+            event: cleanupEvent,
+            gitea,
+            context: buildGiteaContext(payload, {
+              eventAction: cleanupEvent,
+              family: kind === 'issue' ? 'issues' : 'merge_request',
+              labels: [],
+              mentionText: undefined,
+              index: cleanupIndex
+            }),
+            ...(rule.target ? { target: rule.target } : {})
+          }
+          void dispatchHookFire(
+            { table: deps.table, daemons: deps.daemons, report: deps.report, clock: deps.clock, log: deps.log },
+            rule,
+            msg
+          )
+        }
+        return reply.code(202).send({ deliveryKey })
+      }
+
+      const ctx = normalizeGiteaEvent(eventType, payload)
+      if (!ctx) return reply.code(202).send({ deliveryKey })
+      const context = buildGiteaContext(payload, ctx)
+
+      const dispatchRule = (rule: RcHookAssign): void => {
+        if (!deps.limiter.allow(rule.hookId)) {
+          deps.log.info(`gitea ingress: rate-limited ${rule.hookId}:${deliveryKey} (${ctx.eventAction})`)
+          return
+        }
+        const gitea = buildTrustedGiteaMetadata(payload, ctx, rule)
+        if (!gitea) {
+          deps.log.info(`gitea ingress: rejected incomplete identity ${rule.hookId}:${deliveryKey}`)
+          return
+        }
+        const msg: RdMsgHook = {
+          source: 'hook',
+          agentId: rule.agentId,
+          sessionKey: giteaSessionKey(rule, gitea.target),
+          msgId: `${rule.hookId}:${deliveryKey}`,
+          hookId: rule.hookId,
+          deliveryKey,
+          firedAt,
+          ...hookSnapshotForDelivery(rule),
+          event: ctx.eventAction,
+          gitea,
+          context,
+          ...(rule.target ? { target: rule.target } : {})
+        }
+        void dispatchHookFire(
+          { table: deps.table, daemons: deps.daemons, report: deps.report, clock: deps.clock, log: deps.log },
+          rule,
+          msg
+        )
+        deps.log.info(`gitea ingress: queued ${rule.hookId}:${deliveryKey} (${ctx.eventAction} ${msg.sessionKey})`)
+      }
+
+      const reportReviewRequestRequired = (rule: RcHookAssign): void => {
+        const gitea = buildTrustedGiteaMetadata(payload, ctx, rule)
+        deps.report({
+          hookId: rule.hookId,
+          deliveryKey,
+          firedAt,
+          agentId: rule.agentId,
+          daemonId: rule.daemonId,
+          ...hookSnapshotForDelivery(rule),
+          event: ctx.eventAction,
+          ...(gitea ? { gitea } : {}),
+          status: 'failed',
+          reason: HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED
+        })
+      }
+
+      const candidates =
+        ctx.eventAction === 'merge_request:review_requested' ? rules : giteaMentionCandidates(rules, ctx.mentionText)
+      const matched = candidates
+        .map((rule) => ({ rule, verdict: giteaRuleVerdict(rule, ctx) }))
+        .filter((candidate) => candidate.verdict !== 'no-match')
+      for (const { rule, verdict } of matched) if (verdict === 'trusted') dispatchRule(rule)
+      const needsAuthz = matched.filter((candidate) => candidate.verdict === 'needs-authz').map(({ rule }) => rule)
+      if (needsAuthz.length === 0) return reply.code(202).send({ deliveryKey })
+
+      // §8: one live membership decision fences the whole fan-out. An external pull request
+      // (`head.repo_id` ≠ `repository.id`) never starts automatically — its author fails the gate.
+      const isLifecycle = ctx.family === 'issues' || ctx.family === 'merge_request'
+      // Lifecycle authorizes the subject author, comments and reviews their own author, and a
+      // reviewer request the REQUESTING actor — never the untrusted pull-request author (§8).
+      const gated =
+        ctx.eventAction !== 'merge_request:review_requested' && isLifecycle && ctx.subjectAuthorId !== undefined
+          ? { id: ctx.subjectAuthorId, login: ctx.subjectAuthorLogin }
+          : { id: ctx.actorId, login: ctx.actorLogin }
+      const actorId = gated.id
+      // Only a denied pull-request REVISION leaves the durable actionable row (§8).
+      const onDenied: 'skip' | 'request-review' =
+        ctx.eventAction === 'merge_request:opened' || ctx.eventAction === 'merge_request:synchronize'
+          ? 'request-review'
+          : 'skip'
+
+      const authorizeAndDispatch = async (fanout: RcHookAssign[], requireSubjectAuthor: boolean): Promise<void> => {
+        const representative = fanout[0]
+        if (!representative?.gitea) return
+        if (
+          !actorId ||
+          (requireSubjectAuthor && !ctx.subjectAuthorId) ||
+          fanout.some((rule) => !rule.gitea || rule.configRevision === undefined || rule.dispatchRevision === undefined)
+        ) {
+          deps.log.info(`gitea ingress: authz metadata incomplete ${representative.hookId}:${deliveryKey}`)
+          if (onDenied === 'request-review') for (const rule of fanout) reportReviewRequestRequired(rule)
+          return
+        }
+        if (!deps.authzLimiter.allow(representative.gitea.repoId)) {
+          deps.log.info(`gitea ingress: authz rate-limited ${representative.hookId}:${deliveryKey}`)
+          return
+        }
+        const request: RcCodeHostMembershipAuthz = {
+          hookId: representative.hookId,
+          provider: 'gitea',
+          repoExternalId: representative.gitea.repoId,
+          actorExternalId: actorId,
+          // Gitea's permission lookup is by username, so the login travels beside the id; the CP
+          // re-resolves the name and refuses a mismatch, so a rename cannot borrow a permission.
+          ...(gated.login ? { actorUsername: gated.login } : {}),
+          ...(requireSubjectAuthor && ctx.subjectAuthorId && ctx.subjectAuthorId !== actorId
+            ? {
+                subjectAuthorExternalId: ctx.subjectAuthorId,
+                ...(ctx.subjectAuthorLogin ? { subjectAuthorUsername: ctx.subjectAuthorLogin } : {})
+              }
+            : {}),
+          configRevision: representative.configRevision!,
+          dispatchRevision: representative.dispatchRevision!,
+          ...(fanout.length > 1
+            ? {
+                siblingFences: fanout.slice(1).map((rule) => ({
+                  hookId: rule.hookId,
+                  configRevision: rule.configRevision!,
+                  dispatchRevision: rule.dispatchRevision!
+                }))
+              }
+            : {})
+        }
+        let allowed = false
+        try {
+          allowed = await deps.authorizeMembership(request)
+        } catch (err) {
+          // Rolling upgrade against an older CP (UNKNOWN_FRAME), timeout, and
+          // transient failures all fail closed (§8).
+          deps.log.warn(`gitea ingress: authz failed ${representative.hookId}:${deliveryKey}: ${String(err)}`)
+        }
+        if (!allowed) {
+          deps.log.info(
+            `gitea ingress: authz denied ${representative.hookId}:${deliveryKey} (${ctx.eventAction} actor ${actorId})`
+          )
+          if (onDenied === 'request-review') for (const rule of fanout) reportReviewRequestRequired(rule)
+          return
+        }
+        // The membership wait crossed a remote boundary: re-read every rule and re-run the
+        // verdict, so a remove/reconfigure/retarget in that window cannot dispatch a stale capture.
+        for (const rule of fanout) {
+          const current = deps.table.getByHookId(rule.hookId)
+          if (
+            !current ||
+            current.kind !== 'gitea' ||
+            !current.gitea ||
+            current.gitea.repoId !== rule.gitea!.repoId ||
+            current.configRevision !== rule.configRevision ||
+            current.dispatchRevision !== rule.dispatchRevision ||
+            current.agentId !== rule.agentId ||
+            giteaRuleVerdict(current, ctx) !== 'needs-authz'
+          ) {
+            deps.log.info(`gitea ingress: authz rule changed ${rule.hookId}:${deliveryKey}`)
+            continue
+          }
+          dispatchRule(current)
+        }
+      }
+
+      // Comments and review submissions on an unmentioned thread continuation also require the
+      // subject author's membership (§8); a summoning comment authorizes only its author.
+      if (ctx.family === 'note' || ctx.family === 'review') {
+        const summonedRules = needsAuthz.filter((rule) => giteaRuleIsSummoned(rule, ctx))
+        const unsummoned = needsAuthz.filter((rule) => !giteaRuleIsSummoned(rule, ctx))
+        if (summonedRules.length > 0)
+          void authorizeAndDispatch(summonedRules, false).catch((err) => {
+            deps.log.warn(`gitea ingress: authz task failed ${deliveryKey}: ${String(err)}`)
+          })
+        if (unsummoned.length > 0)
+          void authorizeAndDispatch(unsummoned, true).catch((err) => {
+            deps.log.warn(`gitea ingress: authz task failed ${deliveryKey}: ${String(err)}`)
+          })
+      } else {
+        void authorizeAndDispatch(needsAuthz, false).catch((err) => {
+          deps.log.warn(`gitea ingress: authz task failed ${deliveryKey}: ${String(err)}`)
+        })
+      }
+      return reply.code(202).send({ deliveryKey })
+    })
+  })
+}
+
+/** The deps one Console-initiated rerun needs — the ordinary ingress subset. */
+export type GiteaRerunDeps = Pick<GiteaIngressDeps, 'table' | 'daemons' | 'report' | 'limiter' | 'clock' | 'log'>
+
+/**
+ * Re-dispatch one gitea hook turn on the Control Plane's `rc/hook-rerun`
+ * (gitea-integration.md §10.4). The CP already revalidated the hook, agent,
+ * binding, and live subject; the relay re-checks the frame against its OWN
+ * compiled rule — a disable, retarget, or reconfigure since the CP read fails
+ * the rerun closed — then reuses the ordinary dispatch path, including its
+ * per-hook run budget.
+ *
+ * The return value IS the admission: only `admitted` means a turn was queued and
+ * a run report will follow. Every refusal is definitive and leaves no HookRun
+ * row, so the Control Plane is free to ask another relay.
+ */
+export function dispatchGiteaRerun(deps: GiteaRerunDeps, rerun: RcHookRerun): RcHookRerunResult {
+  const rule = deps.table.getByHookId(rerun.hookId)
+  // No rule at all reads as an unconverged table: this relay's copy is filled by
+  // the CP's register replay, and the CP only sends a rerun it just compiled.
+  if (!rule) {
+    deps.log.info(`gitea rerun: no rule yet for ${rerun.hookId}:${rerun.deliveryKey}`)
+    return { admitted: false, code: 'replay_pending' }
+  }
+  // The frame is provider-keyed: a member this handler does not own is not a rule mismatch it
+  // can fix, so it refuses definitively and the Control Plane moves on.
+  const gitea = rerun.gitea
+  if (
+    !gitea ||
+    rule.kind !== 'gitea' ||
+    !rule.gitea ||
+    rule.agentId !== rerun.agentId ||
+    rule.gitea.repoId !== gitea.repoId ||
+    rule.configRevision !== rerun.configRevision ||
+    rule.dispatchRevision !== rerun.dispatchRevision
+  ) {
+    deps.log.info(`gitea rerun: ignored stale ${rerun.hookId}:${rerun.deliveryKey}`)
+    return { admitted: false, code: 'rule_mismatch' }
+  }
+  if (!deps.limiter.allow(rule.hookId)) {
+    deps.log.info(`gitea rerun: rate-limited ${rule.hookId}:${rerun.deliveryKey}`)
+    return { admitted: false, code: 'limiter_exhausted' }
+  }
+  const family = gitea.target.kind === 'issue' ? ('issues' as const) : ('merge_request' as const)
+  const msg: RdMsgHook = {
+    source: 'hook',
+    agentId: rule.agentId,
+    sessionKey: giteaSessionKey(rule, gitea.target),
+    msgId: `${rule.hookId}:${rerun.deliveryKey}`,
+    hookId: rule.hookId,
+    deliveryKey: rerun.deliveryKey,
+    firedAt: new Date(deps.clock.now()).toISOString(),
+    ...hookSnapshotForDelivery(rule),
+    event: rerun.event,
+    gitea,
+    // Control-authored envelope: no third-party text, so nothing to fence.
+    context: {
+      source: 'gitea',
+      event: family,
+      action: 'rerun',
+      repo: gitea.repoPath,
+      ...(gitea.target.kind !== 'push' ? { number: gitea.target.index } : {}),
+      truncated: false
+    },
+    ...(rule.target ? { target: rule.target } : {})
+  }
+  void dispatchHookFire(
+    { table: deps.table, daemons: deps.daemons, report: deps.report, clock: deps.clock, log: deps.log },
+    rule,
+    msg
+  )
+  deps.log.info(`gitea rerun: queued ${rule.hookId}:${rerun.deliveryKey} (${rerun.event} ${msg.sessionKey})`)
+  return { admitted: true, deliveryKey: rerun.deliveryKey }
+}

--- a/packages/relay/src/hooks/signature.ts
+++ b/packages/relay/src/hooks/signature.ts
@@ -1,23 +1,29 @@
 /**
- * Shared `sha256=<hex>` HMAC header verification — the security-sensitive core
- * (prefix parse, hex decode, length check BEFORE timingSafeEqual) used by both
- * public ingress endpoints: `X-AC-Signature` on the generic webhook and
- * `X-Hub-Signature-256` on the GitHub endpoint. One implementation so the two
- * cannot drift.
+ * Shared HMAC-SHA256 header verification — the security-sensitive core (hex
+ * decode and length check BEFORE timingSafeEqual) used by every public ingress
+ * endpoint: `X-AC-Signature` on the generic webhook, `X-Hub-Signature-256` on
+ * the GitHub endpoint, and the bare-hex `X-Gitea-Signature` on the Gitea one.
+ * One implementation so they cannot drift.
  */
 import { createHmac, timingSafeEqual } from 'node:crypto'
 
-/** True iff `header` is `sha256=<hex>` of HMAC-SHA256(secret, rawBody), timing-safe. */
-export function verifySha256Header(secret: string, rawBody: Buffer, header: string | undefined): boolean {
-  if (!header || !header.startsWith('sha256=')) return false
+/** True iff `hex` is the lowercase/uppercase hex HMAC-SHA256(secret, rawBody), timing-safe. */
+export function verifyHexHmacSha256(secret: string, rawBody: Buffer, hex: string | undefined): boolean {
+  if (!hex) return false
   const expected = createHmac('sha256', secret).update(rawBody).digest()
   let presented: Buffer
   try {
-    presented = Buffer.from(header.slice('sha256='.length), 'hex')
+    presented = Buffer.from(hex, 'hex')
   } catch {
     return false
   }
   return presented.length === expected.length && timingSafeEqual(presented, expected)
+}
+
+/** True iff `header` is `sha256=<hex>` of HMAC-SHA256(secret, rawBody), timing-safe. */
+export function verifySha256Header(secret: string, rawBody: Buffer, header: string | undefined): boolean {
+  if (!header || !header.startsWith('sha256=')) return false
+  return verifyHexHmacSha256(secret, rawBody, header.slice('sha256='.length))
 }
 
 /** Replay window for Slack's `X-Slack-Request-Timestamp` (Slack's own recommendation). */

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -11,7 +11,9 @@
  */
 import { randomUUID } from 'node:crypto'
 import {
+  codeHostHookMetadataOf,
   RELAY_CP_SUBPROTOCOL,
+  type CodeHostProvider,
   type RcCodeHostMembershipAuthz,
   type RcHookRerun,
   type RcHookRerunResult,
@@ -34,6 +36,7 @@ import { HookRateLimiter } from './hooks/rate-limit.js'
 import { registerHookIngress } from './hooks/ingress.js'
 import { registerGithubIngress } from './hooks/github-ingress.js'
 import { dispatchGitlabRerun, registerGitlabIngress } from './hooks/gitlab-ingress.js'
+import { dispatchGiteaRerun, registerGiteaIngress } from './hooks/gitea/ingress.js'
 import { McpBindingTable } from './mcp/binding-table.js'
 import { registerMcpProxy, registerMemoryPluginProxy } from './mcp/proxy.js'
 import { MemoryConnectionBindingTable } from './memory/binding-table.js'
@@ -62,7 +65,7 @@ async function main(): Promise<void> {
     client?: RelayCpClient
     rdServer?: RelayDaemonServer
     relayIngress?: RelayIngressManager
-    gitlabRerun?: (rerun: RcHookRerun) => RcHookRerunResult
+    hookRerun?: (rerun: RcHookRerun) => RcHookRerunResult
   } = {}
 
   // The bot-agnostic collaboration routing snapshot (agent-collaboration §2.3/§6.2).
@@ -175,9 +178,9 @@ async function main(): Promise<void> {
       }),
     onHookAssign: (rule) => hookTable.upsert(rule),
     onHookRemove: (hookId) => hookTable.remove(hookId),
-    // Late-bound: the gitlab ingress deps this reuses are built after listen, so
+    // Late-bound: the code-host ingress deps this reuses are built after listen, so
     // a frame that somehow beats them finds no rule table either.
-    onHookRerun: (rerun) => held.gitlabRerun?.(rerun) ?? { admitted: false, code: 'replay_pending' },
+    onHookRerun: (rerun) => held.hookRerun?.(rerun) ?? { admitted: false, code: 'replay_pending' },
     // Bot-agnostic collaboration routing snapshot (agent-collaboration §2.3/§6.2) —
     // FULL-REPLACE the relay's cross-daemon agent-call routing/policy table.
     onCollabRoutes: (snap) => collab.replace(snap),
@@ -269,8 +272,34 @@ async function main(): Promise<void> {
     log
   }
   registerGitlabIngress(server, gitlabIngressDeps)
-  // The Console "Run again" action (§16.1) re-enters the same dispatch path.
-  held.gitlabRerun = (rerun) => dispatchGitlabRerun(gitlabIngressDeps, rerun)
+
+  // Gitea repository webhooks (gitea-integration.md §7): rule-carried signing
+  // keys, bare-hex signature, no replay window, live membership through the CP.
+  const giteaAuthzLimiter = new HookRateLimiter(systemClock, { capacity: 10, refillPerSec: 0.25 })
+  const giteaIngressDeps = {
+    table: hookTable,
+    daemons: () => held.rdServer,
+    report: (r: RcRunReport) => client.emitRunReport(r),
+    authorizeMembership: (request: RcCodeHostMembershipAuthz) => client.authorizeCodeHostMembership(request),
+    authzLimiter: giteaAuthzLimiter,
+    limiter,
+    clock: systemClock,
+    log
+  }
+  registerGiteaIngress(server, giteaIngressDeps)
+
+  // The Console "Run again" action (§16.1, gitea-integration.md §10.4) re-enters the ordinary
+  // dispatch path. `rc/hook-rerun` is provider-keyed: its single member picks the handler, and a
+  // member no handler owns is refused definitively so the CP can ask another relay.
+  const rerunByProvider: Partial<Record<CodeHostProvider, (rerun: RcHookRerun) => RcHookRerunResult>> = {
+    gitlab: (rerun) => dispatchGitlabRerun(gitlabIngressDeps, rerun),
+    gitea: (rerun) => dispatchGiteaRerun(giteaIngressDeps, rerun)
+  }
+  held.hookRerun = (rerun) => {
+    const host = codeHostHookMetadataOf(rerun)
+    const dispatch = host && rerunByProvider[host.provider]
+    return dispatch ? dispatch(rerun) : { admitted: false, code: 'rule_mismatch' }
+  }
 
   // MCP reverse proxy (ALL /mcp/:providerId) — resolves a grant to its upstream, SSRF-guards
   // + IP-pins the operator-supplied upstream, swaps the bearer for the real headers, streams

--- a/packages/relay/src/relay-cp-client.test.ts
+++ b/packages/relay/src/relay-cp-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   buildRelayCpFrame,
   RELAY_CP_SUBPROTOCOL,
+  GITEA_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
   GITLAB_INSTANCE_V1_FEATURE,
   GITLAB_RERUN_V1_FEATURE,
@@ -200,7 +201,8 @@ describe('RelayCpClient', () => {
         GITLAB_COM_V1_FEATURE,
         GITLAB_RERUN_V1_FEATURE,
         GITLAB_INSTANCE_V1_FEATURE,
-        PULL_REQUEST_FEEDBACK_FEATURE
+        PULL_REQUEST_FEEDBACK_FEATURE,
+        GITEA_V1_FEATURE
       ]
     })
 

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -15,6 +15,7 @@
 import {
   buildRelayCpFrame,
   decodeRelayCpFrame,
+  GITEA_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
   GITLAB_INSTANCE_V1_FEATURE,
   GITLAB_RERUN_V1_FEATURE,
@@ -557,12 +558,16 @@ export class RelayCpClient {
         // admission REP — strictly newer than gitlab-com-v1 (§17.3).
         // gitlab-instance-v1: this relay carries the compiled rule's host through onto the
         // trusted metadata it forwards, so a self-managed rule is dispatchable here (§24.4).
+        // gitea-v1: this relay verifies and routes Gitea repository webhooks and decodes the
+        // gitea arm of rc/hook-rerun, for gitea.com and a self-hosted address alike
+        // (gitea-integration.md §7, §11).
         features: [
           WEBCHAT_SESSION_CONTINUATION_FEATURE,
           GITLAB_COM_V1_FEATURE,
           GITLAB_RERUN_V1_FEATURE,
           GITLAB_INSTANCE_V1_FEATURE,
-          PULL_REQUEST_FEEDBACK_FEATURE
+          PULL_REQUEST_FEEDBACK_FEATURE,
+          GITEA_V1_FEATURE
         ]
       })
     )

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -528,7 +528,7 @@ relay_route = public_documents.find { |doc| doc['kind'] == 'HTTPRoute' && doc.di
 relay_paths = relay_route.dig('spec', 'rules').flat_map { |rule| rule['matches'].to_a }.map { |match| match.dig('path', 'value') }
 # Every HTTP ingress path the relay registry mounts; a path the route omits falls through to
 # the web catch-all (or the gateway 404) and that platform's ingress silently receives nothing.
-%w[/mcp /memory /webchat /webhooks/in /webhooks/github /webhooks/gitlab /slack/events /slack/interactions /feishu/events /linear/events].each do |path|
+%w[/mcp /memory /webchat /webhooks/in /webhooks/github /webhooks/gitlab /webhooks/gitea /slack/events /slack/interactions /feishu/events /linear/events].each do |path|
   abort("relay route must forward #{path}") unless relay_paths.include?(path)
 end
 


### PR DESCRIPTION
Step **G3** of the Gitea rollout (`docs/designs/gitea-integration.md` §16): the relay's Gitea webhook ingress. Built on the GitLab ingress as its template; G1 (#2049) already landed the protocol members this reads.

## Verification (§7)

`POST /webhooks/gitea`, 1 MiB raw-body cap, bounded first parse for `repository.id`, rule lookup by `(gitea, id)`, then a timing-safe bare-hex HMAC-SHA256 check of `X-Gitea-Signature` over the exact raw bytes — against **every** matching rule's signing key, which is what keeps a table holding both the current and the next key lossless mid-rotation. Only then is the body decoded. Unmatched, malformed, and forged deliveries are indistinguishable from outside (uniform 404); a verified delivery that maps to nothing answers 202.

Gitea sends no timestamp header, so there is no replay window — the same position GitHub is in. `X-Gitea-Delivery` is the delivery key and `msgId` is `${hookId}:${deliveryKey}`, so the daemon's durable `(sessionKey, msgId)` inbox and the unique `(hookId, deliveryKey)` run row absorb provider retries.

The shared `sha256=<hex>` verifier is refactored so the hex decode and the length check that must precede `timingSafeEqual` live in one place (`verifyHexHmacSha256`); the prefixed wrapper keeps its existing callers byte-for-byte.

## Event mapping (§8, as the probes amended it)

Every decision keys on `X-Gitea-Event-Type`. The legacy `X-Gitea-Event` is lossy in both directions — it collapses `pull_request_sync` and `pull_request_review_request` into `pull_request`, and labels a review submission `pull_request_comment`, which is also an ordinary timeline comment's own event type — so it is never read.

| Event type | Normalized |
| --- | --- |
| `issues` `opened` | `issues:opened` |
| `issues` `closed` | `issues:closed` (maintenance cleanup) |
| `issue_comment` `created`, `is_pull: false` | `note:created` on the issue |
| `pull_request_comment` `created`, `is_pull: true` | `note:created` on the pull request |
| `pull_request` `opened` | `merge_request:opened` |
| `pull_request` `closed` + `merged` | `merge_request:merged` (maintenance cleanup) |
| `pull_request_sync` `synchronized` | `merge_request:synchronize` |
| `pull_request_review_request` `review_requested` naming the bot | `merge_request:review_requested` |
| `pull_request_review_comment` / `_approved` / `_rejected`, `action: reviewed` | `review:commented` / `review:approved` / `review:changes_requested` |
| `push` | `push` |

A review submission is one delivery carrying only the summary in `review.content` — no path, line, hunk, body, or review id — so the verdict is the only part of §8's correlation the relay can carry forward, which is why it gets three names rather than one. It is gated by the pull-request comment family, not by an event pattern. `requested_reviewer` is read **only** on `pull_request_review_request`; on a review delivery it names the review's author, and the empty top-level `commit_id` is never used.

Vetoes match GitLab's: edited-comment noise, draft toggles (they ride `pull_request` `edited`), and label/assignment/milestone churn, which Gitea delivers under event types the table simply does not name.

## Gates

- **Loop prevention.** A delivery whose `sender.id` is the rule's bot user is rejected, except the bot's own same-repository pull-request revisions (`opened` / `synchronized` with `head.repo_id === repository.id`), which stay relay-trusted like a push. A fork revision by the bot is not the internal lane and stays vetoed.
- **Cadence, comment families, mention gate**, then the live `rc/codehost-membership-authz` call on its own upstream budget. The request carries the actor's **login beside its numeric id** (and the thread author's, on an unmentioned continuation) because Gitea looks a permission up by name and the Control Plane re-resolves it.
- **External pull requests** never start automatically: the gate resolves the pull request's author, and a denied revision leaves the durable review-request-required row instead of silence.
- **Maintenance deliveries** bypass the actor gate and open no model turn.
- `pull_request.head.sha` and `base.sha` travel as the head fence; the rule's host travels as opaque pass-through for the daemon's turn-time fence.

## Sessions, rerun, advertisement

Session keys are `gitea:<repoId>:<issue|pull>:<index>` and `gitea:<repoId>:push:<ref>`, always derived from the signed subject with a positive index — never a display path or a delivery id. `dispatchGiteaRerun` serves the `gitea` arm of `rc/hook-rerun` through the ordinary dispatch path, and the bootstrap now picks the rerun handler from the frame's single provider member, refusing a member no handler owns definitively so the Control Plane can ask another relay.

The relay advertises `gitea-v1` on register: with the signed ingress and the rerun arm in place its slice is complete, and one string covers gitea.com and a self-hosted address alike.

The gateway route forwards `/webhooks/gitea` to the relay pool, and the path joins the render contract's pinned list — a path the route omits falls through to the web catch-all and the ingress silently receives nothing, which is the failure that list exists to catch.

## Tests

`packages/relay/src/hooks/gitea/ingress.test.ts`, 24 cases modelled on the GitLab suite: signature accept/reject (current key, next key during rotation, wrong key, tampered body, non-hex), the lossy `X-Gitea-Event` vs `X-Gitea-Event-Type` split, every mapping row and every veto, the loop veto with its own-revision exception and the fork counter-case, external-PR refusal, the membership request shape (id + login, actor and thread author), delivery key and `msgId`, cleanup deliveries including the unmerged close that is neither, comment-family scoping, mention narrowing, mention-only, host pass-through, and feature gating that heals without a convergence pass.

Fixtures are shaped by real captured deliveries and carry only synthetic identifiers.

Also records the emitted event vocabulary in §8 — it was described by product family only, and named the reviewer family `merge_request:reviewer_requested` where every existing consumer reads `merge_request:review_requested` — so G4 implements against the same strings.

## Gates run

- `pnpm typecheck` — clean, all packages
- `pnpm --filter @agentconnect.md/relay test` — 31 files, 687 tests passed
- `pnpm lint` — 0 errors (8 pre-existing warnings, none in new files)
- `pnpm format:check` — clean
- `ruby scripts/test-chart-render.rb` — chart render contract ok

No GitHub or GitLab expectation changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
