### PR TITLE
fix(web): name the deployment's Gitea instance before a connection exists

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2004,7 +2004,8 @@ export const GiteaConnectionDto = z.object({
 })
 export type GiteaConnectionDtoT = z.infer<typeof GiteaConnectionDto>
 
-export const GiteaConnectionListDto = z.object({ connections: z.array(GiteaConnectionDto) })
+// `instanceUrl` is the deployment's instance (§3), so the card can name it before any connection exists.
+export const GiteaConnectionListDto = z.object({ connections: z.array(GiteaConnectionDto), instanceUrl: z.string() })
 
 /** The bot token, write-only: it is verified, sealed, and never echoed by any route. */
 export const ConnectGiteaBody = z.object({ token: z.string().trim().min(1).max(512) })

--- a/packages/control-plane/src/http/routes/gitea.ts
+++ b/packages/control-plane/src/http/routes/gitea.ts
@@ -198,7 +198,7 @@ export function giteaRoutes(deps: HttpDeps) {
       async (req) => {
         const orgId = orgOf(req)
         const rows = await deps.repos.giteaConnection.listForOrg(orgId)
-        return { connections: await Promise.all(rows.map((row) => connectionDto(orgId, row))) }
+        return { connections: await Promise.all(rows.map((row) => connectionDto(orgId, row))), instanceUrl }
       }
     )
 

--- a/packages/control-plane/test/integration/gitea-connection.route.test.ts
+++ b/packages/control-plane/test/integration/gitea-connection.route.test.ts
@@ -91,7 +91,10 @@ describe('POST /gitea/connections (§4.1)', () => {
     const secret = await prisma.giteaConnectionSecret.findUniqueOrThrow({ where: { connectionId: row.id } })
     expect(secret.token).toBe(TOKEN)
     const listed = await a.app.inject({ method: 'GET', url: `${ORG}/gitea/connections` })
-    expect((listed.json() as { connections: unknown[] }).connections).toHaveLength(1)
+    const list = listed.json() as { connections: unknown[]; instanceUrl: string }
+    expect(list.connections).toHaveLength(1)
+    // The deployment's instance rides the list so the card can name it before and after connecting.
+    expect(list.instanceUrl).toMatch(/^https:\/\//)
   })
 
   it('refuses a rejected token and a token missing a required scope, storing nothing', async () => {

--- a/packages/web/src/components/console/GiteaCard.test.tsx
+++ b/packages/web/src/components/console/GiteaCard.test.tsx
@@ -202,6 +202,19 @@ describe('GiteaCard', () => {
     expect(host.querySelector('[data-gitea-connect]')).toBeNull()
   })
 
+  it('names the deployment instance before any connection exists', async () => {
+    // A self-hosted deployment must not tell the operator to create the bot on gitea.com (§3).
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [],
+      instanceUrl: 'https://gitea.example.test'
+    })
+    await render()
+
+    expect(host.textContent).toContain('gitea.example.test')
+    expect(host.textContent).not.toContain('gitea.com')
+  })
+
   it('states every requirement the token must satisfy beside the input', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()

--- a/packages/web/src/components/console/GiteaCard.tsx
+++ b/packages/web/src/components/console/GiteaCard.tsx
@@ -208,6 +208,7 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
   const { activeOrg } = useOrgs()
   const [enabled, setEnabled] = useState<boolean | null>(null)
   const [connection, setConnection] = useState<GiteaConnectionDto | null>(null)
+  const [deploymentInstanceUrl, setDeploymentInstanceUrl] = useState<string | null>(null)
   const [bindings, setBindings] = useState<GiteaRepositoryBindingDto[]>([])
   const [candidates, setCandidates] = useState<GiteaRepositoryDto[] | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -232,10 +233,11 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
     setEnabled(null)
     setCandidates(null)
     fetchGiteaConnections()
-      .then(async ({ enabled, connections }) => {
+      .then(async ({ enabled, connections, instanceUrl }) => {
         if (!alive) return
         setEnabled(enabled)
         setConnection(connections[0] ?? null)
+        if (instanceUrl) setDeploymentInstanceUrl(instanceUrl)
         if (!enabled) return
         const seq = supersedeReads()
         const rows = await fetchGiteaRepositories()
@@ -254,7 +256,10 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
       fetchGiteaRepositories().catch(() => null)
     ])
     if (seq !== readSeq.current) return
-    if (conns) setConnection(conns.connections[0] ?? null)
+    if (conns) {
+      setConnection(conns.connections[0] ?? null)
+      if (conns.instanceUrl) setDeploymentInstanceUrl(conns.instanceUrl)
+    }
     if (rows) setBindings(rows)
   }
 
@@ -408,9 +413,8 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
     }
   }
 
-  // One deployment, one instance (§3): the instance is the CARD's fact, and before the first
-  // connection there is nothing to link to anyway.
-  const instanceUrl = connection?.instanceUrl ?? GITEA_DEFAULT_INSTANCE_URL
+  // One deployment, one instance (§3): the instance is the CARD's fact, named by the list before any connection exists.
+  const instanceUrl = connection?.instanceUrl ?? deploymentInstanceUrl ?? GITEA_DEFAULT_INSTANCE_URL
   const instanceHint =
     connection?.instanceVersion == null ? instanceUrl : `${instanceUrl} · Gitea ${connection.instanceVersion}`
   const scopes = connection?.requiredScopes ?? ['read:user', 'write:repository', 'write:issue', 'read:organization']

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5824,10 +5824,12 @@ export interface GiteaWebhookRotationDto {
  *  on this deployment, which is an absence to state rather than a failure. */
 export async function fetchGiteaConnections(
   orgId?: string
-): Promise<{ enabled: boolean; connections: GiteaConnectionDto[] }> {
+): Promise<{ enabled: boolean; connections: GiteaConnectionDto[]; instanceUrl?: string }> {
   try {
-    const body = await apiGet<{ connections: GiteaConnectionDto[] }>(`${orgBase(orgId)}/gitea/connections`)
-    return { enabled: true, connections: body.connections }
+    const body = await apiGet<{ connections: GiteaConnectionDto[]; instanceUrl?: string }>(
+      `${orgBase(orgId)}/gitea/connections`
+    )
+    return { enabled: true, connections: body.connections, instanceUrl: body.instanceUrl }
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) return { enabled: false, connections: [] }
     throw e


### PR DESCRIPTION
## Summary

Found while configuring a self-hosted Gitea instance: the Integrations card's not-connected copy said "Create a bot user on gitea.com" even though the deployment's instance address was already set, because the instance URL only rode inside each connection DTO and there is no connection yet at that point.

- `GET /gitea/connections` now returns `instanceUrl` beside `connections` (declared on `GiteaConnectionListDto`, so it survives the response schema).
- The web client reads it, and `GiteaCard` uses it for the instance hint and the not-connected copy before the first connection; a connection's own value still wins once one exists.

## Gates

- `pnpm typecheck` — clean
- `pnpm --filter @agentconnect.md/control-plane test:int` — 131 files, 2058 tests pass (the connection route test asserts the new field)
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/GiteaCard.test.tsx` — 20 pass (new: the card names a self-hosted instance and never gitea.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
