### PR TITLE
fix(web): shorten the Gitea connect panel copy

### DIFF
--- a/packages/web/src/components/console/GiteaCard.test.tsx
+++ b/packages/web/src/components/console/GiteaCard.test.tsx
@@ -212,8 +212,8 @@ describe('GiteaCard', () => {
     for (const scope of ['read:user', 'write:repository', 'write:issue', 'read:organization']) {
       expect(panel.textContent).toContain(scope)
     }
-    // A dedicated user, Admin on every bound repository (§4.4) …
-    expect(panel.textContent).toContain('Use a dedicated user')
+    // A dedicated bot user, Admin on every bound repository (§4.4) …
+    expect(panel.textContent).toContain('Use a dedicated bot user')
     expect(panel.textContent).toContain('Admin')
     // … and §15's trade-off, said rather than implied.
     expect(panel.textContent).toContain('can do anything the bot can')

--- a/packages/web/src/components/console/GiteaCard.tsx
+++ b/packages/web/src/components/console/GiteaCard.tsx
@@ -92,7 +92,7 @@ function ConnectFields({
         <span className="flex items-start gap-[6px]">
           <Icon name="key-round" size={13} className="mt-[2px] flex-none" />
           <span>
-            Generate it on the bot user&rsquo;s Settings &rarr; Applications page with exactly these scopes:{' '}
+            Bot user&rsquo;s Settings &rarr; Applications, scopes{' '}
             {scopes.map((scope, index) => (
               <span key={scope}>
                 {index > 0 ? ', ' : ''}
@@ -105,18 +105,8 @@ function ConnectFields({
         <span className="flex items-start gap-[6px]">
           <Icon name="users" size={13} className="mt-[2px] flex-none" />
           <span>
-            Use a dedicated user, not a person&rsquo;s account: every comment, review and commit status an agent writes
-            is attributed to it. Give it <span className="text-(--text-secondary)">Admin</span>&#32;on each repository
-            you add here — as a collaborator or through a team — so AgentConnect can install and repair that
-            repository&rsquo;s webhook.
-          </span>
-        </span>
-        <span className="flex items-start gap-[6px]">
-          <Icon name="shield-alert" size={13} className="mt-[2px] flex-none" />
-          <span>
-            This one token is the whole identity, so an agent running on a bound repository can do anything the bot can
-            — including changing that repository&rsquo;s settings. It is sealed at rest and reaches a daemon only as a
-            short lease, never as stored state.
+            Use a dedicated bot user with <span className="text-(--text-secondary)">Admin</span>&#32;on each repository
+            you add. Everything an agent writes is attributed to it, and an agent can do anything the bot can.
           </span>
         </span>
       </div>


### PR DESCRIPTION
## Summary

The Gitea connect panel explained itself in three paragraphs. Two short lines carry the same requirements:

- where the token comes from and the four scopes it needs;
- a dedicated bot user with Admin on each repository you add, everything an agent writes attributed to it, and that an agent can do anything the bot can.

The `GiteaCard` test that pins the panel's requirements is updated for the new wording; the scope list, the Admin requirement, and the trade-off sentence are still asserted.

## Gates

- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/GiteaCard.test.tsx` — 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
