### PR TITLE
fix(web): size code-host card marks like the messaging marks

### DIFF
--- a/packages/web/src/components/console/GiteaCard.test.tsx
+++ b/packages/web/src/components/console/GiteaCard.test.tsx
@@ -271,6 +271,19 @@ describe('GiteaCard', () => {
     )
   })
 
+  it('sizes the card and connection marks like the chat-platform marks beside them', async () => {
+    // The card header and the connection row render the Gitea mark at the fill a full-bleed
+    // square glyph lands on through PlatformMark, which is what the bot tabs' marks render at.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    await render()
+
+    for (const selector of ['.cardtitle svg', '[data-gitea-connection] svg']) {
+      const mark = host.querySelector(selector)
+      expect(mark, selector).not.toBeNull()
+      expect(mark?.getAttribute('style'), selector).toContain('80%')
+    }
+  })
+
   it('says an instance below the floor once, not on every repository', async () => {
     mocks.fetchConnections.mockResolvedValue({
       enabled: true,

--- a/packages/web/src/components/console/GiteaCard.tsx
+++ b/packages/web/src/components/console/GiteaCard.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Button, Icon } from '@/components/ui'
+import { SQUARE_MARK_FILL_PCT } from '@/components/mark-box'
 import { GiteaMark, LoadingState } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
 import {
@@ -425,8 +426,9 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
     <div className="card">
       <div className="cardhead justify-between">
         <span className="cardtitle flex items-center gap-2">
-          <span className="flex h-[15px] w-[15px] items-center justify-center">
-            <GiteaMark />
+          {/* The box and fill the bot tabs' marks use, so a code host reads the same size as a chat platform. */}
+          <span className="flex h-[14px] w-[14px] flex-none items-center justify-center">
+            <GiteaMark fillPct={SQUARE_MARK_FILL_PCT} />
           </span>
           Gitea
           {/* Which instance, and what it runs — one line of hover on the card. */}
@@ -506,7 +508,7 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
             <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
               <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
                 <span className="flex h-[14px] w-[14px] items-center justify-center">
-                  <GiteaMark />
+                  <GiteaMark fillPct={SQUARE_MARK_FILL_PCT} />
                 </span>
               </span>
               <a

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import useSWR from 'swr'
 import { Button, Icon } from '@/components/ui'
+import { SQUARE_MARK_FILL_PCT } from '@/components/mark-box'
 import { AgentIconView, GitlabMark, LoadingState } from '@/components/marks'
 import { useConsoleData } from '@/lib/data-context'
 import { agentLabel } from '@/lib/data'
@@ -461,8 +462,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     <div className="card">
       <div className="cardhead justify-between">
         <span className="cardtitle flex items-center gap-2">
-          <span className="flex h-[15px] w-[15px] items-center justify-center">
-            <GitlabMark />
+          {/* The box and fill the bot tabs' marks use, so a code host reads the same size as a chat platform. */}
+          <span className="flex h-[14px] w-[14px] flex-none items-center justify-center">
+            <GitlabMark fillPct={SQUARE_MARK_FILL_PCT} />
           </span>
           GitLab
           {/* Which instance, and what it runs — one line of hover on the card, not a badge on every identity. */}
@@ -520,7 +522,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
                 <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
                   <span className="flex h-[14px] w-[14px] items-center justify-center">
-                    <GitlabMark />
+                    <GitlabMark fillPct={SQUARE_MARK_FILL_PCT} />
                   </span>
                 </span>
                 <span className="mono min-w-0 truncate text-[12.5px]">{c.gitlabUsername}</span>

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -13,6 +13,7 @@ import { Fragment, useEffect, useMemo, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { Button, Icon, Toggle } from '@/components/ui'
+import { SQUARE_MARK_FILL_PCT } from '@/components/mark-box'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
 import { useModal } from '@/components/console/ModalProvider'
 import { DefaultDispatchPicker } from '@/components/console/DefaultDispatchPicker'
@@ -712,8 +713,9 @@ function GithubCard({ canWrite, isOwner }: { canWrite: boolean; isOwner: boolean
     <div className="card">
       <div className="cardhead justify-between">
         <span className="cardtitle flex items-center gap-2">
-          <span className="flex h-[15px] w-[15px] items-center justify-center">
-            <GithubMark color="var(--text-primary)" />
+          {/* The box and fill the bot tabs' marks use, so a code host reads the same size as a chat platform. */}
+          <span className="flex h-[14px] w-[14px] flex-none items-center justify-center">
+            <GithubMark color="var(--text-primary)" fillPct={SQUARE_MARK_FILL_PCT} />
           </span>
           GitHub
         </span>
@@ -760,7 +762,7 @@ function GithubCard({ canWrite, isOwner }: { canWrite: boolean; isOwner: boolean
               <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
                 <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
                   <span className="flex h-[14px] w-[14px] items-center justify-center">
-                    <GithubMark color="var(--text-primary)" />
+                    <GithubMark color="var(--text-primary)" fillPct={SQUARE_MARK_FILL_PCT} />
                   </span>
                 </span>
                 <span className="mono min-w-0 truncate text-[12.5px]">{i.accountLogin}</span>

--- a/packages/web/src/components/mark-box.ts
+++ b/packages/web/src/components/mark-box.ts
@@ -24,8 +24,11 @@ export function markBox(fillPct: number): MarkBox {
   return box(fillPct)
 }
 
+/** The fill a full-bleed square glyph lands on — what a directly-named mark asks for to match it. */
+export const SQUARE_MARK_FILL_PCT = 80
+
 /**
- * The requested fill, CAPPED at 80%.
+ * The requested fill, CAPPED at {@link SQUARE_MARK_FILL_PCT}.
  *
  * Slack / GitHub / Discord ship as full-bleed square glyphs with no internal
  * padding of their own, so a caller asking for a full-bleed box (`fillPct=100`,
@@ -33,7 +36,7 @@ export function markBox(fillPct: number): MarkBox {
  * mark beside them. Below the cap nothing changes.
  */
 export function squareMarkBox(fillPct: number): MarkBox {
-  return fillPct > 80 ? box(80) : box(fillPct)
+  return fillPct > SQUARE_MARK_FILL_PCT ? box(SQUARE_MARK_FILL_PCT) : box(fillPct)
 }
 
 /** The default fill every mark starts from. */

--- a/packages/web/src/components/marks.test.tsx
+++ b/packages/web/src/components/marks.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { AgentIconView, GitlabMark, OrgIconView, PlatformMark, modelProviderSlug } from './marks'
+import { SQUARE_MARK_FILL_PCT } from './mark-box'
+import { AgentIconView, GiteaMark, GithubMark, GitlabMark, OrgIconView, PlatformMark, modelProviderSlug } from './marks'
 
 describe('modelProviderSlug', () => {
   it('reads the provider prefix from provider/model ids', () => {
@@ -139,6 +140,18 @@ describe('PlatformMark', () => {
     // Below the cap nothing changes, and an uncapped mark still fills its box.
     expect(renderToStaticMarkup(<PlatformMark platform="discord" fillPct={70} />)).toContain('width:70%')
     expect(renderToStaticMarkup(<PlatformMark platform="telegram" fillPct={100} />)).toContain('width:100%')
+  })
+
+  it('lands a full-bleed square glyph on the fill a directly-named mark can ask for', () => {
+    // What the code-host cards rely on: their own mark at SQUARE_MARK_FILL_PCT is the size the
+    // bot tabs' marks render at, so a code host reads the same as a chat platform beside it.
+    const fill = `width:${SQUARE_MARK_FILL_PCT}%`
+    for (const platform of ['github', 'gitlab']) {
+      expect(renderToStaticMarkup(<PlatformMark platform={platform} fillPct={100} />), platform).toContain(fill)
+    }
+    expect(renderToStaticMarkup(<GithubMark fillPct={SQUARE_MARK_FILL_PCT} />)).toContain(fill)
+    expect(renderToStaticMarkup(<GitlabMark fillPct={SQUARE_MARK_FILL_PCT} />)).toContain(fill)
+    expect(renderToStaticMarkup(<GiteaMark fillPct={SQUARE_MARK_FILL_PCT} />)).toContain(fill)
   })
 
   it('uses the filled Lark brand asset for the shared Lark and Feishu platform family', () => {


### PR DESCRIPTION
On the Integrations page the code-host marks read noticeably smaller than the bot tabs' marks above them.

## Why

The bot tabs render their mark in a 14px box at a full-bleed fill — `PlatformMark` caps that to 80% for a square brand glyph, which is what Slack, Discord, GitHub, GitLab and Gitea all are. The three code-host cards rendered the same kind of glyph at the 60% default, inside a 15px box: roughly 9px against the tabs' 11.2px, and 8.4px in the rows beneath against the bot rows' 11.2px in the identical 28px plate.

## The change

Each code-host card header and the rows beneath it now use that box and that fill, for GitHub, GitLab and Gitea alike. `PlatformMark`'s cap gets a name — `SQUARE_MARK_FILL_PCT` in `components/mark-box.ts` — so a mark named directly can ask for the size the shared component lands on rather than restating the number, and the one definition stays the only one.

Nothing else moves: the three mark components still apply a caller's `fillPct` verbatim, so every other call site renders exactly as before. `fillPct` semantics are unchanged (packages/web/STYLE.md rule 8 — the size stays a data-driven inline style, never an assembled class name).

## Tests

- `marks.test.tsx`: a full-bleed square glyph through `PlatformMark` and the same glyph named directly at `SQUARE_MARK_FILL_PCT` land on one size — the invariant the cards rely on.
- `GiteaCard.test.tsx`: the card header mark and the connection row mark render at that fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
