### PR TITLE
ci: fold the chart gate into the static gate job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,10 @@ jobs:
   # Build only typechecks what each package emits, so the no-emit pass here owns the test surface of
   # every package (plus the tsdown bundles, which never typecheck). Web is left out: `next build`
   # already checks its whole tsconfig, tests included.
+  #
+  # The chart's gate joins them, for a different reason than they joined each other: it duplicated no
+  # setup — helm and ruby are preinstalled, so its 9-16 s was all work — and it simply has nowhere
+  # cheaper to be than ~10 s at the end of a job that already has the checkout it needs.
   build:
     name: Build · Check
     runs-on: ubuntu-latest
@@ -84,22 +88,14 @@ jobs:
         env:
           pnpm_config_enable_pre_post_scripts: false
         run: pnpm build
-
-  # The Helm chart's own gate: lint plus the render contract in
-  # scripts/test-chart-render.rb (both preinstalled on the hosted image — helm, ruby).
-  # It runs unconditionally: chart edits are rare but every release publishes the chart,
-  # so a broken chart must fail the same gate that blocks a broken package.
-  chart:
-    name: Chart
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
+      # The chart's gate, on the same `!cancelled()` terms and for the same reason: chart edits are
+      # rare but every release publishes the chart, so a broken chart fails the gate that blocks a
+      # broken package rather than waiting behind one.
       - name: helm lint
+        if: ${{ !cancelled() }}
         run: helm lint charts/agentconnect
       - name: Render contract
+        if: ${{ !cancelled() }}
         run: ruby scripts/test-chart-render.rb
 
   # Keep the fast, Docker-free suites away from the resource-heavy build group


### PR DESCRIPTION
The chart gate joins the static gate job, leaving the workflow at seven jobs.

Worth saying plainly, because it is the opposite of what made the last two merges pay: **the chart job duplicated nothing.** It skipped pnpm, Node and the install entirely — helm and ruby are preinstalled on the hosted image — so its 9–16 s was a shallow checkout plus real work, not a second copy of setup someone else had already done. Merging it therefore buys a runner slot and no wall clock at all; it adds about 10 s to a job that measured 248 s and 293 s on its two runs.

## What this does

`helm lint` and the render contract move into `Build · Check`, which keeps its name — two steps do not need to be in a job's title to be found in it.

Both carry the same `if: ${{ !cancelled() }}` guard as `Build`, so a lint, typecheck or build failure cannot swallow the chart's verdict — that is the property the separate job had for free and the one an appended step would have quietly dropped.

The merged job's checkout is a superset of what the chart job took (it fetches full history), and neither chart step needs anything the job does not already have on disk.

## The cost

Promptness. A broken chart used to report in ~15 s; it now reports at the end of a ~250 s job. Chart edits are rare — the comment this replaces said so — and the job's own red/green arrives at the same time either way, so this only affects how early you can see it inside a running job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
