### PR TITLE
fix(control-plane): forward the relay's refusal category on hook rerun refusals

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3929,6 +3929,11 @@ export const ErrorDto = z.object({
   code: z.string().optional()
 })
 
+/** The rerun route's refusal shape: `RELAY_REJECTED` also carries the relay's own category, which the console branches on. */
+export const HookRerunErrorDto = ErrorDto.extend({
+  relayCode: z.string().optional()
+})
+
 /** The Slack install funnels' error shape. A refusal carrying
  *  `code: 'SLACK_MISSING_SCOPES'` also names the required bot scopes the
  *  workspace authorization did not grant — the console renders THAT list, since

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -47,6 +47,7 @@ import {
   HookRunListDto,
   HookRerunBody,
   HookRerunDto,
+  HookRerunErrorDto,
   ErrorDto,
   IdParam,
   type HookDtoT
@@ -1294,10 +1295,10 @@ export function hookRoutes(deps: HttpDeps) {
             200: HookRerunDto,
             403: ErrorDto,
             404: ErrorDto,
-            409: ErrorDto,
-            429: ErrorDto,
-            502: ErrorDto,
-            503: ErrorDto
+            409: HookRerunErrorDto,
+            429: HookRerunErrorDto,
+            502: HookRerunErrorDto,
+            503: HookRerunErrorDto
           }
         }
       },
@@ -1337,7 +1338,8 @@ export function hookRoutes(deps: HttpDeps) {
             error: RERUN_STATUS_TEXT[outcome.status],
             statusCode: outcome.status,
             message: outcome.message,
-            code: outcome.code
+            code: outcome.code,
+            relayCode: 'relayCode' in outcome ? outcome.relayCode : undefined
           })
         }
         return {

--- a/packages/control-plane/test/integration/gitea-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitea-hooks.route.test.ts
@@ -446,13 +446,15 @@ describe('gitea hook rerun — the Console "Run again" route (gitea-integration.
     const refused = await rerunHarness({ admitted: false, code: 'rule_mismatch' })
     const answer = await rerun(refused.h.a, refused.hookId, { kind: 'merge_request', iid: INDEX })
     expect(answer.statusCode).toBe(409)
-    expect(answer.json()).toMatchObject({ code: 'RELAY_REJECTED' })
+    // The relay's own category rides along so the console can tell "still loading" from "ran too often".
+    expect(answer.json()).toMatchObject({ code: 'RELAY_REJECTED', relayCode: 'rule_mismatch' })
     expect(await prisma.hookRun.count({ where: { hookId: refused.hookId } })).toBe(0)
 
     refused.h.a.relayReg.remove((refused.relay.ch as { relayId: string }).relayId, refused.relay.ch)
     const nobody = await rerun(refused.h.a, refused.hookId, { kind: 'merge_request', iid: INDEX })
     expect(nobody.statusCode).toBe(503)
-    expect((nobody.json() as { code: string }).code).toBe('RELAY_UNAVAILABLE')
+    expect(nobody.json()).toMatchObject({ code: 'RELAY_UNAVAILABLE' })
+    expect(nobody.json()).not.toHaveProperty('relayCode')
   })
 
   it('refuses the rerun once the connection token is rejected, and flips the connection', async () => {

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -1083,8 +1083,10 @@ describe('gitlab hook rerun — the Console "Run again" route (§16.1/§18.2)', 
 
       const res = await rerun(h.a, hookId, { kind: 'merge_request', iid: MR_IID })
       expect(res.statusCode).toBe(status)
-      const body = res.json() as { code: string; message: string }
+      const body = res.json() as { code: string; message: string; relayCode?: string }
       expect(body.code).toBe('RELAY_REJECTED')
+      // The wire category is forwarded verbatim; the console branches on it.
+      expect(body.relayCode).toBe(code)
       // Human prose, never the wire category.
       expect(body.message).not.toContain(code)
       // The relay WAS asked — and answered no. Its verdict is final.


### PR DESCRIPTION
## Summary

`POST /hooks/:id/rerun` answered refusals with `{ error, statusCode, message, code }` only. Both `GitlabHookRerunService` and `GiteaHookRerunService` return an optional `relayCode` (`replay_pending | rule_mismatch | limiter_exhausted`) on a `RELAY_REJECTED` outcome, but the route dropped it, and `ErrorDto` did not declare it, so Fastify's zod response serialization would have stripped it regardless.

The console's `GitlabRerunButton` and `GiteaRerunButton` already read `e.details?.relayCode` to show "still loading" versus "ran too many times" messages. Those messages never fired.

## Changes

- `HookRerunErrorDto` in `packages/control-plane/src/http/dto/index.ts`: `ErrorDto` extended with an optional `relayCode` string.
- The rerun route declares `HookRerunErrorDto` for its 409/429/502/503 responses and forwards `outcome.relayCode`. The 403/404 responses, which never carry a relay verdict, keep `ErrorDto`. OpenAPI `tags`, `summary`, `operationId` are unchanged.
- The `RELAY_REJECTED` case in `gitea-hooks.route.test.ts` asserts `relayCode: 'rule_mismatch'` and that a `RELAY_UNAVAILABLE` body carries no `relayCode`.
- The three-case refusal table in `gitlab-hooks.route.test.ts` asserts `body.relayCode` equals the relay's wire category.

## Verification

- `pnpm typecheck`: green across all packages.
- `pnpm --filter @agentconnect.md/control-plane test:int`: 131 files, 2077 tests passed.
- `pnpm lint`: 0 errors (8 pre-existing warnings in untouched web files).
- `pnpm format:check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
