### PR TITLE
ci: run the static gate and the workspace build in one job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,11 +31,20 @@ concurrency:
   group: test-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Keep builds, static checks, Docker-free unit tests, and the Docker-bound
-# integration suite separate so all four workloads can be scheduled independently.
+# Keep the static gate, the Docker-free unit tests, and the Docker-bound
+# integration suite separate so all three workloads can be scheduled independently.
 jobs:
+  # The static gate: lint, format, typecheck and the workspace build, in one job because they wanted
+  # the same runner state. Separately they each paid a checkout, a pnpm and Node setup, an install
+  # and a `prisma:generate` — about 55 s twice — to reach the same tree, and the build ran 42-85 s of
+  # a 118-153 s job. Merged, one setup carries both and the runner it gives back goes to the suites
+  # that are actually the critical path. Split again if the two ever stop wanting the same state.
+  #
+  # Build only typechecks what each package emits, so the no-emit pass here owns the test surface of
+  # every package (plus the tsdown bundles, which never typecheck). Web is left out: `next build`
+  # already checks its whole tsconfig, tests included.
   build:
-    name: Build
+    name: Build · Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,39 +71,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
       - name: Install
         run: pnpm install --frozen-lockfile
-      - name: Generate Prisma client
-        run: pnpm -r prisma:generate
-      - name: Build
-        env:
-          pnpm_config_enable_pre_post_scripts: false
-        run: pnpm build
-
-  # Build only typechecks what each package emits, so this no-emit pass owns the
-  # test surface of every package (plus the tsdown bundles, which never typecheck).
-  # Web is left out: `next build` already checks its whole tsconfig, tests included.
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: pnpm/action-setup@v6
-        with:
-          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
-          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
-          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
-          version: 11.19.0
-          cache: true
-      - uses: actions/setup-node@v7
-        with:
-          node-version-file: .nvmrc
-      - name: Install
-        run: pnpm install --frozen-lockfile
-      # Run before any workspace build so source-checkout export resolution
-      # cannot be accidentally masked by protocol/connection dist artifacts.
+      # Still the first thing after the install, and the Build step below is why: it has to see the
+      # source checkout before protocol/connection dist artifacts can mask export resolution.
       - name: Evaluation config validation · clean checkout
         env:
           PROMPTFOO_DISABLE_TELEMETRY: '1'
@@ -105,6 +83,13 @@ jobs:
         env:
           pnpm_config_enable_pre_post_scripts: false
         run: pnpm --workspace-concurrency=5 run "/^(lint|format:check|typecheck:ci)$/"
+      # Runs even when the static pass failed: one job must not report a lint error in place of a
+      # broken build, which is what the two jobs it replaces would each have said on their own.
+      - name: Build
+        if: ${{ !cancelled() }}
+        env:
+          pnpm_config_enable_pre_post_scripts: false
+        run: pnpm build
 
   # The Helm chart's own gate: lint plus the render contract in
   # scripts/test-chart-render.rb (both preinstalled on the hosted image — helm, ruby).

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,12 +71,6 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
       - name: Install
         run: pnpm install --frozen-lockfile
-      # Still the first thing after the install, and the Build step below is why: it has to see the
-      # source checkout before protocol/connection dist artifacts can mask export resolution.
-      - name: Evaluation config validation · clean checkout
-        env:
-          PROMPTFOO_DISABLE_TELEMETRY: '1'
-        run: pnpm eval:validate
       - name: Generate Prisma client
         run: pnpm -r prisma:generate
       - name: Lint · Format · Typecheck
@@ -314,15 +308,19 @@ jobs:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
         run: cat "$CAPTURED_JOB_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
 
-  # The evaluation gates, off the Unit Test job's critical path. They are ~48s of the ~3m27s that
-  # job took, and it is the slowest in the workflow, so they buy back most of that on their own
-  # runner. `evals/README.md` calls these the deterministic, credential-free layer — the real
-  # Promptfoo evaluation (`eval:addons`) needs model credentials and never ran here.
+  # Everything the evaluation layer gates, off the Unit Test job's critical path. The gates alone were
+  # ~48s of the ~3m27s that job took, and it is the slowest in the workflow, so they buy back most of
+  # that on their own runner. `evals/README.md` calls these the deterministic, credential-free layer —
+  # the real Promptfoo evaluation (`eval:addons`) needs model credentials and never ran here.
+  #
+  # The config validation is here rather than beside a build because it has to read the source checkout
+  # before protocol/connection dist artifacts can mask export resolution. This job never builds, so that
+  # is a property of where it runs instead of a step order the next edit can reverse.
   #
   # No `prisma:generate` step: this closure reaches evals/, packages/daemon and the protocol-side
   # packages, none of which import the generated client.
   evals:
-    name: Evaluation Gates
+    name: Evaluation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -342,6 +340,10 @@ jobs:
           node-version-file: .nvmrc
       - name: Install
         run: pnpm install --frozen-lockfile
+      - name: Evaluation config validation · clean checkout
+        env:
+          PROMPTFOO_DISABLE_TELEMETRY: '1'
+        run: pnpm eval:validate
       # Evaluation contracts, the Collaboration Arena gate (collaboration-arena.md §14 step 3), and
       # cross-surface activation parity (docs/designs/activation-parity.md) — a PR that changes
       # "who does this message activate" on one surface must either keep every leg green or declare


### PR DESCRIPTION
`Build` and `Check` were two jobs doing the same setup to reach the same tree. Measured across three recent runs:

| | Build | Check |
| --- | --- | --- |
| checkout + pnpm + Node + install + Prisma | 50–70 s | 45–60 s |
| the work it exists for | Build 42–85 s | Lint · Format · Typecheck 114–152 s, eval:validate 15–20 s |
| job total | 118–153 s | 194–230 s |

So roughly 55 s of every Build job was a second copy of what Check had already done. Merged, one setup carries both and a runner goes back to the pool for the suites that actually set the critical path.

`Build` runs under `if: ${{ !cancelled() }}`, so a lint or typecheck failure does not report in place of a broken build. The two jobs this replaces each spoke for themselves; one job has to be told to.

## The evaluation config validation moves to the Evaluation job

`eval:validate` has to read the source checkout before protocol/connection dist artifacts can mask export resolution. That is why it was the first step of `Check` — and it is exactly the constraint merging a build into that job puts under pressure, since the rule then lives in the step order rather than anywhere enforceable.

It now runs in the job that never builds, alongside the gates it validates the config for, which is renamed `Evaluation` since it owns more than the gates. The ordering rule becomes a property of where the step runs instead of one the next edit can reverse, and its ~20 s leaves the merged leg for one that runs 113–128 s.

## The cost, stated plainly

The merged job's first run measured **293 s** — 49 s setup, 20 s eval:validate, 3 s Prisma, 149 s static, 65 s build — against the 118–153 s and 194–230 s of the two it replaces. Moving eval:validate out projects it to ~273 s. Either way this leg goes from ~215 s (the longer of the two) to within touching distance of the `Unit Test` job (262–295 s) and the Windows shards, which are what a pull request actually waits on.

That is the trade being made on purpose — a runner and one duplicated install, for a leg that was never the one being waited on. If the merged job lands at the top of its range often enough to matter, splitting it back out is reverting one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
