### PR TITLE
fix(control-plane): rank GitLab note supersession by acceptance

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1503,7 +1503,11 @@ projection pending rather than creating a second provider egress path.
 
 The durable projection ports the existing generation, lease, pending-intent,
 write-marker, tombstone, and out-of-order completion rules from the
-Control-Plane-owned GitHub Checks writer. Moving the writer to the daemon is a
+Control-Plane-owned GitHub Checks writer. Cross-head supersession is ranked by
+acceptance — a head's rank on the merge request is its run's acceptance time, so
+the Control Plane records the row first and then preempts only strictly older
+heads, and a late terminal report from an older head neither supersedes the
+newer head nor revives its own row. Moving the writer to the daemon is a
 deliberate inversion — GitHub Checks are a dedicated body-free status API the
 Control Plane writes itself, while a GitLab status note lives in the
 merge-request conversation that Section 6.1 keeps the Control Plane out of —

--- a/packages/control-plane/src/codehost/note-projection.service.test.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.test.ts
@@ -25,6 +25,8 @@ import {
 } from './note-projection.service.js'
 
 const NOW = 1_700_000_000_000
+// The accepted run's own time, deliberately earlier than the edge's: it ranks the head, the edge does not.
+const ACCEPTED = NOW - 30_000
 const hookId = HookId('00000000-0000-4000-8000-000000000001')
 const agentId = AgentId('00000000-0000-4000-8000-000000000002')
 const daemonId = DaemonId('00000000-0000-4000-8000-000000000003')
@@ -156,7 +158,10 @@ function harness(
   }
   // The accepted run, whose epoch the projection must spend even after the live hook moves on.
   const runs = {
-    getRun: vi.fn(async () => ({ projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch }))
+    getRun: vi.fn(async () => ({
+      projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch,
+      startedAt: new Date(ACCEPTED)
+    }))
   }
   // The account's own epoch, deliberately DIFFERENT from the binding's: the two
   // counters advance independently and the daemon fences on the account's.
@@ -278,13 +283,40 @@ describe('CodeHostNoteProjectionService', () => {
     expect(sent).toHaveLength(0)
   })
 
-  it('supersedes older heads on the same merge request before opening the new generation', async () => {
+  it('establishes the row first, then preempts older heads by the run’s acceptance', async () => {
     const { service, projections } = harness()
     await service.afterAccepted(edge({ gitlab: gitlab({ headSha: 'b'.repeat(40) }) }))
-    expect(projections.supersede).toHaveBeenCalledWith(hookId, 4455667n, 42, 'b'.repeat(40), new Date(NOW))
-    expect(projections.supersede.mock.invocationCallOrder[0]!).toBeLessThan(
-      projections.upsert.mock.invocationCallOrder[0]!
+    // The acceptance time, never the edge's: a late edge of an older head must outrank nothing.
+    expect(projections.supersede).toHaveBeenCalledWith(
+      hookId,
+      4455667n,
+      42,
+      'b'.repeat(40),
+      new Date(NOW),
+      new Date(ACCEPTED)
     )
+    expect(projections.upsert.mock.invocationCallOrder[0]!).toBeLessThan(
+      projections.supersede.mock.invocationCallOrder[0]!
+    )
+    // That same acceptance is the row's rank on the subject, on every edge of the run.
+    expect(projections.upsert.mock.calls[0]![0].queuedAt).toEqual(new Date(ACCEPTED))
+  })
+
+  it('ranks every edge of a run by the one acceptance, terminal edges included', async () => {
+    const { service, projections } = harness()
+    await service.afterStart(edge({ state: 'running' }))
+    await service.afterReport(edge({ state: 'completed' }))
+    for (const [input] of projections.upsert.mock.calls) expect(input.queuedAt).toEqual(new Date(ACCEPTED))
+    for (const call of projections.supersede.mock.calls) expect(call[5]).toEqual(new Date(ACCEPTED))
+  })
+
+  it('moves nothing for an edge whose row already belongs to a newer run of the same head', async () => {
+    const { service, projections, sent } = harness({ row: projection({ currentDeliveryKey: 'delivery-9' }) })
+    await service.afterReport(edge({ state: 'completed' }))
+    expect(projections.upsert).toHaveBeenCalledOnce()
+    expect(projections.supersede).not.toHaveBeenCalled()
+    expect(projections.setDesired).not.toHaveBeenCalled()
+    expect(sent).toHaveLength(0)
   })
 
   it('leaves the row pending when the daemon does not advertise the feature', async () => {

--- a/packages/control-plane/src/codehost/note-projection.service.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.ts
@@ -235,15 +235,8 @@ export class CodeHostNoteProjectionService {
     const account = await this.deps.accounts.forAgentBinding(edge.orgId, edge.agentId, binding.id)
     if (!account || account.serviceAccountUserId === null || account.state !== 'ready') return
 
-    // A newer head preempts every older generation on the same merge request before the new one
-    // opens, so exactly one note per head reads current.
-    await this.deps.projections.supersede(
-      HookId(edge.hookId),
-      subject.projectId,
-      subject.mergeRequestIid,
-      subject.headSha,
-      edge.at
-    )
+    // The run's acceptance ranks its head on the merge request: the same on every edge, so a late edge of an older head outranks nothing.
+    const acceptedAt = run.startedAt
     const terminal = edge.state !== 'queued' && edge.state !== 'running'
     const reason = normalizedReason(edge.reason)
     const projection = await this.deps.projections.upsert({
@@ -266,7 +259,7 @@ export class CodeHostNoteProjectionService {
       ...subject,
       ...(reason ? { reason } : {}),
       ...(edge.sessionId ? { sessionId: edge.sessionId } : {}),
-      ...(edge.state === 'queued' ? { queuedAt: edge.at } : {}),
+      queuedAt: acceptedAt,
       ...(edge.state === 'running' ? { startedAt: edge.at } : {}),
       ...(terminal ? { completedAt: edge.at } : {}),
       nextAttemptAt: edge.at
@@ -274,11 +267,22 @@ export class CodeHostNoteProjectionService {
     // Null ⇒ the hook was retired under the lifecycle fence while this edge was in flight; a retired
     // hook needs no projection, so the edge is simply dropped.
     if (!projection || projection.tombstonedAt) return
+    // The row already belongs to a newer run of this head: an older delivery's edge moves nothing.
+    if (projection.currentDeliveryKey !== edge.deliveryKey) return
+    // The newest accepted head preempts every older one, this head's own row included when a newer head is already here.
+    await this.deps.projections.supersede(
+      HookId(edge.hookId),
+      subject.projectId,
+      subject.mergeRequestIid,
+      subject.headSha,
+      edge.at,
+      acceptedAt
+    )
     // The upsert parks an edge that landed mid-write; that intent is dispatched when the in-flight
     // generation settles, not now.
     if (projection.writePhase !== null) return
     // Later edges of the same delivery move the state inside this generation. A late queued/running
-    // one loses here against the terminal authority that already sealed it.
+    // one loses here against the terminal authority that already sealed it; a superseded row refuses every edge.
     const moved = await this.deps.projections.setDesired(
       projection.id,
       projection.generation,

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -43,6 +43,7 @@ import {
   GITLAB_INSTANCE_V1_FEATURE,
   GITLAB_RERUN_V1_FEATURE,
   type CodeHostNoteDesired,
+  type CodeHostNoteState,
   type RcHookAssign,
   type RcHookRerun,
   type RcHookRerunResult
@@ -1152,10 +1153,11 @@ describe('gitlab hook rerun — the Console "Run again" route (§16.1/§18.2)', 
 describe('gitlab run projection — the fence follows the agent account (§7.2/§16)', () => {
   const PROJECTION_HEAD = 'a'.repeat(40)
 
-  function projectionService(sent: CodeHostNoteDesired[]) {
+  /** `runs` defaults to one accepted run; a test that ranks heads by acceptance passes the real ledger. */
+  function projectionService(sent: CodeHostNoteDesired[], runs?: PgHookRepo) {
     return new CodeHostNoteProjectionService({
       projections: new PgCodeHostRunProjectionRepo(prisma),
-      runs: { getRun: async () => ({ projectionEpoch: 1n }) } as never,
+      runs: runs ?? ({ getRun: async () => ({ projectionEpoch: 1n, startedAt: new Date() }) } as never),
       agents: new PgAgentRepo(prisma),
       bindings: new PgGitlabProjectBindingRepo(prisma),
       accounts: new PgGitlabAgentAccountRepo(prisma),
@@ -1167,13 +1169,19 @@ describe('gitlab run projection — the fence follows the agent account (§7.2/�
     })
   }
 
-  function edge(agentId: string, hookId: string, daemonId: string, headSha = PROJECTION_HEAD) {
+  function edge(
+    agentId: string,
+    hookId: string,
+    daemonId: string,
+    headSha = PROJECTION_HEAD,
+    over: { deliveryKey?: string; state?: CodeHostNoteState } = {}
+  ) {
     return {
       hookId,
       agentId,
-      deliveryKey: `delivery-${randomUUID().slice(0, 8)}`,
+      deliveryKey: over.deliveryKey ?? `delivery-${randomUUID().slice(0, 8)}`,
       orgId: OrgId(DEFAULT_ORG_ID),
-      state: 'queued' as const,
+      state: over.state ?? ('queued' as const),
       gitlab: {
         projectId: PROJECT.toString(),
         projectPath: 'example-group/example-project',
@@ -1240,6 +1248,73 @@ describe('gitlab run projection — the fence follows the agent account (§7.2/�
     // Fail closed, like every other missing-authority early return.
     expect(sent).toHaveLength(0)
     expect(await prisma.codeHostRunProjection.count({ where: { hookId } })).toBe(0)
+  })
+
+  it('keeps the newest head current when an older head reports late', async () => {
+    const NEXT_HEAD = 'b'.repeat(40)
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    const hookId = (created.json() as { id: string }).id
+    await h.settled()
+    // Two accepted runs on the same merge request, the second one newer: their acceptance is the heads' rank.
+    const accepted = { old: new Date(Date.now() - 60_000), next: new Date(Date.now() - 30_000) }
+    const accept = (deliveryKey: string, startedAt: Date) =>
+      prisma.hookRun.create({
+        data: {
+          hookId,
+          orgId: DEFAULT_ORG_ID,
+          deliveryKey,
+          event: 'merge_request:update',
+          startedAt,
+          agentId: h.agentId,
+          dispatchDaemonId: h.daemonId,
+          projectionEpoch: 1n,
+          repoId: PROJECT,
+          subjectKind: 'merge_request'
+        }
+      })
+    await accept('delivery-old', accepted.old)
+    await accept('delivery-next', accepted.next)
+
+    const sent: CodeHostNoteDesired[] = []
+    const service = projectionService(sent, h.hookRepo)
+    // The daemon owns the note, so every dispatched generation is settled as written before the next edge.
+    const settle = async (desired: CodeHostNoteDesired, noteId: string) =>
+      service.recordResult(
+        {
+          projectionId: desired.projectionId,
+          hookId,
+          generation: desired.generation,
+          writeMarker: desired.writeMarker,
+          outcome: 'written',
+          noteId,
+          observedState: desired.state,
+          observedAt: new Date().toISOString()
+        },
+        h.daemonId,
+        OrgId(DEFAULT_ORG_ID)
+      )
+    const older = (state?: CodeHostNoteState) =>
+      edge(h.agentId, hookId, h.daemonId, PROJECTION_HEAD, { deliveryKey: 'delivery-old', ...(state ? { state } : {}) })
+    const newer = () => edge(h.agentId, hookId, h.daemonId, NEXT_HEAD, { deliveryKey: 'delivery-next' })
+    const row = (headSha: string) => prisma.codeHostRunProjection.findFirstOrThrow({ where: { hookId, headSha } })
+
+    await service.afterAccepted(older() as never)
+    expect(await settle(sent[0]!, '9001')).toBe('settled')
+    await service.afterStart(older('running') as never)
+    expect(await settle(sent[1]!, '9001')).toBe('settled')
+    // The newer head arrives while the older run is still running: it preempts the older head.
+    await service.afterAccepted(newer() as never)
+    expect(await settle(sent[2]!, '9002')).toBe('settled')
+    expect(await row(PROJECTION_HEAD)).toMatchObject({ desiredState: 'superseded' })
+    expect(await row(NEXT_HEAD)).toMatchObject({ desiredState: 'queued', queuedAt: accepted.next })
+    const written = sent.length
+
+    // The older head's run finishes after that: it supersedes nothing, revives nothing, and asks for no write.
+    await service.afterReport(older('completed') as never)
+    expect(sent).toHaveLength(written)
+    expect(await row(PROJECTION_HEAD)).toMatchObject({ desiredState: 'superseded' })
+    expect(await row(NEXT_HEAD)).toMatchObject({ desiredState: 'queued' })
   })
 })
 


### PR DESCRIPTION
Ports the acceptance-ranked cross-head supersession from the Gitea status coordinator (#2058) to the GitLab status-note coordinator (`docs/designs/gitlab-com-integration.md` §16).

## The defect

`CodeHostNoteProjectionService.converge` called `supersede(hookId, projectId, iid, headSha, edge.at)` on every lifecycle edge **before** the upsert, with no acceptance rank, and then moved whatever row the upsert returned. Two consequences:

- a terminal report from an older head A that arrived after a newer head B had been accepted superseded B (and then revived A through the same-run upsert and a terminal `setDesired`);
- an edge whose row already belonged to a newer run of the same head still moved that row's state.

## The fix

`converge` now follows the Gitea coordinator's ordering:

- `queuedAt: run.startedAt` on **every** edge — the accepted run's acceptance time is the head's rank on the merge request, so it is the same value on a late terminal edge as on the accepted one (previously `queuedAt` was the queued edge's own timestamp, and was absent on a run whose first observed edge was not `queued`);
- upsert first, so the row exists before anything is preempted;
- return when `projection.currentDeliveryKey !== edge.deliveryKey` — an older delivery's edge moves nothing;
- `supersede(…, edge.at, acceptedAt)`, the ranked form, which preempts only strictly older heads, the caller's own row included when a newer head is already there.

`setDesired` and the mid-write parking path already refuse a superseded row for every provider, so no repository change was needed. GitLab note semantics are otherwise untouched: the daemon is still the only writer of the note, the frame's fields and the `§7.2` credential fence are unchanged.

## Tests

- `src/codehost/note-projection.service.test.ts`: the renamed ordering test now asserts upsert-before-supersede and the acceptance argument; new cases cover the one acceptance carried by every edge of a run (terminal edges included) and the newer-run guard. The replaced assertion (`supersede` called before `upsert`, with no acceptance argument) encoded the bug — it is the only existing expectation that changed.
- `test/integration/gitlab-hooks.route.test.ts` (the GitLab note projection's integration coverage): `keeps the newest head current when an older head reports late` — A accepted and running against the real ledger and real `HookRun` rows, each dispatched generation settled as the daemon would, then B accepted, then A's terminal report. B stays `queued` with its own acceptance as `queuedAt`, A stays `superseded`, and the late report asks for no further write. Reverting the service makes this test fail.
- Design doc: one sentence in §16 stating the acceptance-ranked rule.

## Gates

- `pnpm typecheck`: green (all packages).
- `pnpm --filter @agentconnect.md/control-plane test:unit`: 201 files / 2382 tests green.
- `pnpm --filter @agentconnect.md/control-plane test:int`: 131 files / 2078 tests green.
- `pnpm lint`: 0 errors (8 pre-existing warnings in files this change does not touch).
- `pnpm format:check`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
