### PR TITLE
docs(designs): correct what the Gitea team mention promises

### DIFF
--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -387,13 +387,18 @@ no delivery at all, so there is no such trigger to build.
 **Summon forms.** A mention-gated rule is summoned by `@<agent-name>`, by the
 connection bot's own handle as the repository-wide broadcast, or by
 `@<owner>/<agent-name>` — Gitea's organization team syntax, which an organization
-makes autocomplete in the comment composer by creating a visible team named after
-the agent; the owner comes from the delivery's own `repository`, matching is pure
-text, and the team is never read back through the API. Gitea's `api.User` carries
-no organization kind, so unlike GitHub's form this one is gated on nothing: it is
-text against the owner login, and is simply inert on a personal repository, where
-Gitea renders no team mention. Because `@<owner>/<slug>` is the team form, it is
-never also read as a bare mention of `<owner>`.
+can turn into a composer suggestion by creating a team named after the agent and
+adding the people who should be offered it: Gitea suggests every team to an
+organization owner or site administrator and only a user's own teams to anyone
+else. The owner comes from the delivery's own `repository`, matching is pure text,
+and the team is never read back through the API, so membership shapes the
+suggestion and never the match. Gitea's `api.User` carries no organization kind,
+so unlike GitHub's form this one is gated on nothing: it stays text against the
+owner login on any repository. What a personal repository lacks is the team, and
+with it the suggestion that is the form's whole point — a hand-typed
+`@<owner>/<agent-name>` still selects the agent there. A delivery naming no owner
+at all yields none, and the form then selects nobody. Because `@<owner>/<slug>` is
+the team form, it is never also read as a bare mention of `<owner>`.
 
 **Loop prevention.** A delivery whose `sender.id` is the connection's bot
 user id is rejected, with the §12.1 exception that the bot's own same-repository

--- a/packages/relay/src/hooks/gitea/events.ts
+++ b/packages/relay/src/hooks/gitea/events.ts
@@ -122,7 +122,8 @@ function labelNames(subject: GiteaIssueRef | undefined): string[] {
 
 /** The owner login a Gitea team mention names. Gitea's `api.Repository.owner` is an `api.User`
  *  with no organization kind in 1.27 (`modules/structs/user.go`), so nothing in the signed payload
- *  gates the form: it is pure text against the owner login, inert where Gitea renders no team. */
+ *  gates the form: it is pure text against the owner login on any repository, and a personal one
+ *  simply has no team to suggest it. */
 function giteaTeamOwner(repository: GiteaPayload['repository']): string | undefined {
   return repository?.owner?.login || repository?.owner?.username || repository?.full_name?.split('/')[0] || undefined
 }
@@ -291,7 +292,8 @@ function normalizeGiteaSubject(eventType: string, payload: GiteaPayload): GiteaM
 }
 
 /** The targeted agent handle in either accepted form: the bare name, or the `@<owner>/<agent-name>`
- *  team an organization creates so the same handle autocompletes in Gitea's comment composer. */
+ *  team an organization creates so Gitea's comment composer suggests the handle to that team's
+ *  members; membership shapes only the suggestion, never this match. */
 function giteaMentionsAgent(body: string | undefined, rule: RcHookAssign, owner: string | undefined): boolean {
   return mentionsGithubHandle(body, rule.gitea?.agentName) || mentionsGithubTeam(body, owner, rule.gitea?.agentName)
 }


### PR DESCRIPTION
Follow-up to #2074, which merged before its review finding was addressed. Comments and prose only — the matcher, the tests, and the console copy are untouched.

Two claims in the §8 **Summon forms** paragraph were wrong:

1. **"Simply inert on a personal repository."** It is not. Nothing gates the form, so a hand-typed `@<owner>/<agent-name>` still selects the agent on a personal repository. What such a repository lacks is the team, and with it the suggestion that is the form's whole point. The paragraph now says that, and says the one case that really does select nobody: a delivery that names no owner at all.

2. **"An organization makes it autocomplete by creating a visible team."** Creating the team is not enough by itself, and Gitea has no visibility axis here. In Gitea 1.27, `Collector.AddMentionableTeams` (`routers/web/shared/mention/mention.go`) calls `org.LoadTeams` only for a site administrator or an organization owner; everyone else goes through `org.GetUserTeams(doer.ID)`, which returns just the teams they belong to. So an empty team suggests nothing to an ordinary contributor, and the people who should get the shortcut have to be members.

Both are documentation-accuracy fixes: membership shapes the suggestion and never the match, which stays pure text against the authored body. The matching docs page carries the same correction in agentconnect-md/docs#109.

Gates: `pnpm --filter @agentconnect.md/relay test`, `pnpm lint`, `pnpm format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
