### PR TITLE
feat: publish Gitea pull-request reviews and commit-status run state

### DIFF
--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -758,8 +758,11 @@ Each step is one pull request, merged in order.
   entry, helper path rules, session-key recompute, transport-scope pin, the ack
   reaction, maintenance cleanup, the final poster and effect broker, and the §8
   review-delivery correlation fetched under the turn's lease before the prompt.
-- **G5 — Reviews and run projection.** The Gitea review adapter, the commit
-  status writer, the Console rerun binding.
+- **G5 — Reviews and run projection.** _Landed (#2058)._ The Gitea review adapter
+  over the code-host seam's shared attempt engine, with `ambiguous_locked`
+  cleared only by a later reconciliation finding the marked review submitted;
+  the Control-Plane-written commit status, one per hook, repository, pull
+  request, and head; and the rerun route's Gitea arm.
 - **G6 — Console and docs.** _Landed (#2055)._ The Gitea card — connect, replace token,
   disconnect, the repository picker, the five binding states with their repair
   reasons, repair, webhook-secret rotation and unbind — the `gitea` hook kind

--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -515,7 +515,14 @@ operator looking at Gitea and seeing no submission has exactly the
 information the automated lookup had. `ambiguous_locked` therefore holds
 the lease indefinitely and suppresses the ordinary fallback, and it clears
 on one condition only — a later reconciliation pass finds the marked review
-submitted. There is no operator force-unlock, matching §15.1: Gitea exposes
+submitted. That pass runs from durable coordinates, not process state: the
+Control Plane keeps the attempt's per-attempt marker seed and its retained
+operation record with the locked lease and hands both to the next daemon
+the lock refuses, which reads the pull request, verifies the marker with
+that seed alone, and names the review when it asks again; the Control Plane
+settles the record by that object, records the owner's effect, and releases.
+A restart or a different daemon changes nothing about it. There is no
+operator force-unlock, matching §15.1: Gitea exposes
 nothing that proves an outstanding request can no longer execute. The
 honest consequence is that a request Gitea genuinely lost mid-flight leaves
 this bot's formal reviews on that pull request blocked until a marked

--- a/packages/control-plane/prisma/migrations/20261003000000_code_host_review_lease_marker_seed/migration.sql
+++ b/packages/control-plane/prisma/migrations/20261003000000_code_host_review_lease_marker_seed/migration.sql
@@ -1,0 +1,4 @@
+-- The owner attempt's per-attempt marker key material, kept with the publication lease so the
+-- daemon a later `ambiguous_locked` refusal reaches can verify that attempt's markers itself
+-- (gitea-integration.md §10.3). Hex key material only; never a review body or provider text.
+ALTER TABLE "code_host_review_lease" ADD COLUMN "markerSeed" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2017,6 +2017,9 @@ model CodeHostReviewLease {
   // Short normalized lock category for operator diagnosis. Never provider text.
   lockedReason             String?
   lockedAt                 DateTime? @db.Timestamptz(6)
+  // The owner attempt's per-attempt marker key (hex), so the daemon a lock later refuses can
+  // verify that attempt's markers itself (gitea-integration.md §10.3). Key material, never text.
+  markerSeed               String?
   createdAt                DateTime  @default(now()) @db.Timestamptz(6)
   updatedAt                DateTime  @updatedAt @db.Timestamptz(6)
 

--- a/packages/control-plane/src/codehost/review-lease.service.test.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.test.ts
@@ -898,10 +898,15 @@ describe('a result releases the lease only through the ledger (§15.1)', () => {
         ORG
       )
     ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
-    // A newer attempt meets the lock, however long it waits.
+    // A newer attempt meets the lock, however long it waits; without a seed left behind it gets no coordinates either.
     advance(365 * 24 * 60 * 60 * 1000)
     const contender = authorizeInput({ deliveryKey: SECOND_DELIVERY, snapshot: SECOND_SNAPSHOT })
-    expect(await service.authorize(contender, OTHER_DAEMON, ORG)).toMatchObject({ reason: 'ambiguous_locked' })
+    expect(await service.authorize(contender, OTHER_DAEMON, ORG)).toEqual({
+      authorized: false,
+      attemptId: contender.attemptId,
+      reason: 'ambiguous_locked',
+      retryable: false
+    })
 
     // The later reconciliation pass found the marked review submitted: identify, then re-report.
     const identified = await service.operate(
@@ -927,6 +932,58 @@ describe('a result releases the lease only through the ledger (§15.1)', () => {
     await expect(
       service.recordResult(resultInput(attemptId, { state: 'ambiguous_locked' }), DAEMON, ORG)
     ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+  })
+
+  it('hands a refused daemon the lock coordinates and admits it when it names the identified object (gitea-integration.md §10.3)', async () => {
+    const { service, advance, leases } = build()
+    const seed = 'ab'.repeat(32)
+    const input = authorizeInput({ markerSeed: seed })
+    const granted = await service.authorize(input, DAEMON, ORG)
+    if (!granted.authorized) throw new Error('expected a lease')
+    const { attemptId } = input
+    const fence = granted.lease.fence
+    const permit = { kind: 'bulk_publish' as const, method: 'POST' as const, target: '/x', ordinal: 0 }
+    const { recordId } = await service.operate({ op: 'issue', attemptId, fence, ...permit }, DAEMON, ORG)
+    await service.operate({ op: 'start', attemptId, fence, recordId, startToken: randomUUID() }, DAEMON, ORG)
+    await service.operate(
+      { op: 'settle', attemptId, fence, recordId, outcome: { kind: 'ambiguous', code: 'publish_unreconciled' } },
+      DAEMON,
+      ORG
+    )
+    await service.recordResult(resultInput(attemptId, { state: 'ambiguous_locked' }), DAEMON, ORG)
+
+    // The refusal carries exactly what the exit needs: the owner, its fence, the retained record, the head, the seed.
+    advance(10 * 60 * 1000)
+    const contender = authorizeInput({ deliveryKey: SECOND_DELIVERY, snapshot: SECOND_SNAPSHOT })
+    expect(await service.authorize(contender, OTHER_DAEMON, ORG)).toEqual({
+      authorized: false,
+      attemptId: contender.attemptId,
+      reason: 'ambiguous_locked',
+      retryable: false,
+      lock: { attemptId, fence, recordId, headSha: HEAD, markerSeed: seed }
+    })
+    // Naming the wrong record, or the wrong fence, changes nothing.
+    const object = { kind: 'review' as const, externalId: '4242' }
+    for (const unlock of [
+      { attemptId, fence, recordId: randomUUID(), externalRef: object },
+      { attemptId, fence: String(BigInt(fence) + 1n), recordId, externalRef: object }
+    ]) {
+      expect(await service.authorize({ ...contender, unlock }, OTHER_DAEMON, ORG)).toMatchObject({
+        reason: 'ambiguous_locked'
+      })
+    }
+    expect(leases.outcomes.get(attemptId)).toEqual({ state: 'ambiguous_locked', externalIds: [] })
+
+    // Another daemon found the marked review submitted: it names the object and is admitted in the same ask.
+    const admitted = await service.authorize(
+      { ...contender, unlock: { attemptId, fence, recordId, externalRef: object } },
+      OTHER_DAEMON,
+      ORG
+    )
+    expect(admitted.authorized).toBe(true)
+    expect(leases.outcomes.get(attemptId)).toEqual({ state: 'submitted', externalIds: ['review:4242'] })
+    expect(leases.operations.get(recordId)).toMatchObject({ state: 'settled', responseExternalId: '4242' })
+    expect([...leases.leases.values()][0]).toMatchObject({ attemptId: contender.attemptId, phase: 'open' })
   })
 })
 

--- a/packages/control-plane/src/codehost/review-lease.service.test.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.test.ts
@@ -291,6 +291,71 @@ describe('provider-neutral hook start (gitlab-com-integration.md §17.2)', () =>
     })
     await expect(service.start(startInput(), DAEMON, ORG)).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
   })
+
+  it('records a gitea pull request head through the same barrier, fenced on the gitea hook (gitea-integration.md §10.3)', async () => {
+    const { service, starts } = build({
+      hook: {
+        getRun: async () => run(),
+        getUnscoped: async () => hook({ kind: 'gitea' }),
+        recordStart: async (_hookId, _daemonId, input) => {
+          starts.push(input)
+          return true
+        }
+      } as CodeHostReviewBrokerDeps['hook']
+    })
+    await service.start(
+      startInput({
+        gitlab: undefined,
+        gitea: {
+          repoId: PROJECT.toString(),
+          repoPath: 'example-org/example-repo',
+          target: { kind: 'pull', index: IID, headSha: HEAD, baseSha: 'b'.repeat(40) }
+        }
+      }),
+      DAEMON,
+      ORG
+    )
+    expect(starts[0]).toMatchObject({ headSha: HEAD, baseSha: 'b'.repeat(40), startedAt: new Date(1_000_000) })
+    // The member must name the hook's own provider: a gitea start against a gitlab hook is refused.
+    const mismatched = build()
+    await expect(
+      mismatched.service.start(
+        startInput({
+          gitlab: undefined,
+          gitea: {
+            repoId: PROJECT.toString(),
+            repoPath: 'example-org/example-repo',
+            target: { kind: 'issue', index: 7 }
+          }
+        }),
+        DAEMON,
+        ORG
+      )
+    ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    expect(mismatched.starts).toEqual([])
+  })
+
+  it('refuses a github member on the provider-neutral barrier', async () => {
+    const { service, starts } = build()
+    await expect(
+      service.start(
+        startInput({
+          gitlab: undefined,
+          github: {
+            repoId: '42',
+            repoFullName: 'example-org/example-repo',
+            sourceInstallationId: '77',
+            subjectKind: 'pull_request',
+            pullNumber: 9,
+            headSha: HEAD
+          }
+        }),
+        DAEMON,
+        ORG
+      )
+    ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    expect(starts).toEqual([])
+  })
 })
 
 describe('code-host review authorization (gitlab-com-integration.md §15)', () => {
@@ -404,6 +469,25 @@ describe('code-host review authorization (gitlab-com-integration.md §15)', () =
       reason: 'reviewer_assignment_required',
       retryable: false
     })
+  })
+
+  it('grants request-changes to a gitea attempt with no reviewer record — the verdict is native there', async () => {
+    const { service } = build({
+      hook: {
+        getRun: async () => run(),
+        getUnscoped: async () => hook({ kind: 'gitea' }),
+        recordStart: async () => true
+      } as CodeHostReviewBrokerDeps['hook'],
+      publisher: async (_orgId, provider) =>
+        provider === 'gitea' ? { serviceAccountExternalId: 9042n, projectPath: 'example-org/example-repo' } : null
+    })
+    const input = authorizeInput({ provider: 'gitea', requestedEvent: 'REQUEST_CHANGES', requestedVerdict: 'fail' })
+    const answer = await service.authorize(input, DAEMON, ORG)
+    expect(answer.authorized).toBe(true)
+    if (answer.authorized) {
+      expect(answer.lease.serviceAccountUserId).toBe('9042')
+      expect(answer.projectPath).toBe('example-org/example-repo')
+    }
   })
 
   it('fences the head of every run the start barrier crossed', async () => {
@@ -784,6 +868,65 @@ describe('a result releases the lease only through the ledger (§15.1)', () => {
       accepted: true,
       phase: 'settled'
     })
+  })
+
+  it('a locked lease clears on exactly one condition: its owner names the object and re-reports the effect', async () => {
+    const { service, advance, attemptId, fence, recordId, leases } = await withPermit()
+    await service.operate({ op: 'start', attemptId, fence, recordId, startToken: randomUUID() }, DAEMON, ORG)
+    await service.operate(
+      { op: 'settle', attemptId, fence, recordId, outcome: { kind: 'ambiguous', code: 'publish_unreconciled' } },
+      DAEMON,
+      ORG
+    )
+    expect(await service.recordResult(resultInput(attemptId, { state: 'ambiguous_locked' }), DAEMON, ORG)).toEqual({
+      accepted: true,
+      phase: 'ambiguous_locked'
+    })
+    // Nothing but the identification reaches the locked lease: no renewal, no new permit, no other settle.
+    await expect(service.renew({ attemptId, fence }, DAEMON, ORG)).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    await expect(
+      service.operate(
+        { op: 'issue', attemptId, fence, kind: 'bulk_publish', method: 'POST', target: '/x', ordinal: 1 },
+        DAEMON,
+        ORG
+      )
+    ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    await expect(
+      service.operate(
+        { op: 'settle', attemptId, fence, recordId, outcome: { kind: 'deterministic', status: 204 } },
+        DAEMON,
+        ORG
+      )
+    ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
+    // A newer attempt meets the lock, however long it waits.
+    advance(365 * 24 * 60 * 60 * 1000)
+    const contender = authorizeInput({ deliveryKey: SECOND_DELIVERY, snapshot: SECOND_SNAPSHOT })
+    expect(await service.authorize(contender, OTHER_DAEMON, ORG)).toMatchObject({ reason: 'ambiguous_locked' })
+
+    // The later reconciliation pass found the marked review submitted: identify, then re-report.
+    const identified = await service.operate(
+      { op: 'settle', attemptId, fence, recordId, outcome: { kind: 'deterministic', status: 200, externalId: '4242' } },
+      DAEMON,
+      ORG
+    )
+    expect(identified.state).toBe('settled')
+    // Identification alone proves the record, not the attempt: the recorded outcome still says nothing.
+    expect(identified.phase).toBe('ambiguous_locked')
+    expect(
+      await service.recordResult(
+        resultInput(attemptId, { state: 'submitted', externalIds: [{ kind: 'review', externalId: '4242' }] }),
+        DAEMON,
+        ORG
+      )
+    ).toEqual({ accepted: true, phase: 'settled' })
+    expect(leases.outcomes.get(attemptId)).toEqual({ state: 'submitted', externalIds: ['review:4242'] })
+    expect([...leases.leases.values()][0]?.attemptId).toBeNull()
+    const next = authorizeInput({ deliveryKey: SECOND_DELIVERY, snapshot: SECOND_SNAPSHOT })
+    expect((await service.authorize(next, OTHER_DAEMON, ORG)).authorized).toBe(true)
+    // A recorded effect never moves again, in either direction.
+    await expect(
+      service.recordResult(resultInput(attemptId, { state: 'ambiguous_locked' }), DAEMON, ORG)
+    ).rejects.toBeInstanceOf(CodeHostReviewBrokerError)
   })
 })
 

--- a/packages/control-plane/src/codehost/review-lease.service.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.ts
@@ -22,6 +22,7 @@ import {
   type CodeHostReviewAuthorized,
   type CodeHostReviewLeaseRenew,
   type CodeHostReviewLeaseRenewed,
+  type CodeHostReviewLockCoordinates,
   type CodeHostReviewOpAccepted,
   type CodeHostReviewOpRequest,
   type CodeHostReviewRefusalReason,
@@ -40,6 +41,7 @@ import { PLACEMENT_ONLY, type PlacementResolver } from '../orchestrator/placemen
 import type {
   AgentRecord,
   AgentRepo,
+  CodeHostReviewAcquireResult,
   CodeHostReviewLeaseRepo,
   CodeHostReviewOpResult,
   CodeHostReviewSubject,
@@ -139,8 +141,28 @@ function snapshotMatches(run: HookRunRecord, snapshot: HookConfigSnapshot, daemo
 }
 
 /** A typed refusal the adapter classifies; not an error, and not a lease. */
-function refuse(attemptId: string, reason: CodeHostReviewRefusalReason, retryable: boolean): CodeHostReviewAuthorized {
-  return { authorized: false, attemptId, reason, retryable }
+function refuse(
+  attemptId: string,
+  reason: CodeHostReviewRefusalReason,
+  retryable: boolean,
+  lock?: CodeHostReviewLockCoordinates
+): CodeHostReviewAuthorized {
+  return { authorized: false, attemptId, reason, retryable, ...(lock ? { lock } : {}) }
+}
+
+/** The lock exit's durable coordinates, when the locked attempt left a seed and a retained record behind (gitea-integration.md §10.3). */
+function lockCoordinates(
+  acquired: Extract<CodeHostReviewAcquireResult, { outcome: 'locked' }>
+): CodeHostReviewLockCoordinates | undefined {
+  const { lease, retained } = acquired
+  if (!lease.attemptId || !lease.headSha || !lease.markerSeed || !retained) return undefined
+  return {
+    attemptId: lease.attemptId,
+    fence: lease.fence.toString(),
+    recordId: retained.id,
+    headSha: lease.headSha,
+    markerSeed: lease.markerSeed
+  }
 }
 
 export class CodeHostReviewBrokerService {
@@ -251,13 +273,32 @@ export class CodeHostReviewBrokerService {
     if (!publisher) return refuse(input.attemptId, 'binding_unavailable', true)
 
     const now = new Date(this.deps.clock.now())
+    const subject: CodeHostReviewSubject = {
+      provider: input.provider,
+      projectExternalId: projectId,
+      mergeRequestIid: input.mergeRequestIid,
+      serviceAccountExternalId: publisher.serviceAccountExternalId
+    }
+    // The lock's one exit (gitea-integration.md §10.3): a refused daemon found the locked attempt's marked object and names it here.
+    if (input.unlock) {
+      let externalRef: string
+      try {
+        externalRef = encodeExternalRef(input.unlock.externalRef.kind, input.unlock.externalRef.externalId)
+      } catch {
+        denied('unlock named a published object that is not a kind and a numeric id')
+      }
+      await this.deps.leases.identifyLocked({
+        subject,
+        orgId: run.orgId,
+        attemptId: input.unlock.attemptId,
+        fence: BigInt(input.unlock.fence),
+        recordId: input.unlock.recordId,
+        externalRef,
+        now
+      })
+    }
     const acquired = await this.deps.leases.acquire({
-      subject: {
-        provider: input.provider,
-        projectExternalId: projectId,
-        mergeRequestIid: input.mergeRequestIid,
-        serviceAccountExternalId: publisher.serviceAccountExternalId
-      },
+      subject,
       orgId: run.orgId,
       attemptId: input.attemptId,
       daemonId: reportingDaemonId,
@@ -268,12 +309,14 @@ export class CodeHostReviewBrokerService {
       verdict: input.requestedVerdict,
       headSha: input.headSha,
       leaseUntil: new Date(now.getTime() + CODE_HOST_REVIEW_LEASE_TTL_SEC * 1000),
-      now
+      now,
+      ...(input.markerSeed ? { markerSeed: input.markerSeed } : {})
     })
     if (acquired.outcome === 'held') return refuse(input.attemptId, 'lease_held', true)
-    // No timeout and no force unlock: recovery needs a definite outcome from the
-    // old broker or positive provider evidence, so this is never retryable.
-    if (acquired.outcome === 'locked') return refuse(input.attemptId, 'ambiguous_locked', false)
+    // Never retryable (no timeout, no force unlock); the coordinates let the refused daemon look for the one exit's evidence itself.
+    if (acquired.outcome === 'locked') {
+      return refuse(input.attemptId, 'ambiguous_locked', false, lockCoordinates(acquired))
+    }
 
     const lease = acquired.lease
     return {

--- a/packages/control-plane/src/codehost/review-lease.service.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.ts
@@ -14,7 +14,10 @@
  * operation makes serialization a correctness boundary.
  */
 import {
+  codeHostHookMetadataOf,
+  codeHostHookRevisionOf,
   isCodeHostProvider,
+  type CodeHostProvider,
   type CodeHostReviewAuthorize,
   type CodeHostReviewAuthorized,
   type CodeHostReviewLeaseRenew,
@@ -100,6 +103,13 @@ export interface CodeHostReviewBrokerDeps {
 
 const POLICY_RANK = { off: 0, comment: 1, request_changes: 2, full: 3 } as const
 
+/** REQUEST_CHANGES needs the publisher's reviewer record on GitLab (§15 step 7), not on Gitea (gitea-integration.md §2). */
+const REQUEST_CHANGES_NEEDS_REVIEWER: Readonly<Record<CodeHostProvider, boolean>> = {
+  github: false,
+  gitlab: true,
+  gitea: false
+}
+
 const EVENT_RANK: Record<HookReviewEvent, number> = {
   COMMENT: POLICY_RANK.comment,
   REQUEST_CHANGES: POLICY_RANK.request_changes,
@@ -140,17 +150,10 @@ export class CodeHostReviewBrokerService {
     return (this.deps.placement ?? PLACEMENT_ONLY).mayAct(agent, daemonId)
   }
 
-  /**
-   * Persist the provider-neutral start barrier before an accepted GitLab hook turn is prompted
-   * (§17.2). It attaches the started head and turn time to the accepted run, which is what gives
-   * every later review authorization a head to fence against and the §16 ledger its `running` edge.
-   *
-   * The GitHub review broker is deliberately not involved: its fence is repository/pull-shaped and
-   * its claimed-offline recovery belongs to GitHub webhook redelivery, which GitLab has no claim on.
-   */
+  /** The provider-neutral start barrier (§17.2): records the started head and turn time later review authorizations fence on. */
   async start(input: HookStart, reportingDaemonId: DaemonId, reportingOrgId: string): Promise<void> {
-    const gitlab = input.gitlab
-    if (!gitlab) denied('this start barrier carries provider-neutral metadata only')
+    const member = codeHostHookMetadataOf(input)
+    if (!member || member.provider === 'github') denied('this start barrier carries provider-neutral metadata only')
     const hookId = HookId(input.hookId)
     const run = await this.deps.hook.getRun(hookId, input.deliveryKey)
     if (
@@ -163,15 +166,15 @@ export class CodeHostReviewBrokerService {
       denied('start dispatch fence does not match the accepted hook run')
     }
     if (run.orgId !== reportingOrgId) denied('organization does not match the accepted hook run')
-    const projectId = BigInt(gitlab.projectId)
+    const projectId = BigInt(member.repo.externalId)
     const hook = await this.deps.hook.getUnscoped(hookId)
     const agent = await this.deps.agent.getUnscoped(run.agentId)
-    if (!this.hookAuthorizes(hook, run, 'gitlab', projectId)) denied('hook is disabled or its project changed')
+    if (!this.hookAuthorizes(hook, run, member.provider, projectId)) denied('hook is disabled or its project changed')
     if (!agent || agent.status !== 'active' || !(await this.serves(agent, reportingDaemonId))) {
       denied('agent is no longer active on the accepted dispatch daemon')
     }
-    // Only a merge request has a revision; an issue or push subject records the turn time alone.
-    const head = gitlab.target.kind === 'merge_request' ? gitlab.target : undefined
+    // Only a pull/merge request has a revision; an issue or push subject records the turn time alone.
+    const head = codeHostHookRevisionOf(member)
     const accepted = await this.deps.hook.recordStart(hookId, reportingDaemonId, {
       deliveryKey: input.deliveryKey,
       agentId: AgentId(input.agentId),
@@ -230,9 +233,12 @@ export class CodeHostReviewBrokerService {
     if (!this.eventAllowed(run, hook!, input.requestedEvent)) {
       return refuse(input.attemptId, 'policy_denied', false)
     }
-    // AgentConnect never assigns itself as a reviewer, so a request-changes attempt
-    // fails before any draft exists rather than after (§15 step 7).
-    if (input.requestedEvent === 'REQUEST_CHANGES' && input.serviceAccountIsReviewer !== true) {
+    // Where the provider needs a reviewer record, a request-changes attempt fails before any draft exists (§15 step 7).
+    if (
+      input.requestedEvent === 'REQUEST_CHANGES' &&
+      REQUEST_CHANGES_NEEDS_REVIEWER[input.provider] &&
+      input.serviceAccountIsReviewer !== true
+    ) {
       return refuse(input.attemptId, 'reviewer_assignment_required', false)
     }
     // A run the start barrier crossed always carries the head it was started on, so this binds for

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -44,6 +44,8 @@ import { GiteaConnectionService } from './gitea/connection.service.js'
 import { GiteaProvisioner } from './gitea/provisioner.js'
 import { GiteaConvergeSweeper } from './gitea/converge-sweeper.js'
 import { GiteaGitcredService } from './gitea/gitcred.service.js'
+import { GiteaHookRerunService } from './gitea/hook-rerun.service.js'
+import { GiteaStatusCoordinator, GiteaStatusReporter } from './gitea/status-projection.js'
 import { GiteaMembershipAuthzService } from './gitea/membership-authz.service.js'
 import { unionGiteaWebhookEvents } from './gitea/webhook-events.js'
 import { resolveSlackPlatformAppConfig } from './config/slack-platform.js'
@@ -1302,7 +1304,22 @@ export function buildContainer(
     api: giteaApi,
     log: { warn: (obj, msg) => http.log.warn(obj, msg) }
   })
-  const gitea = { connections: giteaConnectionService, provisioner: giteaProvisioner, api: giteaApi }
+  const gitea = {
+    connections: giteaConnectionService,
+    provisioner: giteaProvisioner,
+    // The Console "Run again" action (gitea-integration.md §10.4) — fences here, dispatch on the relay.
+    hookRerun: new GiteaHookRerunService({
+      hooks: repos.hook,
+      agents: repos.agent,
+      bindings: repos.giteaRepositoryBinding,
+      connections: repos.giteaConnection,
+      tokens: giteaConnectionService,
+      hookService,
+      relayControl,
+      api: giteaApi
+    }),
+    api: giteaApi
+  }
   // The §6 convergence sweep, the half of a contended pass's obligation that survives a restart.
   const giteaConvergeSweeper = new GiteaConvergeSweeper({
     provisioner: giteaProvisioner,
@@ -1345,6 +1362,34 @@ export function buildContainer(
         log: { warn: (obj, msg) => http.log.warn(obj, msg) }
       })
     : undefined
+
+  // gitea-integration.md §10.4: Gitea's run projection is a commit status the Control Plane writes itself (coordinator + reporter).
+  const giteaStatusReporterRef: { current?: GiteaStatusReporter } = {}
+  const giteaStatusProjection = new GiteaStatusCoordinator({
+    projections: new PgCodeHostRunProjectionRepo(prisma),
+    runs: repos.hook,
+    agents: repos.agent,
+    bindings: repos.giteaRepositoryBinding,
+    connections: repos.giteaConnection,
+    clock,
+    kick: () => giteaStatusReporterRef.current?.kick()
+  })
+  const giteaStatusReporter = new GiteaStatusReporter({
+    projections: new PgCodeHostRunProjectionRepo(prisma),
+    bindings: repos.giteaRepositoryBinding,
+    connections: repos.giteaConnection,
+    tokens: giteaConnectionService,
+    orgs: repos.org,
+    api: giteaApi,
+    clock,
+    ...(webAppUrl ? { webAppUrl } : {}),
+    log: {
+      info: (o, m) => http.log.info(o, m),
+      warn: (o, m) => http.log.warn(o, m),
+      error: (o, m) => http.log.error(o, m)
+    }
+  })
+  giteaStatusReporterRef.current = giteaStatusReporter
 
   // The console PR panel's read projection — long-lived so its short TTL cache actually absorbs mounts.
   const pullRequestView = github ? new PullRequestViewService(github.tokens, clock, opts.githubFetch) : undefined
@@ -1409,29 +1454,33 @@ export function buildContainer(
         placement: placementResolver
       })
     : undefined
-  // Provider-neutral formal reviews (§15.1/§15.2). The publishing identity is the
-  // project binding's service account, so today the broker exists only where GitLab
-  // administration is configured; the frames themselves name no provider.
-  const codeHostReviewBroker = gitlabAppCfg
-    ? new CodeHostReviewBrokerService({
-        leases: new PgCodeHostReviewLeaseRepo(prisma),
-        hook: repos.hook,
-        agent: repos.agent,
-        clock,
-        placement: placementResolver,
-        publisher: async (orgId, provider, projectExternalId, agentId) => {
-          if (provider !== 'gitlab') return null
-          const binding = await repos.gitlabProjectBinding.byProject(orgId, projectExternalId)
-          if (!binding) return null
-          // A binding being repaired or torn down publishes nothing.
-          if (binding.state !== 'ready' && binding.state !== 'admin_degraded') return null
-          // §7.2: the ACTING agent's own account is the coordinator's subject key.
-          const account = await repos.gitlabAgentAccount.forAgentBinding(orgId, agentId, binding.id)
-          if (!account || account.serviceAccountUserId === null) return null
-          return { serviceAccountExternalId: account.serviceAccountUserId, projectPath: binding.projectPath }
-        }
-      })
-    : undefined
+  // Formal reviews (§15.1/§15.2): the publisher is GitLab's per-agent service account or the Gitea connection's bot user (§5).
+  const codeHostReviewBroker = new CodeHostReviewBrokerService({
+    leases: new PgCodeHostReviewLeaseRepo(prisma),
+    hook: repos.hook,
+    agent: repos.agent,
+    clock,
+    placement: placementResolver,
+    publisher: async (orgId, provider, projectExternalId, agentId) => {
+      if (provider === 'gitea') {
+        const binding = await repos.giteaRepositoryBinding.byRepo(orgId, projectExternalId)
+        // A binding mid-removal or waiting on a replacement token publishes nothing.
+        if (!binding || binding.state === 'cleanup_pending' || binding.state === 'runtime_degraded') return null
+        const connection = await repos.giteaConnection.get(orgId, binding.connectionId)
+        if (!connection || connection.state !== 'connected') return null
+        return { serviceAccountExternalId: connection.botUserId, projectPath: binding.repoPath }
+      }
+      if (provider !== 'gitlab' || !gitlabAppCfg) return null
+      const binding = await repos.gitlabProjectBinding.byProject(orgId, projectExternalId)
+      if (!binding) return null
+      // A binding being repaired or torn down publishes nothing.
+      if (binding.state !== 'ready' && binding.state !== 'admin_degraded') return null
+      // §7.2: the ACTING agent's own account is the coordinator's subject key.
+      const account = await repos.gitlabAgentAccount.forAgentBinding(orgId, agentId, binding.id)
+      if (!account || account.serviceAccountUserId === null) return null
+      return { serviceAccountExternalId: account.serviceAccountUserId, projectPath: binding.projectPath }
+    }
+  })
   const githubCommentAuthz = github
     ? new GithubCommentAuthzService({
         hooks: repos.hook,
@@ -2120,9 +2169,10 @@ export function buildContainer(
     // broker must not become a second opinion on when a grant is stale (linear-integration.md §4.4).
     linearTokens: linearTokenService,
     ...(githubReviewBroker ? { githubReviewBroker } : {}),
-    ...(codeHostReviewBroker ? { codeHostReviewBroker } : {}),
+    codeHostReviewBroker,
     ...(githubRunCoordinator ? { githubRunCoordinator } : {}),
     ...(codeHostNoteProjection ? { codeHostNoteProjection } : {}),
+    giteaStatusProjection,
     relayRoster: () => relayRoster.entries(),
     clock,
     config: {
@@ -2352,6 +2402,26 @@ export function buildContainer(
           http.log.warn({ err, hookId: report.hookId }, 'note projection: delivery convergence failed')
         )
       }
+      // gitea-integration.md §10.4: the same delivery-stage edge for the commit-status projection.
+      if (host?.provider === 'gitea') {
+        void (async () => {
+          const hook = await repos.hook.getUnscoped(HookId(report.hookId))
+          if (hook?.kind !== host.provider) return
+          const edge = {
+            hookId: report.hookId,
+            agentId: report.agentId,
+            deliveryKey: report.deliveryKey,
+            orgId: hook.orgId,
+            state: 'queued' as const,
+            reason: report.reason ?? null,
+            gitea: host.metadata,
+            snapshot: report,
+            at: firedAt
+          }
+          if (report.status === 'accepted') await giteaStatusProjection.afterAccepted(edge)
+          else await giteaStatusProjection.afterDeliveryFailed(edge)
+        })().catch((err) => http.log.warn({ err, hookId: report.hookId }, 'gitea status: delivery convergence failed'))
+      }
     },
     // The in-Slack config modal picked a channel's default agent — persist + recompile
     // the bot's routes. Swallow+log: a store error must not close the shared relay link.
@@ -2459,6 +2529,7 @@ export function buildContainer(
       webchatMcpOperationReaper.start()
       agentMemoryStagingSweeper.start()
       githubRunReporter?.start()
+      giteaStatusReporter.start()
       hookRedeliveryReconciler?.start()
       gitlabRotator?.start()
       gitlabRetirementSweeper?.start()
@@ -2482,6 +2553,7 @@ export function buildContainer(
       const webchatMcpOperationSettled = webchatMcpOperationReaper.stopAndSettle()
       agentMemoryStagingSweeper.stop()
       githubRunReporter?.stop()
+      giteaStatusReporter.stop()
       hookRedeliveryReconciler?.stop()
       gitlabRotator?.stop()
       gitlabRetirementSweeper?.stop()

--- a/packages/control-plane/src/domain/code-host-review.ts
+++ b/packages/control-plane/src/domain/code-host-review.ts
@@ -73,6 +73,11 @@ export function outcomeReconciles(state: CodeHostReviewState | null): boolean {
   return state !== null && codeHostReviewPublicEffect(state) !== 'unknown'
 }
 
+/** The one re-classification a recorded outcome admits: from proving nothing to proving the effect (§15.1, found after the lock). */
+export function unlocks(recorded: CodeHostReviewState, next: CodeHostReviewState): boolean {
+  return !outcomeReconciles(recorded) && outcomeReconciles(next)
+}
+
 export type CodeHostReviewAcquisition =
   | { kind: 'fresh' }
   | { kind: 'idempotent' }
@@ -219,7 +224,7 @@ export function returnUnusedTransition(record: CodeHostReviewOpFacts): CodeHostR
   return { ok: false, reason: record.state === 'request_started' ? 'already_started' : 'terminal' }
 }
 
-const EXTERNAL_REF = /^(note|draft_note|discussion|approval):(?:0|[1-9]\d*)$/
+const EXTERNAL_REF = /^(note|draft_note|discussion|approval|review):(?:0|[1-9]\d*)$/
 
 /** Encode one published object for the outcome store: `"<kind>:<numeric id>"`. */
 export function encodeExternalRef(kind: string, externalId: string): string {

--- a/packages/control-plane/src/gitea/api.ts
+++ b/packages/control-plane/src/gitea/api.ts
@@ -481,3 +481,113 @@ export async function giteaTestWebhook(
 ): Promise<void> {
   await giteaRequest<void>(`${hooksPath(owner, repo)}/${webhookId}/tests`, { method: 'POST', token, client })
 }
+
+// ── pull requests, issues, and commit statuses (§10.4, §16.1) ────────────────
+
+export interface GiteaPullRequest {
+  id?: number
+  number: number
+  state: string
+  merged?: boolean
+  draft?: boolean
+  title?: string
+  head?: { sha?: string; ref?: string; repo_id?: number }
+  base?: { sha?: string; ref?: string }
+  user?: { id?: number; login?: string }
+}
+
+/** One pull request by index (`GET /repos/:owner/:repo/pulls/:index`); null on a definitive 404. */
+export async function giteaPullRequest(
+  token: string,
+  owner: string,
+  repo: string,
+  index: number,
+  client: GiteaApiClient
+): Promise<GiteaPullRequest | null> {
+  try {
+    return await giteaRequest<GiteaPullRequest>(
+      `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${index}`,
+      { token, client }
+    )
+  } catch (e) {
+    if (e instanceof GiteaApiError && e.code === 'NOT_FOUND') return null
+    throw e
+  }
+}
+
+export interface GiteaIssue {
+  id?: number
+  number: number
+  state: string
+  title?: string
+  /** Present when the index names a pull request — issues and pull requests share one index space. */
+  pull_request?: unknown
+}
+
+/** One issue by index (`GET /repos/:owner/:repo/issues/:index`); null on a definitive 404. */
+export async function giteaIssue(
+  token: string,
+  owner: string,
+  repo: string,
+  index: number,
+  client: GiteaApiClient
+): Promise<GiteaIssue | null> {
+  try {
+    return await giteaRequest<GiteaIssue>(
+      `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${index}`,
+      { token, client }
+    )
+  } catch (e) {
+    if (e instanceof GiteaApiError && e.code === 'NOT_FOUND') return null
+    throw e
+  }
+}
+
+/** The states `POST …/statuses/:sha` accepts; `warning` is never written (§10.4). */
+export type GiteaCommitStatusState = 'pending' | 'success' | 'error' | 'failure' | 'warning'
+
+export interface GiteaCommitStatusSpec {
+  context: string
+  state: GiteaCommitStatusState
+  description: string
+  target_url?: string
+}
+
+export interface GiteaCommitStatus {
+  id: number | string
+  /** The wire names the state `status`. */
+  status?: string
+  context?: string
+  description?: string
+  target_url?: string
+  creator?: { id?: number | string }
+  created_at?: string
+}
+
+function statusesPath(owner: string, repo: string, sha: string): string {
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/statuses/${encodeURIComponent(sha)}`
+}
+
+/** Append one commit status (`POST …/statuses/:sha`); Gitea keeps the history and shows the latest per context. */
+export async function giteaCreateCommitStatus(
+  token: string,
+  owner: string,
+  repo: string,
+  sha: string,
+  spec: GiteaCommitStatusSpec,
+  client: GiteaApiClient
+): Promise<GiteaCommitStatus> {
+  return giteaRequest<GiteaCommitStatus>(statusesPath(owner, repo, sha), { method: 'POST', token, body: spec, client })
+}
+
+/** Every status row on one commit (`GET …/statuses/:sha`), all pages — the reconciliation read of §10.4. */
+export async function giteaListCommitStatuses(
+  token: string,
+  owner: string,
+  repo: string,
+  sha: string,
+  client: GiteaApiClient,
+  pageSize: number
+): Promise<GiteaCommitStatus[]> {
+  return giteaPagedGet<GiteaCommitStatus>(statusesPath(owner, repo, sha), { token, client, pageSize })
+}

--- a/packages/control-plane/src/gitea/hook-rerun.service.ts
+++ b/packages/control-plane/src/gitea/hook-rerun.service.ts
@@ -1,0 +1,234 @@
+// Console "Run again" for gitea hooks (gitea-integration.md §10.4): fences revalidated live, head read now, dispatched via the relay.
+import { randomUUID } from 'node:crypto'
+import type { GiteaHookMetadata, RcHookRerun, RcHookRerunRefusal } from '@agentconnect.md/protocol'
+import type { HookService } from '../hooks/hook.service.js'
+import type { RelayControlSender } from '../orchestrator/relayControl.js'
+import { AgentId, HookId } from '../domain/ids.js'
+import type {
+  AgentRecord,
+  GiteaConnectionRepo,
+  GiteaRepositoryBindingRepo,
+  HookRecord,
+  HookRepo
+} from '../persistence/ports.js'
+import {
+  GiteaApiError,
+  giteaIssue,
+  giteaPullRequest,
+  isGiteaAuthRejection,
+  splitGiteaRepoPath,
+  type GiteaApiClient
+} from './api.js'
+import { servesRuntime } from './binding-state.js'
+import type { GiteaTokenSource } from './provisioner.js'
+
+/** One rerun subject the Console can name, in the product's subject vocabulary. */
+export interface GiteaRerunSubject {
+  kind: 'merge_request' | 'issue'
+  index: number
+}
+
+/** What a compiled rule pins for one rerun: its revision pair, plus the §3 host the daemon fences the turn on. */
+interface DispatchFence {
+  configRevision: string
+  dispatchRevision: string
+  host?: string
+}
+
+/** Machine-readable refusal reasons; the console branches on these, not on prose. */
+export type GiteaRerunCode =
+  /** Emitted by the route, not this service: no Gitea connection surface is configured. */
+  | 'GITEA_NOT_CONFIGURED'
+  | 'HOOK_NOT_GITEA'
+  | 'HOOK_DISABLED'
+  | 'AGENT_UNAVAILABLE'
+  | 'BINDING_INACTIVE'
+  | 'DISPATCH_UNAVAILABLE'
+  | 'SUBJECT_NOT_FOUND'
+  | 'SUBJECT_CLOSED'
+  | 'HEAD_UNAVAILABLE'
+  | 'GITEA_UNAVAILABLE'
+  | 'RELAY_UNAVAILABLE'
+  /** Every eligible relay declined; nothing ran (the relay's reason rides `relayCode`). */
+  | 'RELAY_REJECTED'
+  /** A relay went quiet mid-request — the turn may or may not have started. */
+  | 'RELAY_AMBIGUOUS'
+
+export type GiteaRerunResult =
+  | { ok: true; deliveryKey: string; event: string; headSha: string | null }
+  | {
+      ok: false
+      status: 409 | 429 | 502 | 503
+      code: GiteaRerunCode
+      message: string
+      /** The relay's own refusal category, when one answered. */
+      relayCode?: RcHookRerunRefusal
+    }
+
+export interface GiteaHookRerunDeps {
+  hooks: Pick<HookRepo, 'getUnscoped'>
+  agents: { getUnscoped(agentId: AgentId): Promise<AgentRecord | null> }
+  bindings: Pick<GiteaRepositoryBindingRepo, 'byRepo'>
+  connections: Pick<GiteaConnectionRepo, 'get'>
+  tokens: GiteaTokenSource
+  hookService: Pick<HookService, 'compile'>
+  relayControl: Pick<RelayControlSender, 'hookRerun'>
+  api: GiteaApiClient
+}
+
+function refuse(status: 409 | 429 | 502 | 503, code: GiteaRerunCode, message: string): GiteaRerunResult {
+  return { ok: false, status, code, message }
+}
+
+/** How a definitive relay refusal reads to the caller; `replay_pending` is the only retryable one. */
+const RELAY_REFUSAL: Record<RcHookRerunRefusal, { status: 409 | 429 | 503; message: string }> = {
+  replay_pending: { status: 503, message: 'the relay pool has not loaded this trigger yet — try again shortly' },
+  rule_mismatch: { status: 409, message: 'this trigger changed while the rerun was being authorized' },
+  limiter_exhausted: { status: 429, message: 'this trigger has run too many times just now — try again shortly' }
+}
+
+export class GiteaHookRerunService {
+  constructor(private readonly deps: GiteaHookRerunDeps) {}
+
+  async rerun(hook: HookRecord, subject: GiteaRerunSubject): Promise<GiteaRerunResult> {
+    if (hook.kind !== 'gitea') {
+      return refuse(409, 'HOOK_NOT_GITEA', 'only a Gitea trigger can be run again through this path')
+    }
+    if (!hook.enabled) return refuse(409, 'HOOK_DISABLED', 'this trigger is disabled')
+    if (hook.repoId === null || !hook.agentId) {
+      return refuse(409, 'BINDING_INACTIVE', 'this trigger names no Gitea repository')
+    }
+    const repoId = hook.repoId
+
+    const agent = await this.deps.agents.getUnscoped(hook.agentId)
+    if (!agent) return refuse(409, 'AGENT_UNAVAILABLE', 'the agent this trigger fires no longer exists')
+    if (agent.pause === true) return refuse(409, 'AGENT_UNAVAILABLE', 'the agent this trigger fires is paused')
+
+    // "Active binding": past provisioning, serving runtime, and not being torn down (§5).
+    const binding = await this.deps.bindings.byRepo(hook.orgId, repoId)
+    if (!binding || binding.state === 'provisioning' || !servesRuntime(binding.state)) {
+      return refuse(409, 'BINDING_INACTIVE', 'this repository has no active Gitea binding')
+    }
+    const connection = await this.deps.connections.get(hook.orgId, binding.connectionId)
+    if (!connection || connection.state !== 'connected') {
+      return refuse(409, 'BINDING_INACTIVE', 'this repository has no usable Gitea connection')
+    }
+    const path = splitGiteaRepoPath(binding.repoPath)
+    if (!path) return refuse(409, 'BINDING_INACTIVE', 'this repository binding has no owner/repo path')
+
+    const fence = await this.dispatchFence(hook)
+    if (!fence) {
+      return refuse(409, 'DISPATCH_UNAVAILABLE', 'this trigger cannot dispatch right now — check the agent placement')
+    }
+
+    // The subject read runs as the connection's bot (§4.2).
+    let token: string
+    try {
+      token = await this.deps.tokens.withToken(hook.orgId, connection.id)
+    } catch {
+      return refuse(409, 'BINDING_INACTIVE', 'this repository has no usable Gitea token')
+    }
+
+    let target: GiteaHookMetadata['target']
+    let headSha: string | null = null
+    try {
+      if (subject.kind === 'merge_request') {
+        const pull = await giteaPullRequest(token, path.owner, path.repo, subject.index, this.deps.api)
+        if (!pull) return refuse(409, 'SUBJECT_NOT_FOUND', 'this pull request no longer exists')
+        if (pull.state !== 'open' || pull.merged === true) {
+          return refuse(409, 'SUBJECT_CLOSED', `this pull request is ${pull.merged ? 'merged' : pull.state}`)
+        }
+        // The CURRENT head, read now — a stored one could re-run a stale revision.
+        headSha = pull.head?.sha ?? null
+        if (!headSha) return refuse(409, 'HEAD_UNAVAILABLE', 'Gitea reported no current head for this pull request')
+        target = {
+          kind: 'pull',
+          index: subject.index,
+          ...(pull.head?.repo_id !== undefined ? { sourceRepoId: String(pull.head.repo_id) } : {}),
+          headSha,
+          ...(pull.base?.sha ? { baseSha: pull.base.sha } : {}),
+          ...(pull.draft !== undefined ? { isDraft: pull.draft } : {}),
+          // The console action is an explicit authorized request, like a reviewer re-request.
+          explicitReviewRequest: true
+        }
+      } else {
+        const issue = await giteaIssue(token, path.owner, path.repo, subject.index, this.deps.api)
+        // Issues and pull requests share one index space; an index that is a pull request is not this subject.
+        if (!issue || issue.pull_request) return refuse(409, 'SUBJECT_NOT_FOUND', 'this issue no longer exists')
+        if (issue.state !== 'open') return refuse(409, 'SUBJECT_CLOSED', `this issue is ${issue.state}`)
+        target = { kind: 'issue', index: subject.index }
+      }
+    } catch (e) {
+      if (isGiteaAuthRejection(e)) {
+        // A definite rejection is the connection's verdict (§4.3), not this click's.
+        await this.deps.tokens.onAuthRejected(hook.orgId, connection.id).catch(() => undefined)
+        return refuse(409, 'BINDING_INACTIVE', 'the Gitea token was rejected — replace it')
+      }
+      if (e instanceof GiteaApiError) {
+        return refuse(502, 'GITEA_UNAVAILABLE', 'Gitea could not be reached to confirm the current subject')
+      }
+      throw e
+    }
+
+    // Re-read the hook and recompile after the Gitea round trip so a disable or retarget meanwhile cannot authorize this turn.
+    const refreshed = await this.deps.hooks.getUnscoped(HookId(hook.id))
+    if (!refreshed || refreshed.orgId !== hook.orgId || refreshed.agentId !== hook.agentId) {
+      return refuse(409, 'DISPATCH_UNAVAILABLE', 'this trigger changed while the rerun was being authorized')
+    }
+    const refreshedFence = await this.dispatchFence(refreshed)
+    if (
+      !refreshedFence ||
+      refreshedFence.configRevision !== fence.configRevision ||
+      refreshedFence.dispatchRevision !== fence.dispatchRevision
+    ) {
+      return refuse(409, 'DISPATCH_UNAVAILABLE', 'this trigger changed while the rerun was being authorized')
+    }
+
+    const frame: RcHookRerun = {
+      hookId: hook.id,
+      agentId: hook.agentId,
+      deliveryKey: `rerun_${randomUUID()}`,
+      configRevision: refreshedFence.configRevision,
+      dispatchRevision: refreshedFence.dispatchRevision,
+      event: subject.kind === 'issue' ? 'issues:rerun' : 'merge_request:rerun',
+      gitea: {
+        repoId: repoId.toString(),
+        repoPath: binding.repoPath,
+        // §3: the same fence a webhook delivery carries; the daemon refuses a host its spec is not bound to.
+        ...(refreshedFence.host !== undefined ? { host: refreshedFence.host } : {}),
+        target
+      }
+    }
+    // Only a relay's own admission proves a turn was queued and a run row opened.
+    const outcome = await this.deps.relayControl.hookRerun(frame)
+    if (outcome.kind === 'unreachable') {
+      return refuse(503, 'RELAY_UNAVAILABLE', 'no relay is connected to run this trigger')
+    }
+    if (outcome.kind === 'ambiguous') {
+      return refuse(503, 'RELAY_AMBIGUOUS', 'the relay stopped answering — check the runs before running again')
+    }
+    if (outcome.kind === 'refused') {
+      const mapped = RELAY_REFUSAL[outcome.code]
+      return {
+        ok: false,
+        status: mapped.status,
+        code: 'RELAY_REJECTED',
+        message: mapped.message,
+        relayCode: outcome.code
+      }
+    }
+    return { ok: true, deliveryKey: frame.deliveryKey, event: frame.event, headSha }
+  }
+
+  /** The compiled rule's revisions and host, or null when undispatchable; the rule holds signing keys — never log or return it. */
+  private async dispatchFence(hook: HookRecord): Promise<DispatchFence | null> {
+    const rule = await this.deps.hookService.compile(hook)
+    if (!rule || rule.kind !== 'gitea') return null
+    if (rule.configRevision === undefined || rule.dispatchRevision === undefined) return null
+    return {
+      configRevision: rule.configRevision,
+      dispatchRevision: rule.dispatchRevision,
+      ...(rule.gitea?.host !== undefined ? { host: rule.gitea.host } : {})
+    }
+  }
+}

--- a/packages/control-plane/src/gitea/status-projection.test.ts
+++ b/packages/control-plane/src/gitea/status-projection.test.ts
@@ -208,7 +208,10 @@ describe('GiteaStatusCoordinator', () => {
     const service = new GiteaStatusCoordinator({
       projections,
       runs: {
-        getRun: vi.fn(async () => ({ projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch }))
+        getRun: vi.fn(async () => ({
+          projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch,
+          startedAt: new Date(NOW)
+        }))
       } as never,
       agents: { getUnscoped: vi.fn(async () => agent) },
       bindings: { byRepo: vi.fn(async () => (options.binding === undefined ? binding : options.binding)) },
@@ -222,7 +225,11 @@ describe('GiteaStatusCoordinator', () => {
   it('opens queued on an accepted delivery with the connection epoch and the accepted fence, and kicks the reporter', async () => {
     const { service, projections, kick } = coordinator()
     await service.afterAccepted(edge())
-    expect(projections.supersede).toHaveBeenCalledWith(hookId, REPO, 12, HEAD, new Date(NOW))
+    // The row is established first, then older heads are preempted by the run's acceptance rank.
+    expect(projections.supersede).toHaveBeenCalledWith(hookId, REPO, 12, HEAD, new Date(NOW), new Date(NOW))
+    expect(projections.upsert.mock.invocationCallOrder[0]!).toBeLessThan(
+      projections.supersede.mock.invocationCallOrder[0]!
+    )
     expect(projections.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: 'gitea',
@@ -246,6 +253,15 @@ describe('GiteaStatusCoordinator', () => {
     )
     expect(projections.setDesired).toHaveBeenCalledWith(projection().id, 1n, 'queued', new Date(NOW), undefined)
     expect(kick).toHaveBeenCalledOnce()
+  })
+
+  it('moves nothing for an edge whose row already belongs to a newer run of the same head', async () => {
+    const { service, projections, kick } = coordinator({ row: { ...projection(), currentDeliveryKey: 'delivery-9' } })
+    await service.afterReport(edge({ state: 'completed' }))
+    expect(projections.upsert).toHaveBeenCalledOnce()
+    expect(projections.supersede).not.toHaveBeenCalled()
+    expect(projections.setDesired).not.toHaveBeenCalled()
+    expect(kick).not.toHaveBeenCalled()
   })
 
   it('reads a delivery failure as skipped whatever kept the daemon away — the Control Plane writes', async () => {

--- a/packages/control-plane/src/gitea/status-projection.test.ts
+++ b/packages/control-plane/src/gitea/status-projection.test.ts
@@ -1,0 +1,659 @@
+// Gitea commit-status projection (gitea-integration.md §10.4): state mapping, lifecycle edges, fenced and reconciled writes, token rejection.
+import { randomUUID } from 'node:crypto'
+import {
+  HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+  type CodeHostNoteState,
+  type GiteaHookMetadata
+} from '@agentconnect.md/protocol'
+import { describe, expect, it, vi } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import { AgentId, DaemonId, HookId, OrgId } from '../domain/ids.js'
+import type {
+  AgentRecord,
+  CodeHostRunProjectionRecord,
+  CodeHostRunProjectionWriterRepo,
+  GiteaConnectionRecord,
+  GiteaRepositoryBindingRecord,
+  UpsertCodeHostRunProjectionInput
+} from '../persistence/ports.js'
+import { GiteaApiClient } from './api.js'
+import { GiteaConnectDenied } from './connection.service.js'
+import {
+  GiteaStatusCoordinator,
+  GiteaStatusReporter,
+  giteaProjectionSubject,
+  giteaStatusSpec,
+  type GiteaStatusEdge
+} from './status-projection.js'
+
+const NOW = 1_700_000_000_000
+const hookId = HookId('00000000-0000-4000-8000-000000000001')
+const agentId = AgentId('00000000-0000-4000-8000-000000000002')
+const daemonId = DaemonId('00000000-0000-4000-8000-000000000003')
+const orgId = OrgId('org_1')
+const HEAD = 'a'.repeat(40)
+const REPO = 556677n
+const BOT = 9042n
+const BASE = 'https://gitea.example.test'
+
+const snapshot = {
+  configRevision: '3',
+  dispatchRevision: '5',
+  dispatchDaemonId: daemonId,
+  reviewPolicy: 'off' as const,
+  reportingMode: 'status' as const,
+  gateMode: 'informational' as const
+}
+
+function gitea(overrides: Partial<{ headSha: string; index: number }> = {}): GiteaHookMetadata {
+  return {
+    repoId: REPO.toString(),
+    repoPath: 'example-org/example-repo',
+    target: { kind: 'pull', index: overrides.index ?? 12, headSha: overrides.headSha ?? HEAD }
+  }
+}
+
+function edge(overrides: Partial<GiteaStatusEdge> = {}): GiteaStatusEdge {
+  return {
+    hookId,
+    agentId,
+    deliveryKey: 'delivery-1',
+    orgId,
+    state: 'queued',
+    gitea: gitea(),
+    snapshot,
+    at: new Date(NOW),
+    ...overrides
+  }
+}
+
+function projection(overrides: Partial<CodeHostRunProjectionRecord> = {}): CodeHostRunProjectionRecord {
+  return {
+    id: '10000000-0000-4000-8000-000000000001',
+    provider: 'gitea',
+    hookId,
+    orgId,
+    agentId,
+    agentName: 'reviewer',
+    projectId: REPO,
+    projectPath: 'example-org/example-repo',
+    mergeRequestIid: 12,
+    headSha: HEAD,
+    projectionEpoch: 1n,
+    generation: 1n,
+    currentDeliveryKey: 'delivery-1',
+    currentRunAt: new Date(NOW),
+    externalId: '10000000-0000-4000-8000-000000000001',
+    noteId: null,
+    desiredState: 'queued',
+    observedState: null,
+    reason: null,
+    sealedThrough: 0n,
+    queuedAt: new Date(NOW),
+    startedAt: null,
+    completedAt: null,
+    sessionId: null,
+    credentialEpoch: 2n,
+    configRevision: 3n,
+    dispatchRevision: 5n,
+    dispatchDaemonId: daemonId,
+    reviewPolicySnapshot: 'off',
+    reportingModeSnapshot: 'status',
+    gateModeSnapshot: 'informational',
+    leaseOwner: null,
+    leaseUntil: null,
+    nextAttemptAt: new Date(NOW),
+    attempts: 0,
+    lastErrorCode: null,
+    pendingIntent: null,
+    writeMarker: null,
+    writePhase: null,
+    writeStartedAt: null,
+    tombstonedAt: null,
+    updatedAt: new Date(NOW),
+    ...overrides
+  }
+}
+
+const agent = { id: agentId, orgId, name: 'reviewer' } as unknown as AgentRecord
+const binding = {
+  id: 'binding-1',
+  orgId,
+  connectionId: 'connection-1',
+  repoId: REPO,
+  repoPath: 'example-org/example-repo',
+  state: 'ready'
+} as unknown as GiteaRepositoryBindingRecord
+const connection = {
+  id: 'connection-1',
+  orgId,
+  botUserId: BOT,
+  botUsername: 'example-bot',
+  credentialEpoch: 2n,
+  state: 'connected'
+} as unknown as GiteaConnectionRecord
+
+describe('giteaStatusSpec (§10.4)', () => {
+  it.each([
+    ['queued', 'pending'],
+    ['running', 'pending'],
+    ['completed', 'success'],
+    ['failed', 'error'],
+    ['interrupted', 'error'],
+    ['skipped', 'success'],
+    ['superseded', 'success']
+  ] as Array<[CodeHostNoteState, string]>)('maps %s to %s and never to warning', (state, expected) => {
+    const spec = giteaStatusSpec(projection({ desiredState: state }))
+    expect(spec.state).toBe(expected)
+    expect(spec.state).not.toBe('warning')
+    expect(spec.context).toBe('agentconnect/reviewer')
+    expect(spec.description.length).toBeLessThan(120)
+    expect(spec.target_url).toBeUndefined()
+  })
+
+  it('names the normalized reason on a skipped or failed status, and drops anything else', () => {
+    expect(giteaStatusSpec(projection({ desiredState: 'skipped', reason: 'daemon_offline' })).description).toBe(
+      'AgentConnect review skipped (daemon_offline)'
+    )
+    expect(giteaStatusSpec(projection({ desiredState: 'failed', reason: 'session_start_failed' })).description).toBe(
+      'AgentConnect review failed (session_start_failed)'
+    )
+    // A reason that is not a bounded code never reaches the provider.
+    expect(giteaStatusSpec(projection({ desiredState: 'failed', reason: 'Error: boom at line 3' })).description).toBe(
+      'AgentConnect review failed'
+    )
+    // Only the two reasoned states carry one.
+    expect(giteaStatusSpec(projection({ desiredState: 'completed', reason: 'whatever' })).description).toBe(
+      'AgentConnect review completed'
+    )
+  })
+
+  it('carries the Console session link as target_url and falls back to the agent id for the context', () => {
+    const spec = giteaStatusSpec(
+      projection({ agentName: null }),
+      'https://console.example.test/acme/sessions/s1?source=gitea'
+    )
+    expect(spec.context).toBe(`agentconnect/${agentId}`)
+    expect(spec.target_url).toBe('https://console.example.test/acme/sessions/s1?source=gitea')
+  })
+
+  it('projects only a headed pull request', () => {
+    expect(giteaProjectionSubject(gitea())).toEqual({
+      projectId: REPO,
+      projectPath: 'example-org/example-repo',
+      mergeRequestIid: 12,
+      headSha: HEAD
+    })
+    expect(giteaProjectionSubject({ ...gitea(), target: { kind: 'issue', index: 3 } })).toBeNull()
+    expect(giteaProjectionSubject({ ...gitea(), target: { kind: 'pull', index: 12 } })).toBeNull()
+    expect(giteaProjectionSubject(undefined)).toBeNull()
+  })
+})
+
+describe('GiteaStatusCoordinator', () => {
+  function coordinator(
+    options: {
+      row?: CodeHostRunProjectionRecord
+      binding?: GiteaRepositoryBindingRecord | null
+      runEpoch?: bigint | null
+    } = {}
+  ) {
+    const row = options.row ?? projection()
+    const projections = {
+      upsert: vi.fn(async (_input: UpsertCodeHostRunProjectionInput) => row),
+      setDesired: vi.fn(async () => true),
+      supersede: vi.fn(async () => 0)
+    }
+    const kick = vi.fn()
+    const service = new GiteaStatusCoordinator({
+      projections,
+      runs: {
+        getRun: vi.fn(async () => ({ projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch }))
+      } as never,
+      agents: { getUnscoped: vi.fn(async () => agent) },
+      bindings: { byRepo: vi.fn(async () => (options.binding === undefined ? binding : options.binding)) },
+      connections: { get: vi.fn(async () => connection) },
+      clock: new FakeClock(NOW),
+      kick
+    })
+    return { service, projections, kick }
+  }
+
+  it('opens queued on an accepted delivery with the connection epoch and the accepted fence, and kicks the reporter', async () => {
+    const { service, projections, kick } = coordinator()
+    await service.afterAccepted(edge())
+    expect(projections.supersede).toHaveBeenCalledWith(hookId, REPO, 12, HEAD, new Date(NOW))
+    expect(projections.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'gitea',
+        hookId,
+        orgId,
+        agentId,
+        agentName: 'reviewer',
+        projectId: REPO,
+        projectPath: 'example-org/example-repo',
+        mergeRequestIid: 12,
+        headSha: HEAD,
+        projectionEpoch: 1n,
+        desiredState: 'queued',
+        credentialEpoch: 2n,
+        configRevision: 3n,
+        dispatchRevision: 5n,
+        dispatchDaemonId: daemonId,
+        reportingModeSnapshot: 'status',
+        queuedAt: new Date(NOW)
+      })
+    )
+    expect(projections.setDesired).toHaveBeenCalledWith(projection().id, 1n, 'queued', new Date(NOW), undefined)
+    expect(kick).toHaveBeenCalledOnce()
+  })
+
+  it('reads a delivery failure as skipped whatever kept the daemon away — the Control Plane writes', async () => {
+    const { service, projections } = coordinator()
+    await service.afterDeliveryFailed(edge({ reason: HOOK_DELIVERY_REASON_DAEMON_OFFLINE }))
+    expect(projections.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        desiredState: 'skipped',
+        reason: HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+        completedAt: new Date(NOW)
+      })
+    )
+  })
+
+  it('moves running on the start barrier with the session, and terminal on the report', async () => {
+    const { service, projections } = coordinator()
+    await service.afterStart(edge({ sessionId: 'session-1' }))
+    expect(projections.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({ desiredState: 'running', sessionId: 'session-1', startedAt: new Date(NOW) })
+    )
+    await service.afterReport(edge({ state: 'failed', reason: 'session_start_failed' }))
+    expect(projections.setDesired).toHaveBeenLastCalledWith(
+      expect.any(String),
+      1n,
+      'failed',
+      new Date(NOW),
+      'session_start_failed'
+    )
+  })
+
+  it('opens nothing for reporting off, an issue, an incomplete fence, a retired run, or a missing binding', async () => {
+    const cases: Array<[string, Partial<GiteaStatusEdge>, { binding?: null; runEpoch?: null }]> = [
+      ['reporting off', { snapshot: { ...snapshot, reportingMode: 'off' } }, {}],
+      ['issue subject', { gitea: { ...gitea(), target: { kind: 'issue', index: 3 } } }, {}],
+      ['incomplete fence', { snapshot: { ...snapshot, dispatchDaemonId: undefined } }, {}],
+      ['retired run', {}, { runEpoch: null }],
+      ['no binding', {}, { binding: null }]
+    ]
+    for (const [, over, options] of cases) {
+      const { service, projections } = coordinator(options)
+      await service.afterAccepted(edge(over))
+      expect(projections.upsert).not.toHaveBeenCalled()
+    }
+  })
+
+  it('parks rather than moves the state while a write is in flight, and never touches a tombstone', async () => {
+    const held = coordinator({ row: projection({ writePhase: 'create', writeMarker: randomUUID() }) })
+    await held.service.afterStart(edge())
+    expect(held.projections.setDesired).not.toHaveBeenCalled()
+    expect(held.kick).not.toHaveBeenCalled()
+    const dead = coordinator({ row: projection({ tombstonedAt: new Date(NOW) }) })
+    await dead.service.afterStart(edge())
+    expect(dead.projections.setDesired).not.toHaveBeenCalled()
+  })
+})
+
+/** An in-memory writer ledger carrying the rules the reporter leans on: claim, mutex, fenced settlement. */
+class FakeLedger implements Pick<
+  CodeHostRunProjectionWriterRepo,
+  'claimDue' | 'beginWrite' | 'completeWrite' | 'retryWrite' | 'blockWrite' | 'settleWrite' | 'advancePending' | 'get'
+> {
+  readonly rows = new Map<string, CodeHostRunProjectionRecord>()
+
+  constructor(...rows: CodeHostRunProjectionRecord[]) {
+    for (const row of rows) this.rows.set(row.id, { ...row })
+  }
+
+  async claimDue(
+    provider: string,
+    leaseOwner: string,
+    now: Date,
+    leaseUntil: Date
+  ): Promise<CodeHostRunProjectionRecord[]> {
+    const claimed: CodeHostRunProjectionRecord[] = []
+    for (const row of this.rows.values()) {
+      if (row.provider !== provider || row.nextAttemptAt === null || row.nextAttemptAt > now) continue
+      if (row.leaseUntil !== null && row.leaseUntil >= now && row.leaseOwner !== leaseOwner) continue
+      row.leaseOwner = leaseOwner
+      row.leaseUntil = leaseUntil
+      claimed.push({ ...row })
+    }
+    return claimed
+  }
+
+  async beginWrite(id: string, generation: bigint, leaseOwner: string, marker: string, phase: string, startedAt: Date) {
+    const row = this.rows.get(id)
+    if (!row || row.generation !== generation || row.writeMarker !== null) return false
+    Object.assign(row, { leaseOwner, writeMarker: marker, writePhase: phase, writeStartedAt: startedAt })
+    return true
+  }
+
+  async completeWrite(input: {
+    projectionId: string
+    generation: bigint
+    leaseOwner: string
+    writeMarker: string
+    observedState: CodeHostNoteState
+    noteId?: string
+  }) {
+    const row = this.rows.get(input.projectionId)
+    if (
+      !row ||
+      row.generation !== input.generation ||
+      row.leaseOwner !== input.leaseOwner ||
+      row.writeMarker !== input.writeMarker
+    )
+      return false
+    Object.assign(row, {
+      observedState: input.observedState,
+      noteId: input.noteId ?? row.noteId,
+      writeMarker: null,
+      writePhase: null,
+      writeStartedAt: null,
+      leaseOwner: null,
+      leaseUntil: null,
+      nextAttemptAt: row.pendingIntent !== null || row.desiredState !== input.observedState ? new Date(0) : null,
+      attempts: 0,
+      lastErrorCode: null
+    })
+    return true
+  }
+
+  async retryWrite(
+    id: string,
+    generation: bigint,
+    leaseOwner: string,
+    nextAttemptAt: Date,
+    errorCode: string,
+    keepWriteMutex = false
+  ) {
+    const row = this.rows.get(id)
+    if (!row || row.generation !== generation || row.leaseOwner !== leaseOwner) return false
+    Object.assign(row, {
+      attempts: row.attempts + 1,
+      lastErrorCode: errorCode,
+      nextAttemptAt,
+      leaseOwner: null,
+      leaseUntil: null
+    })
+    if (!keepWriteMutex) Object.assign(row, { writeMarker: null, writePhase: null, writeStartedAt: null })
+    return true
+  }
+
+  async blockWrite(id: string, generation: bigint, errorCode: string, keepWriteMutex = false) {
+    const row = this.rows.get(id)
+    if (!row || row.generation !== generation) return false
+    Object.assign(row, { lastErrorCode: errorCode, nextAttemptAt: null, leaseOwner: null, leaseUntil: null })
+    if (!keepWriteMutex) Object.assign(row, { writeMarker: null, writePhase: null, writeStartedAt: null })
+    return true
+  }
+
+  async settleWrite(id: string, generation: bigint, leaseOwner: string) {
+    const row = this.rows.get(id)
+    if (!row || row.generation !== generation || row.leaseOwner !== leaseOwner) return false
+    Object.assign(row, { nextAttemptAt: null, leaseOwner: null, leaseUntil: null, lastErrorCode: null, attempts: 0 })
+    return true
+  }
+
+  async advancePending(id: string, generation: bigint) {
+    const row = this.rows.get(id)
+    if (!row || row.generation !== generation || row.writeMarker !== null || row.pendingIntent === null) return null
+    const pending = row.pendingIntent as { desiredState: CodeHostNoteState }
+    Object.assign(row, {
+      generation: generation + 1n,
+      desiredState: pending.desiredState,
+      observedState: null,
+      pendingIntent: null,
+      nextAttemptAt: new Date(0)
+    })
+    return { ...row }
+  }
+
+  async get(id: string) {
+    const row = this.rows.get(id)
+    return row ? { ...row } : null
+  }
+}
+
+interface Posted {
+  url: string
+  method: string
+  body?: Record<string, unknown>
+}
+
+/** A fake Gitea edge that appends statuses and lists them newest-first, with a switchable fault per request. */
+function fakeGitea() {
+  const posted: Posted[] = []
+  const statuses: Array<Record<string, unknown>> = []
+  let nextId = 500
+  let fault: 'none' | 'network' | 'landed-but-lost' | 401 | 422 | 500 = 'none'
+  const fetchImpl = async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? 'GET'
+    const body = typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : undefined
+    posted.push({ url, method, ...(body ? { body } : {}) })
+    if (method === 'POST') {
+      if (fault === 'network') throw new Error('socket hang up')
+      if (fault === 500) return Response.json({ message: 'internal' }, { status: 500 })
+      if (fault === 401) return Response.json({ message: 'token is required' }, { status: 401 })
+      if (fault === 422) return Response.json({ message: 'sha is not a valid commit' }, { status: 422 })
+      const status = {
+        id: ++nextId,
+        status: body?.state,
+        context: body?.context,
+        description: body?.description,
+        target_url: body?.target_url ?? '',
+        creator: { id: Number(BOT) }
+      }
+      statuses.push(status)
+      if (fault === 'landed-but-lost') throw new Error('socket hang up')
+      return Response.json(status, { status: 201 })
+    }
+    return Response.json([...statuses].reverse(), { headers: { 'x-total-count': String(statuses.length) } })
+  }
+  return {
+    api: new GiteaApiClient(BASE, fetchImpl),
+    posted,
+    statuses,
+    posts: () => posted.filter((call) => call.method === 'POST'),
+    setFault: (next: typeof fault) => void (fault = next)
+  }
+}
+
+describe('GiteaStatusReporter', () => {
+  function reporter(ledger: FakeLedger, options: { tokenRejected?: boolean; webAppUrl?: string } = {}) {
+    const gitea = fakeGitea()
+    const clock = new FakeClock(NOW)
+    const onAuthRejected = vi.fn(async () => {})
+    const service = new GiteaStatusReporter({
+      projections: ledger,
+      bindings: { byRepo: vi.fn(async () => binding) },
+      connections: { get: vi.fn(async () => connection) },
+      tokens: {
+        withToken: vi.fn(async () => {
+          if (options.tokenRejected)
+            throw new GiteaConnectDenied('the Gitea token was rejected — replace it', 409, 'token_rejected')
+          return 'gitea-token-1'
+        }),
+        onAuthRejected
+      },
+      orgs: { slugById: vi.fn(async () => 'acme') },
+      api: gitea.api,
+      clock,
+      workerId: 'worker-1',
+      ...(options.webAppUrl ? { webAppUrl: options.webAppUrl } : {})
+    })
+    return { service, gitea, clock, onAuthRejected }
+  }
+
+  it('writes one status under a marker and settles the generation against the status id', async () => {
+    const ledger = new FakeLedger(projection({ sessionId: 'session-1' }))
+    const { service, gitea } = reporter(ledger, { webAppUrl: 'https://console.example.test' })
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(1)
+    const [post] = gitea.posts()
+    expect(post!.url).toBe(`${BASE}/api/v1/repos/example-org/example-repo/statuses/${HEAD}`)
+    expect(post!.body).toEqual({
+      context: 'agentconnect/reviewer',
+      state: 'pending',
+      description: 'AgentConnect review queued',
+      target_url: 'https://console.example.test/acme/sessions/session-1?source=gitea'
+    })
+    const row = (await ledger.get(projection().id))!
+    expect(row).toMatchObject({
+      observedState: 'queued',
+      noteId: '501',
+      writeMarker: null,
+      leaseOwner: null,
+      nextAttemptAt: null
+    })
+  })
+
+  it('never replays an ambiguous write: the marker is held, then the landed status is reconciled by content', async () => {
+    const ledger = new FakeLedger(projection({ desiredState: 'running', observedState: 'queued', noteId: '400' }))
+    const { service, gitea, clock } = reporter(ledger)
+    gitea.setFault('landed-but-lost')
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(1)
+    let row = (await ledger.get(projection().id))!
+    expect(row.writeMarker).not.toBeNull()
+    expect(row.observedState).toBe('queued')
+    expect(row.lastErrorCode).toBe('ambiguous_write')
+
+    // The retry pass reads the commit's statuses and finds the newer row that says exactly what it sent.
+    gitea.setFault('none')
+    clock.advance(5_000)
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(1)
+    row = (await ledger.get(projection().id))!
+    expect(row).toMatchObject({ observedState: 'running', noteId: '501', writeMarker: null, nextAttemptAt: null })
+  })
+
+  it('reissues an ambiguous write only once its absence has outlived the grace window', async () => {
+    const ledger = new FakeLedger(projection())
+    const { service, gitea, clock } = reporter(ledger)
+    gitea.setFault('network')
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(1)
+    gitea.setFault('none')
+    // Inside the window the marker holds and nothing is written again.
+    clock.advance(5_000)
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(1)
+    expect((await ledger.get(projection().id))!.writeMarker).not.toBeNull()
+    // Past it, absence proves the request never reached Gitea: the mutex is released and the next pass writes.
+    clock.advance(11 * 60_000)
+    await service.tick()
+    expect((await ledger.get(projection().id))!.lastErrorCode).toBe('ambiguous_write_reissued')
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(2)
+    expect((await ledger.get(projection().id))!.observedState).toBe('queued')
+  })
+
+  it('treats a 5xx like a lost reply and a 4xx as a definite refusal', async () => {
+    const ledger = new FakeLedger(
+      projection({ id: 'a'.repeat(8) + '-0000-4000-8000-000000000001' }),
+      projection({ id: 'b'.repeat(8) + '-0000-4000-8000-000000000002', headSha: 'c'.repeat(40) })
+    )
+    const { service, gitea } = reporter(ledger)
+    gitea.setFault(500)
+    await service.tick()
+    for (const row of ledger.rows.values()) {
+      expect(row.writeMarker).not.toBeNull()
+      expect(row.lastErrorCode).toBe('ambiguous_write')
+    }
+    const refused = new FakeLedger(projection())
+    const second = reporter(refused)
+    second.gitea.setFault(422)
+    await second.service.tick()
+    expect((await refused.get(projection().id))!).toMatchObject({
+      writeMarker: null,
+      nextAttemptAt: null,
+      lastErrorCode: 'validation'
+    })
+  })
+
+  it('feeds a rejected token into the connection path and waits for the replacement without losing the row', async () => {
+    const ledger = new FakeLedger(projection())
+    const { service, gitea, onAuthRejected } = reporter(ledger)
+    gitea.setFault(401)
+    await service.tick()
+    expect(onAuthRejected).toHaveBeenCalledWith(orgId, 'connection-1')
+    const row = (await ledger.get(projection().id))!
+    // A received 401 is a definite non-effect: no marker is held, the row stays due.
+    expect(row).toMatchObject({ writeMarker: null, lastErrorCode: 'token_rejected', observedState: null })
+    expect(row.nextAttemptAt).not.toBeNull()
+
+    // While the connection refuses to hand out its token, the row is retried — nothing is written.
+    const waiting = reporter(new FakeLedger(projection()), { tokenRejected: true })
+    await waiting.service.tick()
+    expect(waiting.gitea.posts()).toHaveLength(0)
+  })
+
+  it('resolves a status a removed hook left pending, and mints nothing for a terminal or never-written one', async () => {
+    const pendingRow = projection({
+      id: '1'.repeat(8) + '-0000-4000-8000-000000000001',
+      desiredState: 'skipped',
+      observedState: 'running',
+      noteId: '300',
+      tombstonedAt: new Date(NOW)
+    })
+    const terminalRow = projection({
+      id: '2'.repeat(8) + '-0000-4000-8000-000000000002',
+      headSha: 'd'.repeat(40),
+      desiredState: 'skipped',
+      observedState: 'completed',
+      noteId: '301',
+      tombstonedAt: new Date(NOW)
+    })
+    const neverRow = projection({
+      id: '3'.repeat(8) + '-0000-4000-8000-000000000003',
+      headSha: 'e'.repeat(40),
+      desiredState: 'skipped',
+      observedState: null,
+      tombstonedAt: new Date(NOW)
+    })
+    const ledger = new FakeLedger(pendingRow, terminalRow, neverRow)
+    const { service, gitea } = reporter(ledger)
+    await service.tick()
+    expect(gitea.posts()).toHaveLength(1)
+    expect(gitea.posts()[0]!.body).toMatchObject({ state: 'success', description: 'AgentConnect review skipped' })
+    expect((await ledger.get(pendingRow.id))!.observedState).toBe('skipped')
+    expect((await ledger.get(terminalRow.id))!).toMatchObject({
+      observedState: 'completed',
+      nextAttemptAt: null,
+      lastErrorCode: 'cleanup_not_needed'
+    })
+    expect((await ledger.get(neverRow.id))!).toMatchObject({ observedState: null, nextAttemptAt: null })
+  })
+
+  it('leaves a settled row out of the due set and drains a parked edge into its own generation', async () => {
+    const settledRow = projection({
+      id: '4'.repeat(8) + '-0000-4000-8000-000000000004',
+      observedState: 'queued',
+      noteId: '300'
+    })
+    const parkedRow = projection({
+      id: '5'.repeat(8) + '-0000-4000-8000-000000000005',
+      headSha: 'f'.repeat(40),
+      observedState: 'queued',
+      noteId: '301',
+      pendingIntent: { desiredState: 'completed' }
+    })
+    const ledger = new FakeLedger(settledRow, parkedRow)
+    const { service, gitea } = reporter(ledger)
+    await service.tick()
+    expect((await ledger.get(settledRow.id))!.nextAttemptAt).toBeNull()
+    const drained = (await ledger.get(parkedRow.id))!
+    expect(drained).toMatchObject({ generation: 2n, desiredState: 'completed', observedState: 'completed' })
+    expect(gitea.posts().map((post) => post.body!.state)).toEqual(['success'])
+  })
+})

--- a/packages/control-plane/src/gitea/status-projection.ts
+++ b/packages/control-plane/src/gitea/status-projection.ts
@@ -1,0 +1,561 @@
+// Gitea run projection (gitea-integration.md §10.4): one Control-Plane-written commit status per (hook, repository, pull request, head).
+import { randomUUID } from 'node:crypto'
+import type {
+  CodeHostNoteState,
+  GiteaHookMetadata,
+  HookConfigSnapshot,
+  OptionalHookConfigSnapshot
+} from '@agentconnect.md/protocol'
+import type { Clock, TimerHandle } from '../domain/clock.js'
+import { AgentId, HookId, type OrgId } from '../domain/ids.js'
+import type {
+  AgentRepo,
+  CodeHostRunProjectionRecord,
+  CodeHostRunProjectionRepo,
+  CodeHostRunProjectionWriterRepo,
+  GiteaConnectionRepo,
+  GiteaRepositoryBindingRepo,
+  HookRepo,
+  OrgRepo
+} from '../persistence/ports.js'
+import { completeSnapshot } from '../codehost/note-projection.service.js'
+import {
+  GITEA_DEFAULT_PAGE_SIZE,
+  GiteaApiError,
+  giteaCreateCommitStatus,
+  giteaListCommitStatuses,
+  isGiteaAuthRejection,
+  splitGiteaRepoPath,
+  type GiteaApiClient,
+  type GiteaCommitStatus,
+  type GiteaCommitStatusSpec,
+  type GiteaCommitStatusState
+} from './api.js'
+import { GiteaConnectDenied } from './connection.service.js'
+import type { GiteaTokenSource } from './provisioner.js'
+
+const PROVIDER = 'gitea'
+const CONTEXT_PREFIX = 'agentconnect/'
+const DEFAULT_INTERVAL_MS = 5_000
+const DEFAULT_LEASE_MS = 30_000
+const DEFAULT_BATCH_SIZE = 25
+const RETRY_BASE_MS = 2_000
+const RETRY_MAX_MS = 5 * 60_000
+/** How long a marker-bearing write may stay unobserved before its absence counts as proof it never landed. */
+const AMBIGUOUS_WRITE_GRACE_MS = 10 * 60_000
+const REASON_CODE = /^[a-z0-9_:-]{1,100}$/
+
+/** §10.4's state mapping; `warning` is never used because Gitea folds it into failure. */
+const STATUS_STATE: Record<CodeHostNoteState, GiteaCommitStatusState> = {
+  queued: 'pending',
+  running: 'pending',
+  completed: 'success',
+  failed: 'error',
+  interrupted: 'error',
+  skipped: 'success',
+  superseded: 'success'
+}
+
+const DESCRIPTION: Record<CodeHostNoteState, string> = {
+  queued: 'AgentConnect review queued',
+  running: 'AgentConnect review in progress',
+  completed: 'AgentConnect review completed',
+  failed: 'AgentConnect review failed',
+  interrupted: 'AgentConnect review interrupted before it finished',
+  skipped: 'AgentConnect review skipped',
+  superseded: 'AgentConnect review superseded by a newer revision'
+}
+
+/** The states whose description names the normalized reason (§10.4). */
+const REASONED: ReadonlySet<CodeHostNoteState> = new Set(['failed', 'skipped'])
+
+export function isGiteaProjectionState(state: string): state is CodeHostNoteState {
+  return state in STATUS_STATE
+}
+
+/** Only a normalized code reaches a projection; anything else (a raw turn failure text) is dropped. */
+function normalizedReason(reason: string | null | undefined): string | undefined {
+  return reason && REASON_CODE.test(reason) ? reason : undefined
+}
+
+/** The pull-request facts a projection needs; an issue or push subject has nothing to project. */
+export function giteaProjectionSubject(
+  gitea: GiteaHookMetadata | undefined
+): { projectId: bigint; projectPath: string; mergeRequestIid: number; headSha: string } | null {
+  if (!gitea || gitea.target.kind !== 'pull' || !gitea.target.headSha) return null
+  return {
+    projectId: BigInt(gitea.repoId),
+    projectPath: gitea.repoPath,
+    mergeRequestIid: gitea.target.index,
+    headSha: gitea.target.headSha
+  }
+}
+
+/** The one status a generation writes: a bounded normalized state, and the ordinary Console link when one exists. */
+export function giteaStatusSpec(
+  row: Pick<CodeHostRunProjectionRecord, 'agentId' | 'agentName' | 'desiredState' | 'reason'>,
+  consoleUrl?: string
+): GiteaCommitStatusSpec {
+  const state = row.desiredState
+  const reason = REASONED.has(state) ? normalizedReason(row.reason) : undefined
+  return {
+    context: `${CONTEXT_PREFIX}${row.agentName ?? row.agentId}`,
+    state: STATUS_STATE[state],
+    description: reason ? `${DESCRIPTION[state]} (${reason})` : DESCRIPTION[state],
+    ...(consoleUrl ? { target_url: consoleUrl } : {})
+  }
+}
+
+/** One lifecycle edge, as the WS/relay frame that carries it already presents it. */
+export interface GiteaStatusEdge {
+  hookId: string
+  agentId: string
+  deliveryKey: string
+  orgId: OrgId
+  state: CodeHostNoteState
+  reason?: string | null
+  sessionId?: string
+  gitea: GiteaHookMetadata | undefined
+  snapshot: OptionalHookConfigSnapshot
+  at: Date
+}
+
+export interface GiteaStatusCoordinatorDeps {
+  projections: Pick<CodeHostRunProjectionRepo, 'upsert' | 'setDesired' | 'supersede'>
+  /** The ACCEPTED run behind an edge — the only authority for its projection epoch. */
+  runs: Pick<HookRepo, 'getRun'>
+  agents: Pick<AgentRepo, 'getUnscoped'>
+  bindings: Pick<GiteaRepositoryBindingRepo, 'byRepo'>
+  connections: Pick<GiteaConnectionRepo, 'get'>
+  clock: Pick<Clock, 'now'>
+  /** Immediate wake-up only; the reporter's periodic scan is authoritative. */
+  kick?: () => void
+}
+
+/** Converts hook-turn lifecycle edges to one current desired commit status; call each after its HookRun mutation commits. */
+export class GiteaStatusCoordinator {
+  constructor(private readonly deps: GiteaStatusCoordinatorDeps) {}
+
+  /** Relay accepted the delivery: the turn is queued, and a newer head preempts older generations. */
+  async afterAccepted(edge: GiteaStatusEdge): Promise<void> {
+    await this.converge({ ...edge, state: 'queued' })
+  }
+
+  /** Delivery failed before any turn ran — the Control Plane can still say so, whatever kept the daemon away. */
+  async afterDeliveryFailed(edge: GiteaStatusEdge): Promise<void> {
+    await this.converge({ ...edge, state: 'skipped' })
+  }
+
+  /** The provider-neutral `hook/start` barrier crossed: the accepted turn is entering the prompt. */
+  async afterStart(edge: GiteaStatusEdge): Promise<void> {
+    await this.converge({ ...edge, state: 'running' })
+  }
+
+  /** Daemon terminal report: completed / failed / skipped / interrupted. */
+  async afterReport(edge: GiteaStatusEdge): Promise<void> {
+    await this.converge(edge)
+  }
+
+  private async converge(edge: GiteaStatusEdge): Promise<void> {
+    const subject = giteaProjectionSubject(edge.gitea)
+    if (!subject) return
+    // A partially rolled-out dispatch tuple cannot authorize an effect, so it cannot open a projection either.
+    const snapshot = completeSnapshot(edge.snapshot)
+    if (!snapshot) return
+    // The status IS the run report, so reporting `off` opens nothing — judged from the ACCEPTED snapshot.
+    if (snapshot.reportingMode === 'off') return
+    // The ACCEPTED run's epoch, never the live hook's: an edit mid-run would otherwise fork a new row.
+    const run = await this.deps.runs.getRun(HookId(edge.hookId), edge.deliveryKey)
+    if (!run || run.projectionEpoch === null) return
+    const agent = await this.deps.agents.getUnscoped(AgentId(edge.agentId))
+    if (!agent || agent.orgId !== edge.orgId) return
+    // The binding names the connection the status is written as; a binding mid-removal writes nothing new.
+    const binding = await this.deps.bindings.byRepo(edge.orgId, subject.projectId)
+    if (!binding || binding.state === 'cleanup_pending') return
+    const connection = await this.deps.connections.get(edge.orgId, binding.connectionId)
+    if (!connection) return
+
+    // A newer head preempts every older generation on the same pull request before the new one opens.
+    await this.deps.projections.supersede(
+      HookId(edge.hookId),
+      subject.projectId,
+      subject.mergeRequestIid,
+      subject.headSha,
+      edge.at
+    )
+    const terminal = edge.state !== 'queued' && edge.state !== 'running'
+    const reason = normalizedReason(edge.reason)
+    const projection = await this.deps.projections.upsert({
+      provider: PROVIDER,
+      hookId: HookId(edge.hookId),
+      orgId: edge.orgId,
+      agentId: AgentId(edge.agentId),
+      agentName: agent.name,
+      projectionEpoch: run.projectionEpoch,
+      desiredState: edge.state,
+      currentDeliveryKey: edge.deliveryKey,
+      currentRunAt: edge.at,
+      credentialEpoch: connection.credentialEpoch,
+      ...this.fence(snapshot),
+      ...subject,
+      ...(reason ? { reason } : {}),
+      ...(edge.sessionId ? { sessionId: edge.sessionId } : {}),
+      ...(edge.state === 'queued' ? { queuedAt: edge.at } : {}),
+      ...(edge.state === 'running' ? { startedAt: edge.at } : {}),
+      ...(terminal ? { completedAt: edge.at } : {}),
+      nextAttemptAt: edge.at
+    })
+    // Null ⇒ the hook was retired under the lifecycle fence while this edge was in flight.
+    if (!projection || projection.tombstonedAt) return
+    // The upsert parks an edge that landed mid-write; the reporter drains it once that write settles.
+    if (projection.writePhase !== null) return
+    // A late queued/running edge loses here against the terminal authority that already sealed it.
+    const moved = await this.deps.projections.setDesired(
+      projection.id,
+      projection.generation,
+      edge.state,
+      edge.at,
+      reason
+    )
+    if (moved) this.deps.kick?.()
+  }
+
+  private fence(snapshot: HookConfigSnapshot) {
+    return {
+      configRevision: BigInt(snapshot.configRevision),
+      dispatchRevision: BigInt(snapshot.dispatchRevision),
+      dispatchDaemonId: snapshot.dispatchDaemonId,
+      reviewPolicySnapshot: snapshot.reviewPolicy,
+      reportingModeSnapshot: snapshot.reportingMode,
+      gateModeSnapshot: snapshot.gateMode
+    }
+  }
+}
+
+export interface GiteaStatusReporterLog {
+  info(obj: unknown, msg?: string): void
+  warn?(obj: unknown, msg?: string): void
+  error(obj: unknown, msg?: string): void
+}
+
+export interface GiteaStatusReporterDeps {
+  projections: Pick<
+    CodeHostRunProjectionWriterRepo,
+    'claimDue' | 'beginWrite' | 'completeWrite' | 'retryWrite' | 'blockWrite' | 'settleWrite' | 'advancePending' | 'get'
+  >
+  bindings: Pick<GiteaRepositoryBindingRepo, 'byRepo'>
+  connections: Pick<GiteaConnectionRepo, 'get'>
+  /** The connection token, and the §4.3 path a definite rejection takes. */
+  tokens: GiteaTokenSource
+  orgs?: Pick<OrgRepo, 'slugById'>
+  api: GiteaApiClient
+  clock: Clock
+  /** Console origin for the ordinary authenticated session link; unset ⇒ the status carries no link. */
+  webAppUrl?: string
+  workerId?: string
+  intervalMs?: number
+  leaseMs?: number
+  batchSize?: number
+  pageSize?: number
+  log?: GiteaStatusReporterLog
+}
+
+/** Durable periodic worker for one commit status per projection row (§10.4). */
+export class GiteaStatusReporter {
+  private readonly workerId: string
+  private readonly intervalMs: number
+  private readonly leaseMs: number
+  private readonly batchSize: number
+  private timer: TimerHandle | undefined
+  private started = false
+  private running = false
+  private rerunRequested = false
+
+  constructor(private readonly deps: GiteaStatusReporterDeps) {
+    this.workerId = deps.workerId ?? `gitea-status-reporter:${randomUUID()}`
+    this.intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS
+    this.leaseMs = deps.leaseMs ?? DEFAULT_LEASE_MS
+    this.batchSize = deps.batchSize ?? DEFAULT_BATCH_SIZE
+  }
+
+  start(): void {
+    this.started = true
+    this.schedule(0)
+  }
+
+  stop(): void {
+    this.started = false
+    this.rerunRequested = false
+    if (this.timer !== undefined) {
+      this.deps.clock.clearTimeout(this.timer)
+      this.timer = undefined
+    }
+  }
+
+  /** Best-effort latency optimization. Periodic scans remain the recovery path. */
+  kick(): void {
+    if (!this.started) return
+    if (this.running) {
+      this.rerunRequested = true
+      return
+    }
+    this.schedule(0)
+  }
+
+  /** One or more claimed batches. Public for deterministic unit tests. */
+  async tick(): Promise<void> {
+    if (this.running) {
+      this.rerunRequested = true
+      return
+    }
+    this.running = true
+    if (this.timer !== undefined) {
+      this.deps.clock.clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    try {
+      do {
+        this.rerunRequested = false
+        const now = new Date(this.deps.clock.now())
+        const claimed = await this.deps.projections.claimDue(
+          PROVIDER,
+          this.workerId,
+          now,
+          new Date(now.getTime() + this.leaseMs),
+          this.batchSize
+        )
+        for (const projection of claimed) {
+          try {
+            await this.process(projection)
+          } catch (err) {
+            // An unexpected worker bug must not strand the lease; `writePhase` decides whether the retry is reconcile-only.
+            await this.retry(
+              projection,
+              'worker_error',
+              projection.writeMarker !== null || projection.writePhase !== null
+            )
+            this.deps.log?.error(
+              { err, projectionId: projection.id, generation: projection.generation.toString() },
+              'gitea-status-reporter: projection failed'
+            )
+          }
+        }
+        if (claimed.length === this.batchSize) this.rerunRequested = true
+      } while (this.rerunRequested)
+    } catch (err) {
+      this.deps.log?.error({ err }, 'gitea-status-reporter: claim failed')
+    } finally {
+      this.running = false
+      if (this.started) this.schedule(this.intervalMs)
+    }
+  }
+
+  private schedule(delayMs: number): void {
+    if (!this.started) return
+    if (this.timer !== undefined) this.deps.clock.clearTimeout(this.timer)
+    this.timer = this.deps.clock.setTimeout(() => void this.tick(), delayMs)
+  }
+
+  private async process(row: CodeHostRunProjectionRecord): Promise<void> {
+    if (!isGiteaProjectionState(row.desiredState)) {
+      await this.blockOrHold(row, 'invalid_state')
+      return
+    }
+    const inFlight = row.writeMarker !== null || row.writePhase !== null
+    // Observed already, nothing in flight: drain a parked edge into its own generation, or leave the due set.
+    if (row.observedState === row.desiredState && !inFlight) {
+      if (row.pendingIntent !== null) await this.advancePending(row)
+      else await this.deps.projections.settleWrite(row.id, row.generation, this.workerId)
+      return
+    }
+    // A tombstone is cleanup-only authority: it resolves a status a removed hook left pending and mints nothing otherwise.
+    if (row.tombstonedAt !== null && !inFlight && row.observedState !== 'queued' && row.observedState !== 'running') {
+      if (row.pendingIntent !== null) await this.advancePending(row)
+      else await this.deps.projections.blockWrite(row.id, row.generation, 'cleanup_not_needed')
+      return
+    }
+
+    const binding = await this.deps.bindings.byRepo(row.orgId, row.projectId)
+    const connection = binding ? await this.deps.connections.get(row.orgId, binding.connectionId) : null
+    const repo = binding ? splitGiteaRepoPath(binding.repoPath) : null
+    if (!binding || !connection || !repo) {
+      await this.blockOrHold(row, 'repo_authorization')
+      return
+    }
+    let token: string
+    try {
+      token = await this.deps.tokens.withToken(row.orgId, connection.id)
+    } catch (err) {
+      // A rejected token is waiting on its replacement; the row stays due and never loses a held marker.
+      await this.retry(row, err instanceof GiteaConnectDenied ? err.code : 'token_unavailable', inFlight)
+      return
+    }
+    const where = { owner: repo.owner, repo: repo.repo, token, botUserId: connection.botUserId }
+
+    if (row.writeMarker && row.writePhase) {
+      await this.reconcileAmbiguous(row, where)
+      return
+    }
+
+    // Keep every fallible local read before the write marker; after it, only the one mutation or a reconcile may follow.
+    const spec = giteaStatusSpec(row, await this.consoleUrl(row))
+    const marker = randomUUID()
+    const now = new Date(this.deps.clock.now())
+    const taken = await this.deps.projections.beginWrite(
+      row.id,
+      row.generation,
+      this.workerId,
+      marker,
+      row.noteId ? 'update' : 'create',
+      now,
+      new Date(now.getTime() + this.leaseMs)
+    )
+    if (!taken) return
+    try {
+      const created = await giteaCreateCommitStatus(token, where.owner, where.repo, row.headSha, spec, this.deps.api)
+      await this.finish(row, marker, String(created.id))
+    } catch (err) {
+      await this.handleWriteError(row, err, connection.id)
+    }
+  }
+
+  /** Proven by a newer row than last observed with the sent state and description; absent past the grace window, it never landed. */
+  private async reconcileAmbiguous(
+    row: CodeHostRunProjectionRecord,
+    where: { owner: string; repo: string; token: string; botUserId: bigint }
+  ): Promise<void> {
+    const spec = giteaStatusSpec(row, await this.consoleUrl(row))
+    let statuses: GiteaCommitStatus[]
+    try {
+      statuses = await giteaListCommitStatuses(
+        where.token,
+        where.owner,
+        where.repo,
+        row.headSha,
+        this.deps.api,
+        this.deps.pageSize ?? GITEA_DEFAULT_PAGE_SIZE
+      )
+    } catch (err) {
+      // Even a definite GET failure says nothing about the earlier mutation: the marker stays.
+      await this.retry(row, errorLabel(err, 'reconcile_failed'), true)
+      return
+    }
+    const lastObserved = row.noteId && /^\d+$/.test(row.noteId) ? BigInt(row.noteId) : -1n
+    const landed = statuses
+      .filter((status) => statusIdOf(status) !== null && statusIdOf(status)! > lastObserved)
+      .filter((status) => status.context === spec.context)
+      .filter((status) => status.creator?.id === undefined || String(status.creator.id) === where.botUserId.toString())
+      .find((status) => status.status === spec.state && status.description === spec.description)
+    if (landed) {
+      await this.finish(row, row.writeMarker!, statusIdOf(landed)!.toString())
+      return
+    }
+    if (this.writeGraceElapsed(row)) {
+      await this.deps.projections.retryWrite(
+        row.id,
+        row.generation,
+        this.workerId,
+        new Date(this.deps.clock.now()),
+        'ambiguous_write_reissued',
+        false
+      )
+      return
+    }
+    await this.retry(row, 'ambiguous_write', true)
+  }
+
+  private writeGraceElapsed(row: CodeHostRunProjectionRecord): boolean {
+    if (!row.writeStartedAt) return false
+    return this.deps.clock.now() - row.writeStartedAt.getTime() >= AMBIGUOUS_WRITE_GRACE_MS
+  }
+
+  private async finish(row: CodeHostRunProjectionRecord, marker: string, statusId: string): Promise<void> {
+    const completed = await this.deps.projections.completeWrite({
+      projectionId: row.id,
+      generation: row.generation,
+      leaseOwner: this.workerId,
+      writeMarker: marker,
+      observedState: row.desiredState,
+      noteId: statusId,
+      recheckAt: new Date(this.deps.clock.now())
+    })
+    if (!completed) return
+    const fresh = await this.deps.projections.get(row.id)
+    if (fresh?.pendingIntent) await this.advancePending(fresh)
+  }
+
+  private async advancePending(row: CodeHostRunProjectionRecord): Promise<void> {
+    const advanced = await this.deps.projections.advancePending(row.id, row.generation, new Date(this.deps.clock.now()))
+    if (advanced) this.rerunRequested = true
+  }
+
+  private async handleWriteError(row: CodeHostRunProjectionRecord, err: unknown, connectionId: string): Promise<void> {
+    if (isGiteaAuthRejection(err)) {
+      // A received rejection is a definite non-effect; the connection's §4.3 path degrades the bindings.
+      await this.deps.tokens.onAuthRejected(row.orgId, connectionId).catch(() => undefined)
+      await this.retry(row, 'token_rejected', false)
+      return
+    }
+    if (err instanceof GiteaApiError && err.code === 'RATE_LIMITED') {
+      await this.retry(row, 'rate_limited', false, 60_000)
+      return
+    }
+    if (err instanceof GiteaApiError && !err.retryable && err.status !== 0) {
+      // A received non-retryable response proves this request did not mutate.
+      await this.deps.projections.blockWrite(row.id, row.generation, errorLabel(err, 'gitea_write_denied'))
+      return
+    }
+    // A transport failure or a 5xx may or may not have applied the effect: keep the marker and reconcile.
+    await this.retry(row, 'ambiguous_write', true)
+  }
+
+  private async blockOrHold(row: CodeHostRunProjectionRecord, code: string): Promise<void> {
+    if (row.writeMarker || row.writePhase) {
+      await this.retry(row, code, true)
+      return
+    }
+    await this.deps.projections.blockWrite(row.id, row.generation, code)
+  }
+
+  private async retry(
+    row: CodeHostRunProjectionRecord,
+    code: string,
+    keepWriteMutex: boolean,
+    waitAtLeastMs = 0
+  ): Promise<void> {
+    const attempt = Math.max(0, row.attempts)
+    const delay = Math.max(Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.min(attempt, 8)), waitAtLeastMs)
+    await this.deps.projections.retryWrite(
+      row.id,
+      row.generation,
+      this.workerId,
+      new Date(this.deps.clock.now() + delay),
+      code,
+      keepWriteMutex
+    )
+  }
+
+  /** An ordinary authenticated Console session URL — never a bearer token, secret, or capability param. */
+  private async consoleUrl(row: CodeHostRunProjectionRecord): Promise<string | undefined> {
+    if (!this.deps.webAppUrl || !this.deps.orgs || !row.sessionId) return undefined
+    try {
+      const slug = await this.deps.orgs.slugById(row.orgId)
+      if (!slug) return undefined
+      const base = `${this.deps.webAppUrl.replace(/\/+$/, '')}/${encodeURIComponent(slug)}`
+      return `${base}/sessions/${encodeURIComponent(row.sessionId)}?source=gitea`
+    } catch (err) {
+      // A console-link lookup must never block the authoritative projection.
+      this.deps.log?.warn?.({ err, projectionId: row.id }, 'gitea-status-reporter: console link lookup failed')
+      return undefined
+    }
+  }
+}
+
+function statusIdOf(status: GiteaCommitStatus): bigint | null {
+  const raw = String(status.id)
+  return /^\d+$/.test(raw) ? BigInt(raw) : null
+}
+
+function errorLabel(err: unknown, fallback: string): string {
+  return err instanceof GiteaApiError ? err.code.toLowerCase() : fallback
+}

--- a/packages/control-plane/src/gitea/status-projection.ts
+++ b/packages/control-plane/src/gitea/status-projection.ts
@@ -175,14 +175,8 @@ export class GiteaStatusCoordinator {
     const connection = await this.deps.connections.get(edge.orgId, binding.connectionId)
     if (!connection) return
 
-    // A newer head preempts every older generation on the same pull request before the new one opens.
-    await this.deps.projections.supersede(
-      HookId(edge.hookId),
-      subject.projectId,
-      subject.mergeRequestIid,
-      subject.headSha,
-      edge.at
-    )
+    // The run's acceptance ranks its head on the pull request: the same on every edge, so a late edge of an older head outranks nothing.
+    const acceptedAt = run.startedAt
     const terminal = edge.state !== 'queued' && edge.state !== 'running'
     const reason = normalizedReason(edge.reason)
     const projection = await this.deps.projections.upsert({
@@ -200,16 +194,27 @@ export class GiteaStatusCoordinator {
       ...subject,
       ...(reason ? { reason } : {}),
       ...(edge.sessionId ? { sessionId: edge.sessionId } : {}),
-      ...(edge.state === 'queued' ? { queuedAt: edge.at } : {}),
+      queuedAt: acceptedAt,
       ...(edge.state === 'running' ? { startedAt: edge.at } : {}),
       ...(terminal ? { completedAt: edge.at } : {}),
       nextAttemptAt: edge.at
     })
     // Null ⇒ the hook was retired under the lifecycle fence while this edge was in flight.
     if (!projection || projection.tombstonedAt) return
+    // The row already belongs to a newer run of this head: an older delivery's edge moves nothing.
+    if (projection.currentDeliveryKey !== edge.deliveryKey) return
+    // The newest accepted head preempts every older one, this head's own row included when a newer head is already here.
+    await this.deps.projections.supersede(
+      HookId(edge.hookId),
+      subject.projectId,
+      subject.mergeRequestIid,
+      subject.headSha,
+      edge.at,
+      acceptedAt
+    )
     // The upsert parks an edge that landed mid-write; the reporter drains it once that write settles.
     if (projection.writePhase !== null) return
-    // A late queued/running edge loses here against the terminal authority that already sealed it.
+    // A late queued/running edge loses against the terminal authority that sealed the generation; a superseded row refuses every edge.
     const moved = await this.deps.projections.setDesired(
       projection.id,
       projection.generation,

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -70,6 +70,7 @@ import type { GitlabAccountService } from '../gitlab/account.service.js'
 import type { GitlabProvisioner } from '../gitlab/provisioner.js'
 import type { GitlabHookRerunService } from '../gitlab/hook-rerun.service.js'
 import type { GiteaConnectionService } from '../gitea/connection.service.js'
+import type { GiteaHookRerunService } from '../gitea/hook-rerun.service.js'
 import type { GiteaProvisioner } from '../gitea/provisioner.js'
 import type { GiteaApiClient } from '../gitea/api.js'
 import type { PullRequestViewService } from '../github/pull-request-view.service.js'
@@ -430,6 +431,8 @@ export interface HttpDeps {
   gitea?: {
     connections: GiteaConnectionService
     provisioner: GiteaProvisioner
+    /** The §10.4 Console rerun authorizer. */
+    hookRerun: GiteaHookRerunService
     api: GiteaApiClient
   }
   /** The PR panel's read projection; absent like {@link github} ⇒ the route 404s, hiding the tab. */

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -1278,20 +1278,15 @@ export function hookRoutes(deps: HttpDeps) {
       }
     )
 
-    // The Console "Run again" action (gitlab-com-integration.md §16.1, §18.2).
-    // GitLab has no native Check button, so this is the replacement start path:
-    // the service revalidates every fence live and reads the subject's CURRENT
-    // head from GitLab, then the relay re-dispatches through the ordinary hook
-    // turn path. Registered unconditionally so the published spec describes it;
-    // a deployment without the GitLab app refuses every call.
+    // Console "Run again" (gitlab §16.1, gitea §10.4): the provider service revalidates every fence live; registered unconditionally.
     r.post(
       '/hooks/:id/rerun',
       {
         schema: {
           tags: [Tag.Hooks],
-          summary: 'Run a GitLab trigger again',
+          summary: 'Run a GitLab or Gitea trigger again',
           description:
-            'Re-dispatches one GitLab trigger turn for a merge request or issue thread. GitLab offers no native re-run control, so this is the console entry point. The enabled trigger, its agent, the managed project binding, and the subject are all revalidated live, and a merge-request rerun targets the head SHA GitLab reports right now — never a stored one. Refusals carry a machine-readable `code`.',
+            'Re-dispatches one GitLab or Gitea trigger turn for a merge/pull request or issue thread. Neither host offers a native re-run control, so this is the console entry point. The enabled trigger, its agent, the managed repository binding, and the subject are all revalidated live, and a merge-request rerun targets the head SHA the host reports right now — never a stored one. Refusals carry a machine-readable `code`. The `merge_request` subject kind names a Gitea pull request by its index.',
           operationId: 'rerunHook',
           params: IdParam,
           body: HookRerunBody,
@@ -1313,15 +1308,30 @@ export function hookRoutes(deps: HttpDeps) {
         if (!hook) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'hook not found' })
         }
-        if (!deps.gitlab) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'this deployment has no GitLab application configured',
-            code: 'GITLAB_NOT_CONFIGURED'
-          })
+        const rerun = async () => {
+          if (hook.kind === 'gitea') {
+            if (!deps.gitea) {
+              return {
+                ok: false as const,
+                status: 409 as const,
+                code: 'GITEA_NOT_CONFIGURED',
+                message: 'this deployment has no Gitea connection surface configured'
+              }
+            }
+            const { kind, iid } = req.body.subject
+            return deps.gitea.hookRerun.rerun(hook, { kind, index: iid })
+          }
+          if (!deps.gitlab) {
+            return {
+              ok: false as const,
+              status: 409 as const,
+              code: 'GITLAB_NOT_CONFIGURED',
+              message: 'this deployment has no GitLab application configured'
+            }
+          }
+          return deps.gitlab.hookRerun.rerun(hook, req.body.subject)
         }
-        const outcome = await deps.gitlab.hookRerun.rerun(hook, req.body.subject)
+        const outcome = await rerun()
         if (!outcome.ok) {
           return reply.code(outcome.status).send({
             error: RERUN_STATUS_TEXT[outcome.status],

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2973,6 +2973,31 @@ export interface CodeHostRunProjectionRepo {
   get(projectionId: string): Promise<CodeHostRunProjectionRecord | null>
 }
 
+/** The Control-Plane-written projection's writer members (gitea-integration.md §10.4); the daemon-written GitLab note never claims. */
+export interface CodeHostRunProjectionWriterRepo extends CodeHostRunProjectionRepo {
+  /** Take the lease on every due row of one provider whose lease is free, expired, or already this worker's. */
+  claimDue(
+    provider: string,
+    leaseOwner: string,
+    now: Date,
+    leaseUntil: Date,
+    limit?: number
+  ): Promise<CodeHostRunProjectionRecord[]>
+  /** Release the lease for a later pass, with or without the write mutex (an ambiguous write keeps it). */
+  retryWrite(
+    projectionId: string,
+    generation: bigint,
+    leaseOwner: string,
+    nextAttemptAt: Date,
+    errorCode: string,
+    keepWriteMutex?: boolean
+  ): Promise<boolean>
+  /** A definitive refusal: leave the due set until the next generation, keeping only a serialized cleanup due. */
+  blockWrite(projectionId: string, generation: bigint, errorCode: string, keepWriteMutex?: boolean): Promise<boolean>
+  /** Nothing left to publish: drop the row out of the due set instead of claiming it again and again. */
+  settleWrite(projectionId: string, generation: bigint, leaseOwner: string): Promise<boolean>
+}
+
 /** Per-hook HMAC signing key — read ONLY here, NEVER joined into a DTO
  *  (BotSecretStore discipline). */
 /**

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2922,7 +2922,7 @@ export interface CodeHostRunProjectionRepo {
    *  provider mutation is in flight is parked as `pendingIntent` instead of moving the generation.
    *  Null ⇒ the owner is retired: creation is refused under the owner-lifecycle fence. */
   upsert(input: UpsertCodeHostRunProjectionInput): Promise<CodeHostRunProjectionRecord | null>
-  /** Move the desired state within one generation. A non-terminal edge loses to `sealedThrough`. */
+  /** Move the desired state within one generation. A non-terminal edge loses to `sealedThrough`; a superseded row never revives. */
   setDesired(
     projectionId: string,
     generation: bigint,
@@ -2930,13 +2930,14 @@ export interface CodeHostRunProjectionRepo {
     nextAttemptAt: Date,
     reason?: string
   ): Promise<boolean>
-  /** A newer head preempted every older generation on the same merge request (§16). */
+  /** A newer head preempts older generations on the subject (§16); with `acceptedAt`, ranked by run acceptance (`queuedAt`), own rows included. */
   supersede(
     hookId: HookId,
     projectId: bigint,
     mergeRequestIid: number,
     currentHeadSha: string,
-    at: Date
+    at: Date,
+    acceptedAt?: Date
   ): Promise<number>
   /** Take the write for one generation on behalf of `leaseOwner` (a daemon id) and arm the mutex.
    *  Refused while another mutation is in flight — ownership may not move mid-write. */
@@ -4004,6 +4005,8 @@ export interface CodeHostReviewLeaseRecord extends CodeHostReviewSubject {
   phase: CodeHostReviewLeasePhase
   leaseUntil: Date | null
   lockedReason: CodeHostReviewLockReason | null
+  /** The owner attempt's marker key material (hex), kept for the lock exit (gitea-integration.md §10.3). */
+  markerSeed: string | null
 }
 
 export interface CodeHostReviewAcquireInput {
@@ -4019,14 +4022,35 @@ export interface CodeHostReviewAcquireInput {
   headSha: string
   leaseUntil: Date
   now: Date
+  markerSeed?: string
 }
 
-/** `held` is ordinary contention; `locked` is the indefinite fail-closed state. */
+/** `held` is ordinary contention; `locked` is the indefinite fail-closed state, with the record it retains. */
 export type CodeHostReviewAcquireResult =
   | { outcome: 'acquired'; lease: CodeHostReviewLeaseRecord; condition: CodeHostReviewTransferCondition | 'fresh' }
   | { outcome: 'idempotent'; lease: CodeHostReviewLeaseRecord }
   | { outcome: 'held'; lease: CodeHostReviewLeaseRecord }
-  | { outcome: 'locked'; lease: CodeHostReviewLeaseRecord; lock: CodeHostReviewLockReason | null }
+  | {
+      outcome: 'locked'
+      lease: CodeHostReviewLeaseRecord
+      lock: CodeHostReviewLockReason | null
+      retained: CodeHostReviewOperationRecord | null
+    }
+
+/** The lock's one exit: the locked owner's retained record, named by a refused daemon that found its object. */
+export interface CodeHostReviewIdentifyInput {
+  subject: CodeHostReviewSubject
+  orgId: string
+  attemptId: string
+  fence: bigint
+  recordId: string
+  /** Already encoded as `"<kind>:<numeric id>"`; the repository refuses anything else. */
+  externalRef: string
+  now: Date
+}
+
+/** `retained` means the effect is recorded but another record still holds the attempt; `mismatch` changed nothing. */
+export type CodeHostReviewIdentifyResult = { outcome: 'released' | 'retained' | 'not_locked' | 'mismatch' }
 
 export interface CodeHostReviewOperationRecord {
   id: string
@@ -4125,6 +4149,8 @@ export interface CodeHostReviewLeaseRepo {
   returnOperationUnused(input: CodeHostReviewAdvanceInput): Promise<CodeHostReviewOpResult>
   /** Persist the terminal classification and release or lock the lease with it. */
   recordOutcome(input: CodeHostReviewOutcomeInput): Promise<CodeHostReviewOutcomeResult>
+  /** The lock's one exit (gitea-integration.md §10.3): settle the retained record by its object and re-record the effect; any daemon of the org may bring it. */
+  identifyLocked(input: CodeHostReviewIdentifyInput): Promise<CodeHostReviewIdentifyResult>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/code-host-projection.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/code-host-projection.repo.ts
@@ -30,7 +30,7 @@ import type { AgentId, HookId, OrgId } from '../../domain/ids.js'
 import type {
   CodeHostProjectionWriteResultInput,
   CodeHostRunProjectionRecord,
-  CodeHostRunProjectionRepo,
+  CodeHostRunProjectionWriterRepo,
   HookGateMode,
   HookReportingMode,
   HookReviewPolicy,
@@ -172,7 +172,7 @@ function toRecord(r: CodeHostRunProjection): CodeHostRunProjectionRecord {
   }
 }
 
-export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionRepo {
+export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionWriterRepo {
   constructor(private readonly db: PrismaLike) {}
 
   private transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
@@ -595,6 +595,108 @@ export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionRepo {
   async get(projectionId: string): Promise<CodeHostRunProjectionRecord | null> {
     const row = await this.db.codeHostRunProjection.findUnique({ where: { id: projectionId } })
     return row ? toRecord(row) : null
+  }
+
+  async claimDue(
+    provider: string,
+    leaseOwner: string,
+    now: Date,
+    leaseUntil: Date,
+    limit = 25
+  ): Promise<CodeHostRunProjectionRecord[]> {
+    return this.transaction(async (tx) => {
+      const free = { OR: [{ leaseUntil: null }, { leaseUntil: { lt: now } }, { leaseOwner }] }
+      const candidates = await tx.codeHostRunProjection.findMany({
+        where: { provider, nextAttemptAt: { lte: now }, ...free },
+        orderBy: [{ nextAttemptAt: 'asc' }, { updatedAt: 'asc' }],
+        take: limit
+      })
+      const claimed: CodeHostRunProjectionRecord[] = []
+      for (const row of candidates) {
+        // The generation fences the claim: a row that moved since the read is left for the next pass.
+        const changed = await tx.codeHostRunProjection.updateMany({
+          where: { id: row.id, generation: row.generation, ...free },
+          data: { leaseOwner, leaseUntil }
+        })
+        if (changed.count !== 1) continue
+        const fresh = await tx.codeHostRunProjection.findUnique({ where: { id: row.id } })
+        if (fresh) claimed.push(toRecord(fresh))
+      }
+      return claimed
+    })
+  }
+
+  async retryWrite(
+    projectionId: string,
+    generation: bigint,
+    leaseOwner: string,
+    nextAttemptAt: Date,
+    errorCode: string,
+    keepWriteMutex = false
+  ): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const current = await this.lockById(tx, projectionId)
+      if (!current || current.generation !== generation || current.leaseOwner !== leaseOwner) return false
+      const changed = await tx.codeHostRunProjection.updateMany({
+        where: { id: projectionId, generation, leaseOwner },
+        data: {
+          attempts: { increment: 1 },
+          lastErrorCode: errorCode,
+          nextAttemptAt,
+          leaseOwner: null,
+          leaseUntil: null,
+          // Only a PROVED non-effect releases the mutex; an ambiguous write keeps it for reconciliation.
+          ...(keepWriteMutex ? {} : { writeMarker: null, writePhase: null, writeStartedAt: null })
+        }
+      })
+      return changed.count === 1
+    })
+  }
+
+  async blockWrite(
+    projectionId: string,
+    generation: bigint,
+    errorCode: string,
+    keepWriteMutex = false
+  ): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const current = await this.lockById(tx, projectionId)
+      if (!current || current.generation !== generation) return false
+      // A definitive old-write failure may clear its marker, but cannot strand a tombstone serialized behind it.
+      const cleanupPending = current.tombstonedAt !== null && current.pendingIntent !== null
+      const changed = await tx.codeHostRunProjection.updateMany({
+        where: { id: projectionId, generation },
+        data: {
+          lastErrorCode: errorCode,
+          nextAttemptAt: cleanupPending ? current.tombstonedAt : null,
+          leaseOwner: null,
+          leaseUntil: null,
+          ...(keepWriteMutex ? {} : { writeMarker: null, writePhase: null, writeStartedAt: null })
+        }
+      })
+      return changed.count === 1
+    })
+  }
+
+  async settleWrite(projectionId: string, generation: bigint, leaseOwner: string): Promise<boolean> {
+    return this.transaction(async (tx) => {
+      const current = await this.lockById(tx, projectionId)
+      if (!current || current.generation !== generation || current.leaseOwner !== leaseOwner) return false
+      // Re-read under the row lock: a converge landing meanwhile re-armed the row, and clearing its due time would strand that intent.
+      if (
+        current.desiredState !== current.observedState ||
+        current.pendingIntent !== null ||
+        current.writePhase !== null ||
+        current.writeMarker !== null
+      ) {
+        return false
+      }
+      const changed = await tx.codeHostRunProjection.updateMany({
+        where: { id: projectionId, generation, leaseOwner },
+        data: { nextAttemptAt: null, leaseOwner: null, leaseUntil: null, lastErrorCode: null, attempts: 0 }
+      })
+      return changed.count === 1
+    })
   }
 }
 

--- a/packages/control-plane/src/persistence/repositories/code-host-projection.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/code-host-projection.repo.ts
@@ -302,6 +302,8 @@ export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionWriterR
       // A write in flight owns this generation: park the edge rather than move the generation, or
       // rewrite the state, under a mutation whose outcome nobody has settled yet.
       if (current.writePhase !== null) {
+        // A superseded head's own late edge parks nothing: draining it would revive the row.
+        if (sameRun && current.desiredState === 'superseded') return toRecord(current)
         const pending: Prisma.InputJsonValue = {
           desiredState: input.desiredState,
           reason: input.reason ?? null,
@@ -370,6 +372,8 @@ export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionWriterR
         id: projectionId,
         generation,
         tombstonedAt: null,
+        // A superseded head never revives: a newer head owns the subject, whatever its late edges say.
+        desiredState: { not: 'superseded' },
         // Once any terminal authority seals this generation a delayed queued/running edge can no
         // longer regress it, even if its caller held a stale row snapshot.
         ...(terminal ? {} : { sealedThrough: { lt: generation } })
@@ -389,7 +393,8 @@ export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionWriterR
     projectId: bigint,
     mergeRequestIid: number,
     currentHeadSha: string,
-    at: Date
+    at: Date,
+    acceptedAt?: Date
   ): Promise<number> {
     return this.transaction(async (tx) => {
       const candidates = await tx.codeHostRunProjection.findMany({
@@ -397,15 +402,20 @@ export class PgCodeHostRunProjectionRepo implements CodeHostRunProjectionWriterR
           hookId,
           projectId,
           mergeRequestIid,
-          headSha: { not: currentHeadSha },
           tombstonedAt: null,
-          desiredState: { notIn: ['superseded'] }
+          desiredState: { notIn: ['superseded'] },
+          ...(acceptedAt ? {} : { headSha: { not: currentHeadSha } })
         },
-        select: { id: true }
+        select: { id: true, headSha: true, queuedAt: true }
       })
+      // With an acceptance time only the newest accepted head stays current, the caller's own rows included; no `queuedAt` ranks oldest.
+      const rank = (row: { headSha: string; queuedAt: Date | null }) =>
+        row.headSha === currentHeadSha ? acceptedAt!.getTime() : (row.queuedAt?.getTime() ?? Number.NEGATIVE_INFINITY)
+      const newest = acceptedAt ? Math.max(acceptedAt.getTime(), ...candidates.map(rank)) : undefined
+      const older = newest === undefined ? candidates : candidates.filter((row) => rank(row) < newest)
       let changed = 0
       // Deterministic id order: supersession overlaps ordinary lifecycle edges on the same subject.
-      for (const { id } of [...candidates].sort((a, b) => a.id.localeCompare(b.id))) {
+      for (const { id } of [...older].sort((a, b) => a.id.localeCompare(b.id))) {
         const row = await this.lockById(tx, id)
         if (!row || row.tombstonedAt !== null || row.desiredState === 'superseded') continue
         // A mutation is in flight for the current generation: park supersession as pending intent

--- a/packages/control-plane/src/persistence/repositories/code-host-review.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/code-host-review.repo.ts
@@ -28,6 +28,7 @@ import {
   classifyAcquisition,
   isEncodedExternalRef,
   outcomeReconciles,
+  unlocks,
   phaseAfterIssue,
   classifyRelease,
   phaseAfterSettle,
@@ -317,37 +318,43 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
   ): Promise<CodeHostReviewOpResult> {
     const replay = await this.replayTerminalRecord(input, (record) => settleTransition(record, input.outcome))
     if (replay) return replay
-    return this.withOwnedLease(input, async (tx, lease) => {
-      const record = await this.ownedRecord(tx, input)
-      if (!record) return { failure: 'no_record' }
-      const transition = settleTransition(facts(record), input.outcome)
-      if (!transition.ok) return { failure: 'transition', reason: transition.reason }
-      if (!transition.idempotent) {
-        const outcome = input.outcome
-        await tx.codeHostReviewOperation.update({
-          where: { id: record.id },
-          data: {
-            state: transition.next,
-            ...(outcome.kind === 'deterministic'
-              ? {
-                  settledAt: input.now,
-                  responseStatus: outcome.status,
-                  responseExternalId: outcome.externalId ?? null,
-                  resultCode: outcome.code ?? null
-                }
-              : { ambiguousAt: record.ambiguousAt ?? input.now, resultCode: outcome.code })
-          }
-        })
-      }
-      const settled = phaseAfterSettle(toPhase(lease.phase), toOperation(record).kind)
-      if (settled !== toPhase(lease.phase)) {
-        await tx.codeHostReviewLease.update({ where: { id: lease.id }, data: { phase: settled } })
-      }
-      // Settling the last outstanding record is what lets an already-reported outcome release.
-      const phase = await this.releaseIfNowSafe(tx, lease.id, settled, input.now)
-      const after = await tx.codeHostReviewOperation.findUniqueOrThrow({ where: { id: record.id } })
-      return { outcome: 'ok', record: toOperation(after), phase }
-    })
+    // Naming the provider object is §15.1's fourth condition, so it alone may reach a locked lease.
+    const identifies = input.outcome.kind === 'deterministic' && input.outcome.externalId !== undefined
+    return this.withOwnedLease(
+      input,
+      async (tx, lease) => {
+        const record = await this.ownedRecord(tx, input)
+        if (!record) return { failure: 'no_record' }
+        const transition = settleTransition(facts(record), input.outcome)
+        if (!transition.ok) return { failure: 'transition', reason: transition.reason }
+        if (!transition.idempotent) {
+          const outcome = input.outcome
+          await tx.codeHostReviewOperation.update({
+            where: { id: record.id },
+            data: {
+              state: transition.next,
+              ...(outcome.kind === 'deterministic'
+                ? {
+                    settledAt: input.now,
+                    responseStatus: outcome.status,
+                    responseExternalId: outcome.externalId ?? null,
+                    resultCode: outcome.code ?? null
+                  }
+                : { ambiguousAt: record.ambiguousAt ?? input.now, resultCode: outcome.code })
+            }
+          })
+        }
+        const settled = phaseAfterSettle(toPhase(lease.phase), toOperation(record).kind)
+        if (settled !== toPhase(lease.phase)) {
+          await tx.codeHostReviewLease.update({ where: { id: lease.id }, data: { phase: settled } })
+        }
+        // Settling the last outstanding record is what lets an already-reported outcome release.
+        const phase = await this.releaseIfNowSafe(tx, lease.id, settled, input.now)
+        const after = await tx.codeHostReviewOperation.findUniqueOrThrow({ where: { id: record.id } })
+        return { outcome: 'ok', record: toOperation(after), phase }
+      },
+      identifies
+    )
   }
 
   async returnOperationUnused(input: CodeHostReviewAdvanceInput): Promise<CodeHostReviewOpResult> {
@@ -407,7 +414,10 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
         return { outcome: 'conflict' }
       }
       const existing = await tx.codeHostReviewAttemptOutcome.findUnique({ where: { attemptId: input.attemptId } })
-      if (existing && existing.state !== input.state) return { outcome: 'conflict' }
+      // A recorded outcome moves once, and only from proving nothing to proving the effect: the lock's exit.
+      if (existing && existing.state !== input.state && !unlocks(existing.state as CodeHostReviewState, input.state)) {
+        return { outcome: 'conflict' }
+      }
       const outcomeFacts = {
         orgId: lease.orgId,
         hookId: input.hookId,
@@ -429,7 +439,7 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
       // Recording the outcome does NOT by itself clear ownership: the release runs the same
       // classification an acquisition would, so an outstanding record keeps the attempt owned.
       const phase = await this.releaseIfNowSafe(tx, lease.id, toPhase(lease.phase), input.now)
-      return { outcome: existing ? 'idempotent' : 'recorded', phase }
+      return { outcome: existing?.state === input.state ? 'idempotent' : 'recorded', phase }
     })
   }
 
@@ -567,10 +577,11 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
     }
   }
 
-  /** Every ledger op runs under the subject lock with the owner and fence re-checked. */
+  /** Ledger ops re-check owner and fence under the subject lock; only a positive identification reaches a locked lease, nothing a settled one. */
   private async withOwnedLease(
     input: { attemptId: string; orgId: string; fence: bigint; daemonId: DaemonId },
-    run: (tx: Prisma.TransactionClient, lease: CodeHostReviewLease) => Promise<CodeHostReviewOpResult>
+    run: (tx: Prisma.TransactionClient, lease: CodeHostReviewLease) => Promise<CodeHostReviewOpResult>,
+    identifies = false
   ): Promise<CodeHostReviewOpResult> {
     const owner = await this.prisma.codeHostReviewLease.findUnique({ where: { attemptId: input.attemptId } })
     if (!owner) return { failure: 'no_lease' }
@@ -585,7 +596,7 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
       if (!lease || lease.attemptId !== input.attemptId) return { failure: 'no_lease' }
       if (lease.ownerDaemonId !== input.daemonId || lease.orgId !== input.orgId) return { failure: 'not_owner' }
       if (lease.fence !== input.fence) return { failure: 'stale_fence' }
-      if (toPhase(lease.phase) === 'settled' || toPhase(lease.phase) === 'ambiguous_locked') {
+      if (toPhase(lease.phase) === 'settled' || (toPhase(lease.phase) === 'ambiguous_locked' && !identifies)) {
         return { failure: 'lease_closed' }
       }
       return run(tx, lease)

--- a/packages/control-plane/src/persistence/repositories/code-host-review.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/code-host-review.repo.ts
@@ -46,6 +46,8 @@ import type {
   CodeHostReviewAcquireInput,
   CodeHostReviewAcquireResult,
   CodeHostReviewAdvanceInput,
+  CodeHostReviewIdentifyInput,
+  CodeHostReviewIdentifyResult,
   CodeHostReviewIssueInput,
   CodeHostReviewLeaseRecord,
   CodeHostReviewLeaseRepo,
@@ -88,8 +90,27 @@ function toLease(r: CodeHostReviewLease): CodeHostReviewLeaseRecord {
     headSha: r.headSha,
     phase: toPhase(r.phase),
     leaseUntil: r.leaseUntil,
-    lockedReason: (r.lockedReason as CodeHostReviewLockReason | null) ?? null
+    lockedReason: (r.lockedReason as CodeHostReviewLockReason | null) ?? null,
+    markerSeed: r.markerSeed
   }
+}
+
+function subjectOf(r: CodeHostReviewLease): CodeHostReviewSubject {
+  return {
+    provider: r.provider,
+    projectExternalId: r.projectExternalId,
+    mergeRequestIid: r.mergeRequestIid,
+    serviceAccountExternalId: r.serviceAccountExternalId
+  }
+}
+
+function sameSubject(a: CodeHostReviewSubject, b: CodeHostReviewSubject): boolean {
+  return (
+    a.provider === b.provider &&
+    a.projectExternalId === b.projectExternalId &&
+    a.mergeRequestIid === b.mergeRequestIid &&
+    a.serviceAccountExternalId === b.serviceAccountExternalId
+  )
 }
 
 function toOperation(r: CodeHostReviewOperation): CodeHostReviewOperationRecord {
@@ -167,7 +188,8 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
       })
 
       if (decision.kind === 'already_locked') {
-        return { outcome: 'locked', lease: toLease(current!), lock: toLease(current!).lockedReason }
+        const lease = toLease(current!)
+        return { outcome: 'locked', lease, lock: lease.lockedReason, retained: await this.retainedRecord(tx, current!) }
       }
       if (decision.kind === 'held') return { outcome: 'held', lease: toLease(current!) }
       if (decision.kind === 'idempotent') {
@@ -183,7 +205,12 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
           where: { id: current!.id },
           data: { phase: 'ambiguous_locked', lockedReason: decision.lock, lockedAt: input.now }
         })
-        return { outcome: 'locked', lease: toLease(locked), lock: decision.lock }
+        return {
+          outcome: 'locked',
+          lease: toLease(locked),
+          lock: decision.lock,
+          retained: await this.retainedRecord(tx, locked)
+        }
       }
 
       const owner = {
@@ -199,7 +226,8 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
         phase: 'open',
         leaseUntil: input.leaseUntil,
         lockedReason: null,
-        lockedAt: null
+        lockedAt: null,
+        markerSeed: input.markerSeed ?? null
       }
       const lease = current
         ? await tx.codeHostReviewLease.update({
@@ -575,6 +603,83 @@ export class PgCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
       // No outcome row means the attempt was transferred away under a §15.1 condition, not locked.
       phase: outcome ? phaseOfSettledOutcome(outcome.state as CodeHostReviewState) : 'settled'
     }
+  }
+
+  /** The lock's one exit (gitea-integration.md §10.3): any daemon of the org that found the locked attempt's object may name it; the subject lock and the record's own state are the fence. */
+  async identifyLocked(input: CodeHostReviewIdentifyInput): Promise<CodeHostReviewIdentifyResult> {
+    if (!isEncodedExternalRef(input.externalRef)) return { outcome: 'mismatch' }
+    const owner = await this.prisma.codeHostReviewLease.findUnique({ where: { attemptId: input.attemptId } })
+    if (!owner) return { outcome: 'not_locked' }
+    return this.prisma.$transaction(async (tx) => {
+      await lockCodeHostReviewSubject(tx, subjectOf(owner))
+      const lease = await tx.codeHostReviewLease.findUnique({ where: { id: owner.id } })
+      if (!lease || lease.attemptId !== input.attemptId || toPhase(lease.phase) !== 'ambiguous_locked') {
+        return { outcome: 'not_locked' }
+      }
+      if (lease.orgId !== input.orgId || lease.fence !== input.fence || !sameSubject(subjectOf(lease), input.subject)) {
+        return { outcome: 'mismatch' }
+      }
+      if (!lease.hookId || !lease.deliveryKey || !lease.event || !lease.verdict || !lease.headSha) {
+        return { outcome: 'mismatch' }
+      }
+      const record = await tx.codeHostReviewOperation.findUnique({ where: { id: input.recordId } })
+      if (
+        !record ||
+        record.attemptId !== lease.attemptId ||
+        record.fence !== lease.fence ||
+        toOpState(record.state) !== 'ambiguous'
+      ) {
+        return { outcome: 'mismatch' }
+      }
+      const existing = await tx.codeHostReviewAttemptOutcome.findUnique({ where: { attemptId: lease.attemptId } })
+      // The recorded outcome moves the one way it may: from proving nothing to proving the effect.
+      if (existing && existing.state !== 'submitted' && !unlocks(existing.state as CodeHostReviewState, 'submitted')) {
+        return { outcome: 'mismatch' }
+      }
+      await tx.codeHostReviewOperation.update({
+        where: { id: record.id },
+        data: {
+          state: 'settled',
+          settledAt: input.now,
+          responseStatus: 200,
+          responseExternalId: input.externalRef.split(':')[1] ?? null,
+          resultCode: null
+        }
+      })
+      const outcomeFacts = {
+        orgId: lease.orgId,
+        hookId: lease.hookId,
+        deliveryKey: lease.deliveryKey,
+        provider: lease.provider,
+        projectExternalId: lease.projectExternalId,
+        mergeRequestIid: lease.mergeRequestIid,
+        event: lease.event,
+        verdict: lease.verdict,
+        headSha: lease.headSha,
+        state: 'submitted',
+        externalIds: [input.externalRef]
+      }
+      await tx.codeHostReviewAttemptOutcome.upsert({
+        where: { attemptId: lease.attemptId },
+        create: { attemptId: lease.attemptId, ...outcomeFacts, recordedAt: input.now },
+        update: outcomeFacts
+      })
+      const phase = await this.releaseIfNowSafe(tx, lease.id, 'ambiguous_locked', input.now)
+      return { outcome: phase === 'settled' ? 'released' : 'retained' }
+    })
+  }
+
+  /** The locked owner's ambiguous record, the one a later positive identification can still settle. */
+  private async retainedRecord(
+    tx: Prisma.TransactionClient,
+    lease: CodeHostReviewLease
+  ): Promise<CodeHostReviewOperationRecord | null> {
+    if (!lease.attemptId) return null
+    const row = await tx.codeHostReviewOperation.findFirst({
+      where: { leaseId: lease.id, attemptId: lease.attemptId, state: 'ambiguous' },
+      orderBy: { ordinal: 'desc' }
+    })
+    return row ? toOperation(row) : null
   }
 
   /** Ledger ops re-check owner and fence under the subject lock; only a positive identification reaches a locked lease, nothing a settled one. */

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -41,6 +41,7 @@ import type { CodeHostReviewBrokerService } from '../codehost/review-lease.servi
 import type { GithubReviewBrokerService } from '../github/review-broker.service.js'
 import type { GithubRunCoordinator } from '../github/run-reporter.js'
 import type { CodeHostNoteProjectionService } from '../codehost/note-projection.service.js'
+import type { GiteaStatusCoordinator } from '../gitea/status-projection.js'
 import type { ReconcileService } from '../orchestrator/placement.js'
 import type { ConnectionRegistry } from './registry.js'
 import type { Clock } from '../domain/clock.js'
@@ -174,6 +175,8 @@ export interface DaemonWsDeps {
   githubRunCoordinator?: GithubRunCoordinator
   /** §16 desired-generation ledger for the daemon-written run projection; absent ⇒ no GitLab bindings. */
   codeHostNoteProjection?: CodeHostNoteProjectionService
+  /** gitea-integration.md §10.4: the Control-Plane-written commit-status projection's lifecycle edges. */
+  giteaStatusProjection?: GiteaStatusCoordinator
   /** The current relay roster, injected into `register/ok.relays` so a (re)connecting
    *  daemon converges to the relays it should dial (shared-bot-relay.md §5). */
   relayRoster: () => Promise<RelayRosterEntry[]>

--- a/packages/control-plane/src/ws/handlers/hook-report.ts
+++ b/packages/control-plane/src/ws/handlers/hook-report.ts
@@ -98,10 +98,9 @@ export const handleHookReport: Handler = async (frame, conn, deps) => {
   }
   try {
     await deps.githubRunCoordinator?.afterReport(HookId(p.hookId), p.deliveryKey)
-    // §16 terminal edge. Only a gitlab hook projects a note; the desired generation is recorded
-    // before the ACK so a daemon that retries its report cannot outrun the ledger.
-    if (host?.provider === 'gitlab' && hook.kind === host.provider) {
-      await deps.codeHostNoteProjection?.afterReport({
+    // The run projection's terminal edge (§16, gitea §10.4) is recorded before the ACK so a retried report cannot outrun the ledger.
+    if (host && hook.kind === host.provider) {
+      const edge = {
         hookId: p.hookId,
         agentId: p.agentId,
         deliveryKey: p.deliveryKey,
@@ -109,10 +108,12 @@ export const handleHookReport: Handler = async (frame, conn, deps) => {
         state: reportedNoteState(p.status, p.reason),
         reason: p.reason ?? null,
         ...(p.sessionId ? { sessionId: p.sessionId } : {}),
-        gitlab: host.metadata,
         snapshot: p,
         at: completedAt
-      })
+      }
+      if (host.provider === 'gitlab') await deps.codeHostNoteProjection?.afterReport({ ...edge, gitlab: host.metadata })
+      else if (host.provider === 'gitea')
+        await deps.giteaStatusProjection?.afterReport({ ...edge, gitea: host.metadata })
     }
     conn.replyTo(frame, 'ack', { ok: true })
   } catch {

--- a/packages/control-plane/src/ws/handlers/hook-start.test.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.test.ts
@@ -133,6 +133,58 @@ describe('hook/start provider one-of (gitlab-com-integration.md §17.2)', () => 
     )
   })
 
+  it('routes a gitea start through the code-host broker and the commit-status projection only', async () => {
+    const conn = fakeConn()
+    const deps = gitlabDeps({
+      hook: { get: vi.fn(async () => ({ id: HOOK_ID, kind: 'gitea', projectionEpoch: 3n })) },
+      giteaStatusProjection: { afterStart: vi.fn(async () => {}) }
+    })
+    const gitea = {
+      repoId: '556677',
+      repoPath: 'example-org/example-repo',
+      target: { kind: 'pull' as const, index: 12, headSha: 'a'.repeat(40), baseSha: 'b'.repeat(40) }
+    }
+    const frame = startFrame({ gitea })
+
+    await handleHookStart(frame, conn, deps)
+
+    expect(deps.codeHostReviewBroker!.start).toHaveBeenCalledWith(frame.payload, DAEMON_ID, 'org-a')
+    expect(deps.giteaStatusProjection!.afterStart).toHaveBeenCalledWith({
+      hookId: HOOK_ID,
+      agentId: AGENT_ID,
+      deliveryKey: 'delivery-1',
+      orgId: 'org-a',
+      state: 'running',
+      sessionId: 'acp-gitlab-1',
+      gitea,
+      snapshot: frame.payload,
+      at: new Date(NOW)
+    })
+    expect(deps.codeHostNoteProjection!.afterStart).not.toHaveBeenCalled()
+    expect(deps.githubReviewBroker!.start).not.toHaveBeenCalled()
+    expect(conn.replyTo).toHaveBeenCalledWith(frame, 'hook/start/ok', { accepted: true })
+  })
+
+  it('refuses a gitea start whose hook is a gitlab hook, naming the member provider', async () => {
+    const conn = fakeConn()
+    const deps = gitlabDeps()
+    const gitea = {
+      repoId: '556677',
+      repoPath: 'example-org/example-repo',
+      target: { kind: 'issue' as const, index: 7 }
+    }
+
+    await handleHookStart(startFrame({ gitea }), conn, deps)
+
+    expect(deps.codeHostReviewBroker!.start).not.toHaveBeenCalled()
+    expect(conn.sendError).toHaveBeenCalledWith(
+      expect.any(String),
+      'SCOPE_DENIED',
+      'hook is not a gitea hook in this organization',
+      false
+    )
+  })
+
   it('leaves the github arm on the github broker and its check coordinator', async () => {
     const conn = fakeConn()
     const deps = gitlabDeps()

--- a/packages/control-plane/src/ws/handlers/hook-start.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.ts
@@ -13,33 +13,35 @@ export const handleHookStart: Handler = async (frame, conn, deps) => {
     conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
     return
   }
-  // The provider member routes the barrier (§17.2): the GitLab arm records the started head and opens the §16 `running` edge, with no GitHub review broker in it.
+  // The provider member routes the barrier (§17.2): each arm records the started head and opens its run projection's running edge.
   const host = codeHostHookMetadataOf(frame.payload)
-  if (host?.provider === 'gitlab') {
+  if (host && host.provider !== 'github') {
     if (!deps.codeHostReviewBroker) {
       conn.sendError(frame.id, 'SCOPE_DENIED', 'code-host reviews are not enabled on this control plane', false)
       return
     }
     const hook = await deps.hook.get(orgId, HookId(frame.payload.hookId))
     if (!hook || hook.kind !== host.provider) {
-      conn.sendError(frame.id, 'SCOPE_DENIED', 'hook is not a gitlab hook in this organization', false)
+      conn.sendError(frame.id, 'SCOPE_DENIED', `hook is not a ${host.provider} hook in this organization`, false)
       return
     }
     try {
       await deps.codeHostReviewBroker.start(frame.payload, DaemonId(conn.daemonId), orgId)
       // The OK is the daemon's prompt barrier, so the durable start and its projection generation
       // both converge before it is sent; a retry is safe because both writes are idempotent.
-      await deps.codeHostNoteProjection?.afterStart({
+      const edge = {
         hookId: frame.payload.hookId,
         agentId: frame.payload.agentId,
         deliveryKey: frame.payload.deliveryKey,
         orgId,
-        state: 'running',
+        state: 'running' as const,
         ...(frame.payload.sessionId ? { sessionId: frame.payload.sessionId } : {}),
-        gitlab: host.metadata,
         snapshot: frame.payload,
         at: new Date(deps.clock.now())
-      })
+      }
+      if (host.provider === 'gitlab') await deps.codeHostNoteProjection?.afterStart({ ...edge, gitlab: host.metadata })
+      else if (host.provider === 'gitea')
+        await deps.giteaStatusProjection?.afterStart({ ...edge, gitea: host.metadata })
       conn.replyTo(frame, 'hook/start/ok', { accepted: true })
     } catch (error) {
       if (error instanceof CodeHostReviewBrokerError) {

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -22,6 +22,7 @@ import {
   ORGANIZATION_KNOWLEDGE_FEATURE,
   GITCRED_GITHUB_V2_FEATURE,
   GITCRED_PROVIDER_V2_FEATURE,
+  GITEA_V1_FEATURE,
   GITLAB_EFFECT_V1_FEATURE,
   SESSION_LIVE_TAIL_FEATURE,
   SESSION_METADATA_ACK_FEATURE,
@@ -103,6 +104,8 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
       GITCRED_GITHUB_V2_FEATURE,
       // §14.2: …and decodes purpose 'gitlab_effect', the broker's action-time effect lease.
       GITLAB_EFFECT_V1_FEATURE,
+      // gitea-integration.md §11: gitea gitcred purposes, the gitea hook/start arm, and the review and commit-status surfaces.
+      GITEA_V1_FEATURE,
       // §15.1/§17.2: this CP serves the provider-neutral review authorization, the
       // publication lease with its operation ledger, and the body-free result.
       CODEHOST_REVIEW_V1_FEATURE,

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -106,6 +106,7 @@ import { InMemorySessionEventSink } from '../../src/events/sink.js'
 import { SessionUsageWriter } from '../../src/usage/writer.js'
 import { HookService } from '../../src/hooks/hook.service.js'
 import { GitlabHookRerunService } from '../../src/gitlab/hook-rerun.service.js'
+import { GiteaHookRerunService } from '../../src/gitea/hook-rerun.service.js'
 import { buildHttpServer } from '../../src/http/server.js'
 import type { HttpDeps } from '../../src/http/deps.js'
 import { buildCpPlatformRegistry } from '../../src/platforms/registry.js'
@@ -250,9 +251,10 @@ export function buildHttpApp(
   // time. Nested config goes through `configOverrides`, not here.
   // The gitlab seam's rerun authorizer is filled in below from the same repos,
   // so a suite wires only `{ oauth, provisioner, fetchImpl }`.
-  depsOverrides?: Partial<Omit<HttpDeps, 'gitlab'>> &
+  depsOverrides?: Partial<Omit<HttpDeps, 'gitlab' | 'gitea'>> &
     Partial<PlatformStubs> & {
       gitlab?: Omit<NonNullable<HttpDeps['gitlab']>, 'hookRerun'> & { hookRerun?: GitlabHookRerunService }
+      gitea?: Omit<NonNullable<HttpDeps['gitea']>, 'hookRerun'> & { hookRerun?: GiteaHookRerunService }
     }
 ): HttpApp {
   // The gitea seam a suite wires: the hook compile sources and the spec host follow it exactly as
@@ -459,6 +461,22 @@ export function buildHttpApp(
         }
       : undefined
   )
+  // The gitea rerun authorizer rides its seam the same way (gitea-integration.md §10.4).
+  if (coreOverrides.gitea && !coreOverrides.gitea.hookRerun) {
+    coreOverrides.gitea = {
+      ...coreOverrides.gitea,
+      hookRerun: new GiteaHookRerunService({
+        hooks: hookRepo,
+        agents: agentRepo,
+        bindings: new PgGiteaRepositoryBindingRepo(prisma),
+        connections: new PgGiteaConnectionRepo(prisma),
+        tokens: coreOverrides.gitea.connections,
+        hookService,
+        relayControl,
+        api: coreOverrides.gitea.api
+      })
+    }
+  }
   // The §16.1 rerun authorizer rides the gitlab seam; a suite may still override it.
   if (coreOverrides.gitlab && !coreOverrides.gitlab.hookRerun) {
     coreOverrides.gitlab = {

--- a/packages/control-plane/test/fakes/code-host-review-lease.ts
+++ b/packages/control-plane/test/fakes/code-host-review-lease.ts
@@ -19,6 +19,8 @@ import type {
   CodeHostReviewAcquireInput,
   CodeHostReviewAcquireResult,
   CodeHostReviewAdvanceInput,
+  CodeHostReviewIdentifyInput,
+  CodeHostReviewIdentifyResult,
   CodeHostReviewIssueInput,
   CodeHostReviewLeaseRecord,
   CodeHostReviewLeaseRepo,
@@ -91,7 +93,7 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
       reconciled: outcomeReconciles(this.outcomes.get(current?.attemptId ?? '')?.state ?? null)
     })
     if (decision.kind === 'already_locked') {
-      return { outcome: 'locked', lease: current!, lock: current!.lockedReason }
+      return { outcome: 'locked', lease: current!, lock: current!.lockedReason, retained: this.retainedOf(current!) }
     }
     if (decision.kind === 'held') return { outcome: 'held', lease: current! }
     if (decision.kind === 'idempotent') {
@@ -101,7 +103,7 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
     if (decision.kind === 'lock') {
       current!.phase = 'ambiguous_locked'
       current!.lockedReason = decision.lock
-      return { outcome: 'locked', lease: current!, lock: decision.lock }
+      return { outcome: 'locked', lease: current!, lock: decision.lock, retained: this.retainedOf(current!) }
     }
     const lease: CodeHostReviewLeaseRecord = {
       id: current?.id ?? this.id('lease'),
@@ -118,7 +120,8 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
       headSha: input.headSha,
       phase: 'open',
       leaseUntil: input.leaseUntil,
-      lockedReason: null
+      lockedReason: null,
+      markerSeed: input.markerSeed ?? null
     }
     this.leases.set(k, lease)
     return {
@@ -253,6 +256,40 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
     this.outcomes.set(input.attemptId, { state: input.state, externalIds: input.externalIds })
     // Recording the outcome never clears ownership by itself — the ledger decides.
     return { outcome: existing?.state === input.state ? 'idempotent' : 'recorded', phase: this.releaseIfNowSafe(lease) }
+  }
+
+  async identifyLocked(input: CodeHostReviewIdentifyInput): Promise<CodeHostReviewIdentifyResult> {
+    if (!isEncodedExternalRef(input.externalRef)) return { outcome: 'mismatch' }
+    const lease = this.byAttemptSync(input.attemptId)
+    if (!lease || lease.phase !== 'ambiguous_locked') return { outcome: 'not_locked' }
+    if (lease.orgId !== input.orgId || lease.fence !== input.fence || key(lease) !== key(input.subject)) {
+      return { outcome: 'mismatch' }
+    }
+    const record = this.operations.get(input.recordId)
+    if (
+      !record ||
+      record.attemptId !== lease.attemptId ||
+      record.fence !== lease.fence ||
+      record.state !== 'ambiguous'
+    ) {
+      return { outcome: 'mismatch' }
+    }
+    const existing = this.outcomes.get(lease.attemptId!)
+    if (existing && existing.state !== 'submitted' && !unlocks(existing.state, 'submitted'))
+      return { outcome: 'mismatch' }
+    record.state = 'settled'
+    record.responseStatus = 200
+    record.responseExternalId = input.externalRef.split(':')[1] ?? null
+    this.outcomes.set(lease.attemptId!, { state: 'submitted', externalIds: [input.externalRef] })
+    return { outcome: this.releaseIfNowSafe(lease) === 'settled' ? 'released' : 'retained' }
+  }
+
+  /** The locked owner's ambiguous record, the one a later positive identification can still settle. */
+  private retainedOf(lease: CodeHostReviewLeaseRecord): CodeHostReviewOperationRecord | null {
+    const rows = [...this.operations.values()]
+      .filter((op) => op.attemptId === lease.attemptId && op.state === 'ambiguous')
+      .sort((a, b) => b.ordinal - a.ordinal)
+    return rows[0] ?? null
   }
 
   /** The same release classification the Postgres repository runs under the subject lock. */

--- a/packages/control-plane/test/fakes/code-host-review-lease.ts
+++ b/packages/control-plane/test/fakes/code-host-review-lease.ts
@@ -4,6 +4,7 @@ import {
   classifyAcquisition,
   isEncodedExternalRef,
   outcomeReconciles,
+  unlocks,
   phaseAfterIssue,
   classifyRelease,
   phaseAfterSettle,
@@ -203,19 +204,24 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
   ): Promise<CodeHostReviewOpResult> {
     const replay = this.replayTerminalRecord(input, (record) => settleTransition(record, input.outcome))
     if (replay) return replay
-    return this.advance(input, (record, lease) => {
-      const transition = settleTransition(record, input.outcome)
-      if (!transition.ok) return { failure: 'transition', reason: transition.reason }
-      record.state = transition.next
-      if (input.outcome.kind === 'deterministic') {
-        record.responseStatus = input.outcome.status
-        record.responseExternalId = input.outcome.externalId ?? null
-      } else {
-        record.everAmbiguous = true
-      }
-      lease.phase = phaseAfterSettle(lease.phase, record.kind)
-      return { outcome: 'ok', record, phase: this.releaseIfNowSafe(lease) }
-    })
+    const identifies = input.outcome.kind === 'deterministic' && input.outcome.externalId !== undefined
+    return this.advance(
+      input,
+      (record, lease) => {
+        const transition = settleTransition(record, input.outcome)
+        if (!transition.ok) return { failure: 'transition', reason: transition.reason }
+        record.state = transition.next
+        if (input.outcome.kind === 'deterministic') {
+          record.responseStatus = input.outcome.status
+          record.responseExternalId = input.outcome.externalId ?? null
+        } else {
+          record.everAmbiguous = true
+        }
+        lease.phase = phaseAfterSettle(lease.phase, record.kind)
+        return { outcome: 'ok', record, phase: this.releaseIfNowSafe(lease) }
+      },
+      identifies
+    )
   }
 
   async returnOperationUnused(input: CodeHostReviewAdvanceInput): Promise<CodeHostReviewOpResult> {
@@ -242,10 +248,11 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
     if (lease.event !== input.event || lease.verdict !== input.verdict || lease.headSha !== input.headSha) {
       return { outcome: 'conflict' }
     }
-    if (existing && existing.state !== input.state) return { outcome: 'conflict' }
+    if (existing && existing.state !== input.state && !unlocks(existing.state, input.state))
+      return { outcome: 'conflict' }
     this.outcomes.set(input.attemptId, { state: input.state, externalIds: input.externalIds })
     // Recording the outcome never clears ownership by itself — the ledger decides.
-    return { outcome: existing ? 'idempotent' : 'recorded', phase: this.releaseIfNowSafe(lease) }
+    return { outcome: existing?.state === input.state ? 'idempotent' : 'recorded', phase: this.releaseIfNowSafe(lease) }
   }
 
   /** The same release classification the Postgres repository runs under the subject lock. */
@@ -273,17 +280,21 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
     return null
   }
 
-  private ownedLease(input: {
-    attemptId: string
-    orgId: string
-    fence: bigint
-    daemonId: CodeHostReviewAcquireInput['daemonId']
-  }): CodeHostReviewLeaseRecord | Extract<CodeHostReviewOpResult, { failure: string }> {
+  private ownedLease(
+    input: {
+      attemptId: string
+      orgId: string
+      fence: bigint
+      daemonId: CodeHostReviewAcquireInput['daemonId']
+    },
+    identifies = false
+  ): CodeHostReviewLeaseRecord | Extract<CodeHostReviewOpResult, { failure: string }> {
     const lease = this.byAttemptSync(input.attemptId)
     if (!lease) return { failure: 'no_lease' }
     if (lease.ownerDaemonId !== input.daemonId || lease.orgId !== input.orgId) return { failure: 'not_owner' }
     if (lease.fence !== input.fence) return { failure: 'stale_fence' }
-    if (lease.phase === 'settled' || lease.phase === 'ambiguous_locked') return { failure: 'lease_closed' }
+    if (lease.phase === 'settled' || (lease.phase === 'ambiguous_locked' && !identifies))
+      return { failure: 'lease_closed' }
     return lease
   }
 
@@ -314,9 +325,10 @@ export class FakeCodeHostReviewLeaseRepo implements CodeHostReviewLeaseRepo {
 
   private advance(
     input: CodeHostReviewAdvanceInput,
-    run: (record: StoredOperation, lease: CodeHostReviewLeaseRecord) => CodeHostReviewOpResult
+    run: (record: StoredOperation, lease: CodeHostReviewLeaseRecord) => CodeHostReviewOpResult,
+    identifies = false
   ): CodeHostReviewOpResult {
-    const lease = this.ownedLease(input)
+    const lease = this.ownedLease(input, identifies)
     if ('failure' in lease) return lease
     const record = this.operations.get(input.recordId)
     if (!record || record.attemptId !== input.attemptId || record.fence !== input.fence) {

--- a/packages/control-plane/test/fakes/gitea-api.ts
+++ b/packages/control-plane/test/fakes/gitea-api.ts
@@ -64,6 +64,33 @@ export interface FakeGiteaHook {
   active: boolean
 }
 
+/** One pull request as the rerun and status paths read it (§10.4, §16.1). */
+export interface FakeGiteaPull {
+  state: 'open' | 'closed'
+  headSha: string
+  baseSha?: string
+  merged?: boolean
+  draft?: boolean
+  headRepoId?: number
+}
+
+export interface FakeGiteaIssue {
+  state: 'open' | 'closed'
+  /** Issues and pull requests share one index space; a pull request answers the issue read too. */
+  isPull?: boolean
+}
+
+/** One appended commit status; Gitea keeps the history and shows the latest per context. */
+export interface FakeGiteaStatus {
+  id: number
+  sha: string
+  context: string
+  status: string
+  description: string
+  target_url?: string
+  creator: { id: number }
+}
+
 /** Subscription names Gitea knows; anything else is dropped with a 201 (§16). */
 const KNOWN_EVENTS = new Set([
   'create',
@@ -122,6 +149,11 @@ export class FakeGitea {
   repositories: FakeGiteaRepo[]
   permissions: Record<string, 'none' | 'read' | 'write' | 'admin' | 'owner'>
   hooks = new Map<number, FakeGiteaHook>()
+  /** Pull requests and issues by index, for the rerun subject reads; absent ⇒ 404. */
+  pulls = new Map<number, FakeGiteaPull>()
+  issues = new Map<number, FakeGiteaIssue>()
+  /** Every commit status ever written, in order. */
+  statuses: FakeGiteaStatus[] = []
   /** Test deliveries fired, by hook id. */
   tests: number[] = []
   /** Every call the CP made, with the token it presented — WHICH token a check used is part of the contract. */
@@ -170,6 +202,19 @@ export class FakeGitea {
       html_url: `${this.opts.baseUrl}/${repo.full_name}`,
       default_branch: repo.default_branch ?? 'main',
       permissions: { admin: repo.admin, push: true, pull: true }
+    }
+  }
+
+  private statusJson(status: FakeGiteaStatus): Record<string, unknown> {
+    return {
+      id: status.id,
+      status: status.status,
+      context: status.context,
+      description: status.description,
+      target_url: status.target_url ?? '',
+      creator: { id: status.creator.id, login: this.opts.bot.login },
+      created_at: '2026-09-12T00:00:00Z',
+      updated_at: '2026-09-12T00:00:00Z'
     }
   }
 
@@ -323,6 +368,67 @@ export class FakeGitea {
           return Response.json({ message: `user does not exist [uid: 0, name: ${login}]` }, { status: 404 })
         const answer = this.permissions[login] ?? 'none'
         return Response.json({ permission: answer, role_name: answer, user: { id, login, username: login } })
+      }
+
+      const pullRoute = /^\/repos\/([^/]+)\/([^/]+)\/pulls\/(\d+)$/.exec(route)
+      if (pullRoute && method === 'GET') {
+        const repo = this.repositories.find((candidate) => candidate.full_name === `${pullRoute[1]}/${pullRoute[2]}`)
+        const pull = this.pulls.get(Number(pullRoute[3]))
+        if (!repo || !pull) return Response.json({ message: "The target couldn't be found." }, { status: 404 })
+        return Response.json({
+          id: 7_000_000 + Number(pullRoute[3]),
+          number: Number(pullRoute[3]),
+          state: pull.state,
+          merged: pull.merged === true,
+          ...(pull.draft !== undefined ? { draft: pull.draft } : {}),
+          head: { sha: pull.headSha, ref: 'feature', repo_id: pull.headRepoId ?? repo.id },
+          base: { sha: pull.baseSha ?? 'b'.repeat(40), ref: repo.default_branch ?? 'main' },
+          user: { id: this.opts.users.alice ?? 1, login: 'alice' }
+        })
+      }
+      const issueByIndex = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)$/.exec(route)
+      if (issueByIndex && method === 'GET' && this.issues.has(Number(issueByIndex[3]))) {
+        const repo = this.repositories.find(
+          (candidate) => candidate.full_name === `${issueByIndex[1]}/${issueByIndex[2]}`
+        )
+        if (!repo) return Response.json({ message: "The target couldn't be found." }, { status: 404 })
+        const issue = this.issues.get(Number(issueByIndex[3]))!
+        return Response.json({
+          id: 8_000_000 + Number(issueByIndex[3]),
+          number: Number(issueByIndex[3]),
+          state: issue.state,
+          title: 'example issue',
+          ...(issue.isPull ? { pull_request: { merged: false } } : {})
+        })
+      }
+      const statusRoute = /^\/repos\/([^/]+)\/([^/]+)\/statuses\/([^/]+)$/.exec(route)
+      if (statusRoute) {
+        const repo = this.repositories.find(
+          (candidate) => candidate.full_name === `${statusRoute[1]}/${statusRoute[2]}`
+        )
+        if (!repo) return Response.json({ message: "The target couldn't be found." }, { status: 404 })
+        const sha = decodeURIComponent(statusRoute[3]!)
+        if (method === 'POST') {
+          const payload = body()
+          const status: FakeGiteaStatus = {
+            id: ++this.nextId,
+            sha,
+            context: String(payload.context ?? ''),
+            status: String(payload.state ?? ''),
+            description: String(payload.description ?? ''),
+            ...(typeof payload.target_url === 'string' ? { target_url: payload.target_url } : {}),
+            creator: { id: this.opts.bot.id }
+          }
+          this.statuses.push(status)
+          return Response.json(this.statusJson(status), { status: 201 })
+        }
+        // Upstream lists newest first, with X-Total-Count and a Link header.
+        const rows = this.statuses.filter((status) => status.sha === sha).reverse()
+        return page(
+          url,
+          rows.map((status) => this.statusJson(status)),
+          this.opts.maxResponseItems
+        )
       }
 
       // The issue-scoped writes the connect step probes against a nonexistent repository (§4.1).

--- a/packages/control-plane/test/integration/gitea-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitea-hooks.route.test.ts
@@ -4,9 +4,16 @@
  * feature-gated broadcast, the managed-webhook converge kick and its inverse, and the Gitea arm of
  * rc/codehost-membership-authz.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import { GITEA_V1_FEATURE, GITLAB_COM_V1_FEATURE, type RcHookAssign } from '@agentconnect.md/protocol'
+import {
+  GITEA_V1_FEATURE,
+  GITLAB_COM_V1_FEATURE,
+  GITLAB_RERUN_V1_FEATURE,
+  type RcHookAssign,
+  type RcHookRerun,
+  type RcHookRerunResult
+} from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
@@ -285,5 +292,176 @@ describe('rc/codehost-membership-authz — the gitea arm (§8)', () => {
     expect(await service.allowed(request())).toBe(false)
     expect((await h.seam.connectionRepo.get(DEFAULT_ORG_ID, h.connection.id))!.state).toBe('token_rejected')
     expect((await h.seam.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('runtime_degraded')
+  })
+})
+
+describe('gitea hook rerun — the Console "Run again" route (gitea-integration.md §10.4)', () => {
+  const INDEX = 12
+  const CURRENT_HEAD = 'cafebabe0000000000000000000000000000cafe'
+
+  /** A relay stand-in that answers `rc/hook-rerun`; `answer` scripts its verdict. */
+  function rerunChannel(features: string[], answer?: RcHookRerunResult | (() => RcHookRerunResult)) {
+    const sent: Array<{ type: string; payload: unknown }> = []
+    const requests: Array<{ type: string; payload: unknown }> = []
+    const ch = {
+      relayId: `r-${randomUUID().slice(0, 8)}`,
+      features,
+      send: (type: string, payload: unknown) => {
+        sent.push({ type, payload })
+      },
+      request: async (type: string, payload: unknown) => {
+        requests.push({ type, payload })
+        const reply = typeof answer === 'function' ? answer() : answer
+        return reply ?? { admitted: true, deliveryKey: (payload as { deliveryKey: string }).deliveryKey }
+      },
+      close() {}
+    } as unknown as RelayChannel
+    return { ch, sent, requests }
+  }
+
+  async function rerunHarness(answer?: RcHookRerunResult | (() => RcHookRerunResult)) {
+    const h = await harness()
+    const relay = rerunChannel([GITEA_V1_FEATURE], answer)
+    h.a.relayReg.add(relay.ch)
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: body(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    const hookId = (created.json() as { id: string }).id
+    // Until the create kick has converged the webhook the hook has no compilable rule.
+    await vi.waitFor(
+      () => {
+        expect(h.fake.hooks.size).toBe(1)
+        expect(relay.sent.some((frame) => frame.type === 'rc/hook-assign')).toBe(true)
+      },
+      { timeout: 20_000 }
+    )
+    await h.seam.settled()
+    // The subject as Gitea reports it NOW — a stale stored head must never win.
+    h.fake.pulls.set(INDEX, {
+      state: 'open',
+      headSha: CURRENT_HEAD,
+      baseSha: 'ba5e0000000000000000000000000000000ba5e0'
+    })
+    relay.sent.length = 0
+    return { h, relay, hookId }
+  }
+
+  const rerun = (a: HttpApp, hookId: string, subject: Record<string, unknown>) =>
+    a.app.inject({ method: 'POST', url: `${ORG}/hooks/${hookId}/rerun`, payload: { subject } })
+
+  const reruns = (frames: Array<{ type: string; payload: unknown }>) =>
+    frames.filter((frame) => frame.type === 'rc/hook-rerun').map((frame) => frame.payload as RcHookRerun)
+
+  it('re-dispatches the current head to ONE gitea-v1 relay through the gitea member of the frame', async () => {
+    const { h, relay, hookId } = await rerunHarness()
+    const legacy = rerunChannel([GITLAB_COM_V1_FEATURE, GITLAB_RERUN_V1_FEATURE])
+    h.a.relayReg.add(legacy.ch)
+    const res = await rerun(h.a, hookId, { kind: 'merge_request', iid: INDEX })
+    expect(res.statusCode).toBe(200)
+    const dto = res.json() as { accepted: boolean; deliveryKey: string; event: string; headSha: string }
+    expect(dto).toMatchObject({ accepted: true, event: 'merge_request:rerun', headSha: CURRENT_HEAD })
+
+    const frames = reruns(relay.requests)
+    expect(frames).toHaveLength(1)
+    const frame = frames[0]!
+    expect(frame).toMatchObject({ hookId, agentId: h.agentId, deliveryKey: dto.deliveryKey })
+    expect(frame.gitlab).toBeUndefined()
+    expect(frame.gitea).toMatchObject({
+      repoId: REPO.toString(),
+      repoPath: 'example-org/example-repo',
+      host: h.fake.opts.baseUrl,
+      target: {
+        kind: 'pull',
+        index: INDEX,
+        headSha: CURRENT_HEAD,
+        sourceRepoId: REPO.toString(),
+        explicitReviewRequest: true
+      }
+    })
+    // The fence the relay re-checks against its own compiled rule.
+    const row = (await new PgHookRepo(prisma).get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!
+    expect(frame.configRevision).toBe(row.configRevision.toString())
+    expect(frame.dispatchRevision).toBe(row.dispatchRevision.toString())
+    // One click is one turn, to a relay that can decode the member — never to one without gitea-v1.
+    expect(reruns(legacy.requests)).toHaveLength(0)
+    expect(reruns(relay.sent)).toHaveLength(0)
+    // The subject read ran as the connection's bot.
+    const subjectReads = h.fake.requests.filter((request) => request.url.includes(`/pulls/${INDEX}`))
+    expect(subjectReads.at(-1)!.token).toBe(h.fake.token)
+  })
+
+  it('follows the head between reruns instead of pinning the first one', async () => {
+    const { h, relay, hookId } = await rerunHarness()
+    expect((await rerun(h.a, hookId, { kind: 'merge_request', iid: INDEX })).statusCode).toBe(200)
+    h.fake.pulls.set(INDEX, { state: 'open', headSha: 'f00d'.repeat(10) })
+    const second = await rerun(h.a, hookId, { kind: 'merge_request', iid: INDEX })
+    expect(second.statusCode).toBe(200)
+    expect((second.json() as { headSha: string }).headSha).toBe('f00d'.repeat(10))
+    const frames = reruns(relay.requests)
+    expect(frames.map((frame) => (frame.gitea!.target as { headSha?: string }).headSha)).toEqual([
+      CURRENT_HEAD,
+      'f00d'.repeat(10)
+    ])
+    expect(new Set(frames.map((frame) => frame.deliveryKey)).size).toBe(2)
+  })
+
+  it('runs an open issue with no head, and refuses a closed, merged, missing, or pull-request-shaped subject', async () => {
+    const { h, relay, hookId } = await rerunHarness()
+    h.fake.issues.set(7, { state: 'open' })
+    h.fake.issues.set(8, { state: 'closed' })
+    h.fake.issues.set(INDEX, { state: 'open', isPull: true })
+
+    const open = await rerun(h.a, hookId, { kind: 'issue', iid: 7 })
+    expect(open.statusCode).toBe(200)
+    expect(open.json()).toMatchObject({ event: 'issues:rerun', headSha: null })
+    expect(reruns(relay.requests)[0]!.gitea!.target).toEqual({ kind: 'issue', index: 7 })
+
+    expect((await rerun(h.a, hookId, { kind: 'issue', iid: 8 })).json()).toMatchObject({ code: 'SUBJECT_CLOSED' })
+    expect((await rerun(h.a, hookId, { kind: 'issue', iid: 9 })).json()).toMatchObject({ code: 'SUBJECT_NOT_FOUND' })
+    // Issues and pull requests share one index space: a pull request is not an issue subject.
+    expect((await rerun(h.a, hookId, { kind: 'issue', iid: INDEX })).json()).toMatchObject({
+      code: 'SUBJECT_NOT_FOUND'
+    })
+
+    h.fake.pulls.set(INDEX, { state: 'closed', headSha: CURRENT_HEAD, merged: true })
+    const merged = await rerun(h.a, hookId, { kind: 'merge_request', iid: INDEX })
+    expect(merged.statusCode).toBe(409)
+    expect((merged.json() as { code: string }).code).toBe('SUBJECT_CLOSED')
+    expect((await rerun(h.a, hookId, { kind: 'merge_request', iid: 99 })).json()).toMatchObject({
+      code: 'SUBJECT_NOT_FOUND'
+    })
+    expect(reruns(relay.requests)).toHaveLength(1)
+  })
+
+  it('revalidates the hook fence live: a disabled trigger and an unknown hook never reach a relay', async () => {
+    const { h, relay, hookId } = await rerunHarness()
+    await prisma.hookDef.update({ where: { id: hookId }, data: { enabled: false } })
+    const disabled = await rerun(h.a, hookId, { kind: 'merge_request', iid: INDEX })
+    expect(disabled.statusCode).toBe(409)
+    expect((disabled.json() as { code: string }).code).toBe('HOOK_DISABLED')
+    expect((await rerun(h.a, randomUUID(), { kind: 'merge_request', iid: INDEX })).statusCode).toBe(404)
+    expect(reruns(relay.requests)).toHaveLength(0)
+  })
+
+  it('surfaces a relay refusal as RELAY_REJECTED and no eligible relay as RELAY_UNAVAILABLE', async () => {
+    const refused = await rerunHarness({ admitted: false, code: 'rule_mismatch' })
+    const answer = await rerun(refused.h.a, refused.hookId, { kind: 'merge_request', iid: INDEX })
+    expect(answer.statusCode).toBe(409)
+    expect(answer.json()).toMatchObject({ code: 'RELAY_REJECTED' })
+    expect(await prisma.hookRun.count({ where: { hookId: refused.hookId } })).toBe(0)
+
+    refused.h.a.relayReg.remove((refused.relay.ch as { relayId: string }).relayId, refused.relay.ch)
+    const nobody = await rerun(refused.h.a, refused.hookId, { kind: 'merge_request', iid: INDEX })
+    expect(nobody.statusCode).toBe(503)
+    expect((nobody.json() as { code: string }).code).toBe('RELAY_UNAVAILABLE')
+  })
+
+  it('refuses the rerun once the connection token is rejected, and flips the connection', async () => {
+    const { h, relay, hookId } = await rerunHarness()
+    h.fake.token = 'gitea-token-rotated-elsewhere'
+    const res = await rerun(h.a, hookId, { kind: 'merge_request', iid: INDEX })
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { code: string }).code).toBe('BINDING_INACTIVE')
+    expect(reruns(relay.requests)).toHaveLength(0)
+    expect((await h.seam.connectionRepo.get(DEFAULT_ORG_ID, h.connection.id))!.state).toBe('token_rejected')
   })
 })

--- a/packages/control-plane/test/integration/gitea-status.test.ts
+++ b/packages/control-plane/test/integration/gitea-status.test.ts
@@ -1,0 +1,302 @@
+// Gitea commit-status projection end to end (gitea-integration.md §10.4): real ledger, fake Gitea edge, reconciled ambiguity, token rejection.
+import { describe, it, expect, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { buildGiteaSeam, type GiteaSeam } from '../fakes/gitea-seam.js'
+import { FakeClock } from '../fakes/fake-clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
+import { GiteaStatusCoordinator, GiteaStatusReporter, type GiteaStatusEdge } from '../../src/gitea/status-projection.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgCodeHostRunProjectionRepo } from '../../src/persistence/repositories/code-host-projection.repo.js'
+import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
+import { makeSecretCipher } from '../../src/secrets/cipher.js'
+import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
+
+const REPO = 556677n
+const HEAD = 'a'.repeat(40)
+const NEXT_HEAD = 'b'.repeat(40)
+const NOW = new Date('2026-09-12T00:00:00.000Z').getTime()
+const CONSOLE = 'https://console.example.test'
+const seamClock = trackedTestClock()
+const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
+
+let seam: GiteaSeam | undefined
+afterEach(async () => {
+  await seam?.settled()
+  seam = undefined
+})
+
+async function harness() {
+  const built = buildGiteaSeam(prisma, cipher, seamClock)
+  seam = built
+  const connection = await built.connections.connect(DEFAULT_ORG_ID, built.fake.token)
+  const binding = await built.bindings.createWithClaim({
+    orgId: DEFAULT_ORG_ID,
+    connectionId: connection.id,
+    repoId: REPO,
+    repoPath: 'example-org/example-repo',
+    cloneUrl: 'https://gitea.com/example-org/example-repo.git',
+    axisBaseUrl: built.fake.opts.baseUrl
+  })
+  expect(await built.provisioner.provision(DEFAULT_ORG_ID, binding.id)).toEqual({ state: 'ready', reason: null })
+  const daemonId = randomUUID()
+  await seedDaemon(prisma, daemonId)
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId, giteaRepoId: REPO, name: 'review-bot' })
+  const hookId = randomUUID()
+  await prisma.hookDef.create({
+    data: {
+      id: hookId,
+      orgId: DEFAULT_ORG_ID,
+      agentId,
+      kind: 'gitea',
+      name: 'pull reviews',
+      sessionMode: 'perThread',
+      repoId: REPO,
+      repoFullName: 'example-org/example-repo',
+      family: 'merge_request',
+      events: ['merge_request:*'],
+      configRevision: 3n,
+      dispatchRevision: 5n,
+      reportingMode: 'status'
+    }
+  })
+  const snapshot = {
+    configRevision: '3',
+    dispatchRevision: '5',
+    dispatchDaemonId: daemonId,
+    reviewPolicy: 'off' as const,
+    reportingMode: 'status' as const,
+    gateMode: 'informational' as const
+  }
+  const accept = async (deliveryKey: string) => {
+    await prisma.hookRun.create({
+      data: {
+        hookId,
+        orgId: DEFAULT_ORG_ID,
+        deliveryKey,
+        event: 'merge_request:opened',
+        startedAt: new Date(NOW),
+        agentId,
+        configRevision: 3n,
+        dispatchRevision: 5n,
+        dispatchDaemonId: daemonId,
+        projectionEpoch: 1n,
+        reviewPolicySnapshot: 'off',
+        reportingModeSnapshot: 'status',
+        gateModeSnapshot: 'informational',
+        repoId: REPO,
+        subjectKind: 'pull_request',
+        status: 'running'
+      }
+    })
+  }
+  const clock = new FakeClock(NOW)
+  const projections = new PgCodeHostRunProjectionRepo(prisma)
+  const coordinator = new GiteaStatusCoordinator({
+    projections,
+    runs: new PgHookRepo(prisma),
+    agents: new PgAgentRepo(prisma),
+    bindings: built.bindings,
+    connections: built.connectionRepo,
+    clock
+  })
+  const reporter = new GiteaStatusReporter({
+    projections,
+    bindings: built.bindings,
+    connections: built.connectionRepo,
+    tokens: built.connections,
+    orgs: new PgOrgRepo(prisma),
+    api: built.fake.api,
+    clock,
+    webAppUrl: CONSOLE,
+    workerId: 'gitea-status-reporter:test'
+  })
+  const edge = (over: Partial<GiteaStatusEdge> = {}): GiteaStatusEdge => ({
+    hookId,
+    agentId,
+    deliveryKey: 'delivery-1',
+    orgId: OrgId(DEFAULT_ORG_ID),
+    state: 'queued',
+    gitea: {
+      repoId: REPO.toString(),
+      repoPath: 'example-org/example-repo',
+      target: { kind: 'pull', index: 12, headSha: HEAD }
+    },
+    snapshot,
+    at: new Date(clock.now()),
+    ...over
+  })
+  const statuses = () => built.fake.statuses.filter((status) => status.sha === HEAD)
+  const row = async () =>
+    (await prisma.codeHostRunProjection.findFirstOrThrow({ where: { hookId, headSha: HEAD, projectId: REPO } }))!
+  return {
+    seam: built,
+    fake: built.fake,
+    connection,
+    binding,
+    hookId: HookId(hookId),
+    agentId: AgentId(agentId),
+    clock,
+    coordinator,
+    reporter,
+    edge,
+    accept,
+    statuses,
+    row
+  }
+}
+
+describe('gitea commit-status projection (§10.4)', () => {
+  it('writes one status per lifecycle edge with the connection token, the agent context, and the console link', async () => {
+    const h = await harness()
+    await h.accept('delivery-1')
+    await h.coordinator.afterAccepted(h.edge())
+    await h.reporter.tick()
+    expect(h.statuses()).toHaveLength(1)
+    expect(h.statuses()[0]).toMatchObject({
+      context: 'agentconnect/review-bot',
+      status: 'pending',
+      description: 'AgentConnect review queued',
+      creator: { id: h.fake.opts.bot.id }
+    })
+    expect(h.statuses()[0]!.target_url).toBeUndefined()
+    const posted = h.fake.requests.filter((request) => request.method === 'POST' && request.url.includes('/statuses/'))
+    expect(posted).toHaveLength(1)
+    expect(posted[0]!.token).toBe(h.fake.token)
+    let stored = await h.row()
+    expect(stored).toMatchObject({
+      provider: 'gitea',
+      desiredState: 'queued',
+      observedState: 'queued',
+      noteId: String(h.statuses()[0]!.id)
+    })
+    expect(stored.writeMarker).toBeNull()
+
+    // The start barrier brings the session: the status now links the ordinary authenticated Console page.
+    h.clock.advance(1_000)
+    await h.coordinator.afterStart(h.edge({ sessionId: 'session-1' }))
+    await h.reporter.tick()
+    expect(h.statuses()).toHaveLength(2)
+    expect(h.statuses()[1]).toMatchObject({
+      status: 'pending',
+      description: 'AgentConnect review in progress',
+      target_url: `${CONSOLE}/${encodeURIComponent((await new PgOrgRepo(prisma).slugById(DEFAULT_ORG_ID))!)}/sessions/session-1?source=gitea`
+    })
+    expect(h.statuses()[1]!.target_url).not.toContain('token')
+
+    // The terminal report completes it; a settled row leaves the due set.
+    h.clock.advance(1_000)
+    await h.coordinator.afterReport(h.edge({ state: 'completed', sessionId: 'session-1' }))
+    await h.reporter.tick()
+    expect(h.statuses()).toHaveLength(3)
+    expect(h.statuses()[2]).toMatchObject({ status: 'success', description: 'AgentConnect review completed' })
+    stored = await h.row()
+    expect(stored).toMatchObject({ observedState: 'completed', generation: 1n })
+    await h.reporter.tick()
+    expect(h.statuses()).toHaveLength(3)
+    expect((await h.row()).nextAttemptAt).toBeNull()
+  })
+
+  it('supersedes the older head and maps every terminal state without ever writing warning', async () => {
+    const h = await harness()
+    await h.accept('delivery-1')
+    await h.coordinator.afterAccepted(h.edge())
+    await h.reporter.tick()
+    await h.accept('delivery-2')
+    const next = {
+      repoId: REPO.toString(),
+      repoPath: 'example-org/example-repo',
+      target: { kind: 'pull' as const, index: 12, headSha: NEXT_HEAD }
+    }
+    h.clock.advance(1_000)
+    await h.coordinator.afterAccepted(h.edge({ deliveryKey: 'delivery-2', gitea: next }))
+    await h.reporter.tick()
+    // The old head reads superseded (success, named as such); the new head reads queued.
+    const old = h.fake.statuses.filter((status) => status.sha === HEAD)
+    expect(old.at(-1)).toMatchObject({
+      status: 'success',
+      description: 'AgentConnect review superseded by a newer revision'
+    })
+    expect(h.fake.statuses.filter((status) => status.sha === NEXT_HEAD).at(-1)).toMatchObject({ status: 'pending' })
+
+    h.clock.advance(1_000)
+    await h.coordinator.afterReport(
+      h.edge({ deliveryKey: 'delivery-2', gitea: next, state: 'failed', reason: 'session_start_failed' })
+    )
+    await h.reporter.tick()
+    expect(h.fake.statuses.filter((status) => status.sha === NEXT_HEAD).at(-1)).toMatchObject({
+      status: 'error',
+      description: 'AgentConnect review failed (session_start_failed)'
+    })
+    expect(h.fake.statuses.some((status) => status.status === 'warning')).toBe(false)
+  })
+
+  it('keeps an ambiguous write under its marker and reconciles the landed status instead of replaying it', async () => {
+    const h = await harness()
+    await h.accept('delivery-1')
+    await h.coordinator.afterAccepted(h.edge())
+    // The request reaches Gitea; the reply is lost.
+    h.fake.opts.intercept = (method, route) => {
+      if (method === 'POST' && route.includes('/statuses/')) {
+        h.fake.statuses.push({
+          id: 9_500,
+          sha: HEAD,
+          context: 'agentconnect/review-bot',
+          status: 'pending',
+          description: 'AgentConnect review queued',
+          creator: { id: h.fake.opts.bot.id }
+        })
+        throw new Error('socket hang up')
+      }
+      return undefined
+    }
+    await h.reporter.tick()
+    let stored = await h.row()
+    expect(stored.writeMarker).not.toBeNull()
+    expect(stored.observedState).toBeNull()
+    expect(stored.lastErrorCode).toBe('ambiguous_write')
+    h.fake.opts.intercept = undefined
+
+    // Nothing is written again; the retry pass reads the commit's statuses and adopts the one that landed.
+    h.clock.advance(5_000)
+    await h.reporter.tick()
+    stored = await h.row()
+    expect(stored).toMatchObject({ observedState: 'queued', noteId: '9500', writeMarker: null })
+    expect(
+      h.fake.requests.filter((request) => request.method === 'POST' && request.url.includes('/statuses/'))
+    ).toHaveLength(1)
+    expect(h.statuses()).toHaveLength(1)
+  })
+
+  it('feeds a rejected token into the connection path and resumes once the token is replaced', async () => {
+    const h = await harness()
+    await h.accept('delivery-1')
+    await h.coordinator.afterAccepted(h.edge())
+    h.fake.token = 'gitea-token-rotated-elsewhere'
+    await h.reporter.tick()
+    expect(h.statuses()).toEqual([])
+    expect((await h.seam.connectionRepo.get(DEFAULT_ORG_ID, h.connection.id))!.state).toBe('token_rejected')
+    expect((await h.seam.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('runtime_degraded')
+    let stored = await h.row()
+    expect(stored).toMatchObject({ lastErrorCode: 'token_rejected', writeMarker: null, observedState: null })
+    // While the connection waits for its replacement the row stays due and nothing is written.
+    h.clock.advance(60_000)
+    await h.reporter.tick()
+    expect(h.statuses()).toEqual([])
+    expect((await h.row()).lastErrorCode).toBe('token_rejected')
+
+    // The replacement is the whole recovery: the next pass writes with the new token.
+    await h.seam.connections.replaceToken(DEFAULT_ORG_ID, h.connection.id, 'gitea-token-rotated-elsewhere')
+    h.clock.advance(10 * 60_000)
+    await h.reporter.tick()
+    expect(h.statuses()).toHaveLength(1)
+    const posted = h.fake.requests.filter((request) => request.method === 'POST' && request.url.includes('/statuses/'))
+    expect(posted.at(-1)!.token).toBe('gitea-token-rotated-elsewhere')
+    stored = await h.row()
+    expect(stored.observedState).toBe('queued')
+  })
+})

--- a/packages/control-plane/test/integration/gitea-status.test.ts
+++ b/packages/control-plane/test/integration/gitea-status.test.ts
@@ -72,14 +72,14 @@ async function harness() {
     reportingMode: 'status' as const,
     gateMode: 'informational' as const
   }
-  const accept = async (deliveryKey: string) => {
+  const accept = async (deliveryKey: string, startedAt: Date = new Date(NOW)) => {
     await prisma.hookRun.create({
       data: {
         hookId,
         orgId: DEFAULT_ORG_ID,
         deliveryKey,
         event: 'merge_request:opened',
-        startedAt: new Date(NOW),
+        startedAt,
         agentId,
         configRevision: 3n,
         dispatchRevision: 5n,
@@ -206,13 +206,13 @@ describe('gitea commit-status projection (§10.4)', () => {
     await h.accept('delivery-1')
     await h.coordinator.afterAccepted(h.edge())
     await h.reporter.tick()
-    await h.accept('delivery-2')
     const next = {
       repoId: REPO.toString(),
       repoPath: 'example-org/example-repo',
       target: { kind: 'pull' as const, index: 12, headSha: NEXT_HEAD }
     }
     h.clock.advance(1_000)
+    await h.accept('delivery-2', new Date(h.clock.now()))
     await h.coordinator.afterAccepted(h.edge({ deliveryKey: 'delivery-2', gitea: next }))
     await h.reporter.tick()
     // The old head reads superseded (success, named as such); the new head reads queued.
@@ -233,6 +233,44 @@ describe('gitea commit-status projection (§10.4)', () => {
       description: 'AgentConnect review failed (session_start_failed)'
     })
     expect(h.fake.statuses.some((status) => status.status === 'warning')).toBe(false)
+  })
+
+  it('keeps the newest head current when an older head reports late', async () => {
+    const h = await harness()
+    await h.accept('delivery-1')
+    await h.coordinator.afterAccepted(h.edge())
+    h.clock.advance(1_000)
+    await h.coordinator.afterStart(h.edge({ state: 'running', sessionId: 'session-1' }))
+    await h.reporter.tick()
+    const next = {
+      repoId: REPO.toString(),
+      repoPath: 'example-org/example-repo',
+      target: { kind: 'pull' as const, index: 12, headSha: NEXT_HEAD }
+    }
+    h.clock.advance(1_000)
+    await h.accept('delivery-2', new Date(h.clock.now()))
+    await h.coordinator.afterAccepted(h.edge({ deliveryKey: 'delivery-2', gitea: next }))
+    await h.reporter.tick()
+    const on = (sha: string) => h.fake.statuses.filter((status) => status.sha === sha)
+    expect(on(HEAD).at(-1)).toMatchObject({
+      status: 'success',
+      description: 'AgentConnect review superseded by a newer revision'
+    })
+    expect(on(NEXT_HEAD).at(-1)).toMatchObject({ status: 'pending' })
+    const written = h.fake.statuses.length
+
+    // The older head's run finishes after the newer head arrived: nothing is written, the newer head stays current, the older stays superseded.
+    h.clock.advance(1_000)
+    await h.coordinator.afterReport(h.edge({ state: 'completed', sessionId: 'session-1' }))
+    await h.reporter.tick()
+    expect(h.fake.statuses).toHaveLength(written)
+    expect(on(HEAD).at(-1)).toMatchObject({ description: 'AgentConnect review superseded by a newer revision' })
+    expect(on(NEXT_HEAD).at(-1)).toMatchObject({ status: 'pending' })
+    expect(await h.row()).toMatchObject({ desiredState: 'superseded' })
+    const newer = await prisma.codeHostRunProjection.findFirstOrThrow({
+      where: { hookId: h.hookId, headSha: NEXT_HEAD }
+    })
+    expect(newer.desiredState).toBe('queued')
   })
 
   it('keeps an ambiguous write under its marker and reconciles the landed status instead of replaying it', async () => {

--- a/packages/control-plane/test/repo/code-host-projection.repo.test.ts
+++ b/packages/control-plane/test/repo/code-host-projection.repo.test.ts
@@ -154,6 +154,59 @@ describe('code-host run projection ledger (gitlab-com-integration.md §16)', () 
     expect(await ledger.supersede(hookId, PROJECT, 42, NEXT_HEAD, LATER)).toBe(0)
   })
 
+  it('ranks heads by acceptance when asked to: an older head’s late edge preempts nothing and its row never revives (gitea-integration.md §10.4)', async () => {
+    const ledger = repo()
+    const subject = await owner()
+    const { hookId } = subject
+    const THIRD_HEAD = 'c'.repeat(40)
+    const accepted = { old: NOW, next: new Date(NOW.getTime() + 30_000), third: new Date(NOW.getTime() - 60_000) }
+    const late = new Date(LATER.getTime() + 60_000)
+    const old = await upsert({ ...subject, headSha: HEAD, desiredState: 'running', queuedAt: accepted.old })
+    const next = await upsert({
+      ...subject,
+      headSha: NEXT_HEAD,
+      currentDeliveryKey: 'delivery-2',
+      currentRunAt: LATER,
+      queuedAt: accepted.next
+    })
+    // The newer head's edge supersedes the older head.
+    expect(await ledger.supersede(hookId, PROJECT, 42, NEXT_HEAD, LATER, accepted.next)).toBe(1)
+    expect((await ledger.get(old.id))!.desiredState).toBe('superseded')
+
+    // The older head's late terminal report ranks by its acceptance: it preempts nothing ...
+    expect(await ledger.supersede(hookId, PROJECT, 42, HEAD, late, accepted.old)).toBe(0)
+    expect((await ledger.get(next.id))!.desiredState).toBe('queued')
+    // ... and its own row refuses the edge, terminal or not.
+    const superseded = (await ledger.get(old.id))!
+    expect(await ledger.setDesired(superseded.id, superseded.generation, 'completed', late)).toBe(false)
+    expect((await ledger.get(old.id))!.desiredState).toBe('superseded')
+    // Mid-write the late edge parks nothing either: draining it would revive the row.
+    expect(
+      await ledger.beginWrite(superseded.id, superseded.generation, DAEMON, randomUUID(), 'update', late, late)
+    ).toBe(true)
+    const parked = await upsert({
+      ...subject,
+      headSha: HEAD,
+      desiredState: 'completed',
+      completedAt: late,
+      currentRunAt: late
+    })
+    expect(parked.pendingIntent).toBeNull()
+    expect(parked.desiredState).toBe('superseded')
+
+    // An older head whose first edge arrives after a newer head was accepted is superseded on arrival, the newer head untouched.
+    const third = await upsert({
+      ...subject,
+      headSha: THIRD_HEAD,
+      currentDeliveryKey: 'delivery-0',
+      currentRunAt: late,
+      queuedAt: accepted.third
+    })
+    expect(await ledger.supersede(hookId, PROJECT, 42, THIRD_HEAD, late, accepted.third)).toBe(1)
+    expect((await ledger.get(third.id))!.desiredState).toBe('superseded')
+    expect((await ledger.get(next.id))!.desiredState).toBe('queued')
+  })
+
   it('holds one write at a time and ignores an older generation settling it', async () => {
     const ledger = repo()
     const base = input(await owner())

--- a/packages/control-plane/test/repo/code-host-projection.repo.test.ts
+++ b/packages/control-plane/test/repo/code-host-projection.repo.test.ts
@@ -318,6 +318,107 @@ describe('code-host run projection ledger (gitlab-com-integration.md §16)', () 
     expect(stillHeld.noteId).toBeNull()
   })
 
+  it('claims due rows of one provider whose lease is free, expired, or its own, and fences the claim on the generation', async () => {
+    const ledger = repo()
+    const WORKER = 'gitea-status-reporter:one'
+    const OTHER = 'gitea-status-reporter:two'
+    const gitea = await upsert({ ...(await owner()), provider: 'gitea' })
+    const gitlab = await upsert({ ...(await owner()), provider: 'gitlab', headSha: NEXT_HEAD })
+    const later = await upsert({ ...(await owner()), provider: 'gitea', headSha: 'c'.repeat(40), nextAttemptAt: LATER })
+
+    // Only the provider's due rows: the gitlab row is another writer's, the future row is not due yet.
+    const first = await ledger.claimDue('gitea', WORKER, NOW, new Date(NOW.getTime() + 30_000))
+    expect(first.map((row) => row.id)).toEqual([gitea.id])
+    expect(first[0]).toMatchObject({ leaseOwner: WORKER })
+    expect((await ledger.get(gitlab.id))!.leaseOwner).toBeNull()
+    // A live lease keeps another worker out, while the owner re-claims freely.
+    expect(await ledger.claimDue('gitea', OTHER, NOW, new Date(NOW.getTime() + 30_000))).toEqual([])
+    expect(
+      (await ledger.claimDue('gitea', WORKER, NOW, new Date(NOW.getTime() + 30_000))).map((row) => row.id)
+    ).toEqual([gitea.id])
+    // Past expiry the row — and the row that came due meanwhile — go to whoever asks.
+    const expired = await ledger.claimDue(
+      'gitea',
+      OTHER,
+      new Date(LATER.getTime() + 60_000),
+      new Date(LATER.getTime() + 90_000)
+    )
+    expect(expired.map((row) => row.id).sort()).toEqual([gitea.id, later.id].sort())
+    expect(expired.every((row) => row.leaseOwner === OTHER)).toBe(true)
+  })
+
+  it('retries release the lease and, unless the write was ambiguous, the mutex; blocks leave the due set', async () => {
+    const ledger = repo()
+    const WORKER = 'gitea-status-reporter:one'
+    const opened = await upsert({ ...(await owner()), provider: 'gitea' })
+    await ledger.claimDue('gitea', WORKER, NOW, LATER)
+    const marker = randomUUID()
+    expect(await ledger.beginWrite(opened.id, 1n, WORKER, marker, 'create', NOW, LATER)).toBe(true)
+
+    // An ambiguous write keeps its marker; the lease goes so a later pass (any worker) may reconcile it.
+    expect(await ledger.retryWrite(opened.id, 1n, WORKER, LATER, 'ambiguous_write', true)).toBe(true)
+    let row = (await ledger.get(opened.id))!
+    expect(row).toMatchObject({ writeMarker: marker, leaseOwner: null, attempts: 1, lastErrorCode: 'ambiguous_write' })
+    expect(row.nextAttemptAt).toEqual(LATER)
+    // Fenced on the generation and the lease owner.
+    expect(await ledger.retryWrite(opened.id, 2n, WORKER, LATER, 'x')).toBe(false)
+    expect(await ledger.retryWrite(opened.id, 1n, 'someone-else', LATER, 'x')).toBe(false)
+
+    // The reconciling worker re-claims, proves absence past the grace window, and releases the mutex.
+    await ledger.claimDue('gitea', WORKER, LATER, new Date(LATER.getTime() + 30_000))
+    expect(await ledger.retryWrite(opened.id, 1n, WORKER, LATER, 'ambiguous_write_reissued', false)).toBe(true)
+    row = (await ledger.get(opened.id))!
+    expect(row).toMatchObject({ writeMarker: null, writePhase: null, attempts: 2 })
+
+    // A definitive refusal leaves the due set for this generation.
+    expect(await ledger.blockWrite(opened.id, 1n, 'gitea_write_denied')).toBe(true)
+    row = (await ledger.get(opened.id))!
+    expect(row).toMatchObject({ nextAttemptAt: null, leaseOwner: null, lastErrorCode: 'gitea_write_denied' })
+    expect(await ledger.blockWrite(opened.id, 2n, 'x')).toBe(false)
+  })
+
+  it('a block keeps a tombstone serialized behind the refused write due, and a settle clears only a quiet row', async () => {
+    const ledger = repo()
+    const WORKER = 'gitea-status-reporter:one'
+    const { hookId, agentId } = await owner()
+    const opened = await upsert({ hookId, agentId, provider: 'gitea' })
+    await ledger.claimDue('gitea', WORKER, NOW, LATER)
+    const marker = randomUUID()
+    await ledger.beginWrite(opened.id, 1n, WORKER, marker, 'create', NOW, LATER)
+    // The hook goes mid-write: the cleanup rides as pending intent behind the held marker.
+    await tombstone([hookId])
+    expect(await ledger.blockWrite(opened.id, 1n, 'repo_authorization')).toBe(true)
+    const parked = (await ledger.get(opened.id))!
+    expect(parked.pendingIntent).toMatchObject({ desiredState: 'skipped', tombstoned: true })
+    expect(parked.nextAttemptAt).toEqual(LATER)
+
+    // A row whose desired state is already observed, with nothing parked or in flight, leaves the due set.
+    const quiet = await upsert({ ...(await owner()), provider: 'gitea', headSha: NEXT_HEAD })
+    await ledger.claimDue('gitea', WORKER, NOW, LATER)
+    const written = randomUUID()
+    await ledger.beginWrite(quiet.id, 1n, WORKER, written, 'create', NOW, LATER)
+    expect(
+      await ledger.completeWrite({
+        projectionId: quiet.id,
+        generation: 1n,
+        leaseOwner: WORKER,
+        writeMarker: written,
+        observedState: 'queued',
+        noteId: '501',
+        recheckAt: LATER
+      })
+    ).toBe(true)
+    // A later edge re-arms the row without changing what it says; the worker finds nothing to write.
+    expect(await ledger.setDesired(quiet.id, 1n, 'queued', LATER)).toBe(true)
+    await ledger.claimDue('gitea', WORKER, LATER, new Date(LATER.getTime() + 30_000))
+    expect(await ledger.settleWrite(quiet.id, 1n, WORKER)).toBe(true)
+    expect((await ledger.get(quiet.id))!).toMatchObject({ nextAttemptAt: null, leaseOwner: null, attempts: 0 })
+    // ...but not while the desired state has moved on: the re-read under the row lock refuses.
+    expect(await ledger.setDesired(quiet.id, 1n, 'running', LATER)).toBe(true)
+    await ledger.claimDue('gitea', WORKER, LATER, new Date(LATER.getTime() + 30_000))
+    expect(await ledger.settleWrite(quiet.id, 1n, WORKER)).toBe(false)
+  })
+
   it("drains a parked edge with its OWN placement and credential fence, not the in-flight run's", async () => {
     const ledger = repo()
     const base = input(await owner())

--- a/packages/control-plane/test/repo/code-host-review.repo.test.ts
+++ b/packages/control-plane/test/repo/code-host-review.repo.test.ts
@@ -584,6 +584,67 @@ describe('a result releases the lease only through the ledger (§15.1)', () => {
     )
   })
 
+  it('keeps the owner attempt’s marker seed with the lease', async () => {
+    const s = subject()
+    const seed = 'ab'.repeat(32)
+    const acquired = await repo().acquire(acquire(s, { markerSeed: seed }))
+    expect(acquired.outcome === 'acquired' && acquired.lease.markerSeed).toBe(seed)
+    expect((await repo().bySubject(s))?.markerSeed).toBe(seed)
+  })
+
+  it('lets any daemon of the organization bring the lock exit by naming the retained record and its object (gitea-integration.md §10.3)', async () => {
+    const { s, base, attemptId, recordId } = await withPermit()
+    await repo().startOperation({ ...base, recordId, startToken: randomUUID() })
+    await repo().settleOperation({ ...base, recordId, outcome: { kind: 'ambiguous', code: 'publish_unreconciled' } })
+    await repo().recordOutcome(outcome(s, attemptId, { state: 'ambiguous_locked' }))
+    const later = new Date('2027-09-06T00:00:00.000Z')
+    const locked = await repo().acquire(acquire(s, { daemonId: DAEMON_B, now: later }))
+    expect(locked.outcome).toBe('locked')
+    if (locked.outcome !== 'locked') return
+    // The refusal names the retained record; the seed rides along only when the owner left one.
+    expect(locked.retained?.id).toBe(recordId)
+    expect(locked.lease.markerSeed).toBeNull()
+
+    const identify = {
+      subject: s,
+      orgId: DEFAULT_ORG_ID,
+      attemptId,
+      fence: base.fence,
+      recordId,
+      externalRef: 'review:4242',
+      now: later
+    }
+    // The wrong subject, fence, record, or encoding changes nothing.
+    expect(await repo().identifyLocked({ ...identify, subject: { ...s, mergeRequestIid: 43 } })).toEqual({
+      outcome: 'mismatch'
+    })
+    expect(await repo().identifyLocked({ ...identify, fence: base.fence + 1n })).toEqual({ outcome: 'mismatch' })
+    expect(await repo().identifyLocked({ ...identify, recordId: randomUUID() })).toEqual({ outcome: 'mismatch' })
+    expect(await repo().identifyLocked({ ...identify, externalRef: 'review:not-a-number' })).toEqual({
+      outcome: 'mismatch'
+    })
+    expect(
+      (await prisma.codeHostReviewLease.findFirstOrThrow({ where: { projectExternalId: s.projectExternalId } })).phase
+    ).toBe('ambiguous_locked')
+
+    expect(await repo().identifyLocked(identify)).toEqual({ outcome: 'released' })
+    expect(await prisma.codeHostReviewOperation.findUniqueOrThrow({ where: { id: recordId } })).toMatchObject({
+      state: 'settled',
+      responseStatus: 200,
+      responseExternalId: '4242'
+    })
+    expect(await prisma.codeHostReviewAttemptOutcome.findUniqueOrThrow({ where: { attemptId } })).toMatchObject({
+      state: 'submitted',
+      externalIds: ['review:4242']
+    })
+    expect(
+      await prisma.codeHostReviewLease.findFirstOrThrow({ where: { projectExternalId: s.projectExternalId } })
+    ).toMatchObject({ phase: 'settled', attemptId: null })
+    // Released, the subject is no longer locked: a second identification finds nothing to exit, and the next attempt gets in.
+    expect(await repo().identifyLocked(identify)).toEqual({ outcome: 'not_locked' })
+    expect((await repo().acquire(acquire(s, { daemonId: DAEMON_B, now: later }))).outcome).toBe('acquired')
+  })
+
   it('an attempt that issued no permit at all releases immediately', async () => {
     const s = subject()
     const input = acquire(s)

--- a/packages/control-plane/test/repo/code-host-review.repo.test.ts
+++ b/packages/control-plane/test/repo/code-host-review.repo.test.ts
@@ -526,6 +526,64 @@ describe('a result releases the lease only through the ledger (§15.1)', () => {
     expect('outcome' in returned && returned.phase).toBe('settled')
   })
 
+  it('a locked lease clears only when its owner names the ambiguous object and re-reports the effect (gitea-integration.md §10.3)', async () => {
+    const { s, base, attemptId, recordId } = await withPermit()
+    await repo().startOperation({ ...base, recordId, startToken: randomUUID() })
+    await repo().settleOperation({ ...base, recordId, outcome: { kind: 'ambiguous', code: 'publish_unreconciled' } })
+    expect(await repo().recordOutcome(outcome(s, attemptId, { state: 'ambiguous_locked' }))).toEqual({
+      outcome: 'recorded',
+      phase: 'ambiguous_locked'
+    })
+    // Nothing but a positive identification reaches the locked lease.
+    expect(await repo().renew({ ...base, leaseUntil: new Date(Date.now() + 60_000) })).toBeNull()
+    expect(await repo().issueOperation({ ...base, ...permit, kind: 'bulk_publish', ordinal: 1 })).toEqual({
+      failure: 'lease_closed'
+    })
+    // A settle that names no object identifies nothing: the ambiguous record refuses it before the lease is even asked.
+    expect(
+      await repo().settleOperation({ ...base, recordId, outcome: { kind: 'deterministic', status: 204 } })
+    ).toHaveProperty('failure')
+    expect((await prisma.codeHostReviewOperation.findUniqueOrThrow({ where: { id: recordId } })).state).toBe(
+      'ambiguous'
+    )
+    // A foreign daemon cannot identify it either.
+    expect(
+      await repo().settleOperation({
+        ...base,
+        daemonId: DAEMON_B,
+        recordId,
+        outcome: { kind: 'deterministic', status: 200, externalId: '4242' }
+      })
+    ).toEqual({ failure: 'not_owner' })
+    const later = new Date('2027-09-06T00:00:00.000Z')
+    expect((await repo().acquire(acquire(s, { daemonId: DAEMON_B, now: later }))).outcome).toBe('locked')
+
+    // The owner's later reconciliation pass found the marked review submitted.
+    const identified = await repo().settleOperation({
+      ...base,
+      recordId,
+      outcome: { kind: 'deterministic', status: 200, externalId: '4242' }
+    })
+    expect('outcome' in identified && identified.record.state).toBe('settled')
+    expect('outcome' in identified && identified.phase).toBe('ambiguous_locked')
+    expect(
+      await repo().recordOutcome(outcome(s, attemptId, { state: 'submitted', externalIds: ['review:4242'] }))
+    ).toEqual({ outcome: 'recorded', phase: 'settled' })
+    const stored = await prisma.codeHostReviewAttemptOutcome.findUniqueOrThrow({ where: { attemptId } })
+    expect(stored).toMatchObject({ state: 'submitted', externalIds: ['review:4242'] })
+    const lease = await prisma.codeHostReviewLease.findFirstOrThrow({
+      where: { projectExternalId: s.projectExternalId }
+    })
+    expect(lease.phase).toBe('settled')
+    expect(lease.attemptId).toBeNull()
+    expect((await repo().acquire(acquire(s, { daemonId: DAEMON_B, now: later }))).outcome).toBe('acquired')
+    // A recorded effect never moves again: the released attempt is no owner, and its row stays submitted.
+    expect((await repo().recordOutcome(outcome(s, attemptId, { state: 'ambiguous_locked' }))).outcome).toBe('not_owner')
+    expect((await prisma.codeHostReviewAttemptOutcome.findUniqueOrThrow({ where: { attemptId } })).state).toBe(
+      'submitted'
+    )
+  })
+
   it('an attempt that issued no permit at all releases immediately', async () => {
     const s = subject()
     const input = acquire(s)

--- a/packages/daemon/src/codehost/review-attempt.ts
+++ b/packages/daemon/src/codehost/review-attempt.ts
@@ -1,0 +1,852 @@
+// Provider-neutral engine behind every formal code-host review adapter (gitlab §15–§15.2, gitea §10.3); bodies never reach the CP.
+import { randomUUID } from 'node:crypto'
+import { WireError } from '@agentconnect.md/connection'
+import {
+  codeHostReviewPublicEffect,
+  type CodeHostProvider,
+  type CodeHostReviewAuthorized,
+  type CodeHostReviewExternalRef,
+  type CodeHostReviewOpKind,
+  type CodeHostReviewOpMethod,
+  type CodeHostReviewOpOutcome,
+  type CodeHostReviewOpRequest,
+  type CodeHostReviewRefusalReason,
+  type CodeHostReviewResultReport,
+  type CodeHostReviewState,
+  type HookConfigSnapshot
+} from '@agentconnect.md/protocol'
+import { reviewPolicyAllows, type CodeReviewOperation, type HookDispatchContext } from '../github/hook-coords.js'
+import type { GithubCommentAttribution, PosterScheduler } from '../github/poster.js'
+import {
+  validateCodeReviewInput,
+  type CodeHostReviewAdapter,
+  type CodeReviewEvent,
+  type CodeReviewVerdict,
+  type SubmitCodeReviewReq
+} from './review-adapter.js'
+import { parseCodeHostJson } from './json.js'
+import { ReviewMarkerSigner } from './review-marker.js'
+import {
+  CodeHostReviewOutbox,
+  type CodeHostReviewControlPlane,
+  type ReviewIntentRow,
+  type ReviewIntentStore
+} from './review-outbox.js'
+
+/** One authorized review turn; every field is trusted daemon state. */
+export interface CodeHostReviewTurn {
+  hookId: string
+  agentId: string
+  deliveryKey: string
+  snapshot: HookConfigSnapshot
+  /** Numeric repository/project id (decimal string) — the rename-stable match key. */
+  repoId: string
+  repoPath: string
+  /** The number the provider addresses the subject by: a merge-request IID, a pull-request index. */
+  subjectNumber: number
+  expectedHeadSha: string
+  expectedBaseSha?: string
+  sessionId: string
+  /** The durable hook row this attempt's identity and outcome live on (§15, §15.2). */
+  hook: HookDispatchContext
+  /** Persist that row; `required` makes a failed write fail the caller. */
+  persist: (required?: boolean) => Promise<void>
+  /** §15 step 1: one review attempt per turn, reserved synchronously. */
+  state: 'idle' | 'submitting' | 'done'
+}
+
+export interface CodeHostReviewAdapterDeps<Turn extends CodeHostReviewTurn> {
+  cp: () => CodeHostReviewControlPlane | undefined
+  orgForAgent: (agentId: string) => string | undefined
+  /** The STABLE daemon identity owed frames are recovered under — never a process incarnation. */
+  daemonId: () => string | undefined
+  store: ReviewIntentStore
+  /** The daemon-wide outbox; absent ⇒ this adapter runs one of its own over `store`. */
+  outbox?: CodeHostReviewOutbox
+  /** Restart-stable marker key; see the trust model on {@link ReviewMarkerSigner}. */
+  markerKey: () => Promise<Buffer>
+  /** The effect lease this provider publishes under; it never enters the agent environment. */
+  token: (turn: Turn) => Promise<string>
+  invalidateToken: (turn: Turn, token: string) => void
+  attribution?: (turn: Turn) => Promise<GithubCommentAttribution | undefined>
+  log: { warn: (message: string) => void }
+  /** The instance's REST root for THIS turn's agent, resolved per turn. */
+  apiBaseUrl: (turn: Turn) => string
+  fetchImpl?: typeof fetch
+  newAttemptId?: () => string
+  newStartToken?: () => string
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+  /** §15.2 bounded observation window for an ambiguous publication. */
+  ambiguousWindowMs?: number
+  pollIntervalMs?: number
+  /** Timer seam for the owed-frame resweep; tests drive it, production uses real timers. */
+  scheduler?: PosterScheduler
+  resweepBaseMs?: number
+  resweepCapMs?: number
+}
+
+/** The model-visible outcome: one normalized state plus a plain-English sentence. */
+export interface CodeHostReviewOutcome {
+  provider: CodeHostProvider
+  state: CodeHostReviewState
+  event: CodeReviewEvent
+  verdict: CodeReviewVerdict
+  message: string
+  externalIds?: CodeHostReviewExternalRef[]
+  /** The event actually published when it differs from the requested one (gitea-integration.md §10.3 self-review downgrade). */
+  publishedEvent?: CodeReviewEvent
+}
+
+export const DEFAULT_REVIEW_TIMEOUT_MS = 20_000
+export const DEFAULT_AMBIGUOUS_WINDOW_MS = 30_000
+export const DEFAULT_POLL_INTERVAL_MS = 2_000
+
+/** What a settle left behind: nothing, replayable coordinates, or no replay source at all. */
+type SettleDisposition = 'safe' | 'replayable' | 'blocked'
+
+/** The terminal result is withheld until every unsafe settle has a durable replay source. */
+export class ResultWithheld extends Error {
+  constructor() {
+    super('the formal review outcome could not be made durable yet; the daemon will retry before reporting it')
+    this.name = 'ResultWithheld'
+  }
+}
+
+export class AmbiguousSend extends Error {
+  constructor(
+    readonly host: string,
+    readonly code: string
+  ) {
+    super(`${host} review request outcome is unknown (${code})`)
+    this.name = 'AmbiguousSend'
+  }
+}
+
+export interface SendResult {
+  status: number
+  parsed: unknown
+}
+
+/** The turn plus its live effect token; the token is re-minted in place on a refresh. */
+export interface ReviewSession<Turn extends CodeHostReviewTurn> {
+  turn: Turn
+  token: string
+}
+
+/** What a ledger frame needs to name itself — an in-flight attempt or a recovered record. */
+export interface ReviewLeaseRef<Turn extends CodeHostReviewTurn> {
+  turn: Turn
+  attemptId: string
+  fence: string
+  orgId?: string
+}
+
+/** Everything one attempt carries between steps; a provider extends it with its own facts. */
+export interface CodeHostReviewAttempt<Turn extends CodeHostReviewTurn> extends ReviewSession<Turn> {
+  req: SubmitCodeReviewReq
+  signer: ReviewMarkerSigner
+  orgId?: string
+  attemptId: string
+  fence: string
+  /** The provider user this effect token speaks as — what the lease must name (§15.1). */
+  publisherUserId: string
+  /** Per-kind monotonic operation-record counter; a retried mutation takes the next one. */
+  ordinals: Map<CodeHostReviewOpKind, number>
+  externalIds: CodeHostReviewExternalRef[]
+  /** A settle this attempt owes has no durable replay source yet, so no result may be reported. */
+  settleBlocked?: boolean
+}
+
+/** What a provider reads before the lease: who it publishes as, plus any authorization fact the CP fences on. */
+export interface PreLeaseFacts {
+  publisherUserId: string
+  serviceAccountIsReviewer?: boolean
+}
+
+export type MutationOutcome =
+  | { kind: 'sent'; status: number; parsed: unknown; recordId: string }
+  | { kind: 'rejected'; status: number; parsed: unknown; recordId: string }
+  | { kind: 'ambiguous'; recordId: string }
+
+export function record(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+/** A big-int-safe numeric id as a decimal string; undefined when the value is not one. */
+export function idOf(value: unknown): string | undefined {
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return value
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return String(value)
+  return undefined
+}
+
+export function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export abstract class CodeHostReviewAttemptAdapter<
+  Turn extends CodeHostReviewTurn,
+  Attempt extends CodeHostReviewAttempt<Turn>,
+  Facts extends PreLeaseFacts
+> implements CodeHostReviewAdapter {
+  abstract readonly provider: CodeHostProvider
+  /** How the host is named in model-visible errors (`GitLab`, `Gitea`). */
+  protected abstract readonly hostLabel: string
+  /** How the subject is named in model-visible errors (`merge-request`, `pull-request`). */
+  protected abstract readonly subjectLabel: string
+
+  protected readonly turns = new Map<string, Turn>()
+  protected readonly now: () => number
+  protected readonly sleep: (ms: number) => Promise<void>
+  protected readonly outbox: CodeHostReviewOutbox
+  private readonly ownsOutbox: boolean
+  private signerPromise?: Promise<ReviewMarkerSigner>
+
+  constructor(protected readonly deps: CodeHostReviewAdapterDeps<Turn>) {
+    this.now = deps.now ?? (() => Date.now())
+    this.sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+    this.ownsOutbox = deps.outbox === undefined
+    this.outbox =
+      deps.outbox ??
+      new CodeHostReviewOutbox({
+        cp: deps.cp,
+        daemonId: deps.daemonId,
+        store: deps.store,
+        log: deps.log,
+        ...(deps.scheduler ? { scheduler: deps.scheduler } : {}),
+        ...(deps.resweepBaseMs !== undefined ? { resweepBaseMs: deps.resweepBaseMs } : {}),
+        ...(deps.resweepCapMs !== undefined ? { resweepCapMs: deps.resweepCapMs } : {}),
+        ...(deps.now ? { now: deps.now } : {})
+      })
+  }
+
+  /** Drop the pending resweep so a shutting-down daemon leaves no timer behind. */
+  stop(): void {
+    if (this.ownsOutbox) this.outbox.stop()
+  }
+
+  /** Replay every frame this daemon still owes (§15.1); a shared outbox is swept by its owner. */
+  reconcilePending(): Promise<void> {
+    return this.outbox.reconcilePending()
+  }
+
+  /** The restart-stable signer, minted from the daemon store on first use. */
+  protected markerSigner(): Promise<ReviewMarkerSigner> {
+    this.signerPromise ??= this.deps.markerKey().then((key) => new ReviewMarkerSigner(key))
+    return this.signerPromise
+  }
+
+  closeTurn(key: string, turn?: Turn): void {
+    if (turn && this.turns.get(key) !== turn) return
+    this.turns.delete(key)
+  }
+
+  owns(key: string, agentId: string): boolean {
+    return this.turns.get(key)?.agentId === agentId
+  }
+
+  /** One English sentence per normalized state, so the tool result mirrors §15.2 exactly. */
+  protected abstract outcomeSentence(state: CodeHostReviewState): string
+  /** The sentence appended to a typed CP refusal, naming this provider's subject. */
+  protected abstract refusalDetail(reason: CodeHostReviewRefusalReason): string
+  /** The authentication header(s) this host takes the effect token in. */
+  protected abstract authHeaders(token: string): Record<string, string>
+  /** What the provider reads BEFORE the lease: the publishing identity and any fact the authorization fences on. */
+  protected abstract preLeaseFacts(session: ReviewSession<Turn>, req: SubmitCodeReviewReq): Promise<Facts>
+  /** Widen the engine's attempt with this provider's own facts. */
+  protected abstract openAttempt(base: CodeHostReviewAttempt<Turn>, facts: Facts): Attempt
+  /** The provider's publication pipeline, run under the lease; every path ends in `settle`. */
+  protected abstract publish(cp: CodeHostReviewControlPlane, attempt: Attempt): Promise<CodeHostReviewOutcome>
+  /** §15.1 ledger recovery: classify every operation a previous incarnation left permitted but unsettled. */
+  protected abstract reconcileOperations(
+    cp: CodeHostReviewControlPlane,
+    attempt: Attempt
+  ): Promise<CodeHostReviewOutcome | undefined>
+
+  /** A typed refusal's second chance: `retry` re-asks the authorization once. Default: none. */
+  protected async onRefused(
+    _cp: CodeHostReviewControlPlane,
+    _turn: Turn,
+    _req: SubmitCodeReviewReq,
+    _answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
+  ): Promise<'refuse' | 'retry'> {
+    return 'refuse'
+  }
+
+  async submit(key: string, req: SubmitCodeReviewReq): Promise<CodeHostReviewOutcome> {
+    const turn = this.turns.get(key)
+    if (!turn || turn.agentId !== req.agentId) {
+      throw new Error(
+        `a formal ${this.hostLabel} review is only available during the active ${this.subjectLabel} hook turn`
+      )
+    }
+    // §15: an incompatible pair or unusable body is rejected before any provider effect.
+    const invalid = validateCodeReviewInput(req)
+    if (invalid) throw new Error(invalid)
+    if (!reviewPolicyAllows(turn.snapshot.reviewPolicy, req.event)) {
+      throw new Error(`${req.event} exceeds this hook's ${turn.snapshot.reviewPolicy} review policy`)
+    }
+    if (turn.state !== 'idle')
+      throw new Error(`this ${this.subjectLabel} hook turn already has a formal review attempt`)
+    // §15 step 1: turn-local CAS before the first await.
+    turn.state = 'submitting'
+    const cp = this.deps.cp()
+    if (!cp) {
+      turn.state = 'done'
+      throw new Error('control plane is not connected; formal review denied')
+    }
+    if (!cp.supportsReview()) {
+      turn.state = 'done'
+      throw new Error('the control plane does not serve formal code-host reviews yet (codehost-review-v1)')
+    }
+    try {
+      const outcome = await this.run(turn, req, cp)
+      // A proven no-effect outcome leaves the turn free to correct its input and retry.
+      turn.state = codeHostReviewPublicEffect(outcome.state) === 'absent' ? 'idle' : 'done'
+      return outcome
+    } catch (err) {
+      // A retryable wire failure before the lease exists wrote nothing; once it does, a replay could publish twice.
+      if (err instanceof WireError && err.retryable && turn.hook.codeReview?.fence === undefined) {
+        turn.state = 'idle'
+        throw new Error(`formal review not submitted: control plane unreachable (${err.message}); call the tool again`)
+      }
+      // A withheld result leaves the turn open and the attempt pre-terminal, by design.
+      turn.state = err instanceof ResultWithheld ? 'idle' : 'done'
+      throw err
+    }
+  }
+
+  /** RECORD-FIRST (§15.1): the attempt id lands on the durable hook row before any call, so a crash replays the same attempt. */
+  protected async reserveAttempt(turn: Turn, req: SubmitCodeReviewReq): Promise<string> {
+    const prior = turn.hook.codeReview
+    const recovering = prior !== undefined && prior.state === undefined
+    if (recovering) {
+      if (prior.event !== req.event || prior.verdict !== req.verdict || prior.headSha !== turn.expectedHeadSha) {
+        throw new Error('a recovered formal-review attempt must keep its original event, verdict, and head')
+      }
+      return prior.attemptId
+    }
+    const attemptId = (this.deps.newAttemptId ?? randomUUID)()
+    turn.hook.codeReview = {
+      attemptId,
+      event: req.event,
+      verdict: req.verdict,
+      headSha: turn.expectedHeadSha
+    }
+    try {
+      await turn.persist(true)
+    } catch (err) {
+      if (prior) turn.hook.codeReview = prior
+      else delete turn.hook.codeReview
+      throw new Error(`formal review durability barrier failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    return attemptId
+  }
+
+  private async run(
+    turn: Turn,
+    req: SubmitCodeReviewReq,
+    cp: CodeHostReviewControlPlane
+  ): Promise<CodeHostReviewOutcome> {
+    const orgId = this.deps.orgForAgent(turn.agentId)
+    const attemptId = await this.reserveAttempt(turn, req)
+    const signer = await this.markerSigner()
+    const session: ReviewSession<Turn> = { turn, token: await this.deps.token(turn) }
+    // Read pre-lease so the authorization can carry the provider's facts and prove the leased identity is ours.
+    const facts = await this.preLeaseFacts(session, req)
+
+    // §15 steps 2-3: the durable publication lease and the CP's authorization in one round trip.
+    const authorize = () =>
+      cp.authorize(
+        {
+          hookId: turn.hookId,
+          deliveryKey: turn.deliveryKey,
+          attemptId,
+          provider: this.provider,
+          projectId: turn.repoId,
+          mergeRequestIid: turn.subjectNumber,
+          requestedEvent: req.event,
+          requestedVerdict: req.verdict,
+          snapshot: turn.snapshot,
+          headSha: turn.expectedHeadSha,
+          ...(turn.expectedBaseSha ? { baseSha: turn.expectedBaseSha } : {}),
+          ...(facts.serviceAccountIsReviewer !== undefined
+            ? { serviceAccountIsReviewer: facts.serviceAccountIsReviewer }
+            : {})
+        },
+        orgId
+      )
+    let authorized = await authorize()
+    if (!authorized.authorized && (await this.onRefused(cp, turn, req, authorized)) === 'retry') {
+      authorized = await authorize()
+    }
+    if (!authorized.authorized) return await this.refused(turn, req, authorized)
+    if (
+      authorized.projectId !== turn.repoId ||
+      authorized.mergeRequestIid !== turn.subjectNumber ||
+      authorized.expectedHeadSha !== turn.expectedHeadSha
+    ) {
+      throw new Error('control plane returned a mismatched formal-review target')
+    }
+
+    const attempt = this.openAttempt(
+      {
+        turn,
+        req,
+        signer,
+        ...(orgId ? { orgId } : {}),
+        attemptId,
+        fence: authorized.lease.fence,
+        token: session.token,
+        publisherUserId: facts.publisherUserId,
+        // Seeded from the durable record: a replayed attempt must never reuse a spent coordinate.
+        ordinals: new Map(
+          Object.entries(turn.hook.codeReview?.ordinals ?? {}).map(([kind, next]) => [
+            kind as CodeHostReviewOpKind,
+            next
+          ])
+        ),
+        externalIds: []
+      },
+      facts
+    )
+    // The fence rides the durable record so an owed ledger frame stays derivable after a restart.
+    if (turn.hook.codeReview) {
+      turn.hook.codeReview.fence = attempt.fence
+      await turn.persist(true)
+    }
+    // The leased publishing identity must be the account this effect token speaks as.
+    if (authorized.lease.serviceAccountUserId !== facts.publisherUserId) {
+      return this.settle(cp, attempt, 'not_submitted')
+    }
+    return await this.publish(cp, attempt)
+  }
+
+  /** Hand back a permit no request started (§15.1): returned, or started (classify by provider evidence), or deferred (nothing decided). */
+  protected async returnUnused(
+    cp: CodeHostReviewControlPlane,
+    ref: ReviewLeaseRef<Turn>,
+    op: CodeReviewOperation
+  ): Promise<'returned' | 'started' | 'deferred'> {
+    try {
+      await cp.operate(
+        { op: 'return-unused', attemptId: ref.attemptId, fence: ref.fence, recordId: op.recordId },
+        ref.orgId
+      )
+      await this.clearOperation(ref, op.recordId)
+      return 'returned'
+    } catch (err) {
+      // A permanent refusal means the record moved on without this daemon; evidence decides.
+      if ((err as { retryable?: unknown }).retryable === false) return 'started'
+      this.warn(`unused permit return deferred (${err instanceof Error ? err.message : err})`)
+      return 'deferred'
+    }
+  }
+
+  /** Rebuild owed frames without provider evidence: return unstarted permits, re-owe lost results; started operations await the replay. */
+  async recoverTurn(turn: Turn): Promise<void> {
+    const attemptRecord = turn.hook.codeReview
+    const cp = this.deps.cp()
+    if (!attemptRecord || !cp || !cp.supportsReview()) return
+    const fence = attemptRecord.fence
+    const orgId = this.deps.orgForAgent(turn.agentId)
+    if (fence) {
+      const ref: ReviewLeaseRef<Turn> = { turn, attemptId: attemptRecord.attemptId, fence, ...(orgId ? { orgId } : {}) }
+      for (const op of [...(attemptRecord.operations ?? [])]) {
+        // An unstarted permit is handed back; a started one replays the outcome parked on it.
+        if (op.phase === 'issued') {
+          await this.returnUnused(cp, ref, op)
+          continue
+        }
+        if (!op.outcome) continue
+        if (await this.outbox.owe(this.settleIntent(ref, op.recordId, op.outcome))) {
+          await this.clearOperation(ref, op.recordId)
+        }
+      }
+    }
+    if (!attemptRecord.resultOwed || !attemptRecord.state) return
+    const safe = await this.outbox.owe({
+      intentId: `${attemptRecord.attemptId}:result`,
+      daemonId: this.deps.daemonId() ?? '',
+      attemptId: attemptRecord.attemptId,
+      ...(orgId ? { orgId } : {}),
+      kind: 'result',
+      frame: JSON.stringify(
+        this.resultFrame(turn, attemptRecord.attemptId, attemptRecord.event, attemptRecord.verdict, {
+          headSha: attemptRecord.headSha,
+          state: attemptRecord.state,
+          externalIds: attemptRecord.externalIds ?? []
+        })
+      ),
+      attempts: 0
+    })
+    if (safe) await this.clearResultOwed(turn)
+  }
+
+  /** The body-free result frame, built the same way whether it is owed now or replayed later. */
+  protected resultFrame(
+    turn: Turn,
+    attemptId: string,
+    event: CodeReviewEvent,
+    verdict: CodeReviewVerdict,
+    result: { headSha: string; state: CodeHostReviewState; externalIds: CodeHostReviewExternalRef[] }
+  ): CodeHostReviewResultReport {
+    return {
+      hookId: turn.hookId,
+      deliveryKey: turn.deliveryKey,
+      attemptId,
+      snapshot: turn.snapshot,
+      provider: this.provider,
+      projectId: turn.repoId,
+      mergeRequestIid: turn.subjectNumber,
+      event,
+      verdict,
+      headSha: result.headSha,
+      state: result.state,
+      ...(result.externalIds.length ? { externalIds: result.externalIds } : {})
+    }
+  }
+
+  /** RECORD-FIRST: the coordinates of the one permitted request, before it is permitted. */
+  protected async noteOperation(attempt: Attempt, op: CodeReviewOperation): Promise<void> {
+    const attemptRecord = attempt.turn.hook.codeReview
+    if (!attemptRecord) return
+    attemptRecord.ordinals = Object.fromEntries(attempt.ordinals)
+    attemptRecord.operations = [...(attemptRecord.operations ?? []).filter((e) => e.recordId !== op.recordId), op]
+    await attempt.turn.persist(true)
+  }
+
+  /** Flip the local phase once the control plane acknowledged the start transition. */
+  protected async markOperationStarted(attempt: Attempt, recordId: string): Promise<void> {
+    const op = attempt.turn.hook.codeReview?.operations?.find((entry) => entry.recordId === recordId)
+    if (!op || op.phase === 'started') return
+    op.phase = 'started'
+    await attempt.turn.persist(true)
+  }
+
+  /** Settled, so the coordinates are no longer owed. A lost removal costs one idempotent re-settle. */
+  protected async clearOperation(ref: ReviewLeaseRef<Turn>, recordId: string): Promise<void> {
+    const attemptRecord = ref.turn.hook.codeReview
+    if (!attemptRecord?.operations) return
+    attemptRecord.operations = attemptRecord.operations.filter((op) => op.recordId !== recordId)
+    await ref.turn.persist().catch(() => undefined)
+  }
+
+  /** One mutation per single-use record: issue → start → one request → settle; a definite 401/403 buys one refresh under a NEW record. */
+  protected async mutate(
+    cp: CodeHostReviewControlPlane,
+    attempt: Attempt,
+    kind: CodeHostReviewOpKind,
+    method: CodeHostReviewOpMethod,
+    target: string,
+    body: Record<string, unknown> | undefined,
+    draftOrdinal?: number
+  ): Promise<MutationOutcome> {
+    for (let attemptNo = 0; attemptNo < 2; attemptNo += 1) {
+      const ordinal = attempt.ordinals.get(kind) ?? 0
+      attempt.ordinals.set(kind, ordinal + 1)
+      const issued = await cp.operate(
+        { op: 'issue', attemptId: attempt.attemptId, fence: attempt.fence, kind, method, target, ordinal },
+        attempt.orgId
+      )
+      const startToken = (this.deps.newStartToken ?? randomUUID)()
+      // Durable BEFORE the request is permitted, so a crash between them is reconcilable.
+      await this.noteOperation(attempt, {
+        recordId: issued.recordId,
+        startToken,
+        kind,
+        ordinal,
+        target,
+        phase: 'issued',
+        ...(draftOrdinal !== undefined ? { draftOrdinal } : {})
+      })
+      await this.startOperation(cp, attempt, issued.recordId, startToken)
+      // Only now may a replay assume a request was permitted under this record.
+      await this.markOperationStarted(attempt, issued.recordId)
+      let result: SendResult
+      try {
+        result = await this.send(method, target, undefined, body, attempt.token, attempt.turn)
+      } catch (err) {
+        if (err instanceof AmbiguousSend) {
+          await this.settleAndClear(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code }, true)
+          return { kind: 'ambiguous', recordId: issued.recordId }
+        }
+        throw err
+      }
+      const authRejected = result.status === 401 || result.status === 403
+      const externalId = idOf(record(result.parsed).id)
+      await this.settleAndClear(cp, attempt, issued.recordId, {
+        kind: 'deterministic',
+        status: result.status,
+        ...(externalId ? { externalId } : {})
+      })
+      if (result.status < 300) {
+        return { kind: 'sent', status: result.status, parsed: result.parsed, recordId: issued.recordId }
+      }
+      if (!authRejected || attemptNo === 1) {
+        return { kind: 'rejected', status: result.status, parsed: result.parsed, recordId: issued.recordId }
+      }
+      this.deps.invalidateToken(attempt.turn, attempt.token)
+      attempt.token = await this.deps.token(attempt.turn)
+    }
+    throw new Error(`${this.hostLabel} review mutation exhausted its single authorization refresh`)
+  }
+
+  /** `startToken` names the one intended request, so a lost reply is retransmitted with the SAME token. */
+  private async startOperation(
+    cp: CodeHostReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    startToken: string
+  ): Promise<void> {
+    let last: unknown
+    for (let tries = 0; tries < 2; tries += 1) {
+      try {
+        await cp.operate(
+          { op: 'start', attemptId: attempt.attemptId, fence: attempt.fence, recordId, startToken },
+          attempt.orgId
+        )
+        return
+      } catch (err) {
+        last = err
+      }
+    }
+    throw last instanceof Error ? last : new Error('the control plane refused to start the review operation')
+  }
+
+  /** The settle is owed durably first so a lost ack never strands a started record; returns whether its coordinates may be forgotten. */
+  private async settleOperation(
+    ref: ReviewLeaseRef<Turn>,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome
+  ): Promise<SettleDisposition> {
+    const safe = await this.outbox.owe(this.settleIntent(ref, recordId, outcome))
+    if (safe) return 'safe'
+    // Neither written nor acknowledged: the coordinates become the replay source instead.
+    return (await this.persistSettleOutcome(ref, recordId, outcome)) ? 'replayable' : 'blocked'
+  }
+
+  /** The one settle frame, built the same way whether it is owed now or replayed later. */
+  protected settleIntent(
+    ref: ReviewLeaseRef<Turn>,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome
+  ): ReviewIntentRow {
+    return {
+      intentId: `${ref.attemptId}:op:${recordId}`,
+      daemonId: this.deps.daemonId() ?? '',
+      attemptId: ref.attemptId,
+      ...(ref.orgId ? { orgId: ref.orgId } : {}),
+      kind: 'operation',
+      frame: JSON.stringify({
+        op: 'settle',
+        attemptId: ref.attemptId,
+        fence: ref.fence,
+        recordId,
+        outcome
+      } satisfies CodeHostReviewOpRequest),
+      attempts: 0
+    }
+  }
+
+  /** Park the exact outcome on the surviving coordinates so a restart can replay it blind. */
+  private async persistSettleOutcome(
+    ref: ReviewLeaseRef<Turn>,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome
+  ): Promise<boolean> {
+    const op = ref.turn.hook.codeReview?.operations?.find((entry) => entry.recordId === recordId)
+    if (!op) return false
+    op.outcome = outcome
+    try {
+      await ref.turn.persist(true)
+      return true
+    } catch (err) {
+      this.warn(`settle outcome could not be parked (${err instanceof Error ? err.message : err})`)
+      return false
+    }
+  }
+
+  /** Owe the settle, then forget the coordinates only once something can replay it. */
+  protected async settleAndClear(
+    _cp: CodeHostReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    outcome: CodeHostReviewOpOutcome,
+    // An ambiguous record stays non-terminal until an upgrade names its object; its coordinates are that upgrade's replay source (§15.1).
+    retain = false
+  ): Promise<void> {
+    const disposition = await this.settleOperation(attempt, recordId, outcome)
+    if (disposition === 'safe' && !retain) await this.clearOperation(attempt, recordId)
+    if (disposition === 'blocked') attempt.settleBlocked = true
+  }
+
+  /** Upgrade a positively identified ambiguous record to settled by naming its object; the CP keeps the lease until exactly this frame arrives. */
+  protected async upgradeAmbiguous(
+    cp: CodeHostReviewControlPlane,
+    attempt: Attempt,
+    recordId: string,
+    externalId: string,
+    status: number
+  ): Promise<void> {
+    await this.settleAndClear(cp, attempt, recordId, { kind: 'deterministic', status, externalId })
+  }
+
+  /** Record the terminal classification, releasing (or locking) the publication lease. */
+  protected async settle(
+    _cp: CodeHostReviewControlPlane,
+    attempt: Attempt,
+    state: CodeHostReviewState,
+    extras: { publishedEvent?: CodeReviewEvent; note?: string } = {}
+  ): Promise<CodeHostReviewOutcome> {
+    const externalIds = codeHostReviewPublicEffect(state) === 'absent' ? [] : attempt.externalIds
+    // No terminal result while a started operation lacks a replay source: the CP would hold the lease on a record nothing can settle (§15.1).
+    if (attempt.settleBlocked) {
+      this.outbox.arm()
+      throw new ResultWithheld()
+    }
+    // The durable single-writer gate first (§15.2): only a proven no-effect attempt admits the ordinary reply, and a replay reads the same verdict.
+    await this.recordOutcome(attempt.turn, state, externalIds, true)
+    const safe = await this.outbox.owe({
+      intentId: `${attempt.attemptId}:result`,
+      daemonId: this.deps.daemonId() ?? '',
+      attemptId: attempt.attemptId,
+      ...(attempt.orgId ? { orgId: attempt.orgId } : {}),
+      kind: 'result',
+      frame: JSON.stringify(
+        this.resultFrame(attempt.turn, attempt.attemptId, attempt.req.event, attempt.req.verdict, {
+          headSha: attempt.turn.expectedHeadSha,
+          state,
+          externalIds
+        })
+      ),
+      attempts: 0
+    })
+    if (safe) await this.clearResultOwed(attempt.turn)
+    return {
+      provider: this.provider,
+      state,
+      event: attempt.req.event,
+      verdict: attempt.req.verdict,
+      message: extras.note ? `${this.outcomeSentence(state)} ${extras.note}` : this.outcomeSentence(state),
+      ...(externalIds.length ? { externalIds } : {}),
+      ...(extras.publishedEvent ? { publishedEvent: extras.publishedEvent } : {})
+    }
+  }
+
+  /** A typed CP refusal is an ordinary control outcome the model must read precisely. */
+  private async refused(
+    turn: Turn,
+    req: SubmitCodeReviewReq,
+    answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
+  ): Promise<CodeHostReviewOutcome> {
+    const state: CodeHostReviewState =
+      answer.reason === 'reviewer_assignment_required'
+        ? 'reviewer_assignment_required'
+        : answer.reason === 'ambiguous_locked'
+          ? 'ambiguous_locked'
+          : 'not_submitted'
+    const detail = this.refusalDetail(answer.reason)
+    // No lease was granted, so nothing is owed to the CP, but the durable gate still learns whether the ordinary reply may follow.
+    await this.recordOutcome(turn, state, [], false)
+    return {
+      provider: this.provider,
+      state,
+      event: req.event,
+      verdict: req.verdict,
+      message: `${this.outcomeSentence(state)}${detail}`
+    }
+  }
+
+  /** Stamp the durable attempt with its classification; the in-memory copy guards this process. */
+  protected async recordOutcome(
+    turn: Turn,
+    state: CodeHostReviewState,
+    externalIds: CodeHostReviewExternalRef[],
+    owed: boolean
+  ): Promise<void> {
+    const attemptRecord = turn.hook.codeReview
+    if (!attemptRecord) return
+    attemptRecord.state = state
+    if (owed) attemptRecord.resultOwed = true
+    else delete attemptRecord.resultOwed
+    if (externalIds.length) attemptRecord.externalIds = externalIds
+    else delete attemptRecord.externalIds
+    try {
+      await turn.persist(true)
+    } catch (err) {
+      // A stateless durable attempt reads as unknown, which blocks the fallback — the safe direction.
+      this.warn(`outcome persistence deferred (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /** The result frame is durable or acknowledged, so the attempt no longer owes it. */
+  protected async clearResultOwed(turn: Turn): Promise<void> {
+    if (!turn.hook.codeReview?.resultOwed) return
+    delete turn.hook.codeReview.resultOwed
+    await turn.persist().catch(() => undefined)
+  }
+
+  protected warn(message: string): void {
+    try {
+      this.deps.log.warn(`${this.provider} review: ${message}`)
+    } catch {
+      // A broken logger must not break a settlement path.
+    }
+  }
+
+  protected async get(session: ReviewSession<Turn>, path: string, query?: string): Promise<unknown> {
+    for (let tries = 0; tries < 2; tries += 1) {
+      let result: SendResult
+      try {
+        result = await this.send('GET', path, query, undefined, session.token, session.turn)
+      } catch {
+        throw new Error(`${this.hostLabel} GET ${path} did not complete`)
+      }
+      if (result.status < 300) return result.parsed
+      if ((result.status !== 401 && result.status !== 403) || tries === 1) {
+        throw new Error(`${this.hostLabel} GET ${path} failed with ${result.status}`)
+      }
+      this.deps.invalidateToken(session.turn, session.token)
+      session.token = await this.deps.token(session.turn)
+    }
+    throw new Error(`${this.hostLabel} GET ${path} failed`)
+  }
+
+  protected async send(
+    method: 'GET' | CodeHostReviewOpMethod,
+    path: string,
+    query: string | undefined,
+    body: Record<string, unknown> | undefined,
+    token: string,
+    turn: Turn
+  ): Promise<SendResult> {
+    const doFetch = this.deps.fetchImpl ?? fetch
+    const url = `${this.deps.apiBaseUrl(turn)}${path}${query ? `?${query}` : ''}`
+    let response: Response
+    try {
+      response = await doFetch(url, {
+        method,
+        headers: {
+          ...this.authHeaders(token),
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {})
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        signal: AbortSignal.timeout(DEFAULT_REVIEW_TIMEOUT_MS)
+      })
+    } catch {
+      // Nothing was received, so a mutation's effect is unknown; GETs treat it the same.
+      throw new AmbiguousSend(this.hostLabel, 'transport_failed')
+    }
+    // A 5xx may or may not have applied the effect; only a received 4xx is definite.
+    if (response.status >= 500) throw new AmbiguousSend(this.hostLabel, `upstream_${response.status}`)
+    const raw = await response.text().catch(() => '')
+    let parsed: unknown
+    try {
+      parsed = raw ? parseCodeHostJson(raw) : undefined
+    } catch {
+      parsed = undefined
+    }
+    return { status: response.status, parsed }
+  }
+}

--- a/packages/daemon/src/codehost/review-attempt.ts
+++ b/packages/daemon/src/codehost/review-attempt.ts
@@ -13,6 +13,7 @@ import {
   type CodeHostReviewRefusalReason,
   type CodeHostReviewResultReport,
   type CodeHostReviewState,
+  type CodeHostReviewUnlock,
   type HookConfigSnapshot
 } from '@agentconnect.md/protocol'
 import { reviewPolicyAllows, type CodeReviewOperation, type HookDispatchContext } from '../github/hook-coords.js'
@@ -232,8 +233,18 @@ export abstract class CodeHostReviewAttemptAdapter<
 
   /** The restart-stable signer, minted from the daemon store on first use. */
   protected markerSigner(): Promise<ReviewMarkerSigner> {
-    this.signerPromise ??= this.deps.markerKey().then((key) => new ReviewMarkerSigner(key))
+    this.signerPromise ??= this.deps.markerKey().then((key) => this.buildSigner(key))
     return this.signerPromise
+  }
+
+  /** How this provider's markers are keyed off the daemon key; one key for every attempt by default. */
+  protected buildSigner(key: Buffer): ReviewMarkerSigner {
+    return new ReviewMarkerSigner(key)
+  }
+
+  /** Per-attempt key material the CP may keep with the lease for a later lock exit; none by default. */
+  protected async markerSeed(_attemptId: string): Promise<string | undefined> {
+    return undefined
   }
 
   closeTurn(key: string, turn?: Turn): void {
@@ -263,14 +274,14 @@ export abstract class CodeHostReviewAttemptAdapter<
     attempt: Attempt
   ): Promise<CodeHostReviewOutcome | undefined>
 
-  /** A typed refusal's second chance: `retry` re-asks the authorization once. Default: none. */
+  /** A typed refusal's second chance: a returned retry re-asks once, naming the locked object it identified. Default: none. */
   protected async onRefused(
     _cp: CodeHostReviewControlPlane,
     _turn: Turn,
     _req: SubmitCodeReviewReq,
     _answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
-  ): Promise<'refuse' | 'retry'> {
-    return 'refuse'
+  ): Promise<{ unlock?: CodeHostReviewUnlock } | undefined> {
+    return undefined
   }
 
   async submit(key: string, req: SubmitCodeReviewReq): Promise<CodeHostReviewOutcome> {
@@ -356,7 +367,8 @@ export abstract class CodeHostReviewAttemptAdapter<
     const facts = await this.preLeaseFacts(session, req)
 
     // §15 steps 2-3: the durable publication lease and the CP's authorization in one round trip.
-    const authorize = () =>
+    const markerSeed = await this.markerSeed(attemptId)
+    const authorize = (unlock?: CodeHostReviewUnlock) =>
       cp.authorize(
         {
           hookId: turn.hookId,
@@ -372,13 +384,16 @@ export abstract class CodeHostReviewAttemptAdapter<
           ...(turn.expectedBaseSha ? { baseSha: turn.expectedBaseSha } : {}),
           ...(facts.serviceAccountIsReviewer !== undefined
             ? { serviceAccountIsReviewer: facts.serviceAccountIsReviewer }
-            : {})
+            : {}),
+          ...(markerSeed ? { markerSeed } : {}),
+          ...(unlock ? { unlock } : {})
         },
         orgId
       )
     let authorized = await authorize()
-    if (!authorized.authorized && (await this.onRefused(cp, turn, req, authorized)) === 'retry') {
-      authorized = await authorize()
+    if (!authorized.authorized) {
+      const again = await this.onRefused(cp, turn, req, authorized)
+      if (again) authorized = await authorize(again.unlock)
     }
     if (!authorized.authorized) return await this.refused(turn, req, authorized)
     if (

--- a/packages/daemon/src/codehost/review-marker.ts
+++ b/packages/daemon/src/codehost/review-marker.ts
@@ -1,17 +1,4 @@
-/**
- * Signed hidden attempt markers for GitLab formal reviews
- * (gitlab-com-integration.md §15.1, §15.2).
- *
- * GitLab's note APIs have no idempotency key and its bulk publish has no attempt
- * identifier, so an ambiguous create or publish is recovered by reading the
- * marker back rather than by guessing from the text. Ordinal 0 is the review
- * summary; 1..n are that attempt's inline diff comments, in creation order.
- *
- * Trust model: the HMAC key is daemon-local and the only claim it has to make is
- * "this daemon's attempt authored this draft", which stops a model-authored body
- * from planting a marker; a marker this daemon cannot verify is unrecognized and
- * fails closed as `review_reconciliation_required`, never as someone else's.
- */
+// Daemon-signed hidden attempt markers for formal reviews (gitlab §15.1, gitea §10.3); ordinal 0 is the summary, 1..n the inline comments.
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 
 const MARKER_VERSION = '1'
@@ -38,11 +25,7 @@ export class ReviewMarkerSigner {
     return `<!-- agentconnect-review:${MARKER_VERSION}:${attemptId}:${ordinal}:${signature} -->`
   }
 
-  /**
-   * The verified marker carried by one draft body, or undefined when it carries
-   * none, several, or one this daemon cannot verify. Several is refused because a
-   * body that mentions a marker cannot be allowed to shadow the appended chrome.
-   */
+  /** The verified marker in one body, or undefined when it carries none, several, or one this daemon cannot verify. */
   read(body: string | undefined, headSha: string): ReviewMarker | undefined {
     if (!body) return undefined
     const found = [...body.matchAll(MARKER)]

--- a/packages/daemon/src/codehost/review-marker.ts
+++ b/packages/daemon/src/codehost/review-marker.ts
@@ -11,21 +11,42 @@ export interface ReviewMarker {
   ordinal: number
 }
 
-/** One attempt's marker minting and verification; the key never leaves the daemon. */
-export class ReviewMarkerSigner {
-  private readonly key: Buffer
+/** The key one attempt's markers are signed with; undefined means this signer cannot speak for that attempt. */
+export type ReviewMarkerKeyResolver = (attemptId: string) => Buffer | undefined
 
-  constructor(key?: Buffer) {
-    this.key = key ?? randomBytes(32)
+/** One daemon's marker minting and verification; a key resolver decides which attempts it can vouch for. */
+export class ReviewMarkerSigner {
+  private readonly keyFor: ReviewMarkerKeyResolver
+
+  constructor(key?: Buffer | ReviewMarkerKeyResolver) {
+    const fixed = typeof key === 'function' ? undefined : (key ?? randomBytes(32))
+    this.keyFor = typeof key === 'function' ? key : () => fixed
+  }
+
+  /** Per-attempt keys derived from one daemon key: a seed can be handed out and verifies exactly that attempt. */
+  static derived(daemonKey: Buffer): ReviewMarkerSigner {
+    return new ReviewMarkerSigner((attemptId) => ReviewMarkerSigner.seed(daemonKey, attemptId))
+  }
+
+  /** A signer that vouches for one foreign attempt from the seed it was handed, and for nothing else. */
+  static forSeed(attemptId: string, seed: Buffer): ReviewMarkerSigner {
+    const owner = attemptId.toLowerCase()
+    return new ReviewMarkerSigner((candidate) => (candidate.toLowerCase() === owner ? seed : undefined))
+  }
+
+  /** The attempt's marker key, derived so the daemon key itself never leaves the daemon. */
+  static seed(daemonKey: Buffer, attemptId: string): Buffer {
+    return createHmac('sha256', daemonKey).update(`attempt|${attemptId.toLowerCase()}`).digest()
   }
 
   /** The hidden marker chrome for one draft of one attempt at one head. */
   mint(attemptId: string, ordinal: number, headSha: string): string {
     const signature = this.sign(attemptId, ordinal, headSha)
+    if (!signature) throw new Error('no marker key for this review attempt')
     return `<!-- agentconnect-review:${MARKER_VERSION}:${attemptId}:${ordinal}:${signature} -->`
   }
 
-  /** The verified marker in one body, or undefined when it carries none, several, or one this daemon cannot verify. */
+  /** The verified marker in one body, or undefined when it carries none, several, or one this signer cannot verify. */
   read(body: string | undefined, headSha: string): ReviewMarker | undefined {
     if (!body) return undefined
     const found = [...body.matchAll(MARKER)]
@@ -34,7 +55,8 @@ export class ReviewMarkerSigner {
     if (version !== MARKER_VERSION || !UUID.test(attemptId!)) return undefined
     const index = Number(ordinal)
     if (!Number.isSafeInteger(index) || index < 0) return undefined
-    if (!this.matches(this.sign(attemptId!, index, headSha), signature!)) return undefined
+    const expected = this.sign(attemptId!, index, headSha)
+    if (!expected || !this.matches(expected, signature!)) return undefined
     return { attemptId: attemptId!.toLowerCase(), ordinal: index }
   }
 
@@ -43,8 +65,10 @@ export class ReviewMarkerSigner {
     return body.replace(/agentconnect-review:/gi, 'agentconnect-review​:')
   }
 
-  private sign(attemptId: string, ordinal: number, headSha: string): string {
-    return createHmac('sha256', this.key)
+  private sign(attemptId: string, ordinal: number, headSha: string): string | undefined {
+    const key = this.keyFor(attemptId)
+    if (!key) return undefined
+    return createHmac('sha256', key)
       .update(`${MARKER_VERSION}|${attemptId.toLowerCase()}|${ordinal}|${headSha}`)
       .digest('base64url')
       .slice(0, SIGNATURE_CHARS)

--- a/packages/daemon/src/codehost/review-outbox.ts
+++ b/packages/daemon/src/codehost/review-outbox.ts
@@ -1,0 +1,255 @@
+// The owed-frame outbox shared by every formal review adapter (gitlab §15.1, gitea §10.3): owed durably before sending, replayed until taken.
+import type {
+  CodeHostReviewAuthorize,
+  CodeHostReviewAuthorized,
+  CodeHostReviewLeaseRenew,
+  CodeHostReviewLeaseRenewed,
+  CodeHostReviewOpAccepted,
+  CodeHostReviewOpRequest,
+  CodeHostReviewResultOk,
+  CodeHostReviewResultReport
+} from '@agentconnect.md/protocol'
+import type { PosterScheduler } from '../github/poster.js'
+
+/** One control-plane frame a finished attempt still owes, replayed verbatim until acked (§15.1). */
+export interface ReviewIntentRow {
+  intentId: string
+  daemonId: string
+  attemptId: string
+  orgId?: string
+  kind: 'operation' | 'result'
+  /** The exact JSON payload; both frames are idempotent REQs by contract. */
+  frame: string
+  attempts: number
+}
+
+export interface ReviewIntentStore {
+  recordReviewIntent(row: ReviewIntentRow, now: number): Promise<void>
+  clearReviewIntent(intentId: string): Promise<void>
+  listReviewIntents(daemonId: string): Promise<ReviewIntentRow[]>
+}
+
+/** The narrow Control-Plane surface the review adapters need (§15.1 lease + operation ledger). */
+export interface CodeHostReviewControlPlane {
+  /** The CP advertises `codehost-review-v1`; without it an adapter refuses before any effect. */
+  supportsReview(): boolean
+  authorize(payload: CodeHostReviewAuthorize, orgId?: string): Promise<CodeHostReviewAuthorized>
+  operate(payload: CodeHostReviewOpRequest, orgId?: string): Promise<CodeHostReviewOpAccepted>
+  renew(payload: CodeHostReviewLeaseRenew, orgId?: string): Promise<CodeHostReviewLeaseRenewed>
+  report(payload: CodeHostReviewResultReport, orgId?: string): Promise<CodeHostReviewResultOk>
+}
+
+export interface CodeHostReviewOutboxDeps {
+  cp: () => CodeHostReviewControlPlane | undefined
+  /** The STABLE daemon identity owed frames are recovered under — never a process incarnation. */
+  daemonId: () => string | undefined
+  store: ReviewIntentStore
+  log: { warn: (message: string) => void }
+  /** Timer seam for the owed-frame resweep; tests drive it, production uses real timers. */
+  scheduler?: PosterScheduler
+  resweepBaseMs?: number
+  resweepCapMs?: number
+  now?: () => number
+}
+
+const DEFAULT_RESWEEP_BASE_MS = 30_000
+const DEFAULT_RESWEEP_CAP_MS = 300_000
+/** Pages of owed frames one sweep drains; the store answers a bounded page at a time. */
+const MAX_SWEEP_PAGES = 50
+
+export class CodeHostReviewOutbox {
+  private readonly now: () => number
+  private readonly sched: PosterScheduler
+  /** Owed frames whose durable write has not landed yet; replayed and re-written from here. */
+  private readonly unwritten = new Map<string, ReviewIntentRow>()
+  private resweepHandle?: unknown
+  private resweepAttempt = 0
+  /** Monotonic count of arm REQUESTS, so a zero-work disarm can tell whether it raced new work. */
+  private armGeneration = 0
+  private sweeping = false
+  private stopped = false
+
+  constructor(private readonly deps: CodeHostReviewOutboxDeps) {
+    this.now = deps.now ?? (() => Date.now())
+    this.sched = deps.scheduler ?? {
+      now: () => Date.now(),
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout)
+    }
+  }
+
+  /** Drop the pending resweep so a shutting-down daemon leaves no timer behind. */
+  stop(): void {
+    this.stopped = true
+    this.clearTimer()
+  }
+
+  /** Owe one frame; true once it is durably recorded or answered, else the caller keeps its upstream record as the only replay source (§15.1). */
+  async owe(row: ReviewIntentRow): Promise<boolean> {
+    const durable = await this.persistIntent(row)
+    if (!durable) this.unwritten.set(row.intentId, row)
+    const cp = this.deps.cp()
+    const answer = cp ? await this.deliver(cp, row) : 'retry'
+    if (answer === 'retry') {
+      this.arm()
+      return durable
+    }
+    await this.forget(row.intentId)
+    return true
+  }
+
+  /** Bounded local-write retry; false means the row is only in memory for now. */
+  private async persistIntent(row: ReviewIntentRow): Promise<boolean> {
+    for (let tries = 0; tries < 3; tries += 1) {
+      try {
+        await this.deps.store.recordReviewIntent(row, this.now())
+        this.unwritten.delete(row.intentId)
+        return true
+      } catch (err) {
+        if (tries === 2) {
+          this.warn(`codehost review: owed frame write deferred (${err instanceof Error ? err.message : err})`)
+        }
+      }
+    }
+    return false
+  }
+
+  /** Send one owed frame verbatim. `retry` keeps it; anything else is finished with. */
+  private async deliver(cp: CodeHostReviewControlPlane, row: ReviewIntentRow): Promise<'sent' | 'retry' | 'refused'> {
+    try {
+      if (row.kind === 'operation') await cp.operate(JSON.parse(row.frame) as CodeHostReviewOpRequest, row.orgId)
+      else await cp.report(JSON.parse(row.frame) as CodeHostReviewResultReport, row.orgId)
+      return 'sent'
+    } catch (err) {
+      // A control plane that answered `retryable: false` has decided; replaying cannot change it.
+      const permanent = (err as { retryable?: unknown }).retryable === false
+      this.warn(
+        `codehost review: owed ${row.kind} frame ${permanent ? 'refused' : 'deferred'} (${err instanceof Error ? err.message : err})`
+      )
+      return permanent ? 'refused' : 'retry'
+    }
+  }
+
+  private async forget(intentId: string): Promise<void> {
+    this.unwritten.delete(intentId)
+    try {
+      await this.deps.store.clearReviewIntent(intentId)
+    } catch (err) {
+      // The frame is delivered; a stale row only costs one idempotent replay later.
+      this.warn(`codehost review: owed frame could not be cleared (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /** Replay everything this daemon identity still owes (§15.1): at startup, on reconnect, and re-armed on backoff while anything remains. */
+  async reconcilePending(): Promise<void> {
+    if (this.sweeping) return
+    this.sweeping = true
+    // Read BEFORE the scan: work that arms after this point owns the timer, not this sweep.
+    const armedThrough = this.armGeneration
+    try {
+      const remaining = await this.sweepOnce()
+      if (remaining === undefined || remaining > 0) this.arm()
+      else this.disarm(armedThrough)
+    } finally {
+      this.sweeping = false
+    }
+  }
+
+  /** One pass over the owed frames, draining pages until none is new; returns the count still outstanding, or undefined. */
+  private async sweepOnce(): Promise<number | undefined> {
+    const daemonId = this.deps.daemonId()
+    // Before the control plane adopts an id there is no identity to recover rows under.
+    if (!daemonId) return 0
+    const cp = this.deps.cp()
+    if (!cp) return undefined
+    const seen = new Set<string>()
+    let outstanding = 0
+    let unreadable = false
+    // Hitting the cap proves nothing about what is left, so the sweep stays armed.
+    let capped = true
+    for (let page = 0; page < MAX_SWEEP_PAGES; page += 1) {
+      let rows: ReviewIntentRow[]
+      try {
+        rows = await this.deps.store.listReviewIntents(daemonId)
+      } catch (err) {
+        this.warn(`codehost review: owed frame scan failed (${err instanceof Error ? err.message : err})`)
+        unreadable = true
+        break
+      }
+      const fresh = rows.filter((row) => !seen.has(row.intentId))
+      if (fresh.length === 0) {
+        capped = false
+        break
+      }
+      for (const row of fresh) {
+        seen.add(row.intentId)
+        outstanding += await this.replay(cp, row)
+      }
+    }
+    // Frames whose durable write never landed live only here; they are owed all the same.
+    for (const row of [...this.unwritten.values()]) {
+      if (seen.has(row.intentId)) continue
+      seen.add(row.intentId)
+      await this.persistIntent(row)
+      outstanding += await this.replay(cp, row)
+    }
+    return unreadable || capped ? undefined : outstanding
+  }
+
+  /** Deliver one owed frame; 1 when it is still owed afterwards, 0 when it is finished with. */
+  private async replay(cp: CodeHostReviewControlPlane, row: ReviewIntentRow): Promise<number> {
+    const answer = await this.deliver(cp, row)
+    if (answer !== 'retry') {
+      await this.forget(row.intentId)
+      return 0
+    }
+    const next = { ...row, attempts: row.attempts + 1 }
+    if (this.unwritten.has(row.intentId)) this.unwritten.set(row.intentId, next)
+    await this.deps.store.recordReviewIntent(next, this.now()).catch(() => undefined)
+    return 1
+  }
+
+  /** Arm the next resweep on exponential backoff, capped. An armed timer is never restarted early. */
+  arm(): void {
+    if (this.stopped) return
+    this.armGeneration += 1
+    if (this.resweepHandle !== undefined) return
+    const base = this.deps.resweepBaseMs ?? DEFAULT_RESWEEP_BASE_MS
+    const cap = this.deps.resweepCapMs ?? DEFAULT_RESWEEP_CAP_MS
+    const delay = Math.min(base * 2 ** Math.min(this.resweepAttempt, 16), cap)
+    this.resweepAttempt += 1
+    try {
+      this.resweepHandle = this.sched.setTimeout(() => {
+        this.resweepHandle = undefined
+        void this.reconcilePending()
+      }, delay)
+    } catch (err) {
+      this.warn(`codehost review: resweep scheduling failed (${err instanceof Error ? err.message : err})`)
+    }
+  }
+
+  /** Go quiet — but only if nothing armed after the sweep that decided there was no work left. */
+  private disarm(armedThrough: number): void {
+    if (this.armGeneration !== armedThrough) return
+    this.resweepAttempt = 0
+    this.clearTimer()
+  }
+
+  private clearTimer(): void {
+    if (this.resweepHandle === undefined) return
+    try {
+      this.sched.clearTimeout(this.resweepHandle)
+    } catch {
+      // A failed clear only leaves a sweep that finds nothing to do.
+    }
+    this.resweepHandle = undefined
+  }
+
+  private warn(message: string): void {
+    try {
+      this.deps.log.warn(message)
+    } catch {
+      // A broken logger must not break a settlement path.
+    }
+  }
+}

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -126,8 +126,8 @@ export interface CpClientReadyHost {
   effectiveAgents(): LoadedAgent[]
   /** The §16 run-projection writer: the CP dispatch target and the interrupted-write reconciler. */
   noteProjector(): CodeHostNoteProjector
-  /** The §15 review adapter, for the control-plane frames a finished attempt still owes. */
-  gitlabReviews(): { reconcilePending(): Promise<void> }
+  /** The §15 review outbox, for the control-plane frames a finished attempt still owes. */
+  codeHostReviews(): { reconcilePending(): Promise<void> }
 }
 
 /** Tenant lookups for agent-scoped frames, plus the duty seam the heartbeat carries. */
@@ -303,7 +303,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       void host.noteProjector().reconcilePending()
       // ...and every §15 settle/result frame a review attempt still owes. Both are idempotent
       // REQs, so replaying one the CP already took is a no-op; not replaying wedges its ledger.
-      void host.gitlabReviews().reconcilePending()
+      void host.codeHostReviews().reconcilePending()
       // ...and the retention-GC receipts (#485). A sweep that ran while the CP
       // was unreachable (or before it advertised the feature) left the deleted
       // sessions' metadata rows unmarked; this is the only side that still knows.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -339,7 +339,13 @@ import {
   type GithubReviewHost
 } from './github/review-orchestrator.js'
 import { CodeHostReviewRouter } from './codehost/review-adapter.js'
+import {
+  CodeHostReviewOutbox,
+  type CodeHostReviewControlPlane,
+  type ReviewIntentRow
+} from './codehost/review-outbox.js'
 import { GitlabReviewAdapter, type GitlabReviewAdapterDeps, type GitlabReviewTurn } from './gitlab/review-adapter.js'
+import { GiteaReviewAdapter, type GiteaReviewAdapterDeps, type GiteaReviewTurn } from './gitea/review-adapter.js'
 import {
   collectHookQueueCandidates,
   combineCoordinationWaits,
@@ -1278,8 +1284,12 @@ export class Daemon {
   private readonly activeGithubTurnMeta = new Map<string, ActiveGithubTurnMeta>()
   private readonly activeGithubReplyBatchMeta = new Map<string, ActiveGithubReplyBatchMeta>()
   private readonly githubReviews: GithubReviewOrchestrator
+  /** The owed-frame outbox every formal-review adapter shares (§15.1); one per daemon identity. */
+  private readonly reviewOutbox: CodeHostReviewOutbox
   /** §15 GitLab formal-review adapter and the provider-routing seam both live behind this. */
   private readonly gitlabReviews: GitlabReviewAdapter
+  /** gitea-integration.md §10.3: the Gitea formal-review adapter on the same seam. */
+  private readonly giteaReviews: GiteaReviewAdapter
   private readonly codeReviews = new CodeHostReviewRouter()
   // ── lifecycle (§2.5/§5.3/§7.2/§7.3) ──
   private clock: Clock
@@ -1506,9 +1516,17 @@ export class Daemon {
     this.webchatMcpRevocations = new WebchatMcpRevocations(this.webchatMcpRevocationHost())
     this.commands = new CommandHandlers(this.commandHost())
     this.githubReviews = new GithubReviewOrchestrator(this.githubReviewHost())
+    this.reviewOutbox = new CodeHostReviewOutbox({
+      cp: () => this.codeHostReviewCp(),
+      daemonId: () => this.cfg.daemonId,
+      store: this.reviewIntentStore(),
+      log: { warn: (message: string) => this.log.warn(message) }
+    })
     this.gitlabReviews = new GitlabReviewAdapter(this.gitlabReviewDeps())
+    this.giteaReviews = new GiteaReviewAdapter(this.giteaReviewDeps())
     this.codeReviews.register(this.githubReviews.reviewAdapter)
     this.codeReviews.register(this.gitlabReviews)
+    this.codeReviews.register(this.giteaReviews)
     this.curatedRuntimeAdmission = new CuratedRuntimeAdmission({
       now: () => this.clock.now(),
       ttlMs: PROBE_TTL_MS
@@ -8735,47 +8753,71 @@ export class Daemon {
     return { provider, repoId, ...(repoPath !== undefined ? { repoPath } : {}) }
   }
 
-  /** Everything the GitHub hook-dispatch and formal-review seam reaches back for. */
-  /** §15 GitLab review adapter deps: the CP lease surface plus the never-agent-visible effect PAT. */
-  private gitlabReviewDeps(): GitlabReviewAdapterDeps {
+  /** The provider-neutral review control surface (§15.1), or undefined while the control plane is away. */
+  private codeHostReviewCp(): CodeHostReviewControlPlane | undefined {
+    const client = this.cpClient
+    if (!client) return undefined
     return {
-      cp: () => {
-        const client = this.cpClient
-        if (!client) return undefined
-        return {
-          supportsReview: () => client.supportsServerFeature?.(CODEHOST_REVIEW_V1_FEATURE) === true,
-          authorize: (payload, orgId) => client.authorizeCodeHostReview(payload, orgId),
-          operate: (payload, orgId) => client.operateCodeHostReview(payload, orgId),
-          renew: (payload, orgId) => client.renewCodeHostReviewLease(payload, orgId),
-          report: (payload, orgId) => client.reportCodeHostReviewResult(payload, orgId)
-        }
-      },
-      orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
-      apiBaseUrl: (turn) => this.gitlabApiBase(turn.agentId),
+      supportsReview: () => client.supportsServerFeature?.(CODEHOST_REVIEW_V1_FEATURE) === true,
+      authorize: (payload, orgId) => client.authorizeCodeHostReview(payload, orgId),
+      operate: (payload, orgId) => client.operateCodeHostReview(payload, orgId),
+      renew: (payload, orgId) => client.renewCodeHostReviewLease(payload, orgId),
+      report: (payload, orgId) => client.reportCodeHostReviewResult(payload, orgId)
+    }
+  }
+
+  private reviewIntentStore() {
+    return {
+      recordReviewIntent: (row: ReviewIntentRow, now: number) => this.store.recordReviewIntent(row, now),
+      clearReviewIntent: (intentId: string) => this.store.clearReviewIntent(intentId),
+      listReviewIntents: (daemonId: string) => this.store.listReviewIntents(daemonId)
+    }
+  }
+
+  /** Restart-stable, so a same-attempt recovery can still verify the objects it authored. */
+  private reviewMarkerKey(name: string): () => Promise<Buffer> {
+    return async () =>
+      Buffer.from(
+        await this.store.getOrCreateDaemonSecret(name, () => randomBytes(32).toString('base64'), this.clock.now()),
+        'base64'
+      )
+  }
+
+  /** What every formal-review adapter shares: the CP surface, the outbox, the org lookup, the footer. */
+  private codeHostReviewDeps<Turn extends { agentId: string; sessionId: string }>() {
+    return {
+      cp: () => this.codeHostReviewCp(),
+      orgForAgent: (agentId: string) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
       daemonId: () => this.cfg.daemonId,
-      store: {
-        recordReviewIntent: (row, now) => this.store.recordReviewIntent(row, now),
-        clearReviewIntent: (intentId) => this.store.clearReviewIntent(intentId),
-        listReviewIntents: (daemonId) => this.store.listReviewIntents(daemonId)
-      },
-      // Restart-stable, so a same-attempt recovery can still verify the drafts it authored.
-      markerKey: async () =>
-        Buffer.from(
-          await this.store.getOrCreateDaemonSecret(
-            'gitlab-review-marker-key',
-            () => randomBytes(32).toString('base64'),
-            this.clock.now()
-          ),
-          'base64'
-        ),
-      token: async (turn) =>
-        (await this.gitCreds.getGitlabEffectToken(turn.agentId, turn.projectId, turn.hookId)).token,
-      invalidateToken: (turn, token) => this.gitCreds.invalidateGitlabEffect(turn.agentId, turn.projectId, token),
-      attribution: async (turn) =>
+      store: this.reviewIntentStore(),
+      outbox: this.reviewOutbox,
+      attribution: async (turn: Turn) =>
         this.agents.get(turn.agentId)?.output.showFooter
           ? await this.githubReviews.githubCommentAttribution(turn.agentId, turn.sessionId)
           : undefined,
       log: { warn: (message: string) => this.log.warn(message) }
+    }
+  }
+
+  /** §15 GitLab review adapter deps: the CP lease surface plus the never-agent-visible effect PAT. */
+  private gitlabReviewDeps(): GitlabReviewAdapterDeps {
+    return {
+      ...this.codeHostReviewDeps<GitlabReviewTurn>(),
+      apiBaseUrl: (turn) => this.gitlabApiBase(turn.agentId),
+      markerKey: this.reviewMarkerKey('gitlab-review-marker-key'),
+      token: async (turn) => (await this.gitCreds.getGitlabEffectToken(turn.agentId, turn.repoId, turn.hookId)).token,
+      invalidateToken: (turn, token) => this.gitCreds.invalidateGitlabEffect(turn.agentId, turn.repoId, token)
+    }
+  }
+
+  /** gitea-integration.md §10.3: the same seam over the connection token's `gitea_effect` lease. */
+  private giteaReviewDeps(): GiteaReviewAdapterDeps {
+    return {
+      ...this.codeHostReviewDeps<GiteaReviewTurn>(),
+      apiBaseUrl: (turn) => this.giteaApiBase(turn.agentId),
+      markerKey: this.reviewMarkerKey('gitea-review-marker-key'),
+      token: async (turn) => (await this.gitCreds.getGiteaEffectToken(turn.agentId, turn.repoId, turn.hookId)).token,
+      invalidateToken: (turn, token) => this.gitCreds.invalidateGiteaEffect(turn.agentId, turn.repoId, token)
     }
   }
 
@@ -12201,6 +12243,7 @@ export class Daemon {
     github?: ActiveGithubTurnMeta
     githubReplyBatch?: ActiveGithubReplyBatchMeta
     gitlabReview?: GitlabReviewTurn
+    giteaReview?: GiteaReviewTurn
   }> {
     const { entry, key, plan } = run
     const { agentId, callMeta } = entry
@@ -12248,16 +12291,17 @@ export class Daemon {
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
     // §17.2: the provider-neutral start barrier attaches the head this turn runs on to the accepted
     // run before the prompt, which is what a review authorization fences and §16 opens `running` on.
-    const barrier = await this.startGitlabHookTurn(hookContext, sessionId)
+    const barrier = await this.startCodeHostHookTurn(hookContext, sessionId)
     // A refused barrier keeps the ordinary turn but withholds the formal-review surface, exactly as a
     // failed GitHub barrier does: a run whose started head was not recorded must never reach a lease.
+    const reviewTurn = {
+      ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
+      persist: (required?: boolean) => this.persistHookState(entry, undefined, required)
+    }
     const gitlabReview =
-      barrier === 'failed'
-        ? undefined
-        : this.gitlabReviews.openTurn(key, hookContext, sessionId, {
-            ...(this.cfg.daemonId ? { daemonId: this.cfg.daemonId } : {}),
-            persist: (required) => this.persistHookState(entry, undefined, required)
-          })
+      barrier === 'failed' ? undefined : this.gitlabReviews.openTurn(key, hookContext, sessionId, reviewTurn)
+    const giteaReview =
+      barrier === 'failed' ? undefined : this.giteaReviews.openTurn(key, hookContext, sessionId, reviewTurn)
     // A replayed delivery may still owe the control plane frames a previous incarnation
     // recorded; the ones needing no provider evidence are handed back before the turn runs.
     if (gitlabReview) {
@@ -12265,27 +12309,39 @@ export class Daemon {
         .recoverTurn(gitlabReview)
         .catch((err) => this.log.warn(`gitlab review: turn recovery deferred (${formatErr(err)})`))
     }
+    if (giteaReview) {
+      await this.giteaReviews
+        .recoverTurn(giteaReview)
+        .catch((err) => this.log.warn(`gitea review: turn recovery deferred (${formatErr(err)})`))
+    }
     const activeGithubReplyBatch = plan.githubReplyBatchActive ? { entry, sessionId, called: false } : undefined
     if (activeGithubReplyBatch) this.activeGithubReplyBatchMeta.set(key, activeGithubReplyBatch)
     return {
       ...(activeGithub ? { github: activeGithub } : {}),
       ...(gitlabReview ? { gitlabReview } : {}),
+      ...(giteaReview ? { giteaReview } : {}),
       ...(activeGithubReplyBatch ? { githubReplyBatch: activeGithubReplyBatch } : {})
     }
   }
 
-  /** Cross the gitlab `hook/start` barrier (§17.2): `started` durably recorded the head, `legacy` is a
-   *  control plane that does not serve the barrier, `failed` is an advertised barrier that refused. */
-  private async startGitlabHookTurn(
+  /** The CP feature whose holder routes each provider-neutral arm of `hook/start`; an older CP cannot route the member. */
+  private static readonly HOOK_START_BARRIER_FEATURE: Partial<Record<CodeHostProvider, string>> = {
+    gitlab: CODEHOST_NOTE_PROJECTION_V1_FEATURE,
+    gitea: GITEA_V1_FEATURE
+  }
+
+  /** Cross the hook/start barrier (§17.2): started = head recorded, legacy = CP without the barrier, failed = an advertised barrier refused. */
+  private async startCodeHostHookTurn(
     hook: HookDispatchContext | undefined,
     sessionId: string
   ): Promise<'started' | 'legacy' | 'failed'> {
     const host = hook && codeHostHookMetadataOf(hook)
     const snapshot = hook?.snapshot
-    if (!hook || host?.provider !== 'gitlab' || !snapshot) return 'legacy'
+    const feature = host && Daemon.HOOK_START_BARRIER_FEATURE[host.provider]
+    if (!hook || !feature || !snapshot) return 'legacy'
     const client = this.cpClient
-    // An older CP cannot route the gitlab member of the one-of, so the send waits on its bit.
-    if (!client || client.supportsServerFeature?.(CODEHOST_NOTE_PROJECTION_V1_FEATURE) !== true) return 'legacy'
+    // An older CP cannot route this member of the one-of, so the send waits on its bit.
+    if (!client || client.supportsServerFeature?.(feature) !== true) return 'legacy'
     // A stale dispatch target opens no review turn anyway; the barrier is not this daemon's to cross.
     if (this.cfg.daemonId && snapshot.dispatchDaemonId !== this.cfg.daemonId) return 'legacy'
     const payload = {
@@ -12304,7 +12360,7 @@ export class Daemon {
         return 'started'
       } catch (err) {
         if (attempt === 2) {
-          this.log.warn(`gitlab review: hook/start rejected (${formatErr(err)})`)
+          this.log.warn(`${host.provider} review: hook/start rejected (${formatErr(err)})`)
           return 'failed'
         }
         // The daemon ACK and the relay's accepted report travel on different sockets;
@@ -13247,6 +13303,7 @@ export class Daemon {
       github?: ActiveGithubTurnMeta
       githubReplyBatch?: ActiveGithubReplyBatchMeta
       gitlabReview?: GitlabReviewTurn
+      giteaReview?: GiteaReviewTurn
     }
   ): Promise<void> {
     const { entry, key, plan } = run
@@ -13288,6 +13345,7 @@ export class Daemon {
     const activeGithubReplyBatch = activeTurn.githubReplyBatch
     if (activeGithub && this.activeGithubTurnMeta.get(key) === activeGithub) this.activeGithubTurnMeta.delete(key)
     if (activeTurn.gitlabReview) this.gitlabReviews.closeTurn(key, activeTurn.gitlabReview)
+    if (activeTurn.giteaReview) this.giteaReviews.closeTurn(key, activeTurn.giteaReview)
     if (activeGithubReplyBatch && this.activeGithubReplyBatchMeta.get(key) === activeGithubReplyBatch) {
       this.activeGithubReplyBatchMeta.delete(key)
     }
@@ -18597,7 +18655,7 @@ export class Daemon {
       drainSessionPurges: () => this.drainSessionPurges(),
       effectiveAgents: () => this.effectiveAgents(),
       noteProjector: () => this.noteProjector,
-      gitlabReviews: () => this.gitlabReviews,
+      codeHostReviews: () => this.reviewOutbox,
       cpAgents: () => this.cpAgents,
       cpIntegrations: () => this.cpIntegrations,
       cpCrons: () => this.cpCrons,
@@ -19670,7 +19728,7 @@ export class Daemon {
     this.autoMergeWatcher?.stop()
     // The projection resweep runs on its own clock, so it must be disarmed before the store closes.
     this.noteProjector?.stop()
-    this.gitlabReviews?.stop()
+    this.reviewOutbox?.stop()
     if (this.dataPlane) await this.dataPlane.close().catch((e) => errors.push(e))
     else await this.store?.close()
     if (errors.length) throw new AggregateError(errors, 'stop: partial failure')

--- a/packages/daemon/src/gitea/review-adapter.ts
+++ b/packages/daemon/src/gitea/review-adapter.ts
@@ -2,9 +2,9 @@
 import {
   codeHostReviewPublicEffect,
   type CodeHostReviewAuthorized,
-  type CodeHostReviewExternalRef,
   type CodeHostReviewRefusalReason,
-  type CodeHostReviewState
+  type CodeHostReviewState,
+  type CodeHostReviewUnlock
 } from '@agentconnect.md/protocol'
 import type { CodeReviewOperation, HookDispatchContext } from '../github/hook-coords.js'
 import { giteaOpensReviewGeneration } from '../messages/hook-message.js'
@@ -21,7 +21,6 @@ import {
   type CodeHostReviewOutcome,
   type CodeHostReviewTurn,
   type PreLeaseFacts,
-  type ReviewLeaseRef,
   type ReviewSession
 } from '../codehost/review-attempt.js'
 import type { CodeHostReviewControlPlane } from '../codehost/review-outbox.js'
@@ -103,14 +102,6 @@ type SubmitResult =
   | { kind: 'ambiguous_locked' }
   | { kind: 'self_review_forbidden' }
 
-/** An attempt the lock retained, kept so a later reconciliation pass can clear it (§10.3). */
-interface LockedAttempt {
-  ref: ReviewLeaseRef<GiteaReviewTurn>
-  recordId: string
-  event: CodeReviewEvent
-  verdict: GiteaAttempt['req']['verdict']
-}
-
 function reviewRows(parsed: unknown): ReviewRow[] {
   if (!Array.isArray(parsed)) return []
   return parsed.flatMap((row) => {
@@ -135,15 +126,10 @@ function pullHead(parsed: unknown): string | undefined {
   return text(record(record(parsed).head).sha)
 }
 
-function subjectKey(turn: GiteaReviewTurn): string {
-  return `${turn.repoId}#${turn.subjectNumber}`
-}
-
 export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReviewTurn, GiteaAttempt, GiteaFacts> {
   readonly provider = 'gitea' as const
   protected readonly hostLabel = 'Gitea'
   protected readonly subjectLabel = 'pull-request'
-  private readonly locked = new Map<string, LockedAttempt>()
 
   constructor(deps: GiteaReviewAdapterDeps) {
     super(deps)
@@ -185,14 +171,13 @@ export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReview
     return turn
   }
 
-  /** A replayed delivery whose attempt the lock retained joins the registry and gets one reconciliation pass now. */
-  override async recoverTurn(turn: GiteaReviewTurn): Promise<void> {
-    await super.recoverTurn(turn)
-    const lock = this.lockedAttemptOf(turn)
-    if (!lock) return
-    this.locked.set(subjectKey(turn), lock)
-    const cp = this.deps.cp()
-    if (cp?.supportsReview() && (await this.reconcileLocked(cp, lock))) this.locked.delete(subjectKey(turn))
+  /** Markers are keyed per attempt so the seed of one attempt can travel to the daemon a lock later refuses (§10.3). */
+  protected override buildSigner(key: Buffer): ReviewMarkerSigner {
+    return ReviewMarkerSigner.derived(key)
+  }
+
+  protected override async markerSeed(attemptId: string): Promise<string> {
+    return ReviewMarkerSigner.seed(await this.deps.markerKey(), attemptId).toString('hex')
   }
 
   protected outcomeSentence(state: CodeHostReviewState): string {
@@ -218,18 +203,32 @@ export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReview
     return base
   }
 
-  /** The lock's one exit: a refused attempt on the same pull request runs the reconciliation pass, then asks again. */
+  /** The lock's one exit (§10.3): from the CP's durable coordinates, look for the locked attempt's marked review, then ask again naming it. */
   protected override async onRefused(
-    cp: CodeHostReviewControlPlane,
+    _cp: CodeHostReviewControlPlane,
     turn: GiteaReviewTurn,
     _req: SubmitCodeReviewReq,
     answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
-  ): Promise<'refuse' | 'retry'> {
-    if (answer.reason !== 'ambiguous_locked') return 'refuse'
-    const lock = this.locked.get(subjectKey(turn))
-    if (!lock || !(await this.reconcileLocked(cp, lock))) return 'refuse'
-    this.locked.delete(subjectKey(turn))
-    return 'retry'
+  ): Promise<{ unlock: CodeHostReviewUnlock } | undefined> {
+    const lock = answer.reason === 'ambiguous_locked' ? answer.lock : undefined
+    if (!lock) return undefined
+    try {
+      const session: ReviewSession<GiteaReviewTurn> = { turn, token: await this.deps.token(turn) }
+      const signer = ReviewMarkerSigner.forSeed(lock.attemptId, Buffer.from(lock.markerSeed, 'hex'))
+      const found = await this.findSubmittedReview(session, lock.attemptId, lock.headSha, signer)
+      if (!found) return undefined
+      return {
+        unlock: {
+          attemptId: lock.attemptId,
+          fence: lock.fence,
+          recordId: lock.recordId,
+          externalRef: { kind: 'review', externalId: found.id }
+        }
+      }
+    } catch (err) {
+      this.warn(`lock reconciliation deferred (${err instanceof Error ? err.message : err})`)
+      return undefined
+    }
   }
 
   protected async publish(cp: CodeHostReviewControlPlane, attempt: GiteaAttempt): Promise<GiteaReviewOutcome> {
@@ -324,10 +323,7 @@ export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReview
         await this.settleAndClear(cp, attempt, op.recordId, { kind: 'ambiguous', code: 'publish_unreconciled' }, true)
       }
     }
-    if (!found) {
-      this.rememberLock(attempt, outstanding.at(-1)!.recordId)
-      return await this.settle(cp, attempt, 'ambiguous_locked')
-    }
+    if (!found) return await this.settle(cp, attempt, 'ambiguous_locked')
     attempt.externalIds.push({ kind: 'review', externalId: found.id })
     return await this.settleSubmit(cp, attempt, { kind: 'submitted', review: found })
   }
@@ -427,7 +423,6 @@ export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReview
       await this.sleep(this.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS)
     }
     // A pending review carrying this attempt's inline markers proves staging, not submission: still locked.
-    this.rememberLock(attempt, outcome.recordId)
     return { kind: 'ambiguous_locked' }
   }
 
@@ -435,9 +430,10 @@ export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReview
   private async findSubmittedReview(
     session: ReviewSession<GiteaReviewTurn>,
     attemptId: string,
-    headSha: string
+    headSha: string,
+    by?: ReviewMarkerSigner
   ): Promise<SubmittedReview | undefined> {
-    const signer = await this.markerSigner()
+    const signer = by ?? (await this.markerSigner())
     for (const review of await this.listReviews(session)) {
       if (review.state === undefined || review.state === 'PENDING' || review.state === 'REQUEST_REVIEW') continue
       const marker = signer.read(review.body, headSha)
@@ -462,78 +458,6 @@ export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReview
       if (!Array.isArray(parsed) || parsed.length < REVIEW_PAGE_SIZE) break
     }
     return rows
-  }
-
-  /** The retained ambiguous submission, kept so a later pass on this pull request can clear the lock. */
-  private rememberLock(attempt: GiteaAttempt, recordId: string): void {
-    this.locked.set(subjectKey(attempt.turn), {
-      ref: {
-        turn: attempt.turn,
-        attemptId: attempt.attemptId,
-        fence: attempt.fence,
-        ...(attempt.orgId ? { orgId: attempt.orgId } : {})
-      },
-      recordId,
-      event: attempt.req.event,
-      verdict: attempt.req.verdict
-    })
-  }
-
-  /** The lock a replayed delivery's durable attempt still holds, if its submission record was retained. */
-  private lockedAttemptOf(turn: GiteaReviewTurn): LockedAttempt | undefined {
-    const attemptRecord = turn.hook.codeReview
-    if (attemptRecord?.state !== 'ambiguous_locked' || !attemptRecord.fence) return undefined
-    const submission = attemptRecord.operations?.find((op) => op.kind === 'bulk_publish' && op.phase === 'started')
-    if (!submission) return undefined
-    const orgId = this.deps.orgForAgent(turn.agentId)
-    return {
-      ref: { turn, attemptId: attemptRecord.attemptId, fence: attemptRecord.fence, ...(orgId ? { orgId } : {}) },
-      recordId: submission.recordId,
-      event: attemptRecord.event,
-      verdict: attemptRecord.verdict
-    }
-  }
-
-  /** The later pass (§10.3): only the marked review found submitted clears a lock — the owner names its object and re-reports submitted. */
-  private async reconcileLocked(cp: CodeHostReviewControlPlane, lock: LockedAttempt): Promise<boolean> {
-    const { ref } = lock
-    try {
-      const session: ReviewSession<GiteaReviewTurn> = { turn: ref.turn, token: await this.deps.token(ref.turn) }
-      const found = await this.findSubmittedReview(session, ref.attemptId, ref.turn.expectedHeadSha)
-      if (!found) return false
-      await cp.operate(
-        {
-          op: 'settle',
-          attemptId: ref.attemptId,
-          fence: ref.fence,
-          recordId: lock.recordId,
-          outcome: { kind: 'deterministic', status: 200, externalId: found.id }
-        },
-        ref.orgId
-      )
-      const externalIds: CodeHostReviewExternalRef[] = [{ kind: 'review', externalId: found.id }]
-      await cp.report(
-        this.resultFrame(ref.turn, ref.attemptId, lock.event, lock.verdict, {
-          headSha: ref.turn.expectedHeadSha,
-          state: 'submitted',
-          externalIds
-        }),
-        ref.orgId
-      )
-      // The durable row follows best-effort: the control plane already holds the definite outcome.
-      const attemptRecord = ref.turn.hook.codeReview
-      if (attemptRecord?.attemptId === ref.attemptId) {
-        attemptRecord.state = 'submitted'
-        attemptRecord.externalIds = externalIds
-        attemptRecord.operations = attemptRecord.operations?.filter((op) => op.recordId !== lock.recordId)
-        delete attemptRecord.resultOwed
-        await ref.turn.persist().catch(() => undefined)
-      }
-      return true
-    } catch (err) {
-      this.warn(`lock reconciliation deferred (${err instanceof Error ? err.message : err})`)
-      return false
-    }
   }
 
   /** Single-line inline comments (§10.3): `RIGHT` → `new_position`, `LEFT` → `old_position`; a range collapses to its end line and names its start first. */

--- a/packages/daemon/src/gitea/review-adapter.ts
+++ b/packages/daemon/src/gitea/review-adapter.ts
@@ -1,0 +1,565 @@
+// Gitea formal pull-request reviews (gitea-integration.md §10.3): the GitLab pipeline with one marker-signed POST …/reviews in place of drafts.
+import {
+  codeHostReviewPublicEffect,
+  type CodeHostReviewAuthorized,
+  type CodeHostReviewExternalRef,
+  type CodeHostReviewRefusalReason,
+  type CodeHostReviewState
+} from '@agentconnect.md/protocol'
+import type { CodeReviewOperation, HookDispatchContext } from '../github/hook-coords.js'
+import { giteaOpensReviewGeneration } from '../messages/hook-message.js'
+import type { CodeReviewEvent, CodeReviewInlineComment, SubmitCodeReviewReq } from '../codehost/review-adapter.js'
+import {
+  CodeHostReviewAttemptAdapter,
+  DEFAULT_AMBIGUOUS_WINDOW_MS,
+  DEFAULT_POLL_INTERVAL_MS,
+  idOf,
+  record,
+  text,
+  type CodeHostReviewAdapterDeps,
+  type CodeHostReviewAttempt,
+  type CodeHostReviewOutcome,
+  type CodeHostReviewTurn,
+  type PreLeaseFacts,
+  type ReviewLeaseRef,
+  type ReviewSession
+} from '../codehost/review-attempt.js'
+import type { CodeHostReviewControlPlane } from '../codehost/review-outbox.js'
+import { ReviewMarkerSigner } from '../codehost/review-marker.js'
+import { appendGithubMarkdownChrome, githubAttributionFooter, type GithubCommentAttribution } from '../github/poster.js'
+import { giteaRepoPath } from './api.js'
+
+/** One authorized pull-request review turn: `repoId` is the numeric repository id, `subjectNumber` the pull index. */
+export type GiteaReviewTurn = CodeHostReviewTurn
+export type GiteaReviewAdapterDeps = CodeHostReviewAdapterDeps<GiteaReviewTurn>
+export type GiteaReviewOutcome = CodeHostReviewOutcome
+
+type GiteaFacts = PreLeaseFacts
+type GiteaAttempt = CodeHostReviewAttempt<GiteaReviewTurn>
+
+/** The verdict vocabulary of `POST …/reviews` (§10.3 step 4). */
+const GITEA_EVENT: Record<CodeReviewEvent, string> = {
+  COMMENT: 'COMMENT',
+  REQUEST_CHANGES: 'REQUEST_CHANGES',
+  APPROVE: 'APPROVED'
+}
+
+/** A submitted review's `state` read back as the event it published; pending and reviewer-request rows are neither. */
+const EVENT_OF_STATE: Record<string, CodeReviewEvent> = {
+  COMMENT: 'COMMENT',
+  REQUEST_CHANGES: 'REQUEST_CHANGES',
+  APPROVED: 'APPROVE'
+}
+
+/** Gitea's exact 422 texts for the pull request's own author (§16 probe). */
+const SELF_REVIEW_REFUSAL = /\b(?:approve|reject) your own pull is not allowed\b/i
+
+const SELF_REVIEW_NOTE =
+  'Gitea refuses the pull request author’s own APPROVE and REQUEST_CHANGES, so the same review was published as a COMMENT (self_review_forbidden).'
+
+const REVIEW_PAGE_SIZE = 50
+const MAX_REVIEW_PAGES = 10
+
+/** One English sentence per normalized state; the GitLab-only states keep a truthful sentence in case a shared path ever names one. */
+const OUTCOME_SENTENCE: Record<CodeHostReviewState, string> = {
+  submitted: 'The formal review was published on the pull request.',
+  not_submitted: 'No review was published; nothing was changed on the pull request.',
+  ambiguous_locked:
+    'Gitea did not confirm the publication and no marked review became visible, so this pull request is locked against further automated review attempts until a later reconciliation finds the marked review submitted; no fallback comment was posted.',
+  approval_not_recorded: 'The review was published but the approval was not recorded.',
+  review_state_not_recorded: 'The review was published but Gitea did not report the resulting review state.',
+  review_state_changed_unexpectedly: 'The review was published but the review state changed unexpectedly.',
+  requested_changes_block_observed: 'The review was published and the pull request currently requests changes.',
+  requested_changes_state_ambiguous: 'The review was published but Gitea did not confirm the requested-changes state.',
+  reviewer_assignment_required: 'REQUEST_CHANGES was refused because the publishing account is not a current reviewer.',
+  review_reconciliation_required:
+    'A pending review left on this pull request by the bot could not be reconciled, so no review was published and this pull request stays fail-closed.'
+}
+
+const REFUSAL_DETAIL: Partial<Record<CodeHostReviewRefusalReason, string>> = {
+  lease_held: ' Another review attempt currently owns publication on this pull request.',
+  head_changed: ' The pull request head changed while this turn was running.',
+  policy_denied: " This hook's review policy does not permit that review event.",
+  binding_unavailable: ' This repository has no ready Gitea binding to publish as.',
+  ambiguous_locked: ' A previous attempt on this pull request stays locked until its marked review is found submitted.'
+}
+
+interface ReviewRow {
+  id: string
+  userId?: string
+  state?: string
+  body?: string
+  commitId?: string
+}
+
+interface SubmittedReview {
+  id: string
+  event?: CodeReviewEvent
+}
+
+type SubmitResult =
+  | { kind: 'submitted'; review: SubmittedReview }
+  | { kind: 'not_submitted' }
+  | { kind: 'ambiguous_locked' }
+  | { kind: 'self_review_forbidden' }
+
+/** An attempt the lock retained, kept so a later reconciliation pass can clear it (§10.3). */
+interface LockedAttempt {
+  ref: ReviewLeaseRef<GiteaReviewTurn>
+  recordId: string
+  event: CodeReviewEvent
+  verdict: GiteaAttempt['req']['verdict']
+}
+
+function reviewRows(parsed: unknown): ReviewRow[] {
+  if (!Array.isArray(parsed)) return []
+  return parsed.flatMap((row) => {
+    const review = record(row)
+    const id = idOf(review.id)
+    if (!id) return []
+    const userId = idOf(record(review.user).id)
+    return [
+      {
+        id,
+        ...(userId ? { userId } : {}),
+        ...(text(review.state) ? { state: text(review.state)! } : {}),
+        ...(text(review.body) ? { body: text(review.body)! } : {}),
+        ...(text(review.commit_id) ? { commitId: text(review.commit_id)! } : {})
+      }
+    ]
+  })
+}
+
+/** The one pull-request fact this adapter fences on. */
+function pullHead(parsed: unknown): string | undefined {
+  return text(record(record(parsed).head).sha)
+}
+
+function subjectKey(turn: GiteaReviewTurn): string {
+  return `${turn.repoId}#${turn.subjectNumber}`
+}
+
+export class GiteaReviewAdapter extends CodeHostReviewAttemptAdapter<GiteaReviewTurn, GiteaAttempt, GiteaFacts> {
+  readonly provider = 'gitea' as const
+  protected readonly hostLabel = 'Gitea'
+  protected readonly subjectLabel = 'pull-request'
+  private readonly locked = new Map<string, LockedAttempt>()
+
+  constructor(deps: GiteaReviewAdapterDeps) {
+    super(deps)
+  }
+
+  /** Install the active review turn for one logical session key; undefined for anything but an authorized pull-request review generation. */
+  openTurn(
+    key: string,
+    hook: HookDispatchContext | undefined,
+    sessionId: string,
+    options: { daemonId?: string; persist: (required?: boolean) => Promise<void> }
+  ): GiteaReviewTurn | undefined {
+    const gitea = hook?.gitea
+    const snapshot = hook?.snapshot
+    if (!hook || !gitea || !snapshot) return undefined
+    if (gitea.target.kind !== 'pull' || !gitea.target.headSha) return undefined
+    // The same trusted predicate the prompt uses: only a delivery that OPENS a review generation for this head may publish one.
+    if (!giteaOpensReviewGeneration(hook.event, gitea, snapshot.reviewPolicy)) return undefined
+    if (options.daemonId && snapshot.dispatchDaemonId !== options.daemonId) return undefined
+    // A durable attempt that already reached a present or unknown effect is terminal for this turn.
+    const prior = hook.codeReview
+    const terminal = prior?.state !== undefined && codeHostReviewPublicEffect(prior.state) !== 'absent'
+    const turn: GiteaReviewTurn = {
+      hookId: hook.hookId,
+      agentId: hook.agentId,
+      deliveryKey: hook.deliveryKey,
+      snapshot,
+      repoId: gitea.repoId,
+      repoPath: gitea.repoPath,
+      subjectNumber: gitea.target.index,
+      expectedHeadSha: gitea.target.headSha,
+      ...(gitea.target.baseSha ? { expectedBaseSha: gitea.target.baseSha } : {}),
+      sessionId,
+      hook,
+      persist: options.persist,
+      state: terminal ? 'done' : 'idle'
+    }
+    this.turns.set(key, turn)
+    return turn
+  }
+
+  /** A replayed delivery whose attempt the lock retained joins the registry and gets one reconciliation pass now. */
+  override async recoverTurn(turn: GiteaReviewTurn): Promise<void> {
+    await super.recoverTurn(turn)
+    const lock = this.lockedAttemptOf(turn)
+    if (!lock) return
+    this.locked.set(subjectKey(turn), lock)
+    const cp = this.deps.cp()
+    if (cp?.supportsReview() && (await this.reconcileLocked(cp, lock))) this.locked.delete(subjectKey(turn))
+  }
+
+  protected outcomeSentence(state: CodeHostReviewState): string {
+    return OUTCOME_SENTENCE[state]
+  }
+
+  protected refusalDetail(reason: CodeHostReviewRefusalReason): string {
+    return REFUSAL_DETAIL[reason] ?? ''
+  }
+
+  protected authHeaders(token: string): Record<string, string> {
+    return { authorization: `token ${token}`, accept: 'application/json' }
+  }
+
+  /** Gitea's request-changes needs no reviewer record (§2), so the only pre-lease fact is who the token speaks as. */
+  protected async preLeaseFacts(session: ReviewSession<GiteaReviewTurn>): Promise<GiteaFacts> {
+    const publisherUserId = idOf(record(await this.get(session, '/user')).id)
+    if (!publisherUserId) throw new Error('Gitea did not identify the review publishing account')
+    return { publisherUserId }
+  }
+
+  protected openAttempt(base: CodeHostReviewAttempt<GiteaReviewTurn>): GiteaAttempt {
+    return base
+  }
+
+  /** The lock's one exit: a refused attempt on the same pull request runs the reconciliation pass, then asks again. */
+  protected override async onRefused(
+    cp: CodeHostReviewControlPlane,
+    turn: GiteaReviewTurn,
+    _req: SubmitCodeReviewReq,
+    answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
+  ): Promise<'refuse' | 'retry'> {
+    if (answer.reason !== 'ambiguous_locked') return 'refuse'
+    const lock = this.locked.get(subjectKey(turn))
+    if (!lock || !(await this.reconcileLocked(cp, lock))) return 'refuse'
+    this.locked.delete(subjectKey(turn))
+    return 'retry'
+  }
+
+  protected async publish(cp: CodeHostReviewControlPlane, attempt: GiteaAttempt): Promise<GiteaReviewOutcome> {
+    const { turn, req } = attempt
+
+    // §15.1: a request this attempt already permitted must be classified against the ledger before another is issued.
+    const recovered = await this.reconcileOperations(cp, attempt)
+    if (recovered) return recovered
+
+    // §10.3 step 2: the bot's orphan pending review would be absorbed by the submit, so it goes first.
+    const reconciled = await this.reconcilePendingReviews(cp, attempt)
+    if (reconciled) return reconciled
+
+    // Renew immediately before the one request, then re-fetch the head it is fenced on (step 3).
+    const renewed = await cp.renew({ attemptId: attempt.attemptId, fence: attempt.fence }, attempt.orgId)
+    if (renewed.phase === 'ambiguous_locked') return this.settle(cp, attempt, 'ambiguous_locked')
+    attempt.fence = renewed.fence
+    const head = pullHead(await this.get(attempt, this.pullPath(turn)))
+    if (!head) throw new Error('Gitea did not return the pull request revision')
+    if (head !== turn.expectedHeadSha) return this.settle(cp, attempt, 'not_submitted')
+
+    // Step 4-5: ONE submission, and the self-review downgrade when Gitea refuses the author's own verdict.
+    const first = await this.submitReview(cp, attempt, req.event)
+    if (first.kind !== 'self_review_forbidden') return this.settleSubmit(cp, attempt, first)
+    if (req.event === 'COMMENT') return this.settle(cp, attempt, 'not_submitted')
+    const second = await this.submitReview(cp, attempt, 'COMMENT')
+    if (second.kind === 'submitted') {
+      return this.settle(cp, attempt, 'submitted', { publishedEvent: 'COMMENT', note: SELF_REVIEW_NOTE })
+    }
+    return this.settleSubmit(cp, attempt, second)
+  }
+
+  private settleSubmit(
+    cp: CodeHostReviewControlPlane,
+    attempt: GiteaAttempt,
+    result: SubmitResult
+  ): Promise<GiteaReviewOutcome> {
+    if (result.kind === 'submitted') {
+      const downgraded = result.review.event !== undefined && result.review.event !== attempt.req.event
+      return this.settle(
+        cp,
+        attempt,
+        'submitted',
+        downgraded ? { publishedEvent: result.review.event!, note: SELF_REVIEW_NOTE } : {}
+      )
+    }
+    if (result.kind === 'ambiguous_locked') return this.settle(cp, attempt, 'ambiguous_locked')
+    return this.settle(cp, attempt, 'not_submitted')
+  }
+
+  /** §15.1 ledger recovery: a delete is proven by the absence it asked for, a submission by its summary marker alone — found, or locked. */
+  protected async reconcileOperations(
+    cp: CodeHostReviewControlPlane,
+    attempt: GiteaAttempt
+  ): Promise<GiteaReviewOutcome | undefined> {
+    const pending = [...(attempt.turn.hook.codeReview?.operations ?? [])]
+    if (pending.length === 0) return undefined
+    const outstanding: CodeReviewOperation[] = []
+    let reviews: ReviewRow[] | undefined
+    for (const op of pending) {
+      // A permit whose start was never acknowledged had no request: return it unused.
+      if (op.phase === 'issued' && (await this.returnUnused(cp, attempt, op)) !== 'started') continue
+      if (op.kind === 'bulk_publish') {
+        outstanding.push(op)
+        continue
+      }
+      reviews ??= await this.listReviews(attempt).catch(() => [])
+      const reviewId = op.target.split('/').at(-1) ?? ''
+      const present = reviews.some((review) => review.id === reviewId && review.state === 'PENDING')
+      await this.settleAndClear(
+        cp,
+        attempt,
+        op.recordId,
+        present
+          ? { kind: 'deterministic', status: 422, code: 'draft_present' }
+          : { kind: 'deterministic', status: 204, ...(idOf(reviewId) ? { externalId: reviewId } : {}) }
+      )
+    }
+    if (outstanding.length === 0) return undefined
+    // Only positive provider evidence can classify a permitted submission.
+    const found = await this.findSubmittedReview(attempt, attempt.attemptId, attempt.turn.expectedHeadSha).catch(
+      () => undefined
+    )
+    for (const op of outstanding) {
+      if (found) {
+        await this.settleAndClear(cp, attempt, op.recordId, {
+          kind: 'deterministic',
+          status: 200,
+          externalId: found.id
+        })
+      } else {
+        await this.settleAndClear(cp, attempt, op.recordId, { kind: 'ambiguous', code: 'publish_unreconciled' }, true)
+      }
+    }
+    if (!found) {
+      this.rememberLock(attempt, outstanding.at(-1)!.recordId)
+      return await this.settle(cp, attempt, 'ambiguous_locked')
+    }
+    attempt.externalIds.push({ kind: 'review', externalId: found.id })
+    return await this.settleSubmit(cp, attempt, { kind: 'submitted', review: found })
+  }
+
+  /** §10.3 step 2: delete the bot's pending reviews or refuse; every staged comment must carry another attempt's verified marker. */
+  private async reconcilePendingReviews(
+    cp: CodeHostReviewControlPlane,
+    attempt: GiteaAttempt
+  ): Promise<GiteaReviewOutcome | undefined> {
+    const { turn } = attempt
+    const orphans = (await this.listReviews(attempt)).filter(
+      (review) => review.userId === attempt.publisherUserId && review.state === 'PENDING'
+    )
+    for (const orphan of orphans) {
+      const comments = await this.get(attempt, `${this.pullPath(turn)}/reviews/${orphan.id}/comments`)
+      // A pending review records the head it was staged against; its markers verify under that head.
+      const stagedHead = orphan.commitId ?? turn.expectedHeadSha
+      for (const raw of Array.isArray(comments) ? comments : []) {
+        const marker = attempt.signer.read(text(record(raw).body), stagedHead)
+        if (!marker || marker.attemptId === attempt.attemptId.toLowerCase()) {
+          return this.settle(cp, attempt, 'review_reconciliation_required')
+        }
+      }
+      if (!(await this.deletePendingReview(cp, attempt, orphan.id))) {
+        return this.settle(cp, attempt, 'review_reconciliation_required')
+      }
+    }
+    return undefined
+  }
+
+  /** `DELETE …/reviews/:id` also removes a submitted review, so the state guard is re-read right before it (§16). */
+  private async deletePendingReview(
+    cp: CodeHostReviewControlPlane,
+    attempt: GiteaAttempt,
+    reviewId: string
+  ): Promise<boolean> {
+    const path = `${this.pullPath(attempt.turn)}/reviews/${reviewId}`
+    const current = record(await this.get(attempt, path).catch(() => undefined))
+    if (idOf(current.id) !== reviewId || current.state !== 'PENDING') return false
+    const outcome = await this.mutate(cp, attempt, 'draft_delete', 'DELETE', path, undefined)
+    if (outcome.kind === 'sent') return true
+    // A 404 is the same proven absence the delete was asking for.
+    if (outcome.kind === 'rejected') return outcome.status === 404
+    const remaining = await this.listReviews(attempt).catch(() => undefined)
+    if (remaining === undefined || remaining.some((review) => review.id === reviewId)) return false
+    // Read-after-ambiguous-delete proved the absence, so the record is upgraded, not left ambiguous.
+    await this.upgradeAmbiguous(cp, attempt, outcome.recordId, reviewId, 204)
+    return true
+  }
+
+  /** §10.3 steps 4-5: ONE `POST …/reviews` under one record, then marker-first recovery when it is unknown. */
+  private async submitReview(
+    cp: CodeHostReviewControlPlane,
+    attempt: GiteaAttempt,
+    event: CodeReviewEvent
+  ): Promise<SubmitResult> {
+    const { turn, req } = attempt
+    const attribution = await this.deps.attribution?.(turn)
+    const body = {
+      commit_id: turn.expectedHeadSha,
+      event: GITEA_EVENT[event],
+      body: this.render(req.body, attribution, attempt.signer.mint(attempt.attemptId, 0, turn.expectedHeadSha)),
+      comments: (req.comments ?? []).map((comment, index) => this.inlineComment(attempt, comment, index + 1))
+    }
+    const outcome = await this.mutate(cp, attempt, 'bulk_publish', 'POST', `${this.pullPath(turn)}/reviews`, body)
+    if (outcome.kind === 'rejected') {
+      const message = text(record(outcome.parsed).message) ?? ''
+      return outcome.status === 422 && SELF_REVIEW_REFUSAL.test(message)
+        ? { kind: 'self_review_forbidden' }
+        : { kind: 'not_submitted' }
+    }
+    if (outcome.kind === 'sent') {
+      const review = record(outcome.parsed)
+      const id = idOf(review.id)
+      const published = text(review.state)
+      if (id) attempt.externalIds.push({ kind: 'review', externalId: id })
+      return {
+        kind: 'submitted',
+        review: {
+          id: id ?? '',
+          ...(published && EVENT_OF_STATE[published] ? { event: EVENT_OF_STATE[published] } : {})
+        }
+      }
+    }
+    // §15.2: retain ownership and search the pull request for THIS attempt's summary marker.
+    const deadline = this.now() + (this.deps.ambiguousWindowMs ?? DEFAULT_AMBIGUOUS_WINDOW_MS)
+    for (;;) {
+      const found = await this.findSubmittedReview(attempt, attempt.attemptId, turn.expectedHeadSha).catch(
+        () => undefined
+      )
+      if (found) {
+        attempt.externalIds.push({ kind: 'review', externalId: found.id })
+        await this.upgradeAmbiguous(cp, attempt, outcome.recordId, found.id, 200)
+        return { kind: 'submitted', review: found }
+      }
+      if (this.now() >= deadline) break
+      await this.sleep(this.deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS)
+    }
+    // A pending review carrying this attempt's inline markers proves staging, not submission: still locked.
+    this.rememberLock(attempt, outcome.recordId)
+    return { kind: 'ambiguous_locked' }
+  }
+
+  /** A submitted (never pending, never reviewer-request) review by the bot carrying the attempt's summary marker. */
+  private async findSubmittedReview(
+    session: ReviewSession<GiteaReviewTurn>,
+    attemptId: string,
+    headSha: string
+  ): Promise<SubmittedReview | undefined> {
+    const signer = await this.markerSigner()
+    for (const review of await this.listReviews(session)) {
+      if (review.state === undefined || review.state === 'PENDING' || review.state === 'REQUEST_REVIEW') continue
+      const marker = signer.read(review.body, headSha)
+      if (marker?.attemptId !== attemptId.toLowerCase() || marker.ordinal !== 0) continue
+      const event = EVENT_OF_STATE[review.state]
+      return { id: review.id, ...(event ? { event } : {}) }
+    }
+    return undefined
+  }
+
+  /** Every review of the pull request, bounded; the list is unfiltered and shows the bot its own pending row (§16). */
+  private async listReviews(session: ReviewSession<GiteaReviewTurn>): Promise<ReviewRow[]> {
+    const rows: ReviewRow[] = []
+    for (let page = 1; page <= MAX_REVIEW_PAGES; page += 1) {
+      const parsed = await this.get(
+        session,
+        `${this.pullPath(session.turn)}/reviews`,
+        `page=${page}&limit=${REVIEW_PAGE_SIZE}`
+      )
+      const batch = reviewRows(parsed)
+      rows.push(...batch)
+      if (!Array.isArray(parsed) || parsed.length < REVIEW_PAGE_SIZE) break
+    }
+    return rows
+  }
+
+  /** The retained ambiguous submission, kept so a later pass on this pull request can clear the lock. */
+  private rememberLock(attempt: GiteaAttempt, recordId: string): void {
+    this.locked.set(subjectKey(attempt.turn), {
+      ref: {
+        turn: attempt.turn,
+        attemptId: attempt.attemptId,
+        fence: attempt.fence,
+        ...(attempt.orgId ? { orgId: attempt.orgId } : {})
+      },
+      recordId,
+      event: attempt.req.event,
+      verdict: attempt.req.verdict
+    })
+  }
+
+  /** The lock a replayed delivery's durable attempt still holds, if its submission record was retained. */
+  private lockedAttemptOf(turn: GiteaReviewTurn): LockedAttempt | undefined {
+    const attemptRecord = turn.hook.codeReview
+    if (attemptRecord?.state !== 'ambiguous_locked' || !attemptRecord.fence) return undefined
+    const submission = attemptRecord.operations?.find((op) => op.kind === 'bulk_publish' && op.phase === 'started')
+    if (!submission) return undefined
+    const orgId = this.deps.orgForAgent(turn.agentId)
+    return {
+      ref: { turn, attemptId: attemptRecord.attemptId, fence: attemptRecord.fence, ...(orgId ? { orgId } : {}) },
+      recordId: submission.recordId,
+      event: attemptRecord.event,
+      verdict: attemptRecord.verdict
+    }
+  }
+
+  /** The later pass (§10.3): only the marked review found submitted clears a lock — the owner names its object and re-reports submitted. */
+  private async reconcileLocked(cp: CodeHostReviewControlPlane, lock: LockedAttempt): Promise<boolean> {
+    const { ref } = lock
+    try {
+      const session: ReviewSession<GiteaReviewTurn> = { turn: ref.turn, token: await this.deps.token(ref.turn) }
+      const found = await this.findSubmittedReview(session, ref.attemptId, ref.turn.expectedHeadSha)
+      if (!found) return false
+      await cp.operate(
+        {
+          op: 'settle',
+          attemptId: ref.attemptId,
+          fence: ref.fence,
+          recordId: lock.recordId,
+          outcome: { kind: 'deterministic', status: 200, externalId: found.id }
+        },
+        ref.orgId
+      )
+      const externalIds: CodeHostReviewExternalRef[] = [{ kind: 'review', externalId: found.id }]
+      await cp.report(
+        this.resultFrame(ref.turn, ref.attemptId, lock.event, lock.verdict, {
+          headSha: ref.turn.expectedHeadSha,
+          state: 'submitted',
+          externalIds
+        }),
+        ref.orgId
+      )
+      // The durable row follows best-effort: the control plane already holds the definite outcome.
+      const attemptRecord = ref.turn.hook.codeReview
+      if (attemptRecord?.attemptId === ref.attemptId) {
+        attemptRecord.state = 'submitted'
+        attemptRecord.externalIds = externalIds
+        attemptRecord.operations = attemptRecord.operations?.filter((op) => op.recordId !== lock.recordId)
+        delete attemptRecord.resultOwed
+        await ref.turn.persist().catch(() => undefined)
+      }
+      return true
+    } catch (err) {
+      this.warn(`lock reconciliation deferred (${err instanceof Error ? err.message : err})`)
+      return false
+    }
+  }
+
+  /** Single-line inline comments (§10.3): `RIGHT` → `new_position`, `LEFT` → `old_position`; a range collapses to its end line and names its start first. */
+  private inlineComment(
+    attempt: GiteaAttempt,
+    comment: CodeReviewInlineComment,
+    ordinal: number
+  ): Record<string, unknown> {
+    const range = comment.startLine !== undefined && comment.startLine !== comment.line
+    const lead = range ? `Lines ${comment.startLine}-${comment.line}:\n\n` : ''
+    const body = `${lead}${ReviewMarkerSigner.neutralize(comment.body)}\n\n${attempt.signer.mint(attempt.attemptId, ordinal, attempt.turn.expectedHeadSha)}`
+    return {
+      path: comment.path,
+      body,
+      ...(comment.side === 'LEFT' ? { old_position: comment.line } : { new_position: comment.line })
+    }
+  }
+
+  private render(body: string, attribution: GithubCommentAttribution | undefined, marker: string): string {
+    return appendGithubMarkdownChrome(
+      ReviewMarkerSigner.neutralize(body),
+      `${githubAttributionFooter(attribution)}\n\n${marker}`
+    )
+  }
+
+  private pullPath(turn: GiteaReviewTurn): string {
+    return `${giteaRepoPath(turn.repoPath)}/pulls/${turn.subjectNumber}`
+  }
+}

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -1,151 +1,47 @@
-/**
- * The GitLab formal merge-request review adapter (gitlab-com-integration.md §15).
- *
- * One attempt per active turn, under the Control Plane's durable publication
- * lease: reconcile before create, marker-signed drafts created under single-use
- * operation records, head and reviewer state re-verified around ONE bulk publish,
- * tier-aware postcondition classification, and an approval fenced on the exact
- * head. Every ambiguous effect fails closed — no republish, no ordinary fallback.
- *
- * The target project, merge-request IID, and head come from daemon-private
- * active-turn state; they are never tool input. Review bodies never reach the
- * Control Plane: the result frame carries ids and one normalized state only.
- */
-import { randomUUID } from 'node:crypto'
-import { WireError } from '@agentconnect.md/connection'
+// GitLab formal merge-request reviews (gitlab-com-integration.md §15): the thirteen steps over the seam's engine in codehost/review-attempt.ts.
 import {
   codeHostReviewPublicEffect,
-  type CodeHostReviewAuthorize,
-  type CodeHostReviewAuthorized,
-  type CodeHostReviewExternalRef,
-  type CodeHostReviewLeaseRenew,
-  type CodeHostReviewLeaseRenewed,
-  type CodeHostReviewOpAccepted,
-  type CodeHostReviewOpKind,
-  type CodeHostReviewOpMethod,
-  type CodeHostReviewOpRequest,
   type CodeHostReviewOpOutcome,
-  type CodeHostReviewResultOk,
-  type CodeHostReviewResultReport,
-  type CodeHostReviewState,
-  type HookConfigSnapshot
+  type CodeHostReviewRefusalReason,
+  type CodeHostReviewState
 } from '@agentconnect.md/protocol'
-import { reviewPolicyAllows, type CodeReviewOperation, type HookDispatchContext } from '../github/hook-coords.js'
+import type { CodeReviewOperation, HookDispatchContext } from '../github/hook-coords.js'
 import { gitlabOpensReviewGeneration } from '../messages/hook-message.js'
+import type { SubmitCodeReviewReq } from '../codehost/review-adapter.js'
 import {
-  validateCodeReviewInput,
-  type CodeHostReviewAdapter,
-  type CodeReviewEvent,
-  type CodeReviewVerdict,
-  type SubmitCodeReviewReq
-} from '../codehost/review-adapter.js'
-import {
-  appendGithubMarkdownChrome,
-  githubAttributionFooter,
-  type GithubCommentAttribution,
-  type PosterScheduler
-} from '../github/poster.js'
-import { parseGitlabJson } from './broker.js'
-import { ReviewMarkerSigner } from './review-marker.js'
+  CodeHostReviewAttemptAdapter,
+  idOf,
+  record,
+  text,
+  DEFAULT_AMBIGUOUS_WINDOW_MS,
+  DEFAULT_POLL_INTERVAL_MS,
+  type CodeHostReviewAdapterDeps,
+  type CodeHostReviewAttempt,
+  type CodeHostReviewOutcome,
+  type CodeHostReviewTurn,
+  type PreLeaseFacts,
+  type ReviewSession
+} from '../codehost/review-attempt.js'
+import type { CodeHostReviewControlPlane } from '../codehost/review-outbox.js'
+import { appendGithubMarkdownChrome, githubAttributionFooter, type GithubCommentAttribution } from '../github/poster.js'
+import { ReviewMarkerSigner } from '../codehost/review-marker.js'
 
-/** One authorized merge-request review turn; every field is trusted daemon state. */
-export interface GitlabReviewTurn {
-  hookId: string
-  agentId: string
-  deliveryKey: string
-  snapshot: HookConfigSnapshot
-  /** Numeric project id (decimal string) — the rename-stable match key. */
-  projectId: string
-  projectPath: string
-  mergeRequestIid: number
-  expectedHeadSha: string
-  expectedBaseSha?: string
-  sessionId: string
-  /** The durable hook row this attempt's identity and outcome live on (§15, §15.2). */
-  hook: HookDispatchContext
-  /** Persist that row; `required` makes a failed write fail the caller. */
-  persist: (required?: boolean) => Promise<void>
-  /** §15 step 1: one review attempt per turn, reserved synchronously. */
-  state: 'idle' | 'submitting' | 'done'
-}
+export type { ReviewIntentRow, ReviewIntentStore } from '../codehost/review-outbox.js'
 
-/** One control-plane frame a finished attempt still owes, replayed verbatim until acked (§15.1). */
-export interface ReviewIntentRow {
-  intentId: string
-  daemonId: string
-  attemptId: string
-  orgId?: string
-  kind: 'operation' | 'result'
-  /** The exact JSON payload; both frames are idempotent REQs by contract. */
-  frame: string
-  attempts: number
-}
-
-export interface ReviewIntentStore {
-  recordReviewIntent(row: ReviewIntentRow, now: number): Promise<void>
-  clearReviewIntent(intentId: string): Promise<void>
-  listReviewIntents(daemonId: string): Promise<ReviewIntentRow[]>
-}
+/** One authorized merge-request review turn: `repoId` is the numeric project id, `subjectNumber` the MR IID. */
+export type GitlabReviewTurn = CodeHostReviewTurn
 
 /** The narrow Control-Plane surface this adapter needs (§15.1 lease + operation ledger). */
-export interface GitlabReviewControlPlane {
-  /** The CP advertises `codehost-review-v1`; without it the adapter refuses before any effect. */
-  supportsReview(): boolean
-  authorize(payload: CodeHostReviewAuthorize, orgId?: string): Promise<CodeHostReviewAuthorized>
-  operate(payload: CodeHostReviewOpRequest, orgId?: string): Promise<CodeHostReviewOpAccepted>
-  renew(payload: CodeHostReviewLeaseRenew, orgId?: string): Promise<CodeHostReviewLeaseRenewed>
-  report(payload: CodeHostReviewResultReport, orgId?: string): Promise<CodeHostReviewResultOk>
-}
+export type GitlabReviewControlPlane = CodeHostReviewControlPlane
 
-export interface GitlabReviewAdapterDeps {
-  cp: () => GitlabReviewControlPlane | undefined
-  orgForAgent: (agentId: string) => string | undefined
-  /** The STABLE daemon identity owed frames are recovered under — never a process incarnation. */
-  daemonId: () => string | undefined
-  store: ReviewIntentStore
-  /** Restart-stable marker key; see the trust model on {@link ReviewMarkerSigner}. */
-  markerKey: () => Promise<Buffer>
-  /** §14.1 effect lease: the binding's effect PAT; it never enters the agent environment. */
-  token: (turn: GitlabReviewTurn) => Promise<string>
-  invalidateToken: (turn: GitlabReviewTurn, token: string) => void
-  attribution?: (turn: GitlabReviewTurn) => Promise<GithubCommentAttribution | undefined>
-  log: { warn: (message: string) => void }
-  /** The instance's `/api/v4` root for THIS turn's agent, resolved per turn (§24.4). */
-  apiBaseUrl: (turn: GitlabReviewTurn) => string
-  fetchImpl?: typeof fetch
-  newAttemptId?: () => string
-  newStartToken?: () => string
-  now?: () => number
-  sleep?: (ms: number) => Promise<void>
-  /** §15.2 bounded observation window for an ambiguous bulk publish. */
-  ambiguousWindowMs?: number
+export interface GitlabReviewAdapterDeps extends CodeHostReviewAdapterDeps<GitlabReviewTurn> {
   /** §15.2/§15 step 13 bounded wait for `detailed_merge_status` to leave its unstable values. */
   mergeStatusWindowMs?: number
-  pollIntervalMs?: number
-  /** Timer seam for the owed-frame resweep; tests drive it, production uses real timers. */
-  scheduler?: PosterScheduler
-  resweepBaseMs?: number
-  resweepCapMs?: number
 }
 
-/** The model-visible outcome: one normalized state plus a plain-English sentence. */
-export interface GitlabReviewOutcome {
-  provider: 'gitlab'
-  state: CodeHostReviewState
-  event: CodeReviewEvent
-  verdict: CodeReviewVerdict
-  message: string
-  externalIds?: CodeHostReviewExternalRef[]
-}
+export type GitlabReviewOutcome = CodeHostReviewOutcome
 
-const DEFAULT_TIMEOUT_MS = 20_000
-const DEFAULT_AMBIGUOUS_WINDOW_MS = 30_000
 const DEFAULT_MERGE_STATUS_WINDOW_MS = 30_000
-const DEFAULT_POLL_INTERVAL_MS = 2_000
-const DEFAULT_RESWEEP_BASE_MS = 30_000
-const DEFAULT_RESWEEP_CAP_MS = 300_000
-/** Pages of owed frames one sweep drains; the store answers a bounded page at a time. */
-const MAX_SWEEP_PAGES = 50
 const MAX_NOTE_PAGES = 10
 const NOTES_PER_PAGE = 100
 const MAX_DRAFTS = 100
@@ -175,27 +71,11 @@ const OUTCOME_SENTENCE: Record<CodeHostReviewState, string> = {
     'Pending review drafts on this merge request could not be reconciled, so no review was published and this merge request stays fail-closed.'
 }
 
-/** What a settle left behind: nothing, replayable coordinates, or no replay source at all. */
-type SettleDisposition = 'safe' | 'replayable' | 'blocked'
-
-/** The terminal result is withheld until every unsafe settle has a durable replay source. */
-class ResultWithheld extends Error {
-  constructor() {
-    super('the formal review outcome could not be made durable yet; the daemon will retry before reporting it')
-    this.name = 'ResultWithheld'
-  }
-}
-
-class AmbiguousSend extends Error {
-  constructor(readonly code: string) {
-    super(`GitLab review request outcome is unknown (${code})`)
-    this.name = 'AmbiguousSend'
-  }
-}
-
-interface SendResult {
-  status: number
-  parsed: unknown
+const REFUSAL_DETAIL: Partial<Record<CodeHostReviewRefusalReason, string>> = {
+  lease_held: ' Another review attempt currently owns publication on this merge request.',
+  head_changed: ' The merge request head changed while this turn was running.',
+  policy_denied: " This hook's review policy does not permit that review event.",
+  binding_unavailable: ' This project has no ready GitLab binding to publish as.'
 }
 
 interface DraftNote {
@@ -217,51 +97,15 @@ interface MergeRequestFacts {
   numericId?: string
 }
 
-/** The turn plus its live effect token; the token is re-minted in place on a refresh. */
-interface Session {
-  turn: GitlabReviewTurn
-  token: string
+interface GitlabFacts extends PreLeaseFacts {
+  reviewerBefore?: ReviewerRecord
 }
 
-/** What a ledger frame needs to name itself — an in-flight attempt or a recovered record. */
-interface LeaseRef {
-  turn: GitlabReviewTurn
-  attemptId: string
-  fence: string
-  orgId?: string
-}
-
-/** Everything one attempt carries between steps. */
-interface Attempt extends Session {
-  req: SubmitCodeReviewReq
-  signer: ReviewMarkerSigner
-  orgId?: string
-  attemptId: string
-  fence: string
-  serviceAccountUserId: string
-  /** Per-kind monotonic operation-record counter; a retried mutation takes the next one. */
-  ordinals: Map<CodeHostReviewOpKind, number>
+/** Everything one GitLab attempt carries between steps. */
+interface GitlabAttempt extends CodeHostReviewAttempt<GitlabReviewTurn> {
   /** Draft ordinal (0 = summary) → provider draft id, for the exact-set check. */
   drafts: Map<number, string>
-  externalIds: CodeHostReviewExternalRef[]
   reviewerBefore?: ReviewerRecord
-  /** A settle this attempt owes has no durable replay source yet, so no result may be reported. */
-  settleBlocked?: boolean
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
-}
-
-/** A big-int-safe numeric id as a decimal string; undefined when the value is not one. */
-function idOf(value: unknown): string | undefined {
-  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) return value
-  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return String(value)
-  return undefined
-}
-
-function text(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 function mergeRequestFacts(parsed: unknown): MergeRequestFacts | undefined {
@@ -298,37 +142,13 @@ function draftNotes(parsed: unknown): DraftNote[] {
   })
 }
 
-export class GitlabReviewAdapter implements CodeHostReviewAdapter {
+export class GitlabReviewAdapter extends CodeHostReviewAttemptAdapter<GitlabReviewTurn, GitlabAttempt, GitlabFacts> {
   readonly provider = 'gitlab' as const
+  protected readonly hostLabel = 'GitLab'
+  protected readonly subjectLabel = 'merge-request'
 
-  private readonly turns = new Map<string, GitlabReviewTurn>()
-  private readonly now: () => number
-  private readonly sleep: (ms: number) => Promise<void>
-  private readonly sched: PosterScheduler
-  private signerPromise?: Promise<ReviewMarkerSigner>
-  /** Owed frames whose durable write has not landed yet; replayed and re-written from here. */
-  private readonly unwritten = new Map<string, ReviewIntentRow>()
-  private resweepHandle?: unknown
-  private resweepAttempt = 0
-  /** Monotonic count of arm REQUESTS, so a zero-work disarm can tell whether it raced new work. */
-  private armGeneration = 0
-  private sweeping = false
-  private stopped = false
-
-  constructor(private readonly deps: GitlabReviewAdapterDeps) {
-    this.now = deps.now ?? (() => Date.now())
-    this.sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
-    this.sched = deps.scheduler ?? {
-      now: () => Date.now(),
-      setTimeout: (fn, ms) => setTimeout(fn, ms),
-      clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout)
-    }
-  }
-
-  /** Drop the pending resweep so a shutting-down daemon leaves no timer behind. */
-  stop(): void {
-    this.stopped = true
-    this.clearTimer()
+  constructor(protected override readonly deps: GitlabReviewAdapterDeps) {
+    super(deps)
   }
 
   /**
@@ -358,9 +178,9 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       agentId: hook.agentId,
       deliveryKey: hook.deliveryKey,
       snapshot,
-      projectId: gitlab.projectId,
-      projectPath: gitlab.projectPath,
-      mergeRequestIid: gitlab.target.iid,
+      repoId: gitlab.projectId,
+      repoPath: gitlab.projectPath,
+      subjectNumber: gitlab.target.iid,
       expectedHeadSha: gitlab.target.headSha,
       ...(gitlab.target.baseSha ? { expectedBaseSha: gitlab.target.baseSha } : {}),
       sessionId,
@@ -372,166 +192,36 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return turn
   }
 
-  /** The restart-stable signer, minted from the daemon store on first use. */
-  private markerSigner(): Promise<ReviewMarkerSigner> {
-    this.signerPromise ??= this.deps.markerKey().then((key) => new ReviewMarkerSigner(key))
-    return this.signerPromise
+  protected outcomeSentence(state: CodeHostReviewState): string {
+    return OUTCOME_SENTENCE[state]
   }
 
-  closeTurn(key: string, turn?: GitlabReviewTurn): void {
-    if (turn && this.turns.get(key) !== turn) return
-    this.turns.delete(key)
+  protected refusalDetail(reason: CodeHostReviewRefusalReason): string {
+    return REFUSAL_DETAIL[reason] ?? ''
   }
 
-  owns(key: string, agentId: string): boolean {
-    return this.turns.get(key)?.agentId === agentId
+  protected authHeaders(token: string): Record<string, string> {
+    return { 'private-token': token }
   }
 
-  async submit(key: string, req: SubmitCodeReviewReq): Promise<GitlabReviewOutcome> {
-    const turn = this.turns.get(key)
-    if (!turn || turn.agentId !== req.agentId) {
-      throw new Error('a formal GitLab review is only available during the active merge-request hook turn')
-    }
-    // §15: an incompatible pair or unusable body is rejected before any provider effect.
-    const invalid = validateCodeReviewInput(req)
-    if (invalid) throw new Error(invalid)
-    if (!reviewPolicyAllows(turn.snapshot.reviewPolicy, req.event)) {
-      throw new Error(`${req.event} exceeds this hook's ${turn.snapshot.reviewPolicy} review policy`)
-    }
-    if (turn.state !== 'idle') throw new Error('this merge-request hook turn already has a formal review attempt')
-    // §15 step 1: turn-local CAS before the first await.
-    turn.state = 'submitting'
-    const cp = this.deps.cp()
-    if (!cp) {
-      turn.state = 'done'
-      throw new Error('control plane is not connected; formal review denied')
-    }
-    if (!cp.supportsReview()) {
-      turn.state = 'done'
-      throw new Error('the control plane does not serve formal code-host reviews yet (codehost-review-v1)')
-    }
-    try {
-      const outcome = await this.run(turn, req, cp)
-      // A proven no-effect outcome leaves the turn free to correct its input and retry.
-      turn.state = codeHostReviewPublicEffect(outcome.state) === 'absent' ? 'idle' : 'done'
-      return outcome
-    } catch (err) {
-      // A retryable wire failure before the lease exists wrote nothing; once it does, a replay could publish twice.
-      if (err instanceof WireError && err.retryable && turn.hook.codeReview?.fence === undefined) {
-        turn.state = 'idle'
-        throw new Error(`formal review not submitted: control plane unreachable (${err.message}); call the tool again`)
-      }
-      // A withheld result leaves the turn open and the attempt pre-terminal, by design.
-      turn.state = err instanceof ResultWithheld ? 'idle' : 'done'
-      throw err
-    }
-  }
-
-  /**
-   * RECORD-FIRST (§15, §15.1): the attempt identity lands on the durable hook row
-   * before any provider or control-plane call, so a crash replays the SAME attempt —
-   * its lease is reacquired idempotently and its marked drafts are recoverable. A
-   * prior attempt that proved no effect is superseded by a fresh id.
-   */
-  private async reserveAttempt(turn: GitlabReviewTurn, req: SubmitCodeReviewReq): Promise<string> {
-    const prior = turn.hook.codeReview
-    const recovering = prior !== undefined && prior.state === undefined
-    if (recovering) {
-      if (prior.event !== req.event || prior.verdict !== req.verdict || prior.headSha !== turn.expectedHeadSha) {
-        throw new Error('a recovered formal-review attempt must keep its original event, verdict, and head')
-      }
-      return prior.attemptId
-    }
-    const attemptId = (this.deps.newAttemptId ?? randomUUID)()
-    turn.hook.codeReview = {
-      attemptId,
-      event: req.event,
-      verdict: req.verdict,
-      headSha: turn.expectedHeadSha
-    }
-    try {
-      await turn.persist(true)
-    } catch (err) {
-      if (prior) turn.hook.codeReview = prior
-      else delete turn.hook.codeReview
-      throw new Error(`formal review durability barrier failed: ${err instanceof Error ? err.message : String(err)}`)
-    }
-    return attemptId
-  }
-
-  private async run(
-    turn: GitlabReviewTurn,
-    req: SubmitCodeReviewReq,
-    cp: GitlabReviewControlPlane
-  ): Promise<GitlabReviewOutcome> {
-    const orgId = this.deps.orgForAgent(turn.agentId)
-    const attemptId = await this.reserveAttempt(turn, req)
-    const signer = await this.markerSigner()
-    const session: Session = { turn, token: await this.deps.token(turn) }
-
-    // Read pre-lease so the authz can carry the §15 step 6/7 reviewer fact and prove the leased account is ours.
-    const serviceAccountUserId = idOf(record(await this.get(session, '/user')).id)
-    if (!serviceAccountUserId) throw new Error('GitLab did not identify the review publishing account')
-    const reviewersBefore = reviewerRecords(await this.get(session, this.mrPath(turn, '/reviewers')))
-    const reviewerBefore = reviewersBefore.find((row) => row.userId === serviceAccountUserId)
-
-    // §15 steps 2-3: the durable publication lease and the CP's authorization in one round trip.
-    const authorized = await cp.authorize(
-      {
-        hookId: turn.hookId,
-        deliveryKey: turn.deliveryKey,
-        attemptId,
-        provider: 'gitlab',
-        projectId: turn.projectId,
-        mergeRequestIid: turn.mergeRequestIid,
-        requestedEvent: req.event,
-        requestedVerdict: req.verdict,
-        snapshot: turn.snapshot,
-        headSha: turn.expectedHeadSha,
-        ...(turn.expectedBaseSha ? { baseSha: turn.expectedBaseSha } : {}),
-        serviceAccountIsReviewer: reviewerBefore !== undefined
-      },
-      orgId
-    )
-    if (!authorized.authorized) return await this.refused(turn, req, authorized)
-    if (
-      authorized.projectId !== turn.projectId ||
-      authorized.mergeRequestIid !== turn.mergeRequestIid ||
-      authorized.expectedHeadSha !== turn.expectedHeadSha
-    ) {
-      throw new Error('control plane returned a mismatched formal-review target')
-    }
-
-    const attempt: Attempt = {
-      turn,
-      req,
-      signer,
-      ...(orgId ? { orgId } : {}),
-      attemptId,
-      fence: authorized.lease.fence,
-      token: session.token,
-      serviceAccountUserId,
-      // Seeded from the durable record: a replayed attempt must never reuse a spent coordinate.
-      ordinals: new Map(
-        Object.entries(turn.hook.codeReview?.ordinals ?? {}).map(([kind, next]) => [kind as CodeHostReviewOpKind, next])
-      ),
-      drafts: new Map(),
-      externalIds: [],
+  /** Read pre-lease so the authz can carry the §15 step 6/7 reviewer fact and prove the leased account is ours. */
+  protected async preLeaseFacts(session: ReviewSession<GitlabReviewTurn>): Promise<GitlabFacts> {
+    const publisherUserId = idOf(record(await this.get(session, '/user')).id)
+    if (!publisherUserId) throw new Error('GitLab did not identify the review publishing account')
+    const reviewersBefore = reviewerRecords(await this.get(session, this.mrPath(session.turn, '/reviewers')))
+    const reviewerBefore = reviewersBefore.find((row) => row.userId === publisherUserId)
+    return {
+      publisherUserId,
+      serviceAccountIsReviewer: reviewerBefore !== undefined,
       ...(reviewerBefore ? { reviewerBefore } : {})
     }
-    // The fence rides the durable record so an owed ledger frame stays derivable after a restart.
-    if (turn.hook.codeReview) {
-      turn.hook.codeReview.fence = attempt.fence
-      await turn.persist(true)
-    }
-    // The leased publishing identity must be the account this effect token speaks as.
-    if (authorized.lease.serviceAccountUserId !== serviceAccountUserId) {
-      return this.settle(cp, attempt, 'not_submitted')
-    }
-    return await this.publish(cp, attempt)
   }
 
-  private async publish(cp: GitlabReviewControlPlane, attempt: Attempt): Promise<GitlabReviewOutcome> {
+  protected openAttempt(base: CodeHostReviewAttempt<GitlabReviewTurn>, facts: GitlabFacts): GitlabAttempt {
+    return { ...base, drafts: new Map(), ...(facts.reviewerBefore ? { reviewerBefore: facts.reviewerBefore } : {}) }
+  }
+
+  protected async publish(cp: CodeHostReviewControlPlane, attempt: GitlabAttempt): Promise<GitlabReviewOutcome> {
     const { turn, req } = attempt
 
     // §15.1: a request this attempt already permitted must be classified against the
@@ -602,9 +292,9 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
    * issues another. A publication or approval that got that far is TERMINAL — the
    * attempt must never create or publish again.
    */
-  private async reconcileOperations(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt
+  protected async reconcileOperations(
+    cp: CodeHostReviewControlPlane,
+    attempt: GitlabAttempt
   ): Promise<GitlabReviewOutcome | undefined> {
     const pending = [...(attempt.turn.hook.codeReview?.operations ?? [])]
     if (pending.length === 0) return undefined
@@ -668,90 +358,11 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return await this.settle(cp, attempt, 'review_state_not_recorded')
   }
 
-  /**
-   * Hand back a permit no request ever started (§15.1's second transfer condition).
-   *
-   * `returned` — acknowledged, so the coordinates are gone. `started` — the control plane
-   * had already recorded the start, so the local phase raced behind it and the caller must
-   * classify by provider evidence instead. `deferred` — nothing was decided, so the
-   * coordinates stay exactly as they are.
-   */
-  private async returnUnused(
-    cp: GitlabReviewControlPlane,
-    ref: LeaseRef,
-    op: CodeReviewOperation
-  ): Promise<'returned' | 'started' | 'deferred'> {
-    try {
-      await cp.operate(
-        { op: 'return-unused', attemptId: ref.attemptId, fence: ref.fence, recordId: op.recordId },
-        ref.orgId
-      )
-      await this.clearOperation(ref, op.recordId)
-      return 'returned'
-    } catch (err) {
-      // A permanent refusal means the record moved on without this daemon; evidence decides.
-      if ((err as { retryable?: unknown }).retryable === false) return 'started'
-      this.warn(`gitlab review: unused permit return deferred (${err instanceof Error ? err.message : err})`)
-      return 'deferred'
-    }
-  }
-
-  /**
-   * Rebuild the frames a restart can owe WITHOUT provider evidence: an unstarted permit is
-   * returned, and a classified attempt whose result never became durable is re-owed. An
-   * operation that did start needs a marker read, so it waits for the turn's own replay.
-   */
-  async recoverTurn(turn: GitlabReviewTurn): Promise<void> {
-    const attemptRecord = turn.hook.codeReview
-    const cp = this.deps.cp()
-    if (!attemptRecord || !cp || !cp.supportsReview()) return
-    const fence = attemptRecord.fence
-    const orgId = this.deps.orgForAgent(turn.agentId)
-    if (fence) {
-      const ref: LeaseRef = { turn, attemptId: attemptRecord.attemptId, fence, ...(orgId ? { orgId } : {}) }
-      for (const op of [...(attemptRecord.operations ?? [])]) {
-        // An unstarted permit is handed back; a started one replays the outcome parked on it.
-        if (op.phase === 'issued') {
-          await this.returnUnused(cp, ref, op)
-          continue
-        }
-        if (!op.outcome) continue
-        if (await this.owe(cp, this.settleIntent(ref, op.recordId, op.outcome))) {
-          await this.clearOperation(ref, op.recordId)
-        }
-      }
-    }
-    if (!attemptRecord.resultOwed || !attemptRecord.state) return
-    const safe = await this.owe(cp, {
-      intentId: `${attemptRecord.attemptId}:result`,
-      daemonId: this.deps.daemonId() ?? '',
-      attemptId: attemptRecord.attemptId,
-      ...(orgId ? { orgId } : {}),
-      kind: 'result',
-      frame: JSON.stringify({
-        hookId: turn.hookId,
-        deliveryKey: turn.deliveryKey,
-        attemptId: attemptRecord.attemptId,
-        snapshot: turn.snapshot,
-        provider: 'gitlab',
-        projectId: turn.projectId,
-        mergeRequestIid: turn.mergeRequestIid,
-        event: attemptRecord.event,
-        verdict: attemptRecord.verdict,
-        headSha: attemptRecord.headSha,
-        state: attemptRecord.state,
-        ...(attemptRecord.externalIds?.length ? { externalIds: attemptRecord.externalIds } : {})
-      } satisfies CodeHostReviewResultReport),
-      attempts: 0
-    })
-    if (safe) await this.clearResultOwed(turn)
-  }
-
   /** A draft create is proven by its marker; a draft delete is proven by the absence it asked for. */
   private classifyDraftOperation(
     op: CodeReviewOperation,
     marked: Map<number, string>,
-    attempt: Attempt
+    attempt: GitlabAttempt
   ): CodeHostReviewOpOutcome {
     if (op.kind === 'draft_create') {
       const draftId = op.draftOrdinal === undefined ? undefined : marked.get(op.draftOrdinal)
@@ -768,35 +379,10 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return { kind: 'deterministic', status: 204, ...(idOf(draftId) ? { externalId: draftId } : {}) }
   }
 
-  /** RECORD-FIRST: the coordinates of the one permitted request, before it is permitted. */
-  private async noteOperation(attempt: Attempt, op: CodeReviewOperation): Promise<void> {
-    const attemptRecord = attempt.turn.hook.codeReview
-    if (!attemptRecord) return
-    attemptRecord.ordinals = Object.fromEntries(attempt.ordinals)
-    attemptRecord.operations = [...(attemptRecord.operations ?? []).filter((e) => e.recordId !== op.recordId), op]
-    await attempt.turn.persist(true)
-  }
-
-  /** Flip the local phase once the control plane acknowledged the start transition. */
-  private async markOperationStarted(attempt: Attempt, recordId: string): Promise<void> {
-    const op = attempt.turn.hook.codeReview?.operations?.find((entry) => entry.recordId === recordId)
-    if (!op || op.phase === 'started') return
-    op.phase = 'started'
-    await attempt.turn.persist(true)
-  }
-
-  /** Settled, so the coordinates are no longer owed. A lost removal costs one idempotent re-settle. */
-  private async clearOperation(ref: LeaseRef, recordId: string): Promise<void> {
-    const attemptRecord = ref.turn.hook.codeReview
-    if (!attemptRecord?.operations) return
-    attemptRecord.operations = attemptRecord.operations.filter((op) => op.recordId !== recordId)
-    await ref.turn.persist().catch(() => undefined)
-  }
-
   /** §15.1 orphan recovery, run while holding the lease and before any create. */
   private async reconcileDrafts(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt
+    cp: CodeHostReviewControlPlane,
+    attempt: GitlabAttempt
   ): Promise<GitlabReviewOutcome | undefined> {
     const { turn } = attempt
     const pending = draftNotes(await this.get(attempt, this.mrPath(turn, '/draft_notes')))
@@ -820,7 +406,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   /** Delete one stale draft, with the read-after-ambiguous-delete §15.1 requires. */
-  private async deleteDraft(cp: GitlabReviewControlPlane, attempt: Attempt, draftId: string): Promise<boolean> {
+  private async deleteDraft(cp: CodeHostReviewControlPlane, attempt: GitlabAttempt, draftId: string): Promise<boolean> {
     const path = this.mrPath(attempt.turn, `/draft_notes/${draftId}`)
     const outcome = await this.mutate(cp, attempt, 'draft_delete', 'DELETE', path, undefined)
     if (outcome.kind === 'sent') return true
@@ -833,7 +419,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return true
   }
 
-  private async deleteAttemptDrafts(cp: GitlabReviewControlPlane, attempt: Attempt): Promise<void> {
+  private async deleteAttemptDrafts(cp: CodeHostReviewControlPlane, attempt: GitlabAttempt): Promise<void> {
     for (const draftId of [...attempt.drafts.values()]) {
       await this.deleteDraft(cp, attempt, draftId).catch(() => false)
     }
@@ -842,8 +428,8 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
 
   /** §15 step 8: one regular summary draft plus one diff draft per inline comment. */
   private async createDrafts(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
+    cp: CodeHostReviewControlPlane,
+    attempt: GitlabAttempt,
     facts: MergeRequestFacts
   ): Promise<GitlabReviewOutcome | undefined> {
     const { turn, req } = attempt
@@ -893,7 +479,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return undefined
   }
 
-  private async findDraftByOrdinal(attempt: Attempt, ordinal: number): Promise<string | undefined> {
+  private async findDraftByOrdinal(attempt: GitlabAttempt, ordinal: number): Promise<string | undefined> {
     const pending = draftNotes(await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')).catch(() => []))
     for (const draft of pending) {
       const marker = attempt.signer.read(draft.note, attempt.turn.expectedHeadSha)
@@ -902,13 +488,13 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return undefined
   }
 
-  private async listDraftIds(attempt: Attempt): Promise<Set<string>> {
+  private async listDraftIds(attempt: GitlabAttempt): Promise<Set<string>> {
     const pending = draftNotes(await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')))
     return new Set(pending.map((draft) => draft.id))
   }
 
   /** §15 step 9/11: every pending draft carries this attempt's marker and the ordinal set is exact. */
-  private async draftSetIsExact(attempt: Attempt): Promise<boolean> {
+  private async draftSetIsExact(attempt: GitlabAttempt): Promise<boolean> {
     const pending = draftNotes(
       await this.get(attempt, this.mrPath(attempt.turn, '/draft_notes')).catch(() => undefined)
     )
@@ -923,15 +509,15 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return seen.size === attempt.drafts.size
   }
 
-  private async readReviewer(attempt: Attempt): Promise<ReviewerRecord | undefined> {
+  private async readReviewer(attempt: GitlabAttempt): Promise<ReviewerRecord | undefined> {
     const rows = reviewerRecords(await this.get(attempt, this.mrPath(attempt.turn, '/reviewers')))
-    return rows.find((row) => row.userId === attempt.serviceAccountUserId)
+    return rows.find((row) => row.userId === attempt.publisherUserId)
   }
 
   /** §15 step 11 + §15.2: ONE bulk publish, then marker-first recovery when it is unknown. */
   private async bulkPublish(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt
+    cp: CodeHostReviewControlPlane,
+    attempt: GitlabAttempt
   ): Promise<'published' | 'not_submitted' | 'ambiguous_locked'> {
     const outcome = await this.mutate(
       cp,
@@ -962,7 +548,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     return 'ambiguous_locked'
   }
 
-  private async findSummaryNote(attempt: Attempt): Promise<string | undefined> {
+  private async findSummaryNote(attempt: GitlabAttempt): Promise<string | undefined> {
     for (let page = 1; page <= MAX_NOTE_PAGES; page += 1) {
       const parsed = await this.get(
         attempt,
@@ -982,7 +568,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
 
   /** §15 step 12 / §15.2: publication success alone never proves the recorded state. */
   private async classifyPostcondition(
-    attempt: Attempt,
+    attempt: GitlabAttempt,
     before: ReviewerRecord | undefined
   ): Promise<CodeHostReviewState> {
     let after: ReviewerRecord | undefined
@@ -1004,7 +590,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   /** Read `detailed_merge_status` after it leaves its unstable values, optionally forcing a recheck. */
-  private async stableMergeStatus(attempt: Attempt, recheck: boolean): Promise<string | undefined> {
+  private async stableMergeStatus(attempt: GitlabAttempt, recheck: boolean): Promise<string | undefined> {
     const deadline = this.now() + (this.deps.mergeStatusWindowMs ?? DEFAULT_MERGE_STATUS_WINDOW_MS)
     for (;;) {
       const facts = mergeRequestFacts(
@@ -1023,8 +609,8 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
 
   /** §15 step 13: the SHA-fenced approval, and its readback. A failure here never falls back. */
   private async approve(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
+    cp: CodeHostReviewControlPlane,
+    attempt: GitlabAttempt,
     facts: MergeRequestFacts
   ): Promise<CodeHostReviewState> {
     const status = await this.stableMergeStatus(attempt, false)
@@ -1054,7 +640,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   /** The approval endpoint needs a settled diff; a null `patch_id_sha` means GitLab is still computing. */
-  private async diffIsReady(attempt: Attempt): Promise<boolean> {
+  private async diffIsReady(attempt: GitlabAttempt): Promise<boolean> {
     const deadline = this.now() + (this.deps.mergeStatusWindowMs ?? DEFAULT_MERGE_STATUS_WINDOW_MS)
     for (;;) {
       const versions = await this.get(attempt, this.mrPath(attempt.turn, '/versions')).catch(() => undefined)
@@ -1065,485 +651,12 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     }
   }
 
-  private approvalReadback(parsed: unknown, attempt: Attempt): boolean {
+  private approvalReadback(parsed: unknown, attempt: GitlabAttempt): boolean {
     const body = record(parsed)
     const sha = text(body.sha)
     if (sha !== undefined && sha !== attempt.turn.expectedHeadSha) return false
     const approvers = Array.isArray(body.approved_by) ? body.approved_by : []
-    return approvers.some((row) => idOf(record(record(row).user).id) === attempt.serviceAccountUserId)
-  }
-
-  /**
-   * One provider mutation under one single-use operation record: issue → start →
-   * one outbound request → settle. A definite 401/403 buys exactly ONE lease
-   * refresh, and the retry runs under a NEW record — one record permits one request.
-   */
-  private async mutate(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
-    kind: CodeHostReviewOpKind,
-    method: CodeHostReviewOpMethod,
-    target: string,
-    body: Record<string, unknown> | undefined,
-    draftOrdinal?: number
-  ): Promise<
-    | { kind: 'sent'; status: number; parsed: unknown; recordId: string }
-    | { kind: 'rejected'; status: number; recordId: string }
-    | { kind: 'ambiguous'; recordId: string }
-  > {
-    for (let attemptNo = 0; attemptNo < 2; attemptNo += 1) {
-      const ordinal = attempt.ordinals.get(kind) ?? 0
-      attempt.ordinals.set(kind, ordinal + 1)
-      const issued = await cp.operate(
-        { op: 'issue', attemptId: attempt.attemptId, fence: attempt.fence, kind, method, target, ordinal },
-        attempt.orgId
-      )
-      const startToken = (this.deps.newStartToken ?? randomUUID)()
-      // Durable BEFORE the request is permitted, so a crash between them is reconcilable.
-      await this.noteOperation(attempt, {
-        recordId: issued.recordId,
-        startToken,
-        kind,
-        ordinal,
-        target,
-        phase: 'issued',
-        ...(draftOrdinal !== undefined ? { draftOrdinal } : {})
-      })
-      await this.startOperation(cp, attempt, issued.recordId, startToken)
-      // Only now may a replay assume a request was permitted under this record.
-      await this.markOperationStarted(attempt, issued.recordId)
-      let result: SendResult
-      try {
-        result = await this.send(method, target, undefined, body, attempt.token, attempt.turn)
-      } catch (err) {
-        if (err instanceof AmbiguousSend) {
-          await this.settleAndClear(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code }, true)
-          return { kind: 'ambiguous', recordId: issued.recordId }
-        }
-        throw err
-      }
-      const authRejected = result.status === 401 || result.status === 403
-      const externalId = idOf(record(result.parsed).id)
-      await this.settleAndClear(cp, attempt, issued.recordId, {
-        kind: 'deterministic',
-        status: result.status,
-        ...(externalId ? { externalId } : {})
-      })
-      if (result.status < 300) {
-        return { kind: 'sent', status: result.status, parsed: result.parsed, recordId: issued.recordId }
-      }
-      if (!authRejected || attemptNo === 1) {
-        return { kind: 'rejected', status: result.status, recordId: issued.recordId }
-      }
-      this.deps.invalidateToken(attempt.turn, attempt.token)
-      attempt.token = await this.deps.token(attempt.turn)
-    }
-    throw new Error('GitLab review mutation exhausted its single authorization refresh')
-  }
-
-  /** `startToken` names the one intended request, so a lost reply is retransmitted with the SAME token. */
-  private async startOperation(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
-    recordId: string,
-    startToken: string
-  ): Promise<void> {
-    let last: unknown
-    for (let tries = 0; tries < 2; tries += 1) {
-      try {
-        await cp.operate(
-          { op: 'start', attemptId: attempt.attemptId, fence: attempt.fence, recordId, startToken },
-          attempt.orgId
-        )
-        return
-      } catch (err) {
-        last = err
-      }
-    }
-    throw last instanceof Error ? last : new Error('the control plane refused to start the review operation')
-  }
-
-  /** The settle is owed durably first: a lost ack must never strand a started record.
-   *  Returns whether the operation's own coordinates may now be forgotten. */
-  private async settleOperation(
-    cp: GitlabReviewControlPlane,
-    ref: LeaseRef,
-    recordId: string,
-    outcome: CodeHostReviewOpOutcome
-  ): Promise<SettleDisposition> {
-    const safe = await this.owe(cp, this.settleIntent(ref, recordId, outcome))
-    if (safe) return 'safe'
-    // Neither written nor acknowledged: the coordinates become the replay source instead.
-    return (await this.persistSettleOutcome(ref, recordId, outcome)) ? 'replayable' : 'blocked'
-  }
-
-  /** The one settle frame, built the same way whether it is owed now or replayed later. */
-  private settleIntent(ref: LeaseRef, recordId: string, outcome: CodeHostReviewOpOutcome): ReviewIntentRow {
-    return {
-      intentId: `${ref.attemptId}:op:${recordId}`,
-      daemonId: this.deps.daemonId() ?? '',
-      attemptId: ref.attemptId,
-      ...(ref.orgId ? { orgId: ref.orgId } : {}),
-      kind: 'operation',
-      frame: JSON.stringify({
-        op: 'settle',
-        attemptId: ref.attemptId,
-        fence: ref.fence,
-        recordId,
-        outcome
-      } satisfies CodeHostReviewOpRequest),
-      attempts: 0
-    }
-  }
-
-  /** Park the exact outcome on the surviving coordinates so a restart can replay it blind. */
-  private async persistSettleOutcome(
-    ref: LeaseRef,
-    recordId: string,
-    outcome: CodeHostReviewOpOutcome
-  ): Promise<boolean> {
-    const op = ref.turn.hook.codeReview?.operations?.find((entry) => entry.recordId === recordId)
-    if (!op) return false
-    op.outcome = outcome
-    try {
-      await ref.turn.persist(true)
-      return true
-    } catch (err) {
-      this.warn(`gitlab review: settle outcome could not be parked (${err instanceof Error ? err.message : err})`)
-      return false
-    }
-  }
-
-  /** Owe the settle, then forget the coordinates only once something can replay it. */
-  private async settleAndClear(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
-    recordId: string,
-    outcome: CodeHostReviewOpOutcome,
-    // An `ambiguous` record stays non-terminal until an upgrade names its object, so its
-    // coordinates are kept as the replay source for exactly that upgrade (§15.1).
-    retain = false
-  ): Promise<void> {
-    const disposition = await this.settleOperation(cp, attempt, recordId, outcome)
-    if (disposition === 'safe' && !retain) await this.clearOperation(attempt, recordId)
-    if (disposition === 'blocked') attempt.settleBlocked = true
-  }
-
-  /**
-   * Upgrade a positively identified ambiguous record to `settled` by naming the provider
-   * object. The control plane keeps an ambiguous record non-terminal until exactly this
-   * frame arrives, and retains the publication lease while one remains.
-   */
-  private async upgradeAmbiguous(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
-    recordId: string,
-    externalId: string,
-    status: number
-  ): Promise<void> {
-    await this.settleAndClear(cp, attempt, recordId, { kind: 'deterministic', status, externalId })
-  }
-
-  /** Record the terminal classification, releasing (or locking) the publication lease. */
-  private async settle(
-    cp: GitlabReviewControlPlane,
-    attempt: Attempt,
-    state: CodeHostReviewState
-  ): Promise<GitlabReviewOutcome> {
-    const externalIds = codeHostReviewPublicEffect(state) === 'absent' ? [] : attempt.externalIds
-    // No terminal result while a started operation has no durable replay source: the control
-    // plane would record the outcome and keep the lease on a record nothing can settle (§15.1).
-    if (attempt.settleBlocked) {
-      this.arm()
-      throw new ResultWithheld()
-    }
-    // The durable single-writer gate first: only a PROVEN no-effect attempt may be followed
-    // by the ordinary note, and a replay must read the same verdict this turn reached (§15.2).
-    // The same record is the result frame's upstream entry, so it also marks it owed.
-    await this.recordOutcome(attempt.turn, state, externalIds, true)
-    const safe = await this.owe(cp, {
-      intentId: `${attempt.attemptId}:result`,
-      daemonId: this.deps.daemonId() ?? '',
-      attemptId: attempt.attemptId,
-      ...(attempt.orgId ? { orgId: attempt.orgId } : {}),
-      kind: 'result',
-      frame: JSON.stringify({
-        hookId: attempt.turn.hookId,
-        deliveryKey: attempt.turn.deliveryKey,
-        attemptId: attempt.attemptId,
-        snapshot: attempt.turn.snapshot,
-        provider: 'gitlab',
-        projectId: attempt.turn.projectId,
-        mergeRequestIid: attempt.turn.mergeRequestIid,
-        event: attempt.req.event,
-        verdict: attempt.req.verdict,
-        headSha: attempt.turn.expectedHeadSha,
-        state,
-        ...(externalIds.length ? { externalIds } : {})
-      } satisfies CodeHostReviewResultReport),
-      attempts: 0
-    })
-    if (safe) await this.clearResultOwed(attempt.turn)
-    return {
-      provider: 'gitlab',
-      state,
-      event: attempt.req.event,
-      verdict: attempt.req.verdict,
-      message: OUTCOME_SENTENCE[state],
-      ...(externalIds.length ? { externalIds } : {})
-    }
-  }
-
-  /** A typed CP refusal is an ordinary control outcome the model must read precisely. */
-  private async refused(
-    turn: GitlabReviewTurn,
-    req: SubmitCodeReviewReq,
-    answer: Extract<CodeHostReviewAuthorized, { authorized: false }>
-  ): Promise<GitlabReviewOutcome> {
-    const state: CodeHostReviewState =
-      answer.reason === 'reviewer_assignment_required'
-        ? 'reviewer_assignment_required'
-        : answer.reason === 'ambiguous_locked'
-          ? 'ambiguous_locked'
-          : 'not_submitted'
-    const detail =
-      answer.reason === 'lease_held'
-        ? ' Another review attempt currently owns publication on this merge request.'
-        : answer.reason === 'head_changed'
-          ? ' The merge request head changed while this turn was running.'
-          : answer.reason === 'policy_denied'
-            ? " This hook's review policy does not permit that review event."
-            : answer.reason === 'binding_unavailable'
-              ? ' This project has no ready GitLab binding to publish as.'
-              : ''
-    // No lease was granted, so nothing is owed to the control plane — but the durable
-    // gate still has to learn whether the ordinary note may follow this attempt.
-    await this.recordOutcome(turn, state, [], false)
-    return {
-      provider: 'gitlab',
-      state,
-      event: req.event,
-      verdict: req.verdict,
-      message: `${OUTCOME_SENTENCE[state]}${detail}`
-    }
-  }
-
-  /** Stamp the durable attempt with its classification; the in-memory copy guards this process. */
-  private async recordOutcome(
-    turn: GitlabReviewTurn,
-    state: CodeHostReviewState,
-    externalIds: CodeHostReviewExternalRef[],
-    owed: boolean
-  ): Promise<void> {
-    const attemptRecord = turn.hook.codeReview
-    if (!attemptRecord) return
-    attemptRecord.state = state
-    if (owed) attemptRecord.resultOwed = true
-    else delete attemptRecord.resultOwed
-    if (externalIds.length) attemptRecord.externalIds = externalIds
-    else delete attemptRecord.externalIds
-    try {
-      await turn.persist(true)
-    } catch (err) {
-      // A stateless durable attempt reads as unknown, which blocks the fallback — the safe direction.
-      this.warn(`gitlab review: outcome persistence deferred (${err instanceof Error ? err.message : err})`)
-    }
-  }
-
-  /** The result frame is durable or acknowledged, so the attempt no longer owes it. */
-  private async clearResultOwed(turn: GitlabReviewTurn): Promise<void> {
-    if (!turn.hook.codeReview?.resultOwed) return
-    delete turn.hook.codeReview.resultOwed
-    await turn.persist().catch(() => undefined)
-  }
-
-  /**
-   * Owe one control-plane frame, then try to deliver it.
-   *
-   * The row lands BEFORE the send, so a crash in between still replays it; both frames
-   * are idempotent REQs, so replaying one the control plane already took is a no-op. A
-   * permanently refused frame is dropped rather than replayed forever (§15.1).
-   */
-  /**
-   * Owe one control-plane frame. Returns whether the chain may move on: true once the
-   * frame is durably recorded OR the control plane has answered it. While it is false the
-   * caller must KEEP its own upstream record, because that record is the only thing a
-   * restart could rebuild this frame from (§15.1).
-   */
-  private async owe(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<boolean> {
-    const durable = await this.persistIntent(row)
-    if (!durable) this.unwritten.set(row.intentId, row)
-    const answer = await this.deliver(cp, row)
-    if (answer === 'retry') {
-      this.arm()
-      return durable
-    }
-    await this.forget(row.intentId)
-    return true
-  }
-
-  /** Bounded local-write retry; false means the row is only in memory for now. */
-  private async persistIntent(row: ReviewIntentRow): Promise<boolean> {
-    for (let tries = 0; tries < 3; tries += 1) {
-      try {
-        await this.deps.store.recordReviewIntent(row, this.now())
-        this.unwritten.delete(row.intentId)
-        return true
-      } catch (err) {
-        if (tries === 2) {
-          this.warn(`gitlab review: owed frame write deferred (${err instanceof Error ? err.message : err})`)
-        }
-      }
-    }
-    return false
-  }
-
-  /** Send one owed frame verbatim. `retry` keeps it; anything else is finished with. */
-  private async deliver(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<'sent' | 'retry' | 'refused'> {
-    try {
-      if (row.kind === 'operation') await cp.operate(JSON.parse(row.frame) as CodeHostReviewOpRequest, row.orgId)
-      else await cp.report(JSON.parse(row.frame) as CodeHostReviewResultReport, row.orgId)
-      return 'sent'
-    } catch (err) {
-      // A control plane that answered `retryable: false` has decided; replaying cannot change it.
-      const permanent = (err as { retryable?: unknown }).retryable === false
-      this.warn(
-        `gitlab review: owed ${row.kind} frame ${permanent ? 'refused' : 'deferred'} (${err instanceof Error ? err.message : err})`
-      )
-      return permanent ? 'refused' : 'retry'
-    }
-  }
-
-  private async forget(intentId: string): Promise<void> {
-    this.unwritten.delete(intentId)
-    try {
-      await this.deps.store.clearReviewIntent(intentId)
-    } catch (err) {
-      // The frame is delivered; a stale row only costs one idempotent replay later.
-      this.warn(`gitlab review: owed frame could not be cleared (${err instanceof Error ? err.message : err})`)
-    }
-  }
-
-  /**
-   * Replay everything this daemon identity still owes the control plane (§15.1). Runs at
-   * startup and on reconnect, and re-arms itself on backoff while anything remains, so a
-   * dropped ack cannot leave an operation record started or an outcome unreconciled.
-   */
-  async reconcilePending(): Promise<void> {
-    if (this.sweeping) return
-    this.sweeping = true
-    // Read BEFORE the scan: work that arms after this point owns the timer, not this sweep.
-    const armedThrough = this.armGeneration
-    try {
-      const remaining = await this.sweepOnce()
-      if (remaining === undefined || remaining > 0) this.arm()
-      else this.disarm(armedThrough)
-    } finally {
-      this.sweeping = false
-    }
-  }
-
-  /**
-   * One pass over the owed frames; the count still outstanding after it, or undefined.
-   *
-   * The store answers one PAGE at a time, so the pass drains successive pages until it
-   * sees nothing new — a page of acked rows must never be mistaken for an empty store.
-   */
-  private async sweepOnce(): Promise<number | undefined> {
-    const daemonId = this.deps.daemonId()
-    // Before the control plane adopts an id there is no identity to recover rows under.
-    if (!daemonId) return 0
-    const cp = this.deps.cp()
-    if (!cp) return undefined
-    const seen = new Set<string>()
-    let outstanding = 0
-    let unreadable = false
-    // Hitting the cap proves nothing about what is left, so the sweep stays armed.
-    let capped = true
-    for (let page = 0; page < MAX_SWEEP_PAGES; page += 1) {
-      let rows: ReviewIntentRow[]
-      try {
-        rows = await this.deps.store.listReviewIntents(daemonId)
-      } catch (err) {
-        this.warn(`gitlab review: owed frame scan failed (${err instanceof Error ? err.message : err})`)
-        unreadable = true
-        break
-      }
-      const fresh = rows.filter((row) => !seen.has(row.intentId))
-      if (fresh.length === 0) {
-        capped = false
-        break
-      }
-      for (const row of fresh) {
-        seen.add(row.intentId)
-        outstanding += await this.replay(cp, row)
-      }
-    }
-    // Frames whose durable write never landed live only here; they are owed all the same.
-    for (const row of [...this.unwritten.values()]) {
-      if (seen.has(row.intentId)) continue
-      seen.add(row.intentId)
-      await this.persistIntent(row)
-      outstanding += await this.replay(cp, row)
-    }
-    return unreadable || capped ? undefined : outstanding
-  }
-
-  /** Deliver one owed frame; 1 when it is still owed afterwards, 0 when it is finished with. */
-  private async replay(cp: GitlabReviewControlPlane, row: ReviewIntentRow): Promise<number> {
-    const answer = await this.deliver(cp, row)
-    if (answer !== 'retry') {
-      await this.forget(row.intentId)
-      return 0
-    }
-    const next = { ...row, attempts: row.attempts + 1 }
-    if (this.unwritten.has(row.intentId)) this.unwritten.set(row.intentId, next)
-    await this.deps.store.recordReviewIntent(next, this.now()).catch(() => undefined)
-    return 1
-  }
-
-  /** Arm the next resweep on exponential backoff, capped. An armed timer is never restarted early. */
-  private arm(): void {
-    if (this.stopped) return
-    this.armGeneration += 1
-    if (this.resweepHandle !== undefined) return
-    const base = this.deps.resweepBaseMs ?? DEFAULT_RESWEEP_BASE_MS
-    const cap = this.deps.resweepCapMs ?? DEFAULT_RESWEEP_CAP_MS
-    const delay = Math.min(base * 2 ** Math.min(this.resweepAttempt, 16), cap)
-    this.resweepAttempt += 1
-    try {
-      this.resweepHandle = this.sched.setTimeout(() => {
-        this.resweepHandle = undefined
-        void this.reconcilePending()
-      }, delay)
-    } catch (err) {
-      this.warn(`gitlab review: resweep scheduling failed (${err instanceof Error ? err.message : err})`)
-    }
-  }
-
-  /** Go quiet — but only if nothing armed after the sweep that decided there was no work left. */
-  private disarm(armedThrough: number): void {
-    if (this.armGeneration !== armedThrough) return
-    this.resweepAttempt = 0
-    this.clearTimer()
-  }
-
-  private clearTimer(): void {
-    if (this.resweepHandle === undefined) return
-    try {
-      this.sched.clearTimeout(this.resweepHandle)
-    } catch {
-      // A failed clear only leaves a sweep that finds nothing to do.
-    }
-    this.resweepHandle = undefined
-  }
-
-  private warn(message: string): void {
-    try {
-      this.deps.log.warn(message)
-    } catch {
-      // A broken logger must not break a settlement path.
-    }
+    return approvers.some((row) => idOf(record(record(row).user).id) === attempt.publisherUserId)
   }
 
   private render(body: string, attribution: GithubCommentAttribution | undefined, marker: string): string {
@@ -1554,62 +667,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
   }
 
   private mrPath(turn: GitlabReviewTurn, suffix = ''): string {
-    return `/projects/${turn.projectId}/merge_requests/${turn.mergeRequestIid}${suffix}`
-  }
-
-  private async get(session: Session, path: string, query?: string): Promise<unknown> {
-    for (let tries = 0; tries < 2; tries += 1) {
-      let result: SendResult
-      try {
-        result = await this.send('GET', path, query, undefined, session.token, session.turn)
-      } catch {
-        throw new Error(`GitLab GET ${path} did not complete`)
-      }
-      if (result.status < 300) return result.parsed
-      if ((result.status !== 401 && result.status !== 403) || tries === 1) {
-        throw new Error(`GitLab GET ${path} failed with ${result.status}`)
-      }
-      this.deps.invalidateToken(session.turn, session.token)
-      session.token = await this.deps.token(session.turn)
-    }
-    throw new Error(`GitLab GET ${path} failed`)
-  }
-
-  private async send(
-    method: 'GET' | CodeHostReviewOpMethod,
-    path: string,
-    query: string | undefined,
-    body: Record<string, unknown> | undefined,
-    token: string,
-    turn: GitlabReviewTurn
-  ): Promise<SendResult> {
-    const doFetch = this.deps.fetchImpl ?? fetch
-    const url = `${this.deps.apiBaseUrl(turn)}${path}${query ? `?${query}` : ''}`
-    let response: Response
-    try {
-      response = await doFetch(url, {
-        method,
-        headers: {
-          'private-token': token,
-          ...(body !== undefined ? { 'content-type': 'application/json' } : {})
-        },
-        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS)
-      })
-    } catch {
-      // Nothing was received, so a mutation's effect is unknown; GETs treat it the same.
-      throw new AmbiguousSend('transport_failed')
-    }
-    // A 5xx may or may not have applied the effect; only a received 4xx is definite.
-    if (response.status >= 500) throw new AmbiguousSend(`upstream_${response.status}`)
-    const raw = await response.text().catch(() => '')
-    let parsed: unknown
-    try {
-      parsed = raw ? parseGitlabJson(raw) : undefined
-    } catch {
-      parsed = undefined
-    }
-    return { status: response.status, parsed }
+    return `/projects/${turn.repoId}/merge_requests/${turn.subjectNumber}${suffix}`
   }
 }
 

--- a/packages/daemon/test/gitea-review-adapter.test.ts
+++ b/packages/daemon/test/gitea-review-adapter.test.ts
@@ -1,0 +1,1330 @@
+// Gitea formal review adapter (§10.3): shared-bot lease, reconcile-before-submit, marker-first recovery, the lock's one exit, self-review downgrade.
+import { describe, expect, it } from 'vitest'
+import {
+  codeHostReviewPublicEffect,
+  type CodeHostReviewAuthorize,
+  type CodeHostReviewAuthorized,
+  type CodeHostReviewLeasePhase,
+  type CodeHostReviewOpAccepted,
+  type CodeHostReviewOpRequest,
+  type CodeHostReviewRefusalReason,
+  type CodeHostReviewResultReport,
+  type CodeHostReviewState,
+  type HookConfigSnapshot
+} from '@agentconnect.md/protocol'
+import { sessionKey } from '../src/store/local-store.js'
+import { CodeHostReviewRouter, type SubmitCodeReviewReq } from '../src/codehost/review-adapter.js'
+import { codeHostReviewFallbackAllowed, type HookDispatchContext } from '../src/github/hook-coords.js'
+import { GiteaReviewAdapter, type GiteaReviewOutcome } from '../src/gitea/review-adapter.js'
+import { ReviewMarkerSigner } from '../src/codehost/review-marker.js'
+import type { CodeHostReviewControlPlane, ReviewIntentRow } from '../src/codehost/review-outbox.js'
+
+const BASE = 'https://gitea.example.test/api/v1'
+const REPO = '556677'
+const PATH = 'example-org/example-repo'
+const INDEX = 12
+const HEAD = 'a'.repeat(40)
+const BASE_SHA = 'b'.repeat(40)
+const OTHER_HEAD = 'c'.repeat(40)
+// Deliberately past 2^53 so every id path stays a decimal string end to end.
+const BOT_USER = '9007199254740993'
+const HUMAN_USER = '9007199254740999'
+const ATTEMPT = '11111111-1111-4111-8111-111111111111'
+const OLD_ATTEMPT = '22222222-2222-4222-8222-222222222222'
+const SECOND_ATTEMPT = '55555555-5555-4555-8555-555555555555'
+const THIRD_ATTEMPT = '66666666-6666-4666-8666-666666666666'
+const HOOK_ID = '33333333-3333-4333-8333-333333333333'
+const OTHER_HOOK_ID = '77777777-7777-4777-8777-777777777777'
+const DAEMON_ID = '44444444-4444-4444-8444-444444444444'
+const AGENT_ID = 'bot-a'
+const OTHER_AGENT_ID = 'bot-b'
+const THREAD = `gitea:${REPO}:pull:${INDEX}`
+const KEY = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID)
+const MARKER_SEED = 'gitea-review-marker-test-key-001'
+const PULL_PATH = `/repos/example-org/example-repo/pulls/${INDEX}`
+
+const signer = new ReviewMarkerSigner(Buffer.from(MARKER_SEED, 'utf8'))
+
+const SNAPSHOT: HookConfigSnapshot = {
+  configRevision: '4',
+  dispatchRevision: '9',
+  dispatchDaemonId: DAEMON_ID,
+  reviewPolicy: 'full',
+  reportingMode: 'off',
+  gateMode: 'informational'
+}
+
+function hookContext(overrides: Partial<HookDispatchContext> = {}): HookDispatchContext {
+  return {
+    hookId: HOOK_ID,
+    agentId: AGENT_ID,
+    deliveryKey: 'delivery-1',
+    firedAt: '2026-09-12T00:00:00.000Z',
+    event: 'merge_request:opened',
+    snapshot: SNAPSHOT,
+    gitea: { repoId: REPO, repoPath: PATH, target: { kind: 'pull', index: INDEX, headSha: HEAD, baseSha: BASE_SHA } },
+    ...overrides
+  }
+}
+
+function request(overrides: Partial<SubmitCodeReviewReq> = {}): SubmitCodeReviewReq {
+  return {
+    agentId: AGENT_ID,
+    platform: 'hook',
+    channel: HOOK_ID,
+    thread: THREAD,
+    event: 'COMMENT',
+    verdict: 'neutral',
+    body: 'Looks reasonable overall.',
+    ...overrides
+  }
+}
+
+interface FakeComment {
+  id: string
+  path: string
+  body: string
+  position?: number
+  original_position?: number
+}
+
+interface FakeReview {
+  id: string
+  user: { id: string }
+  state: 'PENDING' | 'COMMENT' | 'APPROVED' | 'REQUEST_CHANGES' | 'REQUEST_REVIEW'
+  body: string
+  commit_id: string
+  comments: FakeComment[]
+}
+
+interface GiteaState {
+  botUserId: string
+  headSha: string
+  /** The pull request's author; the bot authoring it is the §10.3 internal-CI lane. */
+  authorId: string
+  reviews: FakeReview[]
+  nextId: bigint
+}
+
+function giteaState(overrides: Partial<GiteaState> = {}): GiteaState {
+  return {
+    botUserId: BOT_USER,
+    headSha: HEAD,
+    authorId: HUMAN_USER,
+    reviews: [],
+    nextId: 9007199254741001n,
+    ...overrides
+  }
+}
+
+interface Call {
+  method: string
+  path: string
+  query: string
+  token: string
+  body?: Record<string, unknown>
+}
+
+type Reply = 'network' | { status: number; body?: unknown } | 'defer'
+
+interface ScriptEntry {
+  method: string
+  path: RegExp
+  reply: Reply
+  /** Provider-side effect this scripted reply also had (the request landed even though the reply was lost). */
+  then?: () => void
+  used?: boolean
+}
+
+/** Ids are written as strings here and emitted UNQUOTED, so every response exercises the big-int-safe re-quoting. */
+function json(value: unknown, status = 200): Response {
+  const text = JSON.stringify(value).replace(/"((?:[a-z][a-z0-9_]*_)?id)":"(\d{15,})"/g, '"$1":$2')
+  return new Response(text, { status, headers: { 'content-type': 'application/json' } })
+}
+
+const SELF_REVIEW: Record<string, string> = {
+  APPROVED: 'approve your own pull is not allowed',
+  REQUEST_CHANGES: 'reject your own pull is not allowed'
+}
+
+/** Fake Gitea (§16): POST stages then submits the caller's one pending review; the list is unfiltered; DELETE removes submitted reviews; own verdicts 422. */
+function fakeGitea(state: GiteaState, script: ScriptEntry[] = []) {
+  const calls: Call[] = []
+  const deferred: Array<() => void> = []
+  const nextId = () => {
+    const id = state.nextId
+    state.nextId += 1n
+    return String(id)
+  }
+  const reviewJson = (review: FakeReview) => ({
+    id: review.id,
+    user: { id: review.user.id, login: review.user.id === state.botUserId ? 'example-bot' : 'alice' },
+    state: review.state,
+    body: review.body,
+    commit_id: review.commit_id,
+    comments_count: review.comments.length
+  })
+  /** The staging-then-submit the probe recorded (§16). */
+  const submit = (body: Record<string, unknown>): FakeReview => {
+    const event = String(body.event ?? 'PENDING')
+    let pending = state.reviews.find((review) => review.user.id === state.botUserId && review.state === 'PENDING')
+    const comments = Array.isArray(body.comments) ? (body.comments as Record<string, unknown>[]) : []
+    if (!pending && (comments.length > 0 || event !== 'PENDING')) {
+      pending = {
+        id: nextId(),
+        user: { id: state.botUserId },
+        state: 'PENDING',
+        body: '',
+        commit_id: String(body.commit_id ?? state.headSha),
+        comments: []
+      }
+      state.reviews.push(pending)
+    }
+    for (const comment of comments) {
+      pending!.comments.push({
+        id: nextId(),
+        path: String(comment.path),
+        body: String(comment.body),
+        ...(typeof comment.new_position === 'number' ? { position: comment.new_position } : {}),
+        ...(typeof comment.old_position === 'number' ? { original_position: comment.old_position } : {})
+      })
+    }
+    if (event !== 'PENDING') {
+      pending!.state = event as FakeReview['state']
+      pending!.body = String(body.body ?? '')
+      pending!.commit_id = String(body.commit_id ?? state.headSha)
+    }
+    return pending!
+  }
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const parsed = new URL(String(url))
+    const path = parsed.pathname.replace('/api/v1', '')
+    const method = init?.method ?? 'GET'
+    const headers = (init?.headers ?? {}) as Record<string, string>
+    const body = init?.body === undefined ? undefined : (JSON.parse(String(init.body)) as Record<string, unknown>)
+    calls.push({
+      method,
+      path,
+      query: parsed.search,
+      token: (headers.authorization ?? '').replace(/^token /, ''),
+      ...(body === undefined ? {} : { body })
+    })
+    const hit = script.find((entry) => !entry.used && entry.method === method && entry.path.test(path))
+    if (hit) {
+      hit.used = true
+      hit.then?.()
+      if (hit.reply === 'defer') await new Promise<void>((resolve) => deferred.push(resolve))
+      else if (hit.reply === 'network') throw new Error('socket hang up')
+      else {
+        return new Response(hit.reply.body === undefined ? null : JSON.stringify(hit.reply.body), {
+          status: hit.reply.status,
+          ...(hit.reply.body === undefined ? {} : { headers: { 'content-type': 'application/json' } })
+        })
+      }
+    }
+    if (path === '/user') return json({ id: state.botUserId, login: 'example-bot' })
+    if (path === PULL_PATH) {
+      return json({
+        id: '9007199254740995',
+        number: INDEX,
+        state: 'open',
+        head: { sha: state.headSha, ref: 'feature', repo_id: Number(REPO) },
+        base: { sha: BASE_SHA, ref: 'main' },
+        user: { id: state.authorId }
+      })
+    }
+    if (path === `${PULL_PATH}/reviews`) {
+      if (method === 'GET') return json(state.reviews.map(reviewJson))
+      const event = String(body?.event ?? '')
+      if (SELF_REVIEW[event] && state.authorId === state.botUserId) {
+        return json({ message: SELF_REVIEW[event] }, 422)
+      }
+      return json(reviewJson(submit(body ?? {})))
+    }
+    const one = new RegExp(`^${PULL_PATH}/reviews/(\\d+)(/comments)?$`).exec(path)
+    if (one) {
+      const review = state.reviews.find((candidate) => candidate.id === one[1])
+      if (!review) return json({ message: 'review does not exist' }, 404)
+      if (one[2]) return json(review.comments)
+      if (method === 'DELETE') {
+        // Upstream authorizes only the author or an admin and imposes NO pending-only restriction (§16).
+        state.reviews = state.reviews.filter((candidate) => candidate.id !== review.id)
+        return new Response(null, { status: 204 })
+      }
+      return json(reviewJson(review))
+    }
+    return json({ message: 'not found' }, 404)
+  }) as unknown as typeof fetch
+  return { fetchImpl, calls, release: () => deferred.splice(0).forEach((resolve) => resolve()) }
+}
+
+interface LeaseRow {
+  attemptId: string | null
+  fence: number
+  phase: CodeHostReviewLeasePhase
+  leaseUntil: number
+  event?: string
+  verdict?: string
+  headSha?: string
+}
+
+interface OpRow {
+  attemptId: string
+  fence: string
+  kind: string
+  ordinal: number
+  state: 'issued' | 'request_started' | 'settled' | 'ambiguous' | 'unused'
+  everAmbiguous: boolean
+  externalId?: string
+}
+
+interface CpOptions {
+  refuse?: CodeHostReviewRefusalReason
+  supports?: boolean
+  renewPhase?: CodeHostReviewLeasePhase
+  serviceAccountUserId?: string
+  /** Operation records a previous incarnation left permitted but unsettled, owned by the seeded lease. */
+  seedStarted?: { attemptId: string; recordId: string; kind: string; ordinal: number; fence?: number }[]
+  operateFails?: (op: CodeHostReviewOpRequest) => Error | undefined
+  reportFails?: (result: CodeHostReviewResultReport) => Error | undefined
+  now?: () => number
+}
+
+const reconciles = (state: CodeHostReviewState) => codeHostReviewPublicEffect(state) !== 'unknown'
+
+/** The permit key the real ledger uses: attempt, fence, kind, ordinal. */
+const recordIdOf = (attemptId: string, fence: string | number, kind: string, ordinal: number) =>
+  `rec-${attemptId.slice(0, 8)}-${fence}-${kind}-${ordinal}`
+
+function permanent(message: string): Error {
+  return Object.assign(new Error(message), { retryable: false })
+}
+
+/** Fake control plane (§15.1): one lease per subject, idempotent re-acquisition, the indefinite lock, the single-use ledger, the owner's one lock exit. */
+function fakeCp(opts: CpOptions = {}) {
+  const now = opts.now ?? (() => 1_000)
+  const leases = new Map<string, LeaseRow>()
+  const records = new Map<string, OpRow>()
+  const outcomes = new Map<string, CodeHostReviewState>()
+  const authorizations: CodeHostReviewAuthorize[] = []
+  const ops: CodeHostReviewOpRequest[] = []
+  const results: CodeHostReviewResultReport[] = []
+  for (const seed of opts.seedStarted ?? []) {
+    records.set(seed.recordId, {
+      attemptId: seed.attemptId,
+      fence: String(seed.fence ?? 7),
+      kind: seed.kind,
+      ordinal: seed.ordinal,
+      state: 'request_started',
+      everAmbiguous: false
+    })
+  }
+  const subjectOf = (projectId: string, iid: number) => `${projectId}#${iid}`
+  const leaseOf = (attemptId: string): [string, LeaseRow] | undefined => {
+    for (const entry of leases) if (entry[1].attemptId === attemptId) return entry
+    return undefined
+  }
+  const ledger = (attemptId: string) => [...records.values()].filter((row) => row.attemptId === attemptId)
+  const release = (lease: LeaseRow): CodeHostReviewLeasePhase => {
+    if (!lease.attemptId) return lease.phase
+    const outcome = outcomes.get(lease.attemptId)
+    if (!outcome) return lease.phase
+    const rows = ledger(lease.attemptId)
+    if (rows.some((row) => row.state === 'issued' || row.state === 'request_started')) {
+      lease.phase = 'classifying'
+    } else if (rows.some((row) => row.state === 'ambiguous') || !reconciles(outcome)) {
+      lease.phase = 'ambiguous_locked'
+    } else {
+      lease.phase = 'settled'
+      lease.attemptId = null
+    }
+    return lease.phase
+  }
+  const cp: CodeHostReviewControlPlane = {
+    supportsReview: () => opts.supports !== false,
+    authorize: async (payload): Promise<CodeHostReviewAuthorized> => {
+      authorizations.push(payload)
+      if (opts.refuse) return { authorized: false, attemptId: payload.attemptId, reason: opts.refuse, retryable: false }
+      const key = subjectOf(payload.projectId, payload.mergeRequestIid)
+      let lease = leases.get(key)
+      if (lease?.phase === 'ambiguous_locked') {
+        return { authorized: false, attemptId: payload.attemptId, reason: 'ambiguous_locked', retryable: false }
+      }
+      if (lease && lease.attemptId !== null && lease.attemptId !== payload.attemptId && lease.phase !== 'settled') {
+        if (lease.leaseUntil > now()) {
+          return { authorized: false, attemptId: payload.attemptId, reason: 'lease_held', retryable: true }
+        }
+        // An expired lease transfers only under the §15.1 conditions; an outstanding record locks it.
+        if (ledger(lease.attemptId).some((row) => row.state !== 'settled' && row.state !== 'unused')) {
+          lease.phase = 'ambiguous_locked'
+          return { authorized: false, attemptId: payload.attemptId, reason: 'ambiguous_locked', retryable: false }
+        }
+      }
+      if (!lease || lease.attemptId !== payload.attemptId) {
+        lease = {
+          attemptId: payload.attemptId,
+          fence: (lease?.fence ?? 6) + 1,
+          phase: 'open',
+          leaseUntil: now() + 300_000,
+          event: payload.requestedEvent,
+          verdict: payload.requestedVerdict,
+          headSha: payload.headSha
+        }
+        leases.set(key, lease)
+      } else {
+        lease.leaseUntil = now() + 300_000
+      }
+      return {
+        authorized: true,
+        attemptId: payload.attemptId,
+        provider: 'gitea',
+        projectId: payload.projectId,
+        mergeRequestIid: payload.mergeRequestIid,
+        expectedHeadSha: payload.headSha,
+        lease: {
+          attemptId: payload.attemptId,
+          fence: String(lease.fence),
+          leaseUntil: '2026-09-12T00:05:00.000Z',
+          serviceAccountUserId: opts.serviceAccountUserId ?? BOT_USER
+        }
+      }
+    },
+    operate: async (payload): Promise<CodeHostReviewOpAccepted> => {
+      ops.push(payload)
+      const failure = opts.operateFails?.(payload)
+      if (failure) throw failure
+      const owner = leaseOf(payload.attemptId)?.[1]
+      const recordId =
+        payload.op === 'issue'
+          ? recordIdOf(payload.attemptId, payload.fence, payload.kind, payload.ordinal)
+          : payload.recordId
+      const existing = records.get(recordId)
+      // A terminal record answers from itself, even once its lease has moved on (record-first replay).
+      if (payload.op === 'settle' && existing && existing.state === 'settled') {
+        return accepted(payload.op, recordId, existing, owner?.phase ?? 'settled')
+      }
+      if (!owner || String(owner.fence) !== payload.fence)
+        throw permanent('this daemon does not own that operation record')
+      if (owner.phase === 'settled') throw permanent('the publication lease is no longer open')
+      // The lock's one exit: the owner naming the object its ambiguous record left behind.
+      const identifies =
+        payload.op === 'settle' &&
+        payload.outcome.kind === 'deterministic' &&
+        payload.outcome.externalId !== undefined &&
+        existing?.state === 'ambiguous'
+      if (owner.phase === 'ambiguous_locked' && !identifies) throw permanent('the publication lease is no longer open')
+      if (payload.op === 'issue') {
+        if (existing && existing.state !== 'issued')
+          throw permanent('an operation record already exists for those coordinates')
+        const row: OpRow = {
+          attemptId: payload.attemptId,
+          fence: payload.fence,
+          kind: payload.kind,
+          ordinal: payload.ordinal,
+          state: 'issued',
+          everAmbiguous: false
+        }
+        records.set(recordId, row)
+        if (payload.kind === 'bulk_publish' && owner.phase === 'open') owner.phase = 'publishing'
+        return accepted(payload.op, recordId, row, owner.phase)
+      }
+      if (!existing) throw permanent('no such record')
+      if (payload.op === 'start') {
+        if (existing.state !== 'issued' && existing.state !== 'request_started') throw permanent('record is terminal')
+        existing.state = 'request_started'
+      } else if (payload.op === 'return-unused') {
+        if (existing.state !== 'issued' && existing.state !== 'unused') throw permanent('record already started')
+        existing.state = 'unused'
+      } else if (payload.op === 'settle') {
+        if (existing.state === 'issued') throw permanent('record not started')
+        if (payload.outcome.kind === 'ambiguous') {
+          existing.state = 'ambiguous'
+          existing.everAmbiguous = true
+        } else if (existing.state === 'ambiguous' && !payload.outcome.externalId) {
+          throw permanent('an ambiguous record settles only by naming its object')
+        } else {
+          existing.state = 'settled'
+          if (payload.outcome.externalId) existing.externalId = payload.outcome.externalId
+        }
+        if (existing.kind === 'bulk_publish' && owner.phase === 'publishing') owner.phase = 'classifying'
+      }
+      return accepted(payload.op, recordId, existing, release(owner))
+    },
+    renew: async ({ attemptId, fence }) => {
+      const owner = leaseOf(attemptId)?.[1]
+      if (!owner || String(owner.fence) !== fence) throw permanent('this attempt does not own the publication lease')
+      return {
+        attemptId,
+        fence,
+        leaseUntil: '2026-09-12T00:10:00.000Z',
+        phase: opts.renewPhase ?? owner.phase
+      }
+    },
+    report: async (payload) => {
+      results.push(payload)
+      const failure = opts.reportFails?.(payload)
+      if (failure) throw failure
+      const owner = leaseOf(payload.attemptId)?.[1]
+      const existing = outcomes.get(payload.attemptId)
+      if (!owner) {
+        if (existing === payload.state)
+          return { accepted: true, phase: reconciles(payload.state) ? 'settled' : 'ambiguous_locked' }
+        throw permanent('this attempt does not own the publication lease')
+      }
+      if (owner.event !== payload.event || owner.verdict !== payload.verdict || owner.headSha !== payload.headSha) {
+        throw permanent('review result does not match the reserved attempt')
+      }
+      // A recorded outcome moves only from a non-reconciling state to a reconciling one (the lock's exit).
+      if (existing && existing !== payload.state && !(!reconciles(existing) && reconciles(payload.state))) {
+        throw permanent('review result does not match the reserved attempt')
+      }
+      outcomes.set(payload.attemptId, payload.state)
+      return { accepted: true, phase: release(owner) }
+    }
+  }
+  function accepted(
+    op: CodeHostReviewOpRequest['op'],
+    recordId: string,
+    row: OpRow,
+    phase: CodeHostReviewLeasePhase
+  ): CodeHostReviewOpAccepted {
+    return {
+      op,
+      recordId,
+      attemptId: row.attemptId,
+      fence: row.fence,
+      kind: row.kind as CodeHostReviewOpAccepted['kind'],
+      ordinal: row.ordinal,
+      state: row.state,
+      phase
+    }
+  }
+  return { cp, authorizations, ops, results, records, leases, outcomes, subjectOf }
+}
+
+/** The daemon-local durability the adapter depends on, in memory. */
+class FakeReviewStore {
+  readonly rows = new Map<string, ReviewIntentRow>()
+  private secret?: string
+
+  async recordReviewIntent(row: ReviewIntentRow): Promise<void> {
+    this.rows.set(row.intentId, { ...row })
+  }
+
+  async clearReviewIntent(intentId: string): Promise<void> {
+    this.rows.delete(intentId)
+  }
+
+  async listReviewIntents(daemonId: string): Promise<ReviewIntentRow[]> {
+    return [...this.rows.values()].filter((row) => row.daemonId === daemonId)
+  }
+
+  async getOrCreateDaemonSecret(mint: () => string): Promise<string> {
+    this.secret ??= mint()
+    return this.secret
+  }
+}
+
+function fakeScheduler() {
+  const pending: Array<{ fn: () => void; id: number }> = []
+  let next = 1
+  return {
+    now: () => 0,
+    setTimeout: (fn: () => void) => {
+      const id = next++
+      pending.push({ fn, id })
+      return id
+    },
+    clearTimeout: (handle: unknown) => {
+      const index = pending.findIndex((entry) => entry.id === handle)
+      if (index >= 0) pending.splice(index, 1)
+    }
+  }
+}
+
+type Control = ReturnType<typeof fakeCp>
+
+interface HarnessOptions {
+  state?: GiteaState
+  script?: ScriptEntry[]
+  cp?: CpOptions
+  /** Share one control plane between two adapters — two agents, one pull request. */
+  control?: Control
+  tokens?: string[]
+  hook?: HookDispatchContext
+  key?: string
+  reviewStore?: FakeReviewStore
+  attemptIds?: string[]
+  open?: boolean
+  failPersist?: boolean
+}
+
+function harness(opts: HarnessOptions = {}) {
+  const state = opts.state ?? giteaState()
+  const gitea = fakeGitea(state, opts.script ?? [])
+  const control = opts.control ?? fakeCp(opts.cp ?? {})
+  const supply = opts.tokens ?? ['gitea-effect-1']
+  const minted: string[] = []
+  const invalidated: string[] = []
+  const reviewStore = opts.reviewStore ?? new FakeReviewStore()
+  const hook = opts.hook ?? hookContext()
+  const key = opts.key ?? KEY
+  const attemptIds = opts.attemptIds ?? [ATTEMPT]
+  let mintedAttempts = 0
+  let persisted = 0
+  let clock = 1_000
+  const adapter = new GiteaReviewAdapter({
+    cp: () => control.cp,
+    orgForAgent: () => 'org-1',
+    daemonId: () => DAEMON_ID,
+    store: reviewStore,
+    markerKey: async () => Buffer.from(await reviewStore.getOrCreateDaemonSecret(() => MARKER_SEED), 'utf8'),
+    token: async () => {
+      const token = supply[Math.min(minted.length, supply.length - 1)]!
+      minted.push(token)
+      return token
+    },
+    invalidateToken: (_turn, token) => void invalidated.push(token),
+    log: { warn: () => {} },
+    apiBaseUrl: () => BASE,
+    fetchImpl: gitea.fetchImpl,
+    newAttemptId: () => attemptIds[Math.min(mintedAttempts++, attemptIds.length - 1)]!,
+    newStartToken: () => `start-${control.ops.filter((op) => op.op === 'issue').length}`,
+    now: () => clock,
+    sleep: async (ms) => void (clock += ms),
+    ambiguousWindowMs: 4_000,
+    pollIntervalMs: 1_000,
+    scheduler: fakeScheduler(),
+    resweepBaseMs: 1_000
+  })
+  const open = (turnHook = hook, turnKey = key) =>
+    adapter.openTurn(turnKey, turnHook, 'acp-session-1', {
+      daemonId: DAEMON_ID,
+      persist: async () => {
+        persisted += 1
+        if (opts.failPersist) throw new Error('inbox row is missing')
+      }
+    })
+  if (opts.open !== false) open()
+  return {
+    adapter,
+    state,
+    hook,
+    control,
+    calls: gitea.calls,
+    release: gitea.release,
+    ops: control.ops,
+    results: control.results,
+    authorizations: control.authorizations,
+    reviewStore,
+    open,
+    persisted: () => persisted,
+    tokens: () => minted,
+    invalidated: () => invalidated
+  }
+}
+
+const submissions = (calls: Call[]) =>
+  calls.filter((call) => call.method === 'POST' && call.path === `${PULL_PATH}/reviews`)
+const deletes = (calls: Call[]) => calls.filter((call) => call.method === 'DELETE')
+const mutations = (calls: Call[]) =>
+  calls.filter((call) => call.method !== 'GET').map((call) => `${call.method} ${call.path}`)
+
+/** A pending review the bot left behind, staged at `head` with one comment marked by `attemptId`. */
+function seedPending(state: GiteaState, attemptId: string, head = HEAD, marked = true): FakeReview {
+  const review: FakeReview = {
+    id: String(state.nextId++),
+    user: { id: state.botUserId },
+    state: 'PENDING',
+    body: '',
+    commit_id: head,
+    comments: [
+      {
+        id: String(state.nextId++),
+        path: 'src/a.ts',
+        body: marked ? `stale finding\n\n${signer.mint(attemptId, 1, head)}` : 'someone typed this by hand',
+        position: 3
+      }
+    ]
+  }
+  state.reviews.push(review)
+  return review
+}
+
+/** A review the bot already submitted under `attemptId` — what a landed request leaves visible. */
+function seedSubmitted(state: GiteaState, attemptId: string, reviewState: FakeReview['state'] = 'COMMENT'): FakeReview {
+  const review: FakeReview = {
+    id: String(state.nextId++),
+    user: { id: state.botUserId },
+    state: reviewState,
+    body: `summary\n\n${signer.mint(attemptId, 0, HEAD)}`,
+    commit_id: HEAD,
+    comments: []
+  }
+  state.reviews.push(review)
+  return review
+}
+
+describe('Gitea review adapter — pre-effect rejections and turn ownership', () => {
+  it('rejects an incompatible pair, an empty body, and an event above the policy before any call', async () => {
+    const h = harness({ hook: hookContext({ snapshot: { ...SNAPSHOT, reviewPolicy: 'comment' } }) })
+    await expect(h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'fail' }))).rejects.toThrow(
+      /APPROVE requires verdict=pass/
+    )
+    await expect(h.adapter.submit(KEY, request({ body: '  ' }))).rejects.toThrow(/non-empty body/)
+    await expect(h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))).rejects.toThrow(
+      /exceeds this hook's comment review policy/
+    )
+    expect(h.calls).toEqual([])
+    expect(h.authorizations).toEqual([])
+  })
+
+  it('refuses when the control plane does not advertise codehost-review-v1', async () => {
+    const h = harness({ cp: { supports: false } })
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/codehost-review-v1/)
+    expect(h.calls).toEqual([])
+  })
+
+  it('allows only one review attempt per turn and is unavailable outside the active pull-request turn', async () => {
+    const h = harness()
+    await h.adapter.submit(KEY, request())
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/already has a formal review attempt/)
+    await expect(h.adapter.submit('other-key', request())).rejects.toThrow(/active pull-request hook turn/)
+    expect(submissions(h.calls)).toHaveLength(1)
+  })
+
+  it('opens a review turn only for a delivery that opens a review generation on a headed pull request', () => {
+    const h = harness({ open: false })
+    const gitea = hookContext().gitea!
+    expect(h.open(hookContext({ snapshot: { ...SNAPSHOT, reviewPolicy: 'off' } }), 'k1')).toBeUndefined()
+    expect(h.open(hookContext({ gitea: { ...gitea, target: { kind: 'issue', index: 5 } } }), 'k2')).toBeUndefined()
+    expect(h.open(hookContext({ event: 'note:created' }), 'k3')).toBeUndefined()
+    expect(h.open(hookContext({ gitea: { ...gitea, target: { kind: 'pull', index: INDEX } } }), 'k4')).toBeUndefined()
+    expect(
+      h.open(hookContext({ snapshot: { ...SNAPSHOT, dispatchDaemonId: '99999999-9999-4999-8999-999999999999' } }), 'k5')
+    ).toBeUndefined()
+    // The console re-run and a relay-flagged reviewer request open one like a revision does.
+    expect(h.open(hookContext({ event: 'merge_request:rerun' }), 'k6')).toBeDefined()
+    expect(
+      h.open(
+        hookContext({
+          event: 'note:created',
+          gitea: { ...gitea, target: { kind: 'pull', index: INDEX, headSha: HEAD, explicitReviewRequest: true } }
+        }),
+        'k7'
+      )
+    ).toBeDefined()
+    // A durable attempt that already reached an effect leaves the turn terminal.
+    const done = h.open(
+      hookContext({
+        codeReview: { attemptId: ATTEMPT, event: 'COMMENT', verdict: 'neutral', headSha: HEAD, state: 'submitted' }
+      }),
+      'k8'
+    )
+    expect(done?.state).toBe('done')
+  })
+
+  it('routes a code review to the adapter that owns the active turn', async () => {
+    const h = harness()
+    const router = new CodeHostReviewRouter()
+    router.register({ provider: 'gitlab', owns: () => false, submit: async () => undefined })
+    router.register(h.adapter)
+    const outcome = (await router.submit(request())) as GiteaReviewOutcome
+    expect(outcome).toMatchObject({ provider: 'gitea', state: 'submitted' })
+  })
+})
+
+describe('Gitea review adapter — the happy path per verdict (§10.3 steps 1-4)', () => {
+  it('publishes a COMMENT review with marker-signed summary and inline comments, and reports body-free', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({
+        comments: [
+          { path: 'src/a.ts', body: 'Bug here.', line: 9, side: 'RIGHT' },
+          { path: 'src/b.ts', body: 'Removed too much.', line: 4, side: 'LEFT' }
+        ]
+      })
+    )) as GiteaReviewOutcome
+
+    expect(outcome.state).toBe('submitted')
+    expect(outcome.message).toContain('published on the pull request')
+    expect(outcome.publishedEvent).toBeUndefined()
+    const [post] = submissions(h.calls)
+    expect(post!.body).toMatchObject({ commit_id: HEAD, event: 'COMMENT' })
+    expect(String(post!.body!.body)).toContain('Looks reasonable overall.')
+    expect(String(post!.body!.body)).toContain(signer.mint(ATTEMPT, 0, HEAD))
+    const comments = post!.body!.comments as Array<Record<string, unknown>>
+    expect(comments).toHaveLength(2)
+    // RIGHT → new_position, LEFT → old_position, and every inline comment carries its ordinal marker.
+    expect(comments[0]).toMatchObject({ path: 'src/a.ts', new_position: 9 })
+    expect(comments[0]!.old_position).toBeUndefined()
+    expect(String(comments[0]!.body)).toContain(signer.mint(ATTEMPT, 1, HEAD))
+    expect(comments[1]).toMatchObject({ path: 'src/b.ts', old_position: 4 })
+    expect(String(comments[1]!.body)).toContain(signer.mint(ATTEMPT, 2, HEAD))
+    // The reconcile read precedes the one submission; nothing was deleted.
+    expect(mutations(h.calls)).toEqual([`POST ${PULL_PATH}/reviews`])
+    // Body-free result: ids and one normalized state, never review text.
+    const report = h.results.at(-1)!
+    expect(report).toMatchObject({ provider: 'gitea', projectId: REPO, mergeRequestIid: INDEX, state: 'submitted' })
+    expect(JSON.stringify(report)).not.toContain('Looks reasonable overall.')
+    expect(report.externalIds).toEqual([{ kind: 'review', externalId: h.state.reviews[0]!.id }])
+    expect(report.externalIds![0]!.externalId).toMatch(/^\d{16}$/)
+    expect(h.state.reviews[0]!.state).toBe('COMMENT')
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+  })
+
+  it('publishes REQUEST_CHANGES natively, with no reviewer precondition', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event: 'REQUEST_CHANGES', verdict: 'fail' })
+    )) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(submissions(h.calls)[0]!.body).toMatchObject({ event: 'REQUEST_CHANGES' })
+    // Gitea needs no reviewer record, so the authorization carries no reviewer fact.
+    expect(h.authorizations[0]!.serviceAccountIsReviewer).toBeUndefined()
+    expect(h.state.reviews[0]!.state).toBe('REQUEST_CHANGES')
+  })
+
+  it('publishes APPROVE as APPROVED in the same call', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(submissions(h.calls)[0]!.body).toMatchObject({ event: 'APPROVED' })
+    expect(h.state.reviews[0]!.state).toBe('APPROVED')
+    expect(h.results.at(-1)).toMatchObject({ event: 'APPROVE', verdict: 'pass', state: 'submitted' })
+  })
+
+  it('runs issue → start → settle for the one submission and releases the lease on the result', async () => {
+    const h = harness()
+    await h.adapter.submit(KEY, request())
+    expect(h.ops.map((op) => (op.op === 'issue' ? `issue:${op.kind}:${op.ordinal}` : op.op))).toEqual([
+      'issue:bulk_publish:0',
+      'start',
+      'settle'
+    ])
+    expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))).toMatchObject({ phase: 'settled', attemptId: null })
+  })
+
+  it('refreshes the effect lease exactly once after a definite 401 and retries under a new record', async () => {
+    const h = harness({
+      tokens: ['gitea-stale', 'gitea-fresh'],
+      script: [{ method: 'POST', path: /\/reviews$/, reply: { status: 401, body: { message: 'token is required' } } }]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(h.invalidated()).toEqual(['gitea-stale'])
+    const posts = submissions(h.calls)
+    expect(posts.map((post) => post.token)).toEqual(['gitea-stale', 'gitea-fresh'])
+    const issued = h.ops.filter((op) => op.op === 'issue') as Array<{ ordinal: number }>
+    expect(issued.map((op) => op.ordinal)).toEqual([0, 1])
+  })
+
+  it('collapses a range to its end line and names the start on the comment’s first line', async () => {
+    const h = harness()
+    await h.adapter.submit(
+      KEY,
+      request({
+        comments: [
+          { path: 'src/a.ts', body: 'Whole block.', line: 14, side: 'RIGHT', startLine: 10, startSide: 'RIGHT' }
+        ]
+      })
+    )
+    const [comment] = submissions(h.calls)[0]!.body!.comments as Array<Record<string, unknown>>
+    expect(comment).toMatchObject({ path: 'src/a.ts', new_position: 14 })
+    expect(String(comment!.body).startsWith('Lines 10-14:\n\nWhole block.')).toBe(true)
+  })
+})
+
+describe('Gitea review adapter — reconcile before submit (§10.3 step 2)', () => {
+  it('deletes only the bot’s own pending review, never a submitted one or another user’s pending one', async () => {
+    const state = giteaState()
+    const orphan = seedPending(state, OLD_ATTEMPT)
+    const submitted = seedSubmitted(state, OLD_ATTEMPT)
+    const human: FakeReview = {
+      id: String(state.nextId++),
+      user: { id: HUMAN_USER },
+      state: 'PENDING',
+      body: '',
+      commit_id: HEAD,
+      comments: []
+    }
+    state.reviews.push(human)
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(deletes(h.calls).map((call) => call.path)).toEqual([`${PULL_PATH}/reviews/${orphan.id}`])
+    // The state guard is re-read right before the delete, and the delete rides its own record.
+    const reads = h.calls.filter((call) => call.method === 'GET' && call.path === `${PULL_PATH}/reviews/${orphan.id}`)
+    expect(reads).toHaveLength(1)
+    expect(h.ops.some((op) => op.op === 'issue' && op.kind === 'draft_delete')).toBe(true)
+    expect(state.reviews.map((review) => review.id)).toContain(submitted.id)
+    expect(state.reviews.map((review) => review.id)).toContain(human.id)
+    // The delete precedes the submission.
+    expect(h.calls.findIndex((call) => call.method === 'DELETE')).toBeLessThan(
+      h.calls.findIndex((call) => call.method === 'POST')
+    )
+  })
+
+  it('deletes an orphan staged against an earlier head by verifying its markers under that head', async () => {
+    const state = giteaState()
+    seedPending(state, OLD_ATTEMPT, OTHER_HEAD)
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(deletes(h.calls)).toHaveLength(1)
+  })
+
+  it('fails closed on a pending review with an unmarked comment, without deleting or submitting', async () => {
+    const state = giteaState()
+    seedPending(state, OLD_ATTEMPT, HEAD, false)
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+    expect(mutations(h.calls)).toEqual([])
+    expect(h.results.at(-1)!.state).toBe('review_reconciliation_required')
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+  })
+
+  it('fails closed on a marker this daemon cannot verify', async () => {
+    const state = giteaState()
+    const foreign = new ReviewMarkerSigner(Buffer.from('a-different-daemons-marker-key-01'))
+    state.reviews.push({
+      id: String(state.nextId++),
+      user: { id: BOT_USER },
+      state: 'PENDING',
+      body: '',
+      commit_id: HEAD,
+      comments: [
+        { id: String(state.nextId++), path: 'x', body: `x\n\n${foreign.mint(OLD_ATTEMPT, 1, HEAD)}`, position: 1 }
+      ]
+    })
+    const h = harness({ state })
+    expect(((await h.adapter.submit(KEY, request())) as GiteaReviewOutcome).state).toBe(
+      'review_reconciliation_required'
+    )
+    expect(mutations(h.calls)).toEqual([])
+  })
+
+  it('refuses to delete a row that stopped being pending between the list and the delete', async () => {
+    const state = giteaState()
+    const orphan = seedPending(state, OLD_ATTEMPT)
+    const h = harness({
+      state,
+      // The re-read right before the delete sees the row already submitted by a request still in flight.
+      script: [
+        {
+          method: 'GET',
+          path: new RegExp(`/reviews/${orphan.id}$`),
+          reply: { status: 200, body: { id: Number(orphan.id), user: { id: Number(BOT_USER) }, state: 'COMMENT' } }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('review_reconciliation_required')
+    expect(deletes(h.calls)).toEqual([])
+    expect(submissions(h.calls)).toEqual([])
+  })
+
+  it('reads back after an ambiguous delete: proven absence upgrades the record, presence fails closed', async () => {
+    const gone = giteaState()
+    const orphan = seedPending(gone, OLD_ATTEMPT)
+    const h = harness({
+      state: gone,
+      script: [
+        {
+          method: 'DELETE',
+          path: /\/reviews\//,
+          reply: 'network',
+          then: () => void (gone.reviews = gone.reviews.filter((review) => review.id !== orphan.id))
+        }
+      ]
+    })
+    expect(((await h.adapter.submit(KEY, request())) as GiteaReviewOutcome).state).toBe('submitted')
+    const settles = h.ops.filter((op) => op.op === 'settle') as Array<{
+      outcome: { kind: string; externalId?: string }
+    }>
+    expect(settles.map((op) => op.outcome.kind)).toEqual(['ambiguous', 'deterministic', 'deterministic'])
+    expect(settles[1]!.outcome).toMatchObject({ kind: 'deterministic', status: 204, externalId: orphan.id })
+
+    const stuck = giteaState()
+    seedPending(stuck, OLD_ATTEMPT)
+    const h2 = harness({ state: stuck, script: [{ method: 'DELETE', path: /\/reviews\//, reply: 'network' }] })
+    expect(((await h2.adapter.submit(KEY, request())) as GiteaReviewOutcome).state).toBe(
+      'review_reconciliation_required'
+    )
+    expect(submissions(h2.calls)).toEqual([])
+  })
+
+  it('cannot be confused by a marker the model planted in its own review body', async () => {
+    const h = harness()
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ body: `Please look here.\n${signer.mint(ATTEMPT, 0, HEAD)}` })
+    )) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    const body = String(submissions(h.calls)[0]!.body!.body)
+    expect(body.split('<!-- agentconnect-review:')).toHaveLength(2)
+  })
+})
+
+describe('Gitea review adapter — head fences and preemption (§10.3 step 3, §15.1)', () => {
+  it('refuses a changed head before the request and releases the lease with nothing staged', async () => {
+    const h = harness({ state: giteaState({ headSha: OTHER_HEAD }) })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(submissions(h.calls)).toEqual([])
+    expect(h.state.reviews).toEqual([])
+    expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))?.phase).toBe('settled')
+    // A proven no-effect attempt leaves the ordinary reply available and the turn free to retry.
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(true)
+    expect(h.adapter.owns(KEY, AGENT_ID)).toBe(true)
+  })
+
+  it('settles a started request by its own evidence even when the head moves on afterwards', async () => {
+    const state = giteaState()
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'POST',
+          path: /\/reviews$/,
+          reply: 'network',
+          // The request landed, and a newer revision arrived right after it.
+          then: () => {
+            seedSubmitted(state, ATTEMPT)
+            state.headSha = OTHER_HEAD
+          }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(submissions(h.calls)).toHaveLength(1)
+    expect(outcome.externalIds).toEqual([{ kind: 'review', externalId: state.reviews[0]!.id }])
+  })
+
+  it('surfaces a control-plane head_changed or lease_held refusal without touching the provider', async () => {
+    const h = harness({ cp: { refuse: 'head_changed' } })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(outcome.message).toContain('pull request head changed')
+    expect(mutations(h.calls)).toEqual([])
+  })
+})
+
+describe('Gitea review adapter — ambiguous submission (§10.3 step 5, §15.2)', () => {
+  it('identifies an ambiguous submission by its summary marker and never submits twice', async () => {
+    const state = giteaState()
+    const h = harness({
+      state,
+      script: [{ method: 'POST', path: /\/reviews$/, reply: 'network', then: () => void seedSubmitted(state, ATTEMPT) }]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(submissions(h.calls)).toHaveLength(1)
+    expect(outcome.externalIds).toEqual([{ kind: 'review', externalId: state.reviews[0]!.id }])
+    const settle = h.ops.filter((op) => op.op === 'settle').at(-1) as { outcome: { kind: string; externalId?: string } }
+    expect(settle.outcome).toMatchObject({ kind: 'deterministic', externalId: state.reviews[0]!.id })
+  })
+
+  it('treats a pending review carrying this attempt’s inline markers as staged, not submitted', async () => {
+    const state = giteaState()
+    const h = harness({
+      state,
+      script: [
+        {
+          method: 'POST',
+          path: /\/reviews$/,
+          reply: 'network',
+          // Gitea staged the comments and is still running the submission step.
+          then: () => void seedPending(state, ATTEMPT)
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(submissions(h.calls)).toHaveLength(1)
+    // No delete either: deletion is never a basis for release.
+    expect(deletes(h.calls)).toEqual([])
+  })
+
+  it('reports not_submitted for a deterministic rejection and leaves the same attempt free to retry', async () => {
+    const h = harness({
+      attemptIds: [ATTEMPT, SECOND_ATTEMPT],
+      script: [
+        {
+          method: 'POST',
+          path: /\/reviews$/,
+          reply: { status: 422, body: { message: 'review event COMMENT requires a body or a comment' } }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(h.results.at(-1)!.externalIds).toBeUndefined()
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(true)
+    const retry = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(retry.state).toBe('submitted')
+    // A proven no-effect attempt is superseded by a fresh id under a fresh lease.
+    expect(h.authorizations.map((authorization) => authorization.attemptId)).toEqual([ATTEMPT, SECOND_ATTEMPT])
+  })
+
+  it('locks the pull request when no marked review appears, stays locked across a retry, and clears on a later reconciliation', async () => {
+    const state = giteaState()
+    const h = harness({
+      state,
+      attemptIds: [ATTEMPT, SECOND_ATTEMPT, THIRD_ATTEMPT],
+      script: [{ method: 'POST', path: /\/reviews$/, reply: 'network' }]
+    })
+    const locked = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(locked.state).toBe('ambiguous_locked')
+    expect(locked.message).toContain('locked against further automated review attempts')
+    expect(h.results.at(-1)).toMatchObject({ attemptId: ATTEMPT, state: 'ambiguous_locked' })
+    expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))).toMatchObject({
+      phase: 'ambiguous_locked',
+      attemptId: ATTEMPT
+    })
+    expect(codeHostReviewFallbackAllowed(h.hook)).toBe(false)
+
+    // A later delivery on the same pull request is refused by the lock: nothing is submitted, the lock holds.
+    const retryHook = hookContext({ deliveryKey: 'delivery-2', event: 'merge_request:rerun' })
+    const retryKey = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID, `gitea:${REPO}`)
+    h.open(retryHook, retryKey)
+    const retried = (await h.adapter.submit(retryKey, {
+      ...request(),
+      transportScope: `gitea:${REPO}`
+    })) as GiteaReviewOutcome
+    expect(retried.state).toBe('ambiguous_locked')
+    expect(retried.message).toContain('stays locked until its marked review is found submitted')
+    expect(submissions(h.calls)).toHaveLength(1)
+    expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))!.phase).toBe('ambiguous_locked')
+    expect(codeHostReviewFallbackAllowed(retryHook)).toBe(false)
+
+    // The lost request finished at Gitea: the next attempt's refusal runs the pass, the lock clears, and the new attempt publishes under a fresh fence.
+    seedSubmitted(state, ATTEMPT)
+    const laterHook = hookContext({ deliveryKey: 'delivery-3', event: 'merge_request:rerun' })
+    const laterKey = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID, `gitea:${REPO}:later`)
+    h.open(laterHook, laterKey)
+    const cleared = (await h.adapter.submit(laterKey, {
+      ...request(),
+      transportScope: `gitea:${REPO}:later`
+    })) as GiteaReviewOutcome
+    expect(cleared.state).toBe('submitted')
+    expect(submissions(h.calls)).toHaveLength(2)
+    // The locked attempt's record was upgraded by positive identification and its outcome re-reported.
+    const upgrade = h.ops.find(
+      (op) => op.op === 'settle' && op.attemptId === ATTEMPT && op.outcome.kind === 'deterministic'
+    ) as { outcome: { externalId?: string } } | undefined
+    expect(upgrade?.outcome.externalId).toBe(state.reviews[0]!.id)
+    expect(h.results.filter((result) => result.attemptId === ATTEMPT).map((result) => result.state)).toEqual([
+      'ambiguous_locked',
+      'submitted'
+    ])
+    expect(h.control.outcomes.get(ATTEMPT)).toBe('submitted')
+    expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))).toMatchObject({ phase: 'settled', attemptId: null })
+    // The locked delivery's durable row follows: its attempt is now submitted and names the review.
+    expect(h.hook.codeReview).toMatchObject({ attemptId: ATTEMPT, state: 'submitted' })
+    expect(h.hook.codeReview?.externalIds).toEqual([{ kind: 'review', externalId: state.reviews[0]!.id }])
+    expect(h.hook.codeReview?.operations ?? []).toEqual([])
+  })
+
+  it('surfaces a control-plane ambiguous_locked refusal it holds no record for, without touching the provider', async () => {
+    const h = harness({ cp: { refuse: 'ambiguous_locked' } })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(mutations(h.calls)).toEqual([])
+  })
+
+  it('stops before the request when the lease has already locked at renewal', async () => {
+    const h = harness({ cp: { renewPhase: 'ambiguous_locked' } })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(submissions(h.calls)).toEqual([])
+  })
+})
+
+describe('Gitea review adapter — the self-review downgrade (§10.3)', () => {
+  it.each([
+    { event: 'APPROVE' as const, verdict: 'pass' as const, wire: 'APPROVED' },
+    { event: 'REQUEST_CHANGES' as const, verdict: 'fail' as const, wire: 'REQUEST_CHANGES' }
+  ])('republishes a refused $event on the bot’s own pull request as COMMENT', async ({ event, verdict, wire }) => {
+    const state = giteaState({ authorId: BOT_USER })
+    const h = harness({ state })
+    const outcome = (await h.adapter.submit(
+      KEY,
+      request({ event, verdict, comments: [{ path: 'src/a.ts', body: 'Careful.', line: 2, side: 'RIGHT' }] })
+    )) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(outcome.event).toBe(event)
+    expect(outcome.publishedEvent).toBe('COMMENT')
+    expect(outcome.message).toContain('self_review_forbidden')
+    const posts = submissions(h.calls)
+    expect(posts.map((post) => post.body!.event)).toEqual([wire, 'COMMENT'])
+    // The same content, marker included, rides the republish; the first request staged nothing.
+    expect(posts[1]!.body!.body).toBe(posts[0]!.body!.body)
+    expect(posts[1]!.body!.comments).toEqual(posts[0]!.body!.comments)
+    expect(state.reviews).toHaveLength(1)
+    expect(state.reviews[0]!.state).toBe('COMMENT')
+    // Two records, one per request; the result names the requested event and the published review.
+    const issued = h.ops.filter((op) => op.op === 'issue') as Array<{ ordinal: number }>
+    expect(issued.map((op) => op.ordinal)).toEqual([0, 1])
+    expect(h.results.at(-1)).toMatchObject({ event, verdict, state: 'submitted' })
+    expect(h.results.at(-1)!.externalIds).toEqual([{ kind: 'review', externalId: state.reviews[0]!.id }])
+  })
+
+  it('does not downgrade on an unrelated 422', async () => {
+    const h = harness({
+      state: giteaState({ authorId: BOT_USER }),
+      script: [
+        {
+          method: 'POST',
+          path: /\/reviews$/,
+          reply: { status: 422, body: { message: 'review event APPROVED requires a body' } }
+        }
+      ]
+    })
+    const outcome = (await h.adapter.submit(KEY, request({ event: 'APPROVE', verdict: 'pass' }))) as GiteaReviewOutcome
+    expect(outcome.state).toBe('not_submitted')
+    expect(submissions(h.calls)).toHaveLength(1)
+  })
+})
+
+describe('Gitea review adapter — started-operation recovery (§15.1)', () => {
+  const crashed = (): HookDispatchContext =>
+    hookContext({
+      codeReview: {
+        attemptId: ATTEMPT,
+        event: 'COMMENT',
+        verdict: 'neutral',
+        headSha: HEAD,
+        fence: '7',
+        ordinals: { bulk_publish: 1 },
+        operations: [
+          {
+            recordId: recordIdOf(ATTEMPT, 7, 'bulk_publish', 0),
+            startToken: 'start-1',
+            kind: 'bulk_publish',
+            ordinal: 0,
+            target: `${PULL_PATH}/reviews`,
+            phase: 'started'
+          }
+        ]
+      }
+    })
+  const seeded = () => [
+    { attemptId: ATTEMPT, recordId: recordIdOf(ATTEMPT, 7, 'bulk_publish', 0), kind: 'bulk_publish', ordinal: 0 }
+  ]
+
+  it('adopts a started submission that DID land and never submits a second time', async () => {
+    const state = giteaState()
+    const review = seedSubmitted(state, ATTEMPT, 'APPROVED')
+    const h = harness({ state, hook: crashed(), cp: { seedStarted: seeded() } })
+    // The lease is reacquired by the same attempt; the fake mints fence 7 for it.
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(submissions(h.calls)).toEqual([])
+    expect(outcome.externalIds).toEqual([{ kind: 'review', externalId: review.id }])
+    // A review that published a different verdict than the request is reported as the downgrade it is.
+    expect(outcome.publishedEvent).toBe('APPROVE')
+    expect([...h.control.records.values()].filter((row) => row.state === 'request_started')).toEqual([])
+  })
+
+  it('locks instead of resubmitting when a started submission left no marked review', async () => {
+    const h = harness({ hook: crashed(), cp: { seedStarted: seeded() } })
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('ambiguous_locked')
+    expect(submissions(h.calls)).toEqual([])
+    expect(h.control.records.get(recordIdOf(ATTEMPT, 7, 'bulk_publish', 0))?.state).toBe('ambiguous')
+  })
+
+  it('returns an unstarted permit instead of settling a request that never went out', async () => {
+    const hook = crashed()
+    hook.codeReview!.operations![0]!.phase = 'issued'
+    const h = harness({ hook, cp: { seedStarted: seeded() } })
+    h.control.records.get(recordIdOf(ATTEMPT, 7, 'bulk_publish', 0))!.state = 'issued'
+    const outcome = (await h.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(outcome.state).toBe('submitted')
+    expect(h.ops.some((op) => op.op === 'return-unused')).toBe(true)
+    // The replacement request takes the next coordinate.
+    const issued = h.ops.filter((op) => op.op === 'issue') as Array<{ ordinal: number }>
+    expect(issued.map((op) => op.ordinal)).toEqual([1])
+  })
+})
+
+describe('Gitea review adapter — two agents on one pull request (§10.3, §15.1)', () => {
+  it('serializes two agents through the lease and publishes two distinct reviews under the one bot', async () => {
+    const state = giteaState()
+    const control = fakeCp()
+    const first = harness({
+      state,
+      control,
+      script: [{ method: 'POST', path: /\/reviews$/, reply: 'defer', then: () => void 0 }]
+    })
+    const otherHook = hookContext({ hookId: OTHER_HOOK_ID, agentId: OTHER_AGENT_ID, deliveryKey: 'delivery-b' })
+    const otherKey = sessionKey('hook', OTHER_HOOK_ID, THREAD, OTHER_AGENT_ID)
+    const second = harness({ state, control, hook: otherHook, key: otherKey, attemptIds: [SECOND_ATTEMPT] })
+    const otherRequest = request({ agentId: OTHER_AGENT_ID, channel: OTHER_HOOK_ID, body: 'Second opinion.' })
+
+    // Agent A holds the lease while its submission is in flight; agent B is refused, retryably.
+    const inFlight = first.adapter.submit(KEY, request())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const refused = (await second.adapter.submit(otherKey, otherRequest)) as GiteaReviewOutcome
+    expect(refused.state).toBe('not_submitted')
+    expect(refused.message).toContain('Another review attempt currently owns publication')
+    expect(second.calls.filter((call) => call.method === 'POST')).toEqual([])
+
+    // A finishes; the lease releases; B's retry publishes its own review.
+    first.release()
+    expect(((await inFlight) as GiteaReviewOutcome).state).toBe('submitted')
+    expect(control.leases.get(control.subjectOf(REPO, INDEX))!.phase).toBe('settled')
+    const published = (await second.adapter.submit(otherKey, otherRequest)) as GiteaReviewOutcome
+    expect(published.state).toBe('submitted')
+    expect(state.reviews).toHaveLength(2)
+    expect(state.reviews.map((review) => review.state)).toEqual(['COMMENT', 'COMMENT'])
+    expect(new Set(state.reviews.map((review) => review.id)).size).toBe(2)
+    // Each review carries its own attempt's marker; neither absorbed the other's staging.
+    expect(signer.read(state.reviews[0]!.body, HEAD)).toEqual({ attemptId: ATTEMPT, ordinal: 0 })
+    expect(signer.read(state.reviews[1]!.body, HEAD)).toEqual({ attemptId: SECOND_ATTEMPT, ordinal: 0 })
+  })
+})
+
+describe('Gitea review adapter — durable ownership', () => {
+  it('claims the reply gate durably for a submitted review and keeps it across a restart', async () => {
+    const h = harness()
+    expect(((await h.adapter.submit(KEY, request())) as GiteaReviewOutcome).state).toBe('submitted')
+    expect(h.hook.codeReview).toMatchObject({ attemptId: ATTEMPT, state: 'submitted', headSha: HEAD })
+    const restarted = harness({ hook: h.hook, reviewStore: h.reviewStore })
+    await expect(restarted.adapter.submit(KEY, request())).rejects.toThrow(/already has a formal review attempt/)
+    expect(mutations(restarted.calls)).toEqual([])
+  })
+
+  it('records the attempt before the first provider call and refuses when that write fails', async () => {
+    const h = harness({ failPersist: true })
+    await expect(h.adapter.submit(KEY, request())).rejects.toThrow(/durability barrier failed/)
+    expect(h.calls).toEqual([])
+    expect(h.hook.codeReview).toBeUndefined()
+  })
+
+  it('replays an unacknowledged result report through the shared outbox', async () => {
+    let refuse = true
+    const h = harness({
+      cp: {
+        reportFails: () => {
+          const err = refuse ? Object.assign(new Error('control plane unreachable'), { retryable: true }) : undefined
+          refuse = false
+          return err
+        }
+      }
+    })
+    await h.adapter.submit(KEY, request())
+    expect([...h.reviewStore.rows.keys()]).toEqual([`${ATTEMPT}:result`])
+    await h.adapter.reconcilePending()
+    expect(h.reviewStore.rows.size).toBe(0)
+    expect(h.results.filter((row) => row.attemptId === ATTEMPT).at(-1)).toMatchObject({
+      state: 'submitted',
+      provider: 'gitea'
+    })
+  })
+})

--- a/packages/daemon/test/gitea-review-adapter.test.ts
+++ b/packages/daemon/test/gitea-review-adapter.test.ts
@@ -43,7 +43,10 @@ const KEY = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID)
 const MARKER_SEED = 'gitea-review-marker-test-key-001'
 const PULL_PATH = `/repos/example-org/example-repo/pulls/${INDEX}`
 
-const signer = new ReviewMarkerSigner(Buffer.from(MARKER_SEED, 'utf8'))
+const OTHER_DAEMON_SEED = 'gitea-review-marker-test-key-002'
+
+// The adapter keys markers per attempt off the daemon key, so fixtures mint the same way.
+const signer = ReviewMarkerSigner.derived(Buffer.from(MARKER_SEED, 'utf8'))
 
 const SNAPSHOT: HookConfigSnapshot = {
   configRevision: '4',
@@ -266,6 +269,7 @@ interface LeaseRow {
   event?: string
   verdict?: string
   headSha?: string
+  markerSeed?: string
 }
 
 interface OpRow {
@@ -340,6 +344,29 @@ function fakeCp(opts: CpOptions = {}) {
     }
     return lease.phase
   }
+  // The lock's durable coordinates: the owner, its fence, the retained ambiguous record, the head, and the seed the owner left.
+  const retainedOf = (lease: LeaseRow) =>
+    [...records.entries()].find(([, row]) => row.attemptId === lease.attemptId && row.state === 'ambiguous')
+  const lockOf = (lease: LeaseRow): Pick<Extract<CodeHostReviewAuthorized, { authorized: false }>, 'lock'> => {
+    const retained = retainedOf(lease)
+    if (!lease.attemptId || !lease.headSha || !lease.markerSeed || !retained) return {}
+    return {
+      lock: {
+        attemptId: lease.attemptId,
+        fence: String(lease.fence),
+        recordId: retained[0],
+        headSha: lease.headSha,
+        markerSeed: lease.markerSeed
+      }
+    }
+  }
+  const locked = (attemptId: string, lease: LeaseRow): CodeHostReviewAuthorized => ({
+    authorized: false,
+    attemptId,
+    reason: 'ambiguous_locked',
+    retryable: false,
+    ...lockOf(lease)
+  })
   const cp: CodeHostReviewControlPlane = {
     supportsReview: () => opts.supports !== false,
     authorize: async (payload): Promise<CodeHostReviewAuthorized> => {
@@ -347,9 +374,22 @@ function fakeCp(opts: CpOptions = {}) {
       if (opts.refuse) return { authorized: false, attemptId: payload.attemptId, reason: opts.refuse, retryable: false }
       const key = subjectOf(payload.projectId, payload.mergeRequestIid)
       let lease = leases.get(key)
-      if (lease?.phase === 'ambiguous_locked') {
-        return { authorized: false, attemptId: payload.attemptId, reason: 'ambiguous_locked', retryable: false }
+      // The lock's one exit: the refused daemon names the retained record's object; the owner's effect is recorded and the lease releases.
+      const unlock = payload.unlock
+      if (unlock && lease?.phase === 'ambiguous_locked' && lease.attemptId === unlock.attemptId) {
+        const retained = records.get(unlock.recordId)
+        if (
+          String(lease.fence) === unlock.fence &&
+          retained?.attemptId === lease.attemptId &&
+          retained.state === 'ambiguous'
+        ) {
+          retained.state = 'settled'
+          retained.externalId = unlock.externalRef.externalId
+          outcomes.set(lease.attemptId, 'submitted')
+          release(lease)
+        }
       }
+      if (lease?.phase === 'ambiguous_locked') return locked(payload.attemptId, lease)
       if (lease && lease.attemptId !== null && lease.attemptId !== payload.attemptId && lease.phase !== 'settled') {
         if (lease.leaseUntil > now()) {
           return { authorized: false, attemptId: payload.attemptId, reason: 'lease_held', retryable: true }
@@ -357,7 +397,7 @@ function fakeCp(opts: CpOptions = {}) {
         // An expired lease transfers only under the §15.1 conditions; an outstanding record locks it.
         if (ledger(lease.attemptId).some((row) => row.state !== 'settled' && row.state !== 'unused')) {
           lease.phase = 'ambiguous_locked'
-          return { authorized: false, attemptId: payload.attemptId, reason: 'ambiguous_locked', retryable: false }
+          return locked(payload.attemptId, lease)
         }
       }
       if (!lease || lease.attemptId !== payload.attemptId) {
@@ -368,7 +408,8 @@ function fakeCp(opts: CpOptions = {}) {
           leaseUntil: now() + 300_000,
           event: payload.requestedEvent,
           verdict: payload.requestedVerdict,
-          headSha: payload.headSha
+          headSha: payload.headSha,
+          ...(payload.markerSeed ? { markerSeed: payload.markerSeed } : {})
         }
         leases.set(key, lease)
       } else {
@@ -554,6 +595,8 @@ interface HarnessOptions {
   hook?: HookDispatchContext
   key?: string
   reviewStore?: FakeReviewStore
+  /** The daemon key a fresh store mints; a different one is another daemon. */
+  markerSeed?: string
   attemptIds?: string[]
   open?: boolean
   failPersist?: boolean
@@ -578,7 +621,8 @@ function harness(opts: HarnessOptions = {}) {
     orgForAgent: () => 'org-1',
     daemonId: () => DAEMON_ID,
     store: reviewStore,
-    markerKey: async () => Buffer.from(await reviewStore.getOrCreateDaemonSecret(() => MARKER_SEED), 'utf8'),
+    markerKey: async () =>
+      Buffer.from(await reviewStore.getOrCreateDaemonSecret(() => opts.markerSeed ?? MARKER_SEED), 'utf8'),
     token: async () => {
       const token = supply[Math.min(minted.length, supply.length - 1)]!
       minted.push(token)
@@ -1102,7 +1146,10 @@ describe('Gitea review adapter — ambiguous submission (§10.3 step 5, §15.2)'
     expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))!.phase).toBe('ambiguous_locked')
     expect(codeHostReviewFallbackAllowed(retryHook)).toBe(false)
 
-    // The lost request finished at Gitea: the next attempt's refusal runs the pass, the lock clears, and the new attempt publishes under a fresh fence.
+    // The refused attempt read the pull request from the lock's coordinates and found nothing submitted: it asked once.
+    expect(h.authorizations.filter((authorization) => authorization.attemptId === SECOND_ATTEMPT)).toHaveLength(1)
+
+    // The lost request finished at Gitea: the next attempt's refusal runs the pass, names the review when it asks again, and publishes under a fresh fence.
     seedSubmitted(state, ATTEMPT)
     const laterHook = hookContext({ deliveryKey: 'delivery-3', event: 'merge_request:rerun' })
     const laterKey = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID, `gitea:${REPO}:later`)
@@ -1113,21 +1160,96 @@ describe('Gitea review adapter — ambiguous submission (§10.3 step 5, §15.2)'
     })) as GiteaReviewOutcome
     expect(cleared.state).toBe('submitted')
     expect(submissions(h.calls)).toHaveLength(2)
-    // The locked attempt's record was upgraded by positive identification and its outcome re-reported.
-    const upgrade = h.ops.find(
-      (op) => op.op === 'settle' && op.attemptId === ATTEMPT && op.outcome.kind === 'deterministic'
-    ) as { outcome: { externalId?: string } } | undefined
-    expect(upgrade?.outcome.externalId).toBe(state.reviews[0]!.id)
-    expect(h.results.filter((result) => result.attemptId === ATTEMPT).map((result) => result.state)).toEqual([
-      'ambiguous_locked',
-      'submitted'
+    const asks = h.authorizations.filter((authorization) => authorization.attemptId === THIRD_ATTEMPT)
+    expect(asks.map((ask) => ask.unlock)).toEqual([
+      undefined,
+      {
+        attemptId: ATTEMPT,
+        fence: '7',
+        recordId: recordIdOf(ATTEMPT, 7, 'bulk_publish', 0),
+        externalRef: { kind: 'review', externalId: state.reviews[0]!.id }
+      }
     ])
+    // The control plane settled the retained record by its object and recorded the owner's effect; the daemon settles and reports nothing for it.
+    expect(h.control.records.get(recordIdOf(ATTEMPT, 7, 'bulk_publish', 0))).toMatchObject({
+      state: 'settled',
+      externalId: state.reviews[0]!.id
+    })
     expect(h.control.outcomes.get(ATTEMPT)).toBe('submitted')
+    expect(
+      h.ops.filter((op) => op.attemptId === ATTEMPT).flatMap((op) => (op.op === 'settle' ? [op.outcome.kind] : []))
+    ).toEqual(['ambiguous'])
+    expect(h.results.filter((result) => result.attemptId === ATTEMPT).map((result) => result.state)).toEqual([
+      'ambiguous_locked'
+    ])
     expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))).toMatchObject({ phase: 'settled', attemptId: null })
-    // The locked delivery's durable row follows: its attempt is now submitted and names the review.
-    expect(h.hook.codeReview).toMatchObject({ attemptId: ATTEMPT, state: 'submitted' })
-    expect(h.hook.codeReview?.externalIds).toEqual([{ kind: 'review', externalId: state.reviews[0]!.id }])
-    expect(h.hook.codeReview?.operations ?? []).toEqual([])
+  })
+
+  it('clears the lock from another daemon: the seed and the record travel with the lease, not with the process', async () => {
+    const state = giteaState()
+    const first = harness({ state, script: [{ method: 'POST', path: /\/reviews$/, reply: 'network' }] })
+    expect(((await first.adapter.submit(KEY, request())) as GiteaReviewOutcome).state).toBe('ambiguous_locked')
+    // The owner left its per-attempt seed with the lease when it asked.
+    const seed = ReviewMarkerSigner.seed(Buffer.from(MARKER_SEED, 'utf8'), ATTEMPT).toString('hex')
+    expect(first.authorizations[0]!.markerSeed).toBe(seed)
+    expect(first.control.leases.get(first.control.subjectOf(REPO, INDEX))!.markerSeed).toBe(seed)
+
+    // The lost request finished at Gitea after the daemon that sent it was gone; another daemon picks up the next delivery.
+    seedSubmitted(state, ATTEMPT)
+    const second = harness({
+      state,
+      control: first.control,
+      reviewStore: new FakeReviewStore(),
+      markerSeed: OTHER_DAEMON_SEED,
+      hook: hookContext({ deliveryKey: 'delivery-2', event: 'merge_request:rerun' }),
+      attemptIds: [SECOND_ATTEMPT]
+    })
+    const cleared = (await second.adapter.submit(KEY, request())) as GiteaReviewOutcome
+    expect(cleared.state).toBe('submitted')
+    expect(second.authorizations.at(-1)?.unlock).toEqual({
+      attemptId: ATTEMPT,
+      fence: '7',
+      recordId: recordIdOf(ATTEMPT, 7, 'bulk_publish', 0),
+      externalRef: { kind: 'review', externalId: state.reviews[0]!.id }
+    })
+    expect(first.control.records.get(recordIdOf(ATTEMPT, 7, 'bulk_publish', 0))).toMatchObject({
+      state: 'settled',
+      externalId: state.reviews[0]!.id
+    })
+    expect(first.control.outcomes.get(ATTEMPT)).toBe('submitted')
+    expect(first.control.leases.get(first.control.subjectOf(REPO, INDEX))).toMatchObject({
+      phase: 'settled',
+      attemptId: null
+    })
+    // The other daemon's own key never signed that marker: only the seed the lease carried could verify it.
+    const foreign = ReviewMarkerSigner.derived(Buffer.from(OTHER_DAEMON_SEED, 'utf8'))
+    expect(foreign.read(state.reviews[0]!.body, HEAD)).toBeUndefined()
+  })
+
+  it('keeps the lock while the marked review is only pending: the coordinates let a daemon look, not unlock', async () => {
+    const state = giteaState()
+    const h = harness({
+      state,
+      attemptIds: [ATTEMPT, SECOND_ATTEMPT],
+      script: [{ method: 'POST', path: /\/reviews$/, reply: 'network' }]
+    })
+    expect(((await h.adapter.submit(KEY, request())) as GiteaReviewOutcome).state).toBe('ambiguous_locked')
+    // Staging happened; submission did not.
+    seedPending(state, ATTEMPT)
+    const retryHook = hookContext({ deliveryKey: 'delivery-2', event: 'merge_request:rerun' })
+    const retryKey = sessionKey('hook', HOOK_ID, THREAD, AGENT_ID, `gitea:${REPO}`)
+    h.open(retryHook, retryKey)
+    const retried = (await h.adapter.submit(retryKey, {
+      ...request(),
+      transportScope: `gitea:${REPO}`
+    })) as GiteaReviewOutcome
+    expect(retried.state).toBe('ambiguous_locked')
+    expect(h.authorizations.filter((authorization) => authorization.attemptId === SECOND_ATTEMPT)).toHaveLength(1)
+    expect(mutations(h.calls)).toEqual([`POST ${PULL_PATH}/reviews`])
+    expect(h.control.leases.get(h.control.subjectOf(REPO, INDEX))).toMatchObject({
+      phase: 'ambiguous_locked',
+      attemptId: ATTEMPT
+    })
   })
 
   it('surfaces a control-plane ambiguous_locked refusal it holds no record for, without touching the provider', async () => {

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -33,7 +33,7 @@ import {
   type GitlabReviewOutcome,
   type ReviewIntentRow
 } from '../src/gitlab/review-adapter.js'
-import { ReviewMarkerSigner } from '../src/gitlab/review-marker.js'
+import { ReviewMarkerSigner } from '../src/codehost/review-marker.js'
 import { hookCoordinates, reviewSubjectLane, type HookQueueCandidate } from '../src/codehost/hook-admission.js'
 import { planRevisionAdmission, planRevisionAdmissionEffects } from '../src/codehost/queue-admission.js'
 import type { QueueEntry } from '../src/daemon/turn-types.js'

--- a/packages/protocol/src/frames/codehost-review.test.ts
+++ b/packages/protocol/src/frames/codehost-review.test.ts
@@ -257,6 +257,15 @@ describe('codehost review frames (gitlab-com-integration.md §15, §17.2)', () =
     expect(CodeHostReviewResultReport.safeParse({ ...result, state: 'not_submitted', externalIds: [] }).success).toBe(
       true
     )
+    // Gitea's submitted review is a published object of its own kind (gitea-integration.md §10.3).
+    expect(
+      CodeHostReviewResultReport.safeParse({
+        ...result,
+        provider: 'gitea',
+        state: 'submitted',
+        externalIds: [{ kind: 'review', externalId: '4242' }]
+      }).success
+    ).toBe(true)
     const decoded = decodeEnvelope(encode(buildEnvelope('codehost/review-result', result, { orgId: 'org-1' })))
     expect(decoded.ok && isFrame('codehost/review-result')(decoded.frame)).toBe(true)
     expect(CodeHostReviewResultOk.safeParse({ accepted: true, phase: 'settled' }).success).toBe(true)

--- a/packages/protocol/src/frames/codehost-review.test.ts
+++ b/packages/protocol/src/frames/codehost-review.test.ts
@@ -111,6 +111,52 @@ describe('codehost review frames (gitlab-com-integration.md §15, §17.2)', () =
     ).toBe(false)
   })
 
+  it('hands a locked refusal the coordinates of the lock exit, and takes the identified object back (gitea-integration.md §10.3)', () => {
+    const seed = 'ab'.repeat(32)
+    const lock = { attemptId: RECORD_ID, fence: '3', recordId: START_TOKEN, headSha: HEAD, markerSeed: seed }
+    const refused = CodeHostReviewAuthorized.safeParse({
+      authorized: false,
+      attemptId: ATTEMPT_ID,
+      reason: 'ambiguous_locked',
+      retryable: false,
+      lock
+    })
+    expect(refused.success).toBe(true)
+    if (refused.success && !refused.data.authorized) expect(refused.data.lock).toEqual(lock)
+    // The seed is hex key material, never free text.
+    expect(
+      CodeHostReviewAuthorized.safeParse({
+        authorized: false,
+        attemptId: ATTEMPT_ID,
+        reason: 'ambiguous_locked',
+        retryable: false,
+        lock: { ...lock, markerSeed: 'not a key' }
+      }).success
+    ).toBe(false)
+    const asking = CodeHostReviewAuthorize.safeParse({
+      ...authorize,
+      markerSeed: seed,
+      unlock: {
+        attemptId: RECORD_ID,
+        fence: '3',
+        recordId: START_TOKEN,
+        externalRef: { kind: 'review', externalId: '4242' }
+      }
+    })
+    expect(asking.success).toBe(true)
+    expect(
+      CodeHostReviewAuthorize.safeParse({
+        ...authorize,
+        unlock: {
+          attemptId: RECORD_ID,
+          fence: '3',
+          recordId: START_TOKEN,
+          externalRef: { kind: 'review', externalId: 'x' }
+        }
+      }).success
+    ).toBe(false)
+  })
+
   it('rejects an authorization that names no head or a non-numeric project', () => {
     expect(CodeHostReviewAuthorize.safeParse({ ...authorize, headSha: '' }).success).toBe(false)
     expect(CodeHostReviewAuthorize.safeParse({ ...authorize, projectId: 'example/project' }).success).toBe(false)

--- a/packages/protocol/src/frames/codehost-review.ts
+++ b/packages/protocol/src/frames/codehost-review.ts
@@ -56,6 +56,35 @@ export const CodeHostReviewRefusalReason = z.enum([
 ])
 export type CodeHostReviewRefusalReason = z.infer<typeof CodeHostReviewRefusalReason>
 
+/** One published provider object, by kind and numeric id. No URLs, no text. `review` is Gitea's submitted review (gitea-integration.md §10.3). */
+export const CodeHostReviewExternalRef = z.object({
+  kind: z.enum(['note', 'draft_note', 'discussion', 'approval', 'review']),
+  externalId: CodeHostExternalId
+})
+export type CodeHostReviewExternalRef = z.infer<typeof CodeHostReviewExternalRef>
+
+/** Per-attempt marker key material as hex; verifies exactly that attempt's markers and nothing else. */
+export const CodeHostReviewMarkerSeed = z.string().regex(/^[0-9a-f]{64}$/)
+
+/** What a daemon refused by `ambiguous_locked` needs to run the lock's one exit itself (gitea-integration.md §10.3). */
+export const CodeHostReviewLockCoordinates = z.object({
+  attemptId: z.string().uuid(),
+  fence: CodeHostReviewFence,
+  recordId: z.string().uuid(), // the retained ambiguous record
+  headSha: z.string().min(1),
+  markerSeed: CodeHostReviewMarkerSeed
+})
+export type CodeHostReviewLockCoordinates = z.infer<typeof CodeHostReviewLockCoordinates>
+
+/** The locked attempt's object, positively identified by the refused daemon: the one exit from `ambiguous_locked`. */
+export const CodeHostReviewUnlock = z.object({
+  attemptId: z.string().uuid(),
+  fence: CodeHostReviewFence,
+  recordId: z.string().uuid(),
+  externalRef: CodeHostReviewExternalRef
+})
+export type CodeHostReviewUnlock = z.infer<typeof CodeHostReviewUnlock>
+
 /**
  * `codehost/review-authz` (D→C REQ) — authorize ONE formal review attempt on one
  * merge request. The adapter names the exact hook delivery, project, IID, event,
@@ -77,7 +106,11 @@ export const CodeHostReviewAuthorize = z.object({
   baseSha: z.string().min(1).optional(),
   // REQUEST_CHANGES needs a current service-account reviewer record; the adapter
   // reports what it read so the CP can refuse before any draft exists (§15 step 7).
-  serviceAccountIsReviewer: z.boolean().optional()
+  serviceAccountIsReviewer: z.boolean().optional(),
+  // Kept with the lease so a later daemon the lock refuses can verify this attempt's markers.
+  markerSeed: CodeHostReviewMarkerSeed.optional(),
+  // The lock's one exit, carried by the attempt that found the locked attempt's marked object.
+  unlock: CodeHostReviewUnlock.optional()
 })
 export type CodeHostReviewAuthorize = z.infer<typeof CodeHostReviewAuthorize>
 
@@ -100,7 +133,9 @@ export const CodeHostReviewAuthorized = z.discriminatedUnion('authorized', [
     reason: CodeHostReviewRefusalReason,
     // `ambiguous_locked` is never retryable: recovery needs a definite outcome
     // from the old broker or positive provider evidence, not another try.
-    retryable: z.boolean()
+    retryable: z.boolean(),
+    // With `ambiguous_locked`: where the refused daemon can look for that evidence itself.
+    lock: CodeHostReviewLockCoordinates.optional()
   })
 ])
 export type CodeHostReviewAuthorized = z.infer<typeof CodeHostReviewAuthorized>
@@ -272,13 +307,6 @@ const PUBLIC_EFFECT: Record<CodeHostReviewState, CodeHostReviewPublicEffect> = {
 export function codeHostReviewPublicEffect(state: CodeHostReviewState): CodeHostReviewPublicEffect {
   return PUBLIC_EFFECT[state]
 }
-
-/** One published provider object, by kind and numeric id. No URLs, no text. `review` is Gitea's submitted review (gitea-integration.md §10.3). */
-export const CodeHostReviewExternalRef = z.object({
-  kind: z.enum(['note', 'draft_note', 'discussion', 'approval', 'review']),
-  externalId: CodeHostExternalId
-})
-export type CodeHostReviewExternalRef = z.infer<typeof CodeHostReviewExternalRef>
 
 /**
  * `codehost/review-result` (D→C REQ) — the body-free terminal classification of

--- a/packages/protocol/src/frames/codehost-review.ts
+++ b/packages/protocol/src/frames/codehost-review.ts
@@ -273,9 +273,9 @@ export function codeHostReviewPublicEffect(state: CodeHostReviewState): CodeHost
   return PUBLIC_EFFECT[state]
 }
 
-/** One published provider object, by kind and numeric id. No URLs, no text. */
+/** One published provider object, by kind and numeric id. No URLs, no text. `review` is Gitea's submitted review (gitea-integration.md §10.3). */
 export const CodeHostReviewExternalRef = z.object({
-  kind: z.enum(['note', 'draft_note', 'discussion', 'approval']),
+  kind: z.enum(['note', 'draft_note', 'discussion', 'approval', 'review']),
   externalId: CodeHostExternalId
 })
 export type CodeHostReviewExternalRef = z.infer<typeof CodeHostReviewExternalRef>

--- a/packages/protocol/src/frames/hook.test.ts
+++ b/packages/protocol/src/frames/hook.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   codeHostHookMetadataOf,
+  codeHostHookRevisionOf,
   GiteaHookMetadata,
   GithubHookMetadata,
   GithubReviewAuthorize,
@@ -441,6 +442,27 @@ describe('code-host member view (gitea-integration.md §13)', () => {
     })
     expect(decoded.gitlab).toEqual(gitlab)
     expect(codeHostHookMetadataOf(decoded)?.provider).toBe('gitlab')
+  })
+
+  it('reads the pull/merge-request revision off each member and none off an issue or a push', () => {
+    expect(codeHostHookRevisionOf(codeHostHookMetadataOf({ github })!)).toEqual({
+      headSha: github.headSha,
+      baseSha: github.baseSha
+    })
+    expect(codeHostHookRevisionOf(codeHostHookMetadataOf({ gitlab })!)).toEqual({
+      headSha: gitlab.target.headSha,
+      baseSha: gitlab.target.baseSha
+    })
+    expect(codeHostHookRevisionOf(codeHostHookMetadataOf({ gitea })!)).toEqual({
+      headSha: gitea.target.headSha,
+      baseSha: gitea.target.baseSha
+    })
+    const issue = { ...gitea, target: { kind: 'issue' as const, index: 7 } }
+    expect(codeHostHookRevisionOf(codeHostHookMetadataOf({ gitea: issue })!)).toBeUndefined()
+    const push = { ...gitlab, target: { kind: 'push' as const, ref: 'refs/heads/main' } }
+    expect(codeHostHookRevisionOf(codeHostHookMetadataOf({ gitlab: push })!)).toBeUndefined()
+    const headless = { ...gitea, target: { kind: 'pull' as const, index: 42 } }
+    expect(codeHostHookRevisionOf(codeHostHookMetadataOf({ gitea: headless })!)).toBeUndefined()
   })
 
   it('copies the members forward as they are for a frame that only forwards them', () => {

--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -229,6 +229,25 @@ export function codeHostHookMetadataOf(frame: CodeHostHookMembers): CodeHostHook
   return members.length === 1 ? members[0] : undefined
 }
 
+/** The pull/merge-request revision a trusted member carries; undefined for an issue, a push, or a head-less subject. */
+export function codeHostHookRevisionOf(
+  member: CodeHostHookMetadata
+): { headSha: string; baseSha?: string } | undefined {
+  let headSha: string | undefined
+  let baseSha: string | undefined
+  if (member.provider === 'github') {
+    if (member.metadata.subjectKind !== 'pull_request') return undefined
+    ;({ headSha, baseSha } = member.metadata)
+  } else if (member.provider === 'gitlab') {
+    if (member.metadata.target.kind !== 'merge_request') return undefined
+    ;({ headSha, baseSha } = member.metadata.target)
+  } else {
+    if (member.metadata.target.kind !== 'pull') return undefined
+    ;({ headSha, baseSha } = member.metadata.target)
+  }
+  return headSha ? { headSha, ...(baseSha ? { baseSha } : {}) } : undefined
+}
+
 /** A frame's provider members copied forward as they are, for a frame that forwards trusted metadata rather than reading it. */
 export function pickCodeHostHookMembers(frame: CodeHostHookMembers): CodeHostHookMembers {
   return {


### PR DESCRIPTION
Step G5 of the Gitea rollout (`docs/designs/gitea-integration.md` §10.3, §10.4, §16): formal pull-request reviews through the daemon's code-host review seam, the Control-Plane-written commit-status run projection, and the Console "Run again" binding for Gitea hooks.

## Daemon: formal reviews (`packages/daemon/src/gitea/review-adapter.ts`)

`submitCodeReview` keeps its argument schema and routes to a Gitea adapter registered on `CodeHostReviewRouter` for an active pull-request review turn. Under the seam's durable publication lease for `(repository, pull request, bot user)`:

- reserve the turn's single attempt, take the lease and its fence, and hold the Control Plane's single-use operation record for the one `POST …/pulls/:index/reviews`;
- reconcile first: list the pull request's reviews and delete only rows with `state == "PENDING"` authored by the bot, after re-reading each row's state right before the `DELETE` (Gitea's delete also removes a submitted review, §16); a pending review whose staged comments carry no verifiable foreign marker fails closed as `review_reconciliation_required`;
- re-fetch the pull request and refuse a changed head;
- submit with `commit_id` set to the fenced head, `COMMENT → COMMENT`, `REQUEST_CHANGES → REQUEST_CHANGES`, `APPROVE → APPROVED`, an HMAC-signed attempt-and-ordinal marker in the summary and in every inline comment, `RIGHT → new_position`, `LEFT → old_position`, and a range collapsed to its end line with the start named on the comment's first line (the declared parity gap);
- an ambiguous response keeps the lease: a submitted bot review carrying this attempt's summary marker is the outcome, a deterministic rejection before `request_started` is `not_submitted`, and anything else past the observation window is `ambiguous_locked` — a pending review carrying this attempt's inline markers proves staging, not submission;
- `APPROVED`/`REQUEST_CHANGES` refused 422 for the pull request's own author republishes the same content as `COMMENT`, and the attempt outcome reports the downgrade (`publishedEvent`, `self_review_forbidden`);
- only attempt id, external ids (`kind: review`), event, verdict, head, and the normalized state cross the wire.

`ambiguous_locked` has no operator unlock. It clears on one condition: a later reconciliation pass finds the marked review submitted. That pass runs from durable coordinates, never from process state. Gitea markers are keyed per attempt off the daemon key (`ReviewMarkerSigner.derived`), and the attempt sends its seed with `codehost/review-authz`; the Control Plane keeps the seed on the lease (`code_host_review_lease.markerSeed`, one migration) and, when it refuses a later attempt with `ambiguous_locked`, hands back `lock: { attemptId, fence, recordId, headSha, markerSeed }` — the retained ambiguous record included. The refused daemon, whichever daemon it is, lists the pull request's reviews, verifies the locked attempt's summary marker with that seed alone, and asks again with `unlock: { attemptId, fence, recordId, externalRef }`. The Control Plane runs the exit inside the same authorization (`identifyLocked`): the retained record settles by that object, the owner's outcome moves once from proving nothing to proving the effect (`unlocks`), the lease releases, and the acquisition proceeds. A same-daemon owner may still identify its own record directly; nothing else reaches a locked lease.

The attempt engine, operation ledger, and owed-frame outbox were extracted from the GitLab adapter into `codehost/review-attempt.ts` and `codehost/review-outbox.ts` at the moment of their second implementer; one outbox now serves both adapters so neither sweeps the other's frames. The GitLab adapter keeps its thirteen steps, its public surface, and its 77 tests unchanged. The `# Gitea` standing-context block already tells the agent reviews go through `submitCodeReview` with single-line collapse; its wording matches what was built.

## Control Plane: commit-status run projection (`packages/control-plane/src/gitea/status-projection.ts`)

A coordinator turns the accepted-delivery, start-barrier, delivery-failure, and terminal-report edges into desired generations on `CodeHostRunProjection` rows with provider `gitea` (the gitlab arms of `hook/start`, `hook/report`, and `rc/run-report` gained gitea siblings). A periodic reporter — the GitHub Check writer's twin — writes one status per `(hook, repository, pull request, head SHA)` through `POST /repos/:o/:r/statuses/:sha` with the connection token: `context = agentconnect/<agent-slug>`, `target_url` the ordinary authenticated Console session link (no token), a bounded normalized `description`, and `state` mapped `queued|running → pending`, `completed → success`, `failed|interrupted → error`, `skipped|superseded → success` with the reason in the description; `warning` is never written. Generation, lease, write-marker, tombstone, and out-of-order rules are the Check writer's: a lost reply keeps the marker and is reconciled against the commit's status history (a newer row than the last observed one, same context, state, and description) rather than replayed; absence past the grace window reissues it; a received 4xx blocks the generation; a rejected token feeds the connection's `token_rejected` path and the row waits for the replacement. A tombstone resolves only a status a removed hook left pending. The ledger port gains the writer members (`claimDue`, `retryWrite`, `blockWrite`, `settleWrite`) on `CodeHostRunProjectionWriterRepo`; the daemon-written GitLab note never claims.

Cross-head supersession is monotonic. A head's rank on the pull request is its run's acceptance time (`HookRun.startedAt`, stored as the row's `queuedAt` on every edge), so a late terminal report from an older head neither supersedes the newer head nor revives its own row: the coordinator establishes the row first, then `supersede(…, acceptedAt)` preempts only strictly older heads — the caller's own row included when a newer head is already there — and `setDesired` refuses a superseded row outright, as does the mid-write parking path. An edge whose row already belongs to a newer run of the same head moves nothing.

Also in the Control Plane: the provider-neutral review broker's `start` barrier reads the hook's provider through `codeHostHookMetadataOf`/`codeHostHookRevisionOf` instead of assuming GitLab; `REQUEST_CHANGES` needs a reviewer record only where the provider does (GitLab yes, Gitea no); the broker always exists, resolving Gitea's publishing identity to the connection's bot user; and the Control Plane now advertises `gitea-v1` to daemons — the gitea credential leases and the daemon's gitea `hook/start` arm gate on it. Rollout: this is the first Control Plane that advertises `gitea-v1` at all, so no deployed Control Plane can advertise the bit without the Gitea `hook/start` arm behind it; a daemon that meets an older Control Plane takes the `legacy` path, and no new feature string is needed.

## Control Plane: "Run again" (`packages/control-plane/src/gitea/hook-rerun.service.ts`)

`POST /hooks/:id/rerun` takes a gitea arm. The service revalidates the hook, agent, binding, connection, and compiled rule live, reads the pull request's current head (or the open issue) from Gitea with the connection token, re-reads the hook fence after the round trip, and sends `rc/hook-rerun` with the `gitea` member to one relay advertising `gitea-v1`. The existing `merge_request` subject kind names a Gitea pull request by its index.

## Protocol

`CodeHostReviewExternalRef.kind` gains `review`; `codeHostHookRevisionOf` reads the pull/merge-request revision off a decoded member. `codehost/review-authz` gains optional `markerSeed` and `unlock`, and its `ambiguous_locked` refusal an optional `lock` (`CodeHostReviewLockCoordinates`); all additive, nothing strict.

## Tests

- daemon `test/gitea-review-adapter.test.ts` (39): a fake Gitea that stages then submits the caller's pending review, lists unfiltered, deletes submitted reviews, and refuses the author's own verdicts; a fake control plane carrying the lease rules. Happy path per verdict, reconcile deleting only own pending rows, changed-head refusal, ambiguous submit found by marker, `ambiguous_locked` staying locked across a retry and clearing on the later reconciliation, the same exit run by another daemon with a different key from the seed the lease carried, a still-pending marked review keeping the lock, preemption before/after `request_started`, self-review 422 downgrade, single-line collapse, two agents on one pull request serialized by the lease, started-operation recovery, durable ownership.
- control plane: `gitea/status-projection.test.ts` (23, including the row that belongs to a newer run), broker tests for the lock coordinates and the `unlock` admission, repo tests for `identifyLocked`, the seed on the lease, and acceptance-ranked supersession (an older head's late edge preempts nothing and never revives), `test/integration/gitea-status.test.ts` (5, including A running / B accepted / A reports late — B stays current, A stays superseded, nothing is written), the rerun route arm in `test/integration/gitea-hooks.route.test.ts` (6).

## Gates

- `pnpm typecheck`: green (all packages, re-run after rebasing onto main).
- `pnpm --filter @agentconnect.md/daemon test`: 387 files / 6805 tests green; the three failing files (`test/shim-workspace-files.test.ts`, `test/shim-cancellation.test.ts`, `test/acp-matrix/acp-matrix.test.ts`) fail on main too and need a sandbox and live runtimes this change does not touch. `gitea-*`, `gitlab-review-adapter` (77, unchanged), `codehost-*`, `daemon-hook` green.
- `pnpm --filter @agentconnect.md/control-plane test:unit`: 201 files / 2378 tests green. `test:int`: 131 files / 2073 tests green.
- `pnpm --filter @agentconnect.md/protocol test`: 552 tests green.
- `pnpm lint`: 0 errors (8 pre-existing warnings in files this change does not touch). `pnpm format:check`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
