### PR TITLE
fix(web): report Gitea run state as a commit status

### DIFF
--- a/packages/web/src/components/console/CodeHostReviewSettings.tsx
+++ b/packages/web/src/components/console/CodeHostReviewSettings.tsx
@@ -11,10 +11,12 @@ import {
   reviewFormatValue,
   reviewPresetOf,
   withCapability,
+  withStatusMode,
   type CodeHostReviewCapabilities,
   type CodeHostReviewSettingsValue,
   type HookReportingMode,
-  type HookReviewPolicy
+  type HookReviewPolicy,
+  type StatusReportingMode
 } from '@/lib/code-host-review-settings'
 
 /** The four capability labels are shared; only the hover copy differs per host. */
@@ -37,6 +39,7 @@ export function CodeHostReviewSettings({
   onReportingModeChange,
   help,
   statusCheckLabel,
+  statusMode = 'check',
   layout = 'disclosure',
   defaultExpanded = false,
   notices
@@ -47,6 +50,8 @@ export function CodeHostReviewSettings({
   onReportingModeChange: (mode: HookReportingMode) => void
   help: ReviewCapabilityHelp
   statusCheckLabel: string
+  // The reporting mode the status switch stands for on THIS host — Gitea reports a commit status.
+  statusMode?: StatusReportingMode
   layout?: 'disclosure' | 'format'
   defaultExpanded?: boolean
   notices?: ReactNode
@@ -54,7 +59,7 @@ export function CodeHostReviewSettings({
   const [expanded, setExpanded] = useState(defaultExpanded)
   // Custom is a disclosure the value cannot express: an exact Details value the
   // user opened Custom on must keep the checkboxes visible.
-  const [customPinned, setCustomPinned] = useState(() => reviewFormatOf(value) === 'custom')
+  const [customPinned, setCustomPinned] = useState(() => reviewFormatOf(value, statusMode) === 'custom')
   const preset = reviewPresetOf(value)
   const capabilities = codeHostReviewCapabilities(value)
 
@@ -64,7 +69,7 @@ export function CodeHostReviewSettings({
   }
 
   const setCapability = (key: keyof CodeHostReviewCapabilities, enabled: boolean) => {
-    applyValue(codeHostReviewSettingsFromCapabilities(withCapability(capabilities, key, enabled)))
+    applyValue(codeHostReviewSettingsFromCapabilities(withCapability(capabilities, key, enabled), statusMode))
   }
 
   const checkboxes = (
@@ -97,7 +102,7 @@ export function CodeHostReviewSettings({
   )
 
   if (layout === 'format') {
-    const format = customPinned ? 'custom' : reviewFormatOf(value)
+    const format = customPinned ? 'custom' : reviewFormatOf(value, statusMode)
     return (
       <div className="flex flex-col gap-3">
         <div className="fldlbl">Review format</div>
@@ -112,7 +117,7 @@ export function CodeHostReviewSettings({
                 aria-pressed={active}
                 onClick={() => {
                   setCustomPinned(option.id === 'custom')
-                  const next = reviewFormatValue(option.id)
+                  const next = reviewFormatValue(option.id, statusMode)
                   if (next) applyValue(next)
                 }}
                 className={
@@ -154,7 +159,7 @@ export function CodeHostReviewSettings({
                   key={option.id}
                   type="button"
                   aria-pressed={active}
-                  onClick={() => applyValue(option.value)}
+                  onClick={() => applyValue(withStatusMode(option.value, statusMode))}
                   className={
                     active
                       ? 'h-10 rounded-md border border-(--brand) bg-(--brand-soft) font-sans text-[12.5px] font-semibold leading-normal text-(--brand-soft-text)'

--- a/packages/web/src/components/console/GiteaReviewSettings.test.tsx
+++ b/packages/web/src/components/console/GiteaReviewSettings.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+/**
+ * Gitea's half of the review surface. One claim, both directions: Gitea's run
+ * state is a COMMIT STATUS, so the status switch writes `status` — the mode the
+ * Control Plane accepts for a Gitea repository — and a stored `status` value
+ * reads back as the same Details tile a `check` value reads as on the other
+ * hosts (gitea-integration.md §10.4).
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CodeHostReviewSettingsValue } from '@/lib/code-host-review-settings'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const { GiteaReviewSettings } = await import('./GiteaReviewSettings')
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+const onReviewPolicyChange = vi.fn()
+const onReportingModeChange = vi.fn()
+
+async function render(value: CodeHostReviewSettingsValue, layout: 'disclosure' | 'format' = 'format') {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(
+      <GiteaReviewSettings
+        value={value}
+        onReviewPolicyChange={onReviewPolicyChange}
+        onReportingModeChange={onReportingModeChange}
+        layout={layout}
+        defaultExpanded
+      />
+    )
+  })
+}
+
+const formatTile = (id: string) => document.querySelector<HTMLButtonElement>(`[data-review-format="${id}"]`)
+const statusCheckbox = () =>
+  Array.from(document.querySelectorAll('label')).find((label) => label.textContent?.includes('Commit status'))
+    ?.firstElementChild as HTMLInputElement | undefined
+const presetNamed = (label: string) =>
+  Array.from(document.querySelectorAll('button')).find((button) => button.textContent === label)
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  onReviewPolicyChange.mockClear()
+  onReportingModeChange.mockClear()
+})
+
+describe('GiteaReviewSettings', () => {
+  it('reads a stored commit-status value back as the Details tile', async () => {
+    await render({ reviewPolicy: 'full', reportingMode: 'status' })
+    expect(formatTile('details')?.getAttribute('aria-pressed')).toBe('true')
+    expect(formatTile('custom')?.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('names the switch a commit status and writes that mode when it is turned on', async () => {
+    await render({ reviewPolicy: 'off', reportingMode: 'off' })
+    await act(async () => formatTile('custom')?.click())
+    const box = statusCheckbox()
+    expect(box).toBeDefined()
+    expect(box?.checked).toBe(false)
+
+    await act(async () => box?.click())
+    // The one mode a Gitea repository accepts — a run note is refused there.
+    expect(onReportingModeChange).toHaveBeenCalledWith('status')
+    expect(onReportingModeChange).not.toHaveBeenCalledWith('check')
+  })
+
+  it('shows a stored commit status as the switch already on', async () => {
+    await render({ reviewPolicy: 'off', reportingMode: 'status' })
+    await act(async () => formatTile('custom')?.click())
+    expect(statusCheckbox()?.checked).toBe(true)
+
+    await act(async () => statusCheckbox()?.click())
+    expect(onReportingModeChange).toHaveBeenCalledWith('off')
+  })
+
+  it('writes the commit status from the agent page’s Details preset too', async () => {
+    await render({ reviewPolicy: 'off', reportingMode: 'off' }, 'disclosure')
+    await act(async () => presetNamed('Details')?.click())
+    expect(onReviewPolicyChange).toHaveBeenCalledWith('full')
+    expect(onReportingModeChange).toHaveBeenCalledWith('status')
+  })
+})

--- a/packages/web/src/components/console/GiteaReviewSettings.tsx
+++ b/packages/web/src/components/console/GiteaReviewSettings.tsx
@@ -21,7 +21,7 @@ export function GiteaReviewSettings({
   layout?: 'disclosure' | 'format'
   defaultExpanded?: boolean
 }) {
-  const repositoryMissing = !repositoryReady && (value.reviewPolicy !== 'off' || value.reportingMode === 'check')
+  const repositoryMissing = !repositoryReady && (value.reviewPolicy !== 'off' || value.reportingMode !== 'off')
   return (
     <CodeHostReviewSettings
       title="PR review"
@@ -31,6 +31,7 @@ export function GiteaReviewSettings({
       layout={layout}
       defaultExpanded={defaultExpanded}
       statusCheckLabel="Commit status"
+      statusMode="status"
       help={{
         inlineComments:
           'Submit formal COMMENT reviews with optional comments on specific changed lines. Gitea takes one comment per line, never a range.',

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitea.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitea.test.tsx
@@ -232,9 +232,9 @@ describe('AddIntegrationModal, Gitea trigger', () => {
       events: ['merge_request:*'],
       commentFamilies: ['merge_request'],
       mentionOnly: false,
-      // The review format opens on the full set, exactly like the other two panes.
+      // The review format opens on the full set, and Gitea reports the run state as a commit status.
       reviewPolicy: 'full',
-      reportingMode: 'check'
+      reportingMode: 'status'
     })
   })
 
@@ -295,7 +295,7 @@ describe('AddIntegrationModal, Gitea trigger', () => {
       commentFamilies: ['merge_request'],
       mentionOnly: true,
       reviewPolicy: 'full',
-      reportingMode: 'check'
+      reportingMode: 'status'
     })
   })
 

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -627,7 +627,7 @@ export default function AddIntegrationModal({
   const [gtModes, setGtModes] = useState<Partial<Record<GtFamily, GtTriggerMode>>>({})
   const gtModeOf = (fam: GtFamily): GtTriggerMode => gtModes[fam] ?? giteaDefaultTriggerMode(fam)
   const [gtReviewPolicy, setGtReviewPolicy] = useState<HookReviewPolicy>('full')
-  const [gtReportingMode, setGtReportingMode] = useState<HookReportingMode>('check')
+  const [gtReportingMode, setGtReportingMode] = useState<HookReportingMode>('status')
 
   // Reusing a bot is an advanced path; every platform opens on the create flow
   // until the user explicitly chooses an existing identity.

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1839,10 +1839,10 @@ export default function AgentDetailView() {
                             {GT_TRIGGER_PILL[giteaTriggerModeOf(h)]}
                           </span>
                         </span>
-                        {(h.reviewPolicy !== 'off' || h.reportingMode === 'check') && (
+                        {(h.reviewPolicy !== 'off' || h.reportingMode !== 'off') && (
                           <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                             {reviewPolicyLabel(h.reviewPolicy)} review
-                            {h.reportingMode === 'check' ? ' · commit status' : ''}
+                            {h.reportingMode === 'status' ? ' · commit status' : ''}
                           </span>
                         )}
                         {addFamilyError?.key === repoKey && addFamilies.length > 0 && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4099,8 +4099,8 @@ export type GiteaCommentFamily = GitlabCommentFamily
 /** The stored union across code hosts; each row carries only its own host's subset. */
 export type HookCommentFamily = GithubCommentFamily | GitlabCommentFamily
 export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
-// R2a intentionally exposes informational Checks only. `status` is R3.
-export type HookReportingMode = 'off' | 'check'
+// `check` is GitHub's informational Check and GitLab's run note; `status` is Gitea's commit status.
+export type HookReportingMode = 'off' | 'check' | 'status'
 // `required` remains server-rejected until the R2b acceptance gates pass.
 export type HookGateMode = 'informational'
 
@@ -4204,7 +4204,7 @@ export interface CreateGiteaHookInput {
   commentFamilies?: GiteaCommentFamily[]
   mentionOnly?: boolean
   reviewPolicy?: HookReviewPolicy
-  // 'check' publishes the pull request's commit status; no gateMode — a required check is the operator's choice.
+  // 'status' publishes the pull request's commit status; no gateMode — a required check is the operator's choice.
   reportingMode?: HookReportingMode
 }
 

--- a/packages/web/src/lib/code-host-review-settings.test.ts
+++ b/packages/web/src/lib/code-host-review-settings.test.ts
@@ -10,6 +10,7 @@ import {
   reviewPolicyLabel,
   reviewPresetOf,
   withCapability,
+  withStatusMode,
   type CodeHostReviewSettingsValue
 } from './code-host-review-settings'
 
@@ -70,6 +71,55 @@ describe('withCapability', () => {
       reviewPolicy: 'off',
       reportingMode: 'check'
     })
+  })
+})
+
+describe('the per-host reporting transport', () => {
+  it('reports the switch through the mode its host names', () => {
+    const none = codeHostReviewCapabilities({ reviewPolicy: 'off', reportingMode: 'off' })
+    const on = withCapability(none, 'statusCheck', true)
+    expect(codeHostReviewSettingsFromCapabilities(on, 'status')).toEqual({
+      reviewPolicy: 'off',
+      reportingMode: 'status'
+    })
+    expect(codeHostReviewSettingsFromCapabilities(withCapability(on, 'statusCheck', false), 'status')).toEqual({
+      reviewPolicy: 'off',
+      reportingMode: 'off'
+    })
+  })
+
+  it('projects a commit-status value onto the same checkbox a check value does', () => {
+    expect(codeHostReviewCapabilities({ reviewPolicy: 'full', reportingMode: 'status' })).toEqual({
+      inlineComments: true,
+      requestChanges: true,
+      approve: true,
+      statusCheck: true
+    })
+    expect(reviewPresetOf({ reviewPolicy: 'full', reportingMode: 'status' })).toBe('details')
+  })
+
+  it('round-trips a commit-status value through the capability projection', () => {
+    const value: CodeHostReviewSettingsValue = { reviewPolicy: 'request_changes', reportingMode: 'status' }
+    expect(codeHostReviewSettingsFromCapabilities(codeHostReviewCapabilities(value), 'status')).toEqual(value)
+  })
+
+  it('restates a preset in the host transport, leaving the off value alone', () => {
+    expect(withStatusMode({ reviewPolicy: 'full', reportingMode: 'check' }, 'status')).toEqual({
+      reviewPolicy: 'full',
+      reportingMode: 'status'
+    })
+    expect(withStatusMode({ reviewPolicy: 'comment', reportingMode: 'off' }, 'status')).toEqual({
+      reviewPolicy: 'comment',
+      reportingMode: 'off'
+    })
+  })
+
+  it('reads and writes the format tiles in that transport', () => {
+    expect(reviewFormatValue('details', 'status')).toEqual({ reviewPolicy: 'full', reportingMode: 'status' })
+    expect(reviewFormatValue('brief', 'status')).toEqual({ reviewPolicy: 'comment', reportingMode: 'off' })
+    expect(reviewFormatOf({ reviewPolicy: 'full', reportingMode: 'status' }, 'status')).toBe('details')
+    // A value in the OTHER host's transport is not this host's Details tile.
+    expect(reviewFormatOf({ reviewPolicy: 'full', reportingMode: 'check' }, 'status')).toBe('custom')
   })
 })
 

--- a/packages/web/src/lib/code-host-review-settings.ts
+++ b/packages/web/src/lib/code-host-review-settings.ts
@@ -2,7 +2,10 @@
 // projection, and the preset row. Whatever only one host has stays in that host's own module.
 
 export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
-export type HookReportingMode = 'off' | 'check'
+// One run state, three host transports: `check` is GitHub's Check Run and GitLab's run note,
+// `status` is Gitea's commit status. Which one a host's switch stands for is that host's fact.
+export type HookReportingMode = 'off' | 'check' | 'status'
+export type StatusReportingMode = Exclude<HookReportingMode, 'off'>
 export type HookGateMode = 'informational'
 
 export interface CodeHostReviewSettingsValue {
@@ -23,13 +26,14 @@ export function codeHostReviewCapabilities(value: CodeHostReviewSettingsValue): 
     inlineComments: value.reviewPolicy !== 'off',
     requestChanges: value.reviewPolicy === 'request_changes' || value.reviewPolicy === 'full',
     approve: value.reviewPolicy === 'full',
-    statusCheck: value.reportingMode === 'check'
+    statusCheck: value.reportingMode !== 'off'
   }
 }
 
-/** Collapse capability checkboxes back to the strongest enabled policy. */
+/** Collapse capability checkboxes back to the strongest enabled policy, reporting through `statusMode`. */
 export function codeHostReviewSettingsFromCapabilities(
-  capabilities: CodeHostReviewCapabilities
+  capabilities: CodeHostReviewCapabilities,
+  statusMode: StatusReportingMode = 'check'
 ): CodeHostReviewSettingsValue {
   return {
     reviewPolicy: capabilities.approve
@@ -39,11 +43,12 @@ export function codeHostReviewSettingsFromCapabilities(
         : capabilities.inlineComments
           ? 'comment'
           : 'off',
-    reportingMode: capabilities.statusCheck ? 'check' : 'off'
+    reportingMode: capabilities.statusCheck ? statusMode : 'off'
   }
 }
 
-/** The three presets the disclosure opens on, in display order. */
+/** The three presets the disclosure opens on, in display order; `check` is restated per host
+ *  through `withStatusMode`, so the table names the shape and never a host's transport. */
 export const REVIEW_PRESETS = [
   { id: 'none', label: 'None', value: { reviewPolicy: 'off', reportingMode: 'off' } },
   { id: 'brief', label: 'Brief', value: { reviewPolicy: 'comment', reportingMode: 'off' } },
@@ -67,17 +72,35 @@ export type ReviewFormatId = (typeof REVIEW_FORMATS)[number]['id']
 /** The format row's default: the full set — inline comments, request changes, approve, status check. */
 export const REVIEW_FORMAT_DEFAULT: CodeHostReviewSettingsValue = { reviewPolicy: 'full', reportingMode: 'check' }
 
+/** Restate a preset in the reporting mode this host's run state travels on. */
+export function withStatusMode(
+  value: CodeHostReviewSettingsValue,
+  statusMode: StatusReportingMode
+): CodeHostReviewSettingsValue {
+  return value.reportingMode === 'off' ? value : { ...value, reportingMode: statusMode }
+}
+
 /** Which format tile a value reads as — anything but an exact Brief or Details is custom. */
-export function reviewFormatOf(value: CodeHostReviewSettingsValue): ReviewFormatId {
-  const exact = REVIEW_PRESETS.find(
+export function reviewFormatOf(
+  value: CodeHostReviewSettingsValue,
+  statusMode: StatusReportingMode = 'check'
+): ReviewFormatId {
+  const exact = REVIEW_PRESETS.map((preset) => ({
+    id: preset.id,
+    value: withStatusMode(preset.value, statusMode)
+  })).find(
     (preset) => preset.value.reviewPolicy === value.reviewPolicy && preset.value.reportingMode === value.reportingMode
   )
   return exact?.id === 'brief' || exact?.id === 'details' ? exact.id : 'custom'
 }
 
 /** The value a format tile applies; `custom` applies none. */
-export function reviewFormatValue(id: ReviewFormatId): CodeHostReviewSettingsValue | null {
-  return REVIEW_PRESETS.find((preset) => preset.id === id)?.value ?? null
+export function reviewFormatValue(
+  id: ReviewFormatId,
+  statusMode: StatusReportingMode = 'check'
+): CodeHostReviewSettingsValue | null {
+  const preset = REVIEW_PRESETS.find((entry) => entry.id === id)
+  return preset ? withStatusMode(preset.value, statusMode) : null
 }
 
 /** Which preset a stored value reads as; anything richer than "brief" is details. */


### PR DESCRIPTION
Found during the Gitea end-to-end acceptance: creating a Gitea pull-request trigger from the console fails with a 409 — `run notes are not available for Gitea repositories — report a commit status`.

## The cause

`HookReportingMode` is one enum over three host transports. GitHub's `check` is a Check Run, GitLab's `check` is its run note, and Gitea's run state is a **commit status**, which is the `status` member — so `validateGiteaEffects` accepts only `status` or `off`. The console sent `check` for Gitea because the shared status switch hard-coded `check` as the mode it stands for.

## The fix

The switch now carries the mode it reports through instead of assuming one:

- `CodeHostReviewSettings` takes a `statusMode` prop defaulting to `check`, and the capability projection, the preset table and the format tiles all write and read values through it (`withStatusMode`).
- `GiteaReviewSettings` passes `status`; GitHub and GitLab keep the default, so their wire values are unchanged.
- The capability checkbox reads any non-`off` mode as on, so a stored Gitea `status` value reads back as the same Details tile a `check` value reads as elsewhere.
- The Gitea pane's initial reporting mode and the agent page's Gitea row summary follow the same mode.

The Control Plane needed no change: its "not available until R3" gate on `status` sits inside the GitHub arm of both the create and the update path, so a Gitea body never reaches it, and the Gitea status projection already fires on any non-`off` mode.

## Tests

- `GiteaReviewSettings.test.tsx` (new): the switch writes `status` and never `check`, turning it off writes `off`, a stored `status` value shows the switch on and reads as Details, and the agent page's Details preset writes `status` too.
- `code-host-review-settings.test.ts`: the per-host transport — capability round-trip, preset restatement, and the format tiles in both modes.
- `AddIntegrationModal.gitea.test.tsx`: a created Gitea pull-request trigger with reviews on carries `reportingMode: 'status'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
