### PR TITLE
fix(web): drop the duplicated help line on the Gitea trigger form

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitea.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitea.test.tsx
@@ -299,6 +299,17 @@ describe('AddIntegrationModal, Gitea trigger', () => {
     })
   })
 
+  it('states what a subscription does once, where every code host states it', async () => {
+    // The footer under the form carries that sentence for all three hosts; the Gitea pane
+    // printed it a second time of its own.
+    mocks.fetchGiteaRepositories.mockResolvedValue([binding])
+    await renderAgent({ id: 'agent-hint' })
+    await pickRepository()
+
+    const hint = 'reply on the same issue, pull request or push thread'
+    expect((document.body.textContent ?? '').split(hint)).toHaveLength(2)
+  })
+
   it('offers the two subjects only — nothing reachable compiles a push event', async () => {
     mocks.fetchGiteaRepositories.mockResolvedValue([binding])
     await renderAgent({ id: 'agent-subjects' })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -2114,11 +2114,6 @@ export default function AddIntegrationModal({
                     ) : null
                   }
                 />
-
-                <div className="mb-4 flex items-start gap-2 font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                  <Icon name="info" size={13} className="mt-[1px] flex-none" />
-                  <span>{CODE_HOST_SUBSCRIPTION_HINT.gitea}</span>
-                </div>
               </>
             )}
           </>


### PR DESCRIPTION
The Gitea form in the Add-integration modal showed the same help line twice, once with an info icon and once with a hash icon:

> Matching events run the agent in a session and reply on the same issue, pull request or push thread.

## Why

The footer under the form states what a subscription does for every code host, from one provider-keyed table — it has since the provider tables landed. The Gitea arm then added its own info line over the same table entry, so the sentence rendered twice as soon as the repository list loaded. The GitHub and GitLab arms have no second line, and the sentence has no second meaning to carry, so the arm's copy is the one to go.

## Tests

`AddIntegrationModal.gitea.test.tsx` pins the sentence to exactly one occurrence after a repository is picked — it fails on the old component with three split parts instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
