### PR TITLE
feat(relay): accept the team-mention form for Gitea agents

### DIFF
--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -384,6 +384,17 @@ event type before reading it.
 A standalone inline comment — one left outside a review submission — produces
 no delivery at all, so there is no such trigger to build.
 
+**Summon forms.** A mention-gated rule is summoned by `@<agent-name>`, by the
+connection bot's own handle as the repository-wide broadcast, or by
+`@<owner>/<agent-name>` — Gitea's organization team syntax, which an organization
+makes autocomplete in the comment composer by creating a visible team named after
+the agent; the owner comes from the delivery's own `repository`, matching is pure
+text, and the team is never read back through the API. Gitea's `api.User` carries
+no organization kind, so unlike GitHub's form this one is gated on nothing: it is
+text against the owner login, and is simply inert on a personal repository, where
+Gitea renders no team mention. Because `@<owner>/<slug>` is the team form, it is
+never also read as a bare mention of `<owner>`.
+
 **Loop prevention.** A delivery whose `sender.id` is the connection's bot
 user id is rejected, with the §12.1 exception that the bot's own same-repository
 pull-request revisions still enter review. With one identity per organization

--- a/packages/relay/src/hooks/gitea/events.ts
+++ b/packages/relay/src/hooks/gitea/events.ts
@@ -13,7 +13,7 @@
  * plus the Control Plane's live membership resolution.
  */
 import type { GiteaHookMetadata, GiteaHookTarget, HookContext, RcHookAssign } from '@agentconnect.md/protocol'
-import { mentionsGithubHandle, truncateUtf8, GITHUB_BODY_EXCERPT_MAX } from '../github-ingress.js'
+import { mentionsGithubHandle, mentionsGithubTeam, truncateUtf8, GITHUB_BODY_EXCERPT_MAX } from '../github-ingress.js'
 
 /** The Gitea webhook event types this ingress maps; every other type is silently unmapped. */
 export const GITEA_EVENT_ISSUES = 'issues'
@@ -67,7 +67,7 @@ export interface GiteaPayload {
   action?: string
   /** Comment deliveries only: whether the commented subject is a pull request. */
   is_pull?: boolean
-  repository?: { id?: number; full_name?: string }
+  repository?: { id?: number; full_name?: string; owner?: GiteaUserRef }
   sender?: GiteaUserRef
   issue?: GiteaIssueRef
   pull_request?: GiteaPullRequestRef
@@ -94,6 +94,8 @@ export interface GiteaMatchCtx {
   subjectAuthorLogin?: string
   labels: string[]
   mentionText: string | undefined
+  /** The owner login a `@<owner>/<agent-name>` team mention may name (§8). */
+  teamOwnerLogin?: string
   /** Pull-request facts (loop prevention + the §8 external gate + metadata). */
   sourceRepoId?: string
   targetRepoId?: string
@@ -116,6 +118,13 @@ function userId(user: GiteaUserRef | undefined): string | undefined {
 
 function labelNames(subject: GiteaIssueRef | undefined): string[] {
   return (subject?.labels ?? []).map((label) => label.name ?? '').filter(Boolean)
+}
+
+/** The owner login a Gitea team mention names. Gitea's `api.Repository.owner` is an `api.User`
+ *  with no organization kind in 1.27 (`modules/structs/user.go`), so nothing in the signed payload
+ *  gates the form: it is pure text against the owner login, inert where Gitea renders no team. */
+function giteaTeamOwner(repository: GiteaPayload['repository']): string | undefined {
+  return repository?.owner?.login || repository?.owner?.username || repository?.full_name?.split('/')[0] || undefined
 }
 
 function positiveIndex(value: number | undefined): number | undefined {
@@ -170,6 +179,15 @@ function pullRequestCtxBase(payload: GiteaPayload, pull: GiteaPullRequestRef, in
  * `pull_request` `edited`, which is inert here for the same reason.
  */
 export function normalizeGiteaEvent(eventType: string, payload: GiteaPayload): GiteaMatchCtx | undefined {
+  const ctx = normalizeGiteaSubject(eventType, payload)
+  if (!ctx) return undefined
+  // The team-mention owner comes from the delivery's OWN repository, never from a rule.
+  const teamOwnerLogin = giteaTeamOwner(payload.repository)
+  return teamOwnerLogin === undefined ? ctx : { ...ctx, teamOwnerLogin }
+}
+
+/** The subject half of the normalization: everything except the team-mention owner. */
+function normalizeGiteaSubject(eventType: string, payload: GiteaPayload): GiteaMatchCtx | undefined {
   if (eventType === GITEA_EVENT_PUSH) {
     if (!payload.ref) return undefined
     return {
@@ -272,19 +290,27 @@ export function normalizeGiteaEvent(eventType: string, payload: GiteaPayload): G
   return undefined
 }
 
+/** The targeted agent handle in either accepted form: the bare name, or the `@<owner>/<agent-name>`
+ *  team an organization creates so the same handle autocompletes in Gitea's comment composer. */
+function giteaMentionsAgent(body: string | undefined, rule: RcHookAssign, owner: string | undefined): boolean {
+  return mentionsGithubHandle(body, rule.gitea?.agentName) || mentionsGithubTeam(body, owner, rule.gitea?.agentName)
+}
+
 export function giteaRuleIsSummoned(rule: RcHookAssign, ctx: GiteaMatchCtx): boolean {
   return (
     mentionsGithubHandle(ctx.mentionText, rule.gitea?.botUsername) ||
-    mentionsGithubHandle(ctx.mentionText, rule.gitea?.agentName)
+    giteaMentionsAgent(ctx.mentionText, rule, ctx.teamOwnerLogin)
   )
 }
 
 /** Explicit agent handles narrow a repository fan-out; the connection's bot handle is the broadcast form. */
-export function giteaMentionCandidates(rules: RcHookAssign[], body: string | undefined): RcHookAssign[] {
+export function giteaMentionCandidates(
+  rules: RcHookAssign[],
+  body: string | undefined,
+  owner?: string
+): RcHookAssign[] {
   if (rules.some((rule) => mentionsGithubHandle(body, rule.gitea?.botUsername))) return rules
-  const targeted = new Set(
-    rules.filter((rule) => mentionsGithubHandle(body, rule.gitea?.agentName)).map((rule) => rule.agentId)
-  )
+  const targeted = new Set(rules.filter((rule) => giteaMentionsAgent(body, rule, owner)).map((rule) => rule.agentId))
   return targeted.size === 0 ? rules : rules.filter((rule) => targeted.has(rule.agentId))
 }
 

--- a/packages/relay/src/hooks/gitea/ingress.test.ts
+++ b/packages/relay/src/hooks/gitea/ingress.test.ts
@@ -31,7 +31,9 @@ const BOT_USER = 424242
 const BOT_LOGIN = 'example-bot'
 const HUMAN = 515151
 const OUTSIDER = 606060
-const REPO_PATH = 'example-org/example-repo'
+const REPO_OWNER = 'example-org'
+const REPO_PATH = `${REPO_OWNER}/example-repo`
+const REPO_OWNER_ID = 818181
 const HEAD_SHA = 'a'.repeat(40)
 const BASE_SHA = 'b'.repeat(40)
 const KEY = randomBytes(32).toString('hex')
@@ -76,7 +78,7 @@ function sender(id = HUMAN, login = 'alice'): Record<string, unknown> {
 }
 
 function repository(): Record<string, unknown> {
-  return { id: REPO, full_name: REPO_PATH }
+  return { id: REPO, full_name: REPO_PATH, owner: { id: REPO_OWNER_ID, login: REPO_OWNER, username: REPO_OWNER } }
 }
 
 function issuePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -725,6 +727,45 @@ describe('gitea ingress', () => {
     await flush()
     expect(h.sent).toHaveLength(0)
     expect(h.reports).toHaveLength(0)
+  })
+
+  it('the `@<owner>/<agent>` team form summons the agent and narrows a repository fan-out', async () => {
+    h.table.upsert(rule({}, { mentionOnly: true, commentFamilies: ['issues'], agentName: 'oncall' }))
+    h.table.upsert(
+      rule(
+        { hookId: HOOK_B, agentId: AGENT_B },
+        { mentionOnly: true, commentFamilies: ['issues'], agentName: 'deploy' }
+      )
+    )
+    const team = issueCommentPayload({ comment: { id: 2, body: `@${REPO_OWNER}/oncall please look` } })
+    expect((await post(h, team, { eventType: 'issue_comment' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId)).toEqual([HOOK])
+
+    // The bare handle is unaffected by the second accepted form.
+    h.sent.length = 0
+    const bare = issueCommentPayload({ comment: { id: 3, body: '@deploy ship it' } })
+    expect((await post(h, bare, { eventType: 'issue_comment', delivery: 'd2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.sent.map((m) => (m as RdMsgHook).hookId)).toEqual([HOOK_B])
+  })
+
+  it('the team form is never a bare mention of the owner, and is inert without an owner', () => {
+    const body = `@${REPO_OWNER}/oncall please look`
+    const ctx = normalizeGiteaEvent('issue_comment', issueCommentPayload({ comment: { id: 4, body } }) as GiteaPayload)!
+    expect(ctx.teamOwnerLogin).toBe(REPO_OWNER)
+    const mentionOnly = { mentionOnly: true, commentFamilies: ['issues' as const] }
+    expect(giteaRuleVerdict(rule({}, { ...mentionOnly, agentName: 'oncall' }), ctx)).toBe('needs-authz')
+    // `@<owner>/<slug>` is the TEAM form, so an agent named after the owner is not summoned by it.
+    expect(giteaRuleVerdict(rule({}, { ...mentionOnly, agentName: REPO_OWNER }), ctx)).toBe('no-match')
+    expect(giteaRuleVerdict(rule({}, { ...mentionOnly, agentName: 'deploy' }), ctx)).toBe('no-match')
+    // A delivery naming no owner at all yields none, so the form selects nobody there.
+    const ownerless = normalizeGiteaEvent(
+      'issue_comment',
+      issueCommentPayload({ comment: { id: 5, body }, repository: { id: REPO } }) as GiteaPayload
+    )!
+    expect(ownerless.teamOwnerLogin).toBeUndefined()
+    expect(giteaRuleVerdict(rule({}, { ...mentionOnly, agentName: 'oncall' }), ownerless)).toBe('no-match')
   })
 
   it('verdict is pure: patterns gate before authz, and a foreign kind never matches', () => {

--- a/packages/relay/src/hooks/gitea/ingress.ts
+++ b/packages/relay/src/hooks/gitea/ingress.ts
@@ -234,7 +234,9 @@ export function registerGiteaIngress(app: FastifyInstance, deps: GiteaIngressDep
       }
 
       const candidates =
-        ctx.eventAction === 'merge_request:review_requested' ? rules : giteaMentionCandidates(rules, ctx.mentionText)
+        ctx.eventAction === 'merge_request:review_requested'
+          ? rules
+          : giteaMentionCandidates(rules, ctx.mentionText, ctx.teamOwnerLogin)
       const matched = candidates
         .map((rule) => ({ rule, verdict: giteaRuleVerdict(rule, ctx) }))
         .filter((candidate) => candidate.verdict !== 'no-match')

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1109,6 +1109,8 @@ export default function AddIntegrationModal({
     authorizedRepos.some((r) => repoAuthProvider(r) === 'gitlab' && r.repoId === glProject)
 
   const gtPicked = gt.choices.find((choice) => choice.repoId === gtRepo)
+  // The owner segment of the picked repository's path — the only owner the console holds for Gitea.
+  const gtTeamOwner = gtPicked?.repoPath?.split('/')[0] ?? null
   const gtMatches = matchGiteaRepositories(gt.choices, gtQ)
 
   // Picking an unadded repository installs its webhook first; the pick lands on the binding the
@@ -2100,7 +2102,9 @@ export default function AddIntegrationModal({
                   familyAttr="data-gitea-family"
                   triggerAttr="data-gitea-trigger"
                   titleOf={(mode) =>
-                    mode === 'mention' ? giteaMentionUsage(agent.name) : giteaTriggerTooltip(mode, agent.name)
+                    mode === 'mention'
+                      ? giteaMentionUsage(agent.name, gtTeamOwner)
+                      : giteaTriggerTooltip(mode, agent.name)
                   }
                   bodyExtra={(fam) =>
                     giteaFamilyCarriesReviews(fam) ? (

--- a/packages/web/src/lib/gitea-events.test.ts
+++ b/packages/web/src/lib/gitea-events.test.ts
@@ -13,6 +13,7 @@ import {
   giteaFamilyTile,
   giteaHookFamily,
   giteaHookNeedsNormalization,
+  giteaMentionUsage,
   giteaTriggerModeOf,
   giteaTriggerTooltip
 } from './gitea-events'
@@ -30,6 +31,15 @@ describe('GT_TRIGGER_LABEL', () => {
     expect(giteaDefaultTriggerMode('merge_request')).toBe('every')
     expect(giteaDefaultTriggerMode('issues')).toBe('first')
     expect(giteaDefaultTriggerMode('push')).toBe('first')
+  })
+
+  it('offers the owner-qualified team form once a repository owner is known', () => {
+    // No picked repository ⇒ no owner to qualify the handle with.
+    expect(giteaMentionUsage('triager')).toBe('Use @triager to trigger only this agent.')
+    expect(giteaMentionUsage('triager', null)).toBe('Use @triager to trigger only this agent.')
+    const owned = giteaMentionUsage('triager', 'example-org')
+    expect(owned).toContain('@triager')
+    expect(owned).toContain('@example-org/triager')
   })
 
   it('admits the organization bot’s broadcast and reviewer requests, without an absolute "only"', () => {

--- a/packages/web/src/lib/gitea-events.ts
+++ b/packages/web/src/lib/gitea-events.ts
@@ -93,9 +93,14 @@ export function giteaTriggerTooltip(mode: GtTriggerMode, agentName: string): str
   }
 }
 
-/** Concrete hover copy for the agent-targeted Gitea mention form. */
-export function giteaMentionUsage(agentName: string): string {
-  return `Use @${agentName} to trigger only this agent.`
+/** Concrete hover copy for the agent-targeted Gitea mention form. `teamOwner` is the
+ *  repository owner: a Gitea team named after the agent makes the same handle autocomplete in
+ *  the comment composer. Teams exist only under an organization, and no field the console holds
+ *  says whether this owner is one, so the copy names the condition instead of hiding the form. */
+export function giteaMentionUsage(agentName: string, teamOwner?: string | null): string {
+  return teamOwner
+    ? `Use @${agentName} — or @${teamOwner}/${agentName}, once the organization has a team named ${agentName} — to trigger only this agent.`
+    : `Use @${agentName} to trigger only this agent.`
 }
 
 /** The default create-form selection: pull requests only. */


### PR DESCRIPTION
A mention-gated Gitea rule now accepts `@<owner>/<agent-name>` beside the bare `@<agent-name>`, which is the form GitHub triggers already support. The connection bot's own handle stays the repository-wide broadcast and still wins when both are present.

The team exists only for discoverability: Gitea's comment box suggests organization teams as you type `@` but never an agent name, so an organization that creates a visible team named after the agent gets the targeted handle autocompleted as a reporter types. Nothing is read back through the API — the team needs no members, the owner comes from the delivery's own `repository`, and matching is pure text against the authored body. Because `@<owner>/<slug>` is the team syntax, it is never also read as a bare mention of the owner.

**Gating.** GitHub's form is gated on the signed `repository.owner.type`. Gitea has no equivalent: `api.Repository.owner` is an `api.User`, and that struct carries no organization kind in 1.27 (`modules/structs/repo.go`, `modules/structs/user.go`). So the form is gated on nothing — it stays text against the owner login and is simply inert on a personal repository, where Gitea renders no team mention. A delivery that names no owner at all yields none, and the form selects nobody there.

## Changes

- `packages/relay/src/hooks/gitea/events.ts` — the owner login rides the normalized match context, and the summon and fan-out predicates accept both handle forms. `mentionsGithubHandle` / `mentionsGithubTeam` are reused, not re-implemented.
- `packages/relay/src/hooks/gitea/ingress.test.ts` — the team form summons the agent and narrows a repository fan-out, the bare handle is unaffected, the form is never a bare mention of the owner, and an ownerless delivery is inert. Both cases fail without the change.
- `packages/web` — the @-mention hover copy names both forms once a repository is picked, matching the GitHub wording.
- `docs/designs/gitea-integration.md` §8 — a **Summon forms** paragraph stating the accepted forms and why this one is ungated.

Gates: `pnpm typecheck`, `pnpm --filter @agentconnect.md/relay test`, `pnpm --filter @agentconnect.md/web test`, `pnpm lint`, `pnpm format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
