### PR TITLE
ci: weigh the daemon's Windows shards by measured seconds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -213,7 +213,7 @@ jobs:
   unit-windows:
     name: Unit Test (Windows) (${{ matrix.shard }})
     runs-on: windows-latest
-    # The daemon balances its halves by file size (`scripts/vitest-shard-sequencer.ts`); the CLI is 6 s, so it keeps Vitest's own split.
+    # The daemon balances its halves by measured seconds (`scripts/vitest-shard-sequencer.ts`); the CLI is 6 s, so it keeps Vitest's own split.
     strategy:
       fail-fast: false
       matrix:

--- a/packages/daemon/test/shard-weights.test.ts
+++ b/packages/daemon/test/shard-weights.test.ts
@@ -1,0 +1,48 @@
+// An entry that no longer names a real file weighs nothing, silently — the file it replaced falls back to
+// one second and the shards drift back toward the split that measured 2.44 to 1. The sequencer matches a
+// module id by suffix, so a key that is not a package-relative POSIX path never matches either.
+import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { TestSpecification } from 'vitest/node'
+import { weightBalancedSequencer } from '../../../scripts/vitest-shard-sequencer.js'
+import { SHARD_WEIGHTS, SHARD_WEIGHT_FALLBACK } from '../vitest.config.js'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const entries = Object.entries(SHARD_WEIGHTS)
+
+describe('shard weights', () => {
+  it('names files that exist', () => {
+    expect(entries.filter(([file]) => !existsSync(join(packageRoot, file))).map(([file]) => file)).toEqual([])
+  })
+
+  it('keys them the way the sequencer matches them', () => {
+    expect(entries.filter(([file]) => file.includes('\\') || file.startsWith('./') || file.startsWith('/'))).toEqual([])
+  })
+
+  it('weighs each one above the fallback, or the entry buys nothing', () => {
+    expect(entries.filter(([, weight]) => weight <= SHARD_WEIGHT_FALLBACK)).toEqual([])
+  })
+
+  // The whole table reaches the partition through one suffix match against an absolute module id: get that
+  // wrong and every file silently weighs the fallback, which is the imbalance this table exists to remove.
+  it('splits the weight it names evenly between two shards', async () => {
+    const Sequencer = weightBalancedSequencer(SHARD_WEIGHTS, SHARD_WEIGHT_FALLBACK)
+    const specs = entries.map(([file]) => ({ moduleId: join(packageRoot, file) }) as TestSpecification)
+    const halves = await Promise.all(
+      [1, 2].map((index) => new Sequencer({ config: { shard: { index, count: 2 } } } as never).shard(specs))
+    )
+    const weigh = (half: TestSpecification[]) =>
+      half.reduce(
+        (total, spec) => total + (SHARD_WEIGHTS[spec.moduleId.slice(packageRoot.length).replaceAll('\\', '/')] ?? 0),
+        0
+      )
+    const total = entries.reduce((sum, [, weight]) => sum + weight, 0)
+    expect(halves.flat().length).toBe(specs.length)
+    expect(new Set(halves.flat()).size).toBe(specs.length)
+    // Equal to the table's own sum only if every module id matched an entry; a fallback everywhere balances too.
+    expect(weigh(halves[0]!) + weigh(halves[1]!)).toBe(total)
+    expect(Math.abs(weigh(halves[0]!) - weigh(halves[1]!)) / total).toBeLessThan(0.05)
+  })
+})

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, configDefaults } from 'vitest/config'
 import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js'
-import { SizeBalancedSequencer } from '../../scripts/vitest-shard-sequencer.js'
+import { weightBalancedSequencer } from '../../scripts/vitest-shard-sequencer.js'
 import { BASE_TEST_TIMEOUT } from '../../scripts/vitest-test-budget.js'
 
 // The files that call `vi.mock`. A mock is registered per FILE but rewires a module in the registry,
@@ -61,6 +61,40 @@ export const WINDOWS_EXCLUDED = [
   'test/daemon-loop-guard-pool.test.ts'
 ]
 
+// Seconds on the Windows runner, the mean of three runs. These 25 files are 78% of the suite's time, which is
+// why weighing them alone balances the shards; everything else is the fallback below, and a new file needs an
+// entry only once it grows into this tail. `test/shard-weights.test.ts` fails when an entry stops naming a file.
+export const SHARD_WEIGHTS: Record<string, number> = {
+  'test/workspace-session-clone.test.ts': 121,
+  'test/workspace-secondary-roots.test.ts': 100,
+  'test/daemon-message-agent.test.ts': 85,
+  'test/daemon-lifecycle.test.ts': 73,
+  'test/daemon-hook.test.ts': 68,
+  'test/reconcile-watch.test.ts': 59,
+  'test/daemon-duty-install.test.ts': 55,
+  'test/cp/cp-agent-reconcile.test.ts': 50,
+  'test/daemon-duty-drain.test.ts': 46,
+  'test/daemon-commands.test.ts': 39,
+  'test/daemon-webchat.test.ts': 39,
+  'test/daemon-agent-mention-routing.test.ts': 31,
+  'test/workspace-git-write.test.ts': 30,
+  'test/daemon-duty-fence.test.ts': 30,
+  'test/linear-ingress.test.ts': 30,
+  'test/daemon-smoke.test.ts': 29,
+  'test/daemon-session-hosts.test.ts': 28,
+  'test/daemon-transcript.test.ts': 23,
+  'test/durable-inbox.test.ts': 21,
+  'test/telegram-threading.test.ts': 18,
+  'test/daemon-duty-replacement.test.ts': 18,
+  'test/session-manager.test.ts': 17,
+  'test/daemon-serial-gate.test.ts': 14,
+  'test/dream-runner.test.ts': 14,
+  'test/orchestration.test.ts': 13
+}
+
+// The unlisted 326 files measured 0.88 s on average, and rounding that up costs the partition nothing.
+export const SHARD_WEIGHT_FALLBACK = 1
+
 const platformExcluded = process.platform === 'win32' ? WINDOWS_EXCLUDED : []
 
 export default defineConfig({
@@ -70,7 +104,7 @@ export default defineConfig({
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.
     maxWorkers: 4,
-    sequence: { sequencer: SizeBalancedSequencer },
+    sequence: { sequencer: weightBalancedSequencer(SHARD_WEIGHTS, SHARD_WEIGHT_FALLBACK) },
     // The async store pays a microtask hop per statement; on a loaded CI box the IO-heavy store files
     // drift past vitest's 5 s default without being hung. Windows I/O is slower again by enough that
     // the same files need double the budget.

--- a/scripts/vitest-shard-sequencer.ts
+++ b/scripts/vitest-shard-sequencer.ts
@@ -1,16 +1,21 @@
-import { statSync } from 'node:fs'
 import { BaseSequencer, type TestSpecification } from 'vitest/node'
 
-// Vitest shards by sha1 of the file path, which is a random partition — and a fixed one, so a bad
-// draw stays bad. Over this repo's daemon suite a random half lands at 1.33:1 by median and 2:1 at
-// p90. Greedy longest-processing-time over file size is a weak proxy (0.61 correlation with
-// measured duration) but a far better partition: 1.15:1 on the same suite.
-export class SizeBalancedSequencer extends BaseSequencer {
-  async shard(specs: TestSpecification[]): Promise<TestSpecification[]> {
-    const shard = this.ctx.config.shard
-    if (!shard) return specs
-    const weighed = specs.map((spec) => ({ item: spec, weight: sizeOf(spec.moduleId), key: spec.moduleId }))
-    return balancedBuckets(weighed, shard.count)[shard.index - 1] ?? []
+// Vitest shards by sha1 of the file path, a random partition — and a fixed one, so a bad draw stays bad.
+// Greedy longest-processing-time over a weight partitions far better, and that weight has to be measured:
+// file size mis-weighs `daemon-hook.test.ts` (174 KB) as 0.6 s against 67 s measured on the Windows runner,
+// and the halves it drew over three runs came out 1.61, 1.67 and 2.44 to 1 against 1.01 on all three from a table.
+export function weightBalancedSequencer(weights: Record<string, number>, fallback: number) {
+  return class WeightBalancedSequencer extends BaseSequencer {
+    async shard(specs: TestSpecification[]): Promise<TestSpecification[]> {
+      const shard = this.ctx.config.shard
+      if (!shard) return specs
+      const weighed = specs.map((spec) => ({
+        item: spec,
+        weight: weigh(spec.moduleId, weights, fallback),
+        key: spec.moduleId
+      }))
+      return balancedBuckets(weighed, shard.count)[shard.index - 1] ?? []
+    }
   }
 }
 
@@ -31,11 +36,9 @@ export function balancedBuckets<T>(items: { item: T; weight: number; key: string
   return buckets
 }
 
-/** An unreadable file weighs nothing rather than failing the run — it fails on its own in a moment. */
-function sizeOf(path: string): number {
-  try {
-    return statSync(path).size
-  } catch {
-    return 0
-  }
+// Module ids are absolute and the table's keys are package-relative, so match the suffix; a win32 id carries backslashes.
+function weigh(moduleId: string, weights: Record<string, number>, fallback: number): number {
+  const path = moduleId.replaceAll('\\', '/')
+  for (const [file, weight] of Object.entries(weights)) if (path.endsWith(`/${file}`)) return weight
+  return fallback
 }


### PR DESCRIPTION
The `Unit Test (Windows)` job is the slowest leg in the Test workflow, and about half of what it costs is the split, not the tests. The two shards are weighed by file size, and size does not predict duration on that runner: `test/daemon-hook.test.ts` is 174 KB and takes 67 s, where the median file's bytes-per-second would price it at 0.6 s.

Parsing the per-file durations out of three recent runs' Windows logs:

| run | shard 1 | shard 2 | imbalance | heavy shard's wall clock |
| --- | --- | --- | --- | --- |
| A | 464.8 s | 749.7 s | 1.61 : 1 | 295 s |
| B | 547.9 s | 912.5 s | 1.67 : 1 | 382 s |
| C | 388.3 s | 945.8 s | 2.44 : 1 | 379 s |

Shard 2 is the heavy one every time, and the size weights are not just imprecise — being wrong by two orders of magnitude on the few files that dominate also destroys the accidental balance that greedy packing gets from many small ones. Weighing every file equally would already have beaten size on all three runs.

## What this does

`weightBalancedSequencer(weights, fallback)` replaces `SizeBalancedSequencer`: same greedy longest-processing-time partition, but the weight comes from a table of measured seconds, matched against a module id by suffix, and everything unlisted weighs the fallback. `packages/daemon/vitest.config.ts` carries the table — the 25 files that are 78% of the suite's time, the mean of the three runs above — and a fallback of one second for the other 326.

A committed table is viable because the durations are reproducible: the same file's time correlates 0.982 to 0.996 between runs, across different branches.

`test/shard-weights.test.ts` fails when an entry stops naming a real file, is keyed in a shape the suffix match cannot read, or stops reaching the partition at all — that last one matters because a table that silently degrades to the fallback still looks balanced in isolation.

Two shards stay two shards. After balancing, roughly half of each job is fixed setup (checkout, pnpm, Node, install), so a third shard would buy far less than a third.

## Verification

- The committed table simulated against the same three runs' measured durations: **1.013, 1.012 and 1.005 to 1**, taking 18%, 19% and 29% off the heavy shard — about 257 s, 334 s and 303 s of wall clock against the 295 s, 382 s and 379 s those runs actually took.
- `pnpm --filter @agentconnect.md/daemon typecheck`, prettier, eslint, and `test/shard-weights.test.ts` + `test/shard-partition.test.ts` locally.
- The existing partition guard is weight-agnostic and untouched, so disjoint-and-complete is still covered for any shard count.

Caveat worth stating plainly: those three runs are three different pull requests, so the comparison above is observational rather than a matrix. The measurement that settles it is this PR's own Windows job against main's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
