### PR TITLE
ci: run the integration suite as one job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ on:
         value: ${{ jobs.unit.outputs.summary }}
       integration_test_summary:
         description: 'Integration test summary markdown'
-        value: ${{ format('{0}{1}', jobs.integration.outputs.summary_1, jobs.integration.outputs.summary_2) }}
+        value: ${{ jobs.integration.outputs.summary }}
 
 # Cancel superseded runs for the same PR (a newer push makes the old one moot).
 # Reusable release-gate calls use a run-scoped group so their tests can proceed
@@ -471,22 +471,18 @@ jobs:
   # control-plane integration tests against a real Postgres booted by
   # Testcontainers. Each Vitest worker gets an isolated database cloned from one
   # migrated template, so files run concurrently without cross-test TRUNCATEs.
-  # Each shard needs Docker, so it gets its own runner off the critical path.
+  # Needs Docker, so it gets its own runner off the critical path.
   # No build needed — the suite resolves workspace deps from source.
+  #
+  # One job, not two shards: the halves' own runs were 114 s and 95 s of a 165 s job, which projects to
+  # ~200 s merged — under the Unit Test job that sets the critical path at ~280 s either way — and buys
+  # back a runner, a duplicated install and one of the two Postgres boots. Re-split by restoring a matrix:
+  # the suite's sequencer already packs shards by cost and does nothing until `--shard` is passed.
   integration:
-    name: Integration tests (${{ matrix.shard }})
+    name: Integration tests
     runs-on: ubuntu-latest
     outputs:
-      summary_1: ${{ steps.export-summary.outputs.summary_1 }}
-      summary_2: ${{ steps.export-summary.outputs.summary_2 }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - shard: '1/2'
-            summary_output: summary_1
-          - shard: '2/2'
-            summary_output: summary_2
+      summary: ${{ steps.export-summary.outputs.markdown }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -511,7 +507,7 @@ jobs:
         env:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm --filter @agentconnect.md/control-plane test:int --shard=${{ matrix.shard }}
+        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm --filter @agentconnect.md/control-plane test:int
       - name: Merge integration test summaries
         if: ${{ !cancelled() }}
         env:
@@ -519,7 +515,7 @@ jobs:
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: |
           GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" node scripts/merge-vitest-summaries.mjs \
-            'Integration test report · shard ${{ matrix.shard }}' \
+            'Integration test report' \
             'control-plane=@agentconnect.md/control-plane'
       - name: Publish integration test summary
         if: ${{ !cancelled() && !inputs.defer_summaries }}
@@ -533,7 +529,7 @@ jobs:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
         run: |
           {
-            echo '${{ matrix.summary_output }}<<__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
+            echo 'markdown<<__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
             cat "$CAPTURED_JOB_SUMMARY"
             echo '__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The control-plane integration suite has run as two sharded jobs; it no longer needs to. Across four recent runs each shard finished in 154–187 s, and inside one of them the two halves' own Vitest runs were 114 s and 95 s over 65 files each. The rest of each job is ~45 s of checkout, pnpm, Node, install and Prisma — paid twice — plus a second Testcontainers Postgres boot, a second migrate and a second seed.

Merged, the 130 files project to about 200 s of test time on the same four workers, so the job lands near 250 s. The Unit Test job is 262–295 s over those same runs and the Windows job more, so this does not become the critical path; it gives back a runner and one Postgres.

## What this does

- `integration` loses its matrix and becomes one job named `Integration tests`, with one `summary` output instead of `summary_1`/`summary_2`.
- `test:int` runs without `--shard`, and the report title loses its shard suffix.
- The workflow's `integration_test_summary` output stops concatenating two shard summaries — `release.yaml` reads that output by name and is unaffected.

`packages/control-plane/test/shard-sequencer.ts` stays as it is. It only acts when `--shard` is passed, so it costs nothing here, and it is what makes re-splitting this job a matrix away if the suite grows back.

## Verification

- The workflow parses, the job carries no `strategy`, and no `matrix.` reference is left in it.
- Numbers above come from the jobs API and the runs' own logs, not from an estimate of what the suite "should" cost.

The check to watch on this PR is the `Integration tests` job's wall clock against the two shards it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
