### PR TITLE
fix(daemon): brand a code-host session link by its provider

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8784,7 +8784,7 @@ export class Daemon {
   }
 
   /** What every formal-review adapter shares: the CP surface, the outbox, the org lookup, the footer. */
-  private codeHostReviewDeps<Turn extends { agentId: string; sessionId: string }>() {
+  private codeHostReviewDeps<Turn extends { agentId: string; sessionId: string }>(provider: CodeHostProvider) {
     return {
       cp: () => this.codeHostReviewCp(),
       orgForAgent: (agentId: string) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
@@ -8793,7 +8793,7 @@ export class Daemon {
       outbox: this.reviewOutbox,
       attribution: async (turn: Turn) =>
         this.agents.get(turn.agentId)?.output.showFooter
-          ? await this.githubReviews.githubCommentAttribution(turn.agentId, turn.sessionId)
+          ? await this.githubReviews.githubCommentAttribution(turn.agentId, turn.sessionId, provider)
           : undefined,
       log: { warn: (message: string) => this.log.warn(message) }
     }
@@ -8802,7 +8802,7 @@ export class Daemon {
   /** §15 GitLab review adapter deps: the CP lease surface plus the never-agent-visible effect PAT. */
   private gitlabReviewDeps(): GitlabReviewAdapterDeps {
     return {
-      ...this.codeHostReviewDeps<GitlabReviewTurn>(),
+      ...this.codeHostReviewDeps<GitlabReviewTurn>('gitlab'),
       apiBaseUrl: (turn) => this.gitlabApiBase(turn.agentId),
       markerKey: this.reviewMarkerKey('gitlab-review-marker-key'),
       token: async (turn) => (await this.gitCreds.getGitlabEffectToken(turn.agentId, turn.repoId, turn.hookId)).token,
@@ -8813,7 +8813,7 @@ export class Daemon {
   /** gitea-integration.md §10.3: the same seam over the connection token's `gitea_effect` lease. */
   private giteaReviewDeps(): GiteaReviewAdapterDeps {
     return {
-      ...this.codeHostReviewDeps<GiteaReviewTurn>(),
+      ...this.codeHostReviewDeps<GiteaReviewTurn>('gitea'),
       apiBaseUrl: (turn) => this.giteaApiBase(turn.agentId),
       markerKey: this.reviewMarkerKey('gitea-review-marker-key'),
       token: async (turn) => (await this.gitCreds.getGiteaEffectToken(turn.agentId, turn.repoId, turn.hookId)).token,

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -14,6 +14,7 @@ import {
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   pickCodeHostHookMembers,
+  type CodeHostProvider,
   type GithubHookMetadata,
   type HookReviewResult,
   type RdAck,
@@ -52,7 +53,8 @@ import { initiatorLabel } from '../workspace/session-branch.js'
 import { effectiveSessionIsolation, type PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
 import { GithubReplyCollector, type GithubCommentAttribution } from './poster.js'
 import { acknowledgeCodeHostTrigger } from '../codehost/ack.js'
-import type { CodeHostReplyTarget } from '../codehost/reply-target.js'
+import { codeHostLinkSource } from '../platforms/link-source.js'
+import { replyTargetProvider, type CodeHostReplyTarget } from '../codehost/reply-target.js'
 import {
   codeHostHostFence,
   codeHostPromptSupplement,
@@ -860,7 +862,7 @@ export class GithubReviewOrchestrator {
       authorizedReviewTarget(active, attemptId, authorized, recovering),
       req,
       this.agents.get(req.agentId)?.output.showFooter
-        ? await this.githubCommentAttribution(req.agentId, active.sessionId)
+        ? await this.githubCommentAttribution(req.agentId, active.sessionId, 'github')
         : undefined
     )
     const result = await this.persistGithubReviewEffect(active, attemptId, effect)
@@ -985,13 +987,20 @@ export class GithubReviewOrchestrator {
       poster: turnFinal.finalPoster(ref, {
         ...turnFinal.effectLease(agentId, ref, this.turnFinalHost),
         attribution: () =>
-          this.agents.get(agentId)?.output.showFooter ? this.githubCommentAttribution(agentId, sessionId) : undefined,
+          this.agents.get(agentId)?.output.showFooter
+            ? this.githubCommentAttribution(agentId, sessionId, replyTargetProvider(ref))
+            : undefined,
         log: { warn: (m: string) => this.log.warn(m) }
       })
     }
   }
 
-  async githubCommentAttribution(agentId: string, sessionId: string): Promise<GithubCommentAttribution> {
+  /** `provider` is the host that will publish this footer — it brands the session link (§7.4). */
+  async githubCommentAttribution(
+    agentId: string,
+    sessionId: string,
+    provider: CodeHostProvider
+  ): Promise<GithubCommentAttribution> {
     const agent = this.agents.get(agentId)
     const runtime = agent?.runtime
     // The footer links the console, which knows this session by its outward id (§1.1).
@@ -1004,7 +1013,7 @@ export class GithubReviewOrchestrator {
         (await this.host.hostForStoredSession(agentId, sessionId))?.modelOptions?.(sessionId)?.current ??
         agent?.runtimeOverrides?.model ??
         'default',
-      sessionUrl: this.host.sessionLink(outward ?? sessionId, 'github'),
+      sessionUrl: this.host.sessionLink(outward ?? sessionId, codeHostLinkSource(provider)),
       // Same CP-resolved public avatar Slack uses for icon_url; GitHub renders it
       // inline ahead of the footer sentence.
       ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})

--- a/packages/daemon/src/platforms/link-source.ts
+++ b/packages/daemon/src/platforms/link-source.ts
@@ -11,11 +11,13 @@
  *    VALIDATED config (§6.4), which also applies the schema default (`'feishu'`
  *    when a hand-authored payload omits the field, exactly as the pre-flatten
  *    parse did);
+ *  - a code-host link brands by its PUBLISHING host (see codeHostLinkSource), never the hook turn's platform id;
  *  - everyone else contributes nothing, and the link renders unbranded.
  *
  * Presentation-only by contract: nothing routes on this value, so the open
  * `string` return is safe and the console treats unknown hints as no hint.
  */
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
 import type { Integration } from '../agents/agent-schema.js'
 import { platformIntegrationConfig } from './integration-config.js'
 
@@ -31,4 +33,10 @@ const SOURCES = new Map<string, LinkSource>([
  *  `integration`. Total by construction: no registered source means no hint. */
 export function sessionLinkSourceFor(platform: string, integration?: Integration): string | undefined {
   return SOURCES.get(platform)?.(integration)
+}
+
+/** The hint a CODE-HOST-rendered link carries: the host that rendered it, never the platform id the
+ *  hook turn happens to run under — a GitLab or Gitea reply brands as itself, not as GitHub. */
+export function codeHostLinkSource(provider: CodeHostProvider): string {
+  return provider
 }

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -173,7 +173,7 @@ const gitlabReviewFire = (dispatchDaemonId: string): RdMsgHook => {
 }
 
 describe('Daemon rd/msg hook fires', () => {
-  it('uses the display agent, runtime, and session model in GitHub attribution', async () => {
+  it('uses the display agent, runtime, and session model in code-host attribution', async () => {
     const { factory, host } = streamingHost()
     host.modelOptions.mockReturnValue({ current: 'claude-sonnet-4-5' } as never)
     const daemon = new Daemon({
@@ -185,12 +185,17 @@ describe('Daemon rd/msg hook fires', () => {
     ;(daemon as any).runtimeFacts.names.claude = 'Claude Code'
     await (daemon as any).ensureHostAsync(AGENT_ID)
 
-    expect(await (daemon as any).githubReviews.githubCommentAttribution(AGENT_ID, 'acp-hook-1')).toMatchObject({
-      agentName: 'Review Bot',
-      runtime: 'Claude Code',
-      model: 'claude-sonnet-4-5',
-      sessionUrl: 'http://localhost:3000/sessions/acp-hook-1?source=github'
-    })
+    // The session link brands by the host that publishes the footer, never as GitHub for all three.
+    for (const provider of ['github', 'gitlab', 'gitea'] as const) {
+      expect(
+        await (daemon as any).githubReviews.githubCommentAttribution(AGENT_ID, 'acp-hook-1', provider)
+      ).toMatchObject({
+        agentName: 'Review Bot',
+        runtime: 'Claude Code',
+        model: 'claude-sonnet-4-5',
+        sessionUrl: `http://localhost:3000/sessions/acp-hook-1?source=${provider}`
+      })
+    }
 
     await daemon.stop()
   })

--- a/packages/daemon/test/link-source.test.ts
+++ b/packages/daemon/test/link-source.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
+import { GithubReviewOrchestrator } from '../src/github/review-orchestrator.js'
 import { sessionLinkSourceFor } from '../src/platforms/link-source.js'
 
 describe('session-link source strategy', () => {
@@ -26,5 +28,27 @@ describe('session-link source strategy', () => {
     for (const p of ['telegram', 'discord', 'webchat', 'hook', 'some-future-platform']) {
       expect(sessionLinkSourceFor(p, feishuInt({ appId: 'c1', appSecret: 's', region: 'lark' }))).toBeUndefined()
     }
+  })
+})
+
+// A code-host reply's footer brands by the host that publishes it: all three linked `?source=github`
+// while the hint came from the one platform id every code-host hook turn runs under.
+describe('code-host footer session link', () => {
+  const attributionFor = async (provider: CodeHostProvider): Promise<string> => {
+    const orchestrator = new GithubReviewOrchestrator({
+      log: () => ({ warn: () => undefined }),
+      agents: () => new Map([['bot-review', { id: 'bot-review', name: 'bot-review', runtime: 'claude' }]]),
+      agentLink: () => 'https://console.example.test/agents/bot-review',
+      runtimeNames: () => ({ claude: 'Claude Code' }),
+      outwardSessionId: async () => 'out-1',
+      hostForStoredSession: async () => undefined,
+      sessionLink: (sessionId: string, source?: string) =>
+        `https://console.example.test/sessions/${sessionId}${source ? `?source=${source}` : ''}`
+    } as never)
+    return (await orchestrator.githubCommentAttribution('bot-review', 'acp-1', provider)).sessionUrl
+  }
+
+  it.each(['github', 'gitlab', 'gitea'] as const)('links the session as %s', async (provider) => {
+    expect(await attributionFor(provider)).toBe(`https://console.example.test/sessions/out-1?source=${provider}`)
   })
 })


### PR DESCRIPTION
A Gitea hook reply's footer linked the session as `?source=github`, and so did a GitLab one.

## Why

The `?source=` hint is presentation-only — the console's 404 profile-linking action uses it to name the right brand — and the footer attribution resolved it from a literal `'github'`. That was right while GitHub was the only code host writing a footer; the reply-target provider has been the real answer since GitLab arrived.

## The change

The hint follows the host that publishes the footer:

- the turn-final reply reads it off its own `CodeHostReplyTarget` provider, through `replyTargetProvider` so a row persisted before the member was explicit still resolves;
- each formal-review adapter's shared deps name their own host, so a GitLab or Gitea review comment brands as itself;
- the GitHub review submission names GitHub, where it was implicit before.

`codeHostLinkSource` sits in `platforms/link-source.ts` beside the platform strategy that renders every other hint, so the `?source=` vocabulary still lives in one module rather than spreading into the poster.

No console change is needed: the profile-linking hint accepts only providers that are sign-in methods, and anything else is already treated as no hint.

## Tests

- `link-source.test.ts`: the footer's session link for all three providers, against a stubbed host.
- `daemon-hook.test.ts`: the existing attribution test now covers the three providers instead of GitHub alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
