### PR TITLE
feat: bind Gitea repositories on first use

### DIFF
--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -226,10 +226,17 @@ never a provider role.
 The picker pages `GET /user/repos` and, for each organization the bot belongs
 to, `GET /orgs/:org/repos` (`limit` at the instance's `max_response_items`,
 following `Link`), keeps rows with `permissions.admin`, and keys them by
-numeric `id`. Selecting one runs the §10.2 saga with the account and
-membership steps removed:
+numeric `id`. It lists what the bot administers, not what is already bound.
 
-1. acquire the deployment-global claim for `(gitea, id)`;
+**Binding is implicit.** A repository becomes a managed binding the first time
+a write names it: creating a Gitea trigger, making the repository an agent's
+workspace, or granting it as an additional repository. The write re-reads the
+repository as the bot (by numeric id for a trigger or grant, by `owner/repo`
+under the instance base for a workspace address), requires `permissions.admin`
+(§4.4), and runs the §10.2 saga with the account and membership steps removed:
+
+1. acquire the deployment-global claim for `(gitea, id)` and create the
+   binding and catalog row in the same transaction;
 2. refresh the repository by id and store path, clone URL, default branch;
 3. install or reconcile the managed webhook (§7); and
 4. issue a test delivery and require the relay to observe it before the
@@ -241,6 +248,27 @@ membership steps removed:
    verified it; the compiled rules go out before the test is fired, because
    the relay verifies only what it holds a key for, and a later observation
    clears the warning on a binding whose test never arrived.
+
+The saga converges inline, so the write that bound the repository reads a
+settled state; the trigger that bound it is then what makes step 3 want a
+webhook, which the write's own post-commit convergence installs. The §8.3 rule
+is untouched: a trigger never creates a **grant**, and the agent gate runs
+before the bind, so a refused trigger binds nothing. Two writes racing for one
+repository resolve on the claim's uniqueness — the loser adopts the winner's
+binding and joins its convergence rather than creating a second. The resolve
+preview (`GET /git/resolve`) reports an administered-but-unbound address as a
+managed Gitea repository without binding it; only the persisting routes bind.
+The card's "Add repository" remains as an optional pre-warm over the same path.
+
+Several agents share one binding: one webhook per repository, its subscription
+the union of every enabled trigger on it (§7), widened and narrowed by PATCH as
+triggers — or the agents holding them — come and go. A binding is bound on
+first use but never unbound on last use: when the last trigger leaves, the
+webhook follows §7's inverse (no enabled trigger, no ingress) while the binding
+and its claim stay for the operator. Removing a binding that a trigger, an agent
+workspace or an additional-repository grant still references is refused with a
+409 naming the references; a binding already parked in `cleanup_pending`
+finishes its cleanup regardless.
 
 Repair, transfer, and unbind follow §10 and §19.4. A created webhook's id is
 recorded the moment the create answers, before the read-back that can fail,
@@ -629,19 +657,29 @@ floor check. `GITEA_BASE_URL` is the no-document fallback.
 
 The Console's Gitea card offers connect (paste token, with the scope list and
 the bot-user requirements beside it), replace token, disconnect, and the
-repository picker; binding rows show the five states with the same
-translations GitLab uses plus `token_rejected`, `admin_lost`, and
-`webhook_unverified` reasons. Hooks use kind `gitea`; workspaces and
+repositories in use under the connection, each with Repair, rotate, and
+Remove; "Add repository" binds one ahead of its first use and is optional.
+Binding rows show the five states with the same translations GitLab uses plus
+`token_rejected`, `admin_lost`, and `webhook_unverified` reasons. The trigger,
+workspace, and additional-repository pickers list what the bot administers and
+mark an unbound row "added on save"; the write binds it (§6), so the pickers
+run no saga of their own. Hooks use kind `gitea`; workspaces and
 additional-repository grants use the host-neutral git mode with credential
 `{ provider: 'gitea', repoId }`.
 
 REST at the organization scope: `POST /gitea/connections` (connect),
 `GET /gitea/connections`, `POST /gitea/connections/:id/token` (replace),
 `DELETE /gitea/connections/:id`, `GET /gitea/connections/:id/repositories`
-(picker), `GET|POST /gitea/repositories`, `POST
-/gitea/repositories/:id/repair`, and `DELETE /gitea/repositories/:id`. Every
-route carries the OpenAPI tags, summary, description, and operation id the docs
-surface requires.
+(picker), `GET|POST /gitea/repositories` (the POST is the optional pre-warm;
+an already bound repository answers 409), `POST
+/gitea/repositories/:id/repair`, and `DELETE /gitea/repositories/:id` (409
+`repository_in_use` naming the trigger, workspace, or grant that still
+references it). `POST /hooks`, `POST|PUT /agents/:id/workspace`, and `POST
+/agents/:id/repos` bind on first use and answer the bind's own refusals —
+400 for a repository the bot cannot see, 403 for one it does not administer,
+404 without a connection, 409 for a rejected token or a claim held elsewhere.
+Every route carries the OpenAPI tags, summary, description, and operation id
+the docs surface requires.
 
 The upstream connector id `gitea` joins the open-connector provider blocklist
 default, following the native-integration convention.
@@ -777,6 +815,13 @@ Each step is one pull request, merged in order.
   User- and operator-facing setup lives on the documentation site:
   https://docs.agentconnect.md/docs/gitea and
   https://docs.agentconnect.md/docs/deployment-and-configuration#gitea.
+- **G7 — Binding on first use.** _Landed._ The explicit "Add repository" step
+  became optional: a trigger, a workspace, or an additional-repository grant
+  binds the repository it names as the same write (§6), the pickers stopped
+  running the saga themselves, several agents share one binding and one
+  webhook whose subscription is the union of their triggers, agent deletion
+  narrows that union, and removing a binding something still references is
+  refused naming the reference (§12).
 
 ### Probe results (2026-09-12, gitea.com, Gitea 1.27 development build)
 

--- a/docs/designs/gitea-integration.md
+++ b/docs/designs/gitea-integration.md
@@ -268,7 +268,11 @@ webhook follows §7's inverse (no enabled trigger, no ingress) while the binding
 and its claim stay for the operator. Removing a binding that a trigger, an agent
 workspace or an additional-repository grant still references is refused with a
 409 naming the references; a binding already parked in `cleanup_pending`
-finishes its cleanup regardless.
+finishes its cleanup regardless. The refusal is fenced on the claim row: every
+transaction that commits a reference locks the repository's claim shared and
+re-reads the binding as live, and the removal counts references and parks under
+the same row held exclusively, so a reference can neither land after the count
+nor survive the park.
 
 Repair, transfer, and unbind follow §10 and §19.4. A created webhook's id is
 recorded the moment the create answers, before the read-back that can fail,

--- a/packages/control-plane/src/codehost/provider.ts
+++ b/packages/control-plane/src/codehost/provider.ts
@@ -124,6 +124,8 @@ export interface CodeHostWorkspaceDerivation {
   gitRepo: string
   /** Unstated ⇒ the highest tier the target carries. */
   requestedAccess?: 'read' | 'write'
+  /** True when the caller persists the outcome: a host that binds on first use binds HERE (gitea-integration.md §6); a preview never writes. */
+  write?: boolean
 }
 
 /** The persisted workspace fields one of this host's derivations writes. */

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -41,6 +41,7 @@ import { resolveGiteaInstanceConfig } from './gitea/config.js'
 import { GiteaApiClient, type FetchLike as GiteaFetchLike } from './gitea/api.js'
 import { GiteaConnectionService } from './gitea/connection.service.js'
 import { GiteaProvisioner } from './gitea/provisioner.js'
+import { GiteaBindingService } from './gitea/binding.service.js'
 import { GiteaConvergeSweeper } from './gitea/converge-sweeper.js'
 import { GiteaGitcredService } from './gitea/gitcred.service.js'
 import { GiteaStatusCoordinator, GiteaStatusReporter } from './gitea/status-projection.js'
@@ -1290,9 +1291,18 @@ export function buildContainer(
     api: giteaApi,
     log: { warn: (obj, msg) => http.log.warn(obj, msg) }
   })
+  // §6 binding on first use: the path every write that names a repository binds it through.
+  const giteaBindingService = new GiteaBindingService({
+    connections: repos.giteaConnection,
+    tokens: giteaConnectionService,
+    bindings: repos.giteaRepositoryBinding,
+    provisioner: giteaProvisioner,
+    api: giteaApi
+  })
   const gitea = {
     connections: giteaConnectionService,
     provisioner: giteaProvisioner,
+    bindings: giteaBindingService,
     api: giteaApi
   }
   // The §6 convergence sweep, the half of a contended pass's obligation that survives a restart.

--- a/packages/control-plane/src/gitea/api.ts
+++ b/packages/control-plane/src/gitea/api.ts
@@ -328,6 +328,24 @@ export async function giteaPublicRepository(
   }
 }
 
+/** One repository by path AS THE BOT (`GET /repos/:owner/:repo`); null when the bot cannot see it — the first-use read of §6. */
+export async function giteaRepositoryByPath(
+  token: string,
+  owner: string,
+  repo: string,
+  client: GiteaApiClient
+): Promise<GiteaRepository | null> {
+  try {
+    return await giteaRequest<GiteaRepository>(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, {
+      token,
+      client
+    })
+  } catch (e) {
+    if (e instanceof GiteaApiError && (e.code === 'NOT_FOUND' || e.code === 'FORBIDDEN')) return null
+    throw e
+  }
+}
+
 /** The `owner/repo` halves of a repository path; null unless it has exactly two segments. */
 export function splitGiteaRepoPath(path: string): { owner: string; repo: string } | null {
   const segments = path.split('/')

--- a/packages/control-plane/src/gitea/binding-state.ts
+++ b/packages/control-plane/src/gitea/binding-state.ts
@@ -14,6 +14,8 @@ export const ADMIN_LOST_REASON = 'admin_lost' as const
 export const WEBHOOK_UNVERIFIED_REASON = 'webhook_unverified' as const
 /** The subscription Gitea stored is missing names the union asked for (§7 read-back). */
 export const WEBHOOK_EVENTS_UNSUPPORTED_REASON = 'webhook_events_unsupported' as const
+/** A removal refused because a trigger, workspace or grant still names the repository (§6). */
+export const REPOSITORY_IN_USE_REASON = 'repository_in_use' as const
 
 /** Runtime keeps serving through an admin-plane fault; a rejected token or cleanup stops it (§4.4, §6). */
 export function servesRuntime(state: GiteaBindingState): boolean {

--- a/packages/control-plane/src/gitea/binding.service.ts
+++ b/packages/control-plane/src/gitea/binding.service.ts
@@ -1,0 +1,169 @@
+/**
+ * Binding on first use (gitea-integration.md §6). Every write that names a Gitea repository — a
+ * trigger, an agent workspace, an additional-repository grant, the card's own Add — makes it a
+ * managed binding through this one path: the connection must accept writes, the bot must administer
+ * the repository (§4.4), the deployment-global claim is taken, and the saga converges inline so the
+ * caller reads a settled state. Two writers racing for one repository resolve on the claim's
+ * uniqueness: the loser adopts the winner's binding and joins its convergence, never creating a second.
+ */
+import type {
+  GiteaConnectionRecord,
+  GiteaConnectionRepo,
+  GiteaRepositoryBindingRecord,
+  GiteaRepositoryBindingRepo
+} from '../persistence/ports.js'
+import { GiteaRepositoryClaimConflict } from '../persistence/errors.js'
+import {
+  GiteaApiError,
+  giteaRepositoryById,
+  giteaRepositoryByPath,
+  isGiteaAuthRejection,
+  type GiteaApiClient,
+  type GiteaRepository
+} from './api.js'
+import { TOKEN_REJECTED_REASON } from './binding-state.js'
+import { GiteaConnectDenied } from './connection.service.js'
+import type { GiteaProvisioner, GiteaTokenSource } from './provisioner.js'
+
+/** A first use is an HTTP request: outwait a brief contention, then let the follow-up finish the job. */
+const FIRST_USE_CONVERGE_ATTEMPTS = 6
+
+/** The repository as the bot sees it, beside the connection that sees it. */
+export interface GiteaAdministeredRepository {
+  connection: GiteaConnectionRecord
+  repo: GiteaRepository
+}
+
+export interface GiteaEnsureBoundOutcome {
+  binding: GiteaRepositoryBindingRecord
+  /** False when the repository was already bound, by an earlier write or by a racing one. */
+  created: boolean
+}
+
+export interface GiteaBindingServiceDeps {
+  connections: Pick<GiteaConnectionRepo, 'forOrg'>
+  tokens: GiteaTokenSource
+  bindings: Pick<GiteaRepositoryBindingRepo, 'byRepo' | 'createWithClaim' | 'get'>
+  provisioner: Pick<GiteaProvisioner, 'convergeRepository'>
+  api: GiteaApiClient
+}
+
+export class GiteaBindingService {
+  constructor(private readonly deps: GiteaBindingServiceDeps) {}
+
+  /** The organization's connection when it can bind; the §4.3 verdicts otherwise. */
+  private async writableConnection(orgId: string): Promise<GiteaConnectionRecord> {
+    const connection = await this.deps.connections.forOrg(orgId)
+    if (!connection) {
+      throw new GiteaConnectDenied(
+        'this organization has no Gitea connection — connect the bot on the Integrations card first',
+        404,
+        'connection_missing'
+      )
+    }
+    if (connection.state === 'token_rejected') {
+      throw new GiteaConnectDenied('the Gitea token was rejected — replace it first', 409, TOKEN_REJECTED_REASON)
+    }
+    if (connection.state === 'disconnecting') {
+      throw new GiteaConnectDenied('the Gitea connection is being removed', 409, 'connection_disconnecting')
+    }
+    return connection
+  }
+
+  /** A definite rejection is the connection's verdict (§4.3), answered as one; anything else bubbles. */
+  private async rejected(orgId: string, connection: GiteaConnectionRecord, e: unknown): Promise<never> {
+    if (isGiteaAuthRejection(e)) {
+      await this.deps.tokens.onAuthRejected(orgId, connection.id)
+      throw new GiteaConnectDenied('the Gitea token was rejected — replace it', 409, TOKEN_REJECTED_REASON)
+    }
+    throw e
+  }
+
+  /** The repository by numeric id as the bot sees it; refused unless the bot administers it (§4.4). */
+  async administered(orgId: string, repoId: bigint): Promise<GiteaAdministeredRepository> {
+    const connection = await this.writableConnection(orgId)
+    const token = await this.deps.tokens.withToken(orgId, connection.id)
+    let repo: GiteaRepository | null
+    try {
+      // The server re-fetches; a caller-supplied id is never trusted for facts (§6).
+      repo = await giteaRepositoryById(token, repoId, this.deps.api)
+    } catch (e) {
+      return this.rejected(orgId, connection, e)
+    }
+    if (!repo) {
+      throw new GiteaConnectDenied(
+        'repository is not accessible through this connection',
+        400,
+        'repository_not_accessible'
+      )
+    }
+    if (repo.permissions?.admin !== true) {
+      throw new GiteaConnectDenied(
+        `the bot ${connection.botUsername} must hold admin on ${repo.full_name} — grant it as a collaborator or through a team first`,
+        403,
+        'admin_required'
+      )
+    }
+    return { connection, repo }
+  }
+
+  /** The same by `owner/repo`; null when no connection accepts writes, the bot cannot see it, or does not administer it. */
+  async administeredByPath(orgId: string, owner: string, repo: string): Promise<GiteaAdministeredRepository | null> {
+    const connection = await this.deps.connections.forOrg(orgId)
+    if (!connection || connection.state !== 'connected') return null
+    const token = await this.deps.tokens.withToken(orgId, connection.id)
+    let found: GiteaRepository | null
+    try {
+      found = await giteaRepositoryByPath(token, owner, repo, this.deps.api)
+    } catch (e) {
+      if (e instanceof GiteaApiError) return this.rejected(orgId, connection, e)
+      throw e
+    }
+    return found?.permissions?.admin === true ? { connection, repo: found } : null
+  }
+
+  /** Bound, binding on first use; a caller's own gates (§8.3) run BEFORE this, never after. */
+  async ensureBound(orgId: string, repoId: bigint): Promise<GiteaEnsureBoundOutcome> {
+    const existing = await this.deps.bindings.byRepo(orgId, repoId)
+    if (existing) {
+      // A binding mid-removal must refuse, never be adopted as if it were live.
+      if (existing.state === 'cleanup_pending') {
+        throw new GiteaConnectDenied(
+          `${existing.repoPath} is being removed from this organization — wait for cleanup to finish`,
+          409,
+          'binding_cleanup_pending'
+        )
+      }
+      return { binding: existing, created: false }
+    }
+    const { connection, repo } = await this.administered(orgId, repoId)
+    let binding: GiteaRepositoryBindingRecord
+    try {
+      binding = await this.deps.bindings.createWithClaim({
+        orgId,
+        connectionId: connection.id,
+        repoId,
+        repoPath: repo.full_name,
+        ...(repo.default_branch ? { defaultBranch: repo.default_branch } : {}),
+        ...(repo.clone_url ? { cloneUrl: repo.clone_url } : {}),
+        axisBaseUrl: this.deps.api.baseUrl
+      })
+    } catch (e) {
+      if (!(e instanceof GiteaRepositoryClaimConflict)) throw e
+      // The claim is unique per deployment: a racing first use in THIS organization won it, so its binding is adopted; a foreign one is never disclosed.
+      const peer = await this.deps.bindings.byRepo(orgId, repoId)
+      if (!peer) {
+        throw new GiteaConnectDenied('repository is already claimed by another organization', 409, 'repository_claimed')
+      }
+      await this.converge(orgId, repoId)
+      return { binding: (await this.deps.bindings.byRepo(orgId, repoId)) ?? peer, created: false }
+    }
+    await this.converge(orgId, repoId)
+    return { binding: (await this.deps.bindings.get(orgId, binding.id)) ?? binding, created: true }
+  }
+
+  /** One inline convergence: a racing writer joins the running pass instead of taking its own lease. */
+  private converge(orgId: string, repoId: bigint): Promise<void> {
+    return this.deps.provisioner.convergeRepository(orgId, repoId, { attempts: FIRST_USE_CONVERGE_ATTEMPTS })
+  }
+}

--- a/packages/control-plane/src/gitea/connection.service.ts
+++ b/packages/control-plane/src/gitea/connection.service.ts
@@ -43,7 +43,7 @@ export const GITEA_REQUIRED_TOKEN_SCOPES = [
 export class GiteaConnectDenied extends Error {
   constructor(
     message: string,
-    readonly status: 400 | 404 | 409 | 502,
+    readonly status: 400 | 403 | 404 | 409 | 502,
     readonly code: string
   ) {
     super(message)

--- a/packages/control-plane/src/gitea/provider.ts
+++ b/packages/control-plane/src/gitea/provider.ts
@@ -15,10 +15,34 @@ import {
   type DerivedWorkspace
 } from '../codehost/provider.js'
 import type { AgentWorkspaceCredentialDtoT } from '../http/dto/index.js'
+import type { GiteaRepositoryBindingRecord } from '../persistence/ports.js'
 import { gitlabManagedProjectPath } from '../domain/git-host.js'
 import { giteaPublicRepository, splitGiteaRepoPath } from './api.js'
+import { GiteaConnectDenied } from './connection.service.js'
 
-/** The gitea arm of the §6 outcome table: a managed binding, else an anonymous public repository. */
+/** The managed outcome: the persisted catalog row, never caller input or a composed URL, is the clone authority. */
+async function managedGiteaWorkspace(
+  derivation: CodeHostWorkspaceDerivation,
+  binding: GiteaRepositoryBindingRecord
+): Promise<DerivedWorkspace> {
+  const catalogRow = await derivation.deps.repos.codeHostRepository.byExternalId(
+    derivation.orgId,
+    'gitea',
+    binding.repoId
+  )
+  if (!catalogRow?.cloneUrl) {
+    refuseWorkspaceCredential('the Gitea repository binding has no clone URL yet — repair the repository first')
+  }
+  return {
+    kind: 'gitea',
+    repoId: binding.repoId,
+    gitRepo: catalogRow.cloneUrl,
+    defaultBranch: binding.defaultBranch ?? 'main',
+    access: derivation.requestedAccess ?? 'write'
+  }
+}
+
+/** The gitea arm of the §6 outcome table: a managed binding — bound on first use where the bot administers the address — else an anonymous public repository. */
 async function deriveGiteaWorkspace(derivation: CodeHostWorkspaceDerivation): Promise<DerivedWorkspace | null> {
   const { deps, orgId, gitRepo, requestedAccess } = derivation
   const gitea = deps.gitea
@@ -32,28 +56,50 @@ async function deriveGiteaWorkspace(derivation: CodeHostWorkspaceDerivation): Pr
     if (binding.state === 'cleanup_pending') {
       refuseWorkspaceCredential(`${repoPath} is being removed from this organization — wait for cleanup to finish`)
     }
-    // The persisted catalog row, not caller input and never a composed URL, is the clone authority.
-    const catalogRow = await deps.repos.codeHostRepository.byExternalId(orgId, 'gitea', binding.repoId)
-    if (!catalogRow?.cloneUrl) {
-      refuseWorkspaceCredential('the Gitea repository binding has no clone URL yet — repair the repository first')
+    return managedGiteaWorkspace(derivation, binding)
+  }
+  // Not bound yet: a repository the bot administers is managed all the same (§6) — a write binds it here, a preview only says so.
+  let administered
+  try {
+    administered = await gitea.bindings.administeredByPath(orgId, split.owner, split.repo)
+  } catch (e) {
+    if (e instanceof GiteaConnectDenied) refuseWorkspaceCredential(e.message)
+    throw e
+  }
+  if (administered) {
+    if (derivation.write) {
+      try {
+        const bound = await gitea.bindings.ensureBound(orgId, BigInt(administered.repo.id))
+        return managedGiteaWorkspace(derivation, bound.binding)
+      } catch (e) {
+        if (e instanceof GiteaConnectDenied) refuseWorkspaceCredential(e.message)
+        throw e
+      }
+    }
+    let cloneUrl: string
+    try {
+      cloneUrl = normalizeGitCloneUrl(administered.repo.clone_url ?? gitRepo)
+    } catch (e) {
+      if (!(e instanceof GitCloneUrlError)) throw e
+      cloneUrl = normalizeGitUrl(gitRepo)
     }
     return {
       kind: 'gitea',
-      repoId: binding.repoId,
-      gitRepo: catalogRow.cloneUrl,
-      defaultBranch: binding.defaultBranch ?? 'main',
+      repoId: BigInt(administered.repo.id),
+      gitRepo: cloneUrl,
+      defaultBranch: administered.repo.default_branch ?? 'main',
       access: requestedAccess ?? 'write'
     }
   }
   if (requestedAccess === 'write') {
     refuseWorkspaceCredential(
-      'gitea write access requires a managed repository — add the repository to the organization first'
+      `gitea write access requires a repository the connected bot administers — give it admin on ${repoPath}, or check the connection on the Integrations card`
     )
   }
   const repository = await giteaPublicRepository(split.owner, split.repo, gitea.api)
   if (!repository) {
     refuseWorkspaceCredential(
-      `${repoPath} is not a managed Gitea repository in this organization — add the repository first`
+      `${repoPath} is not a Gitea repository the connected bot administers — give it admin on the repository, or check the connection on the Integrations card`
     )
   }
   let cloneUrl: string

--- a/packages/control-plane/src/gitea/provisioner.ts
+++ b/packages/control-plane/src/gitea/provisioner.ts
@@ -42,6 +42,7 @@ import {
   ADMIN_LOST_REASON,
   afterDeliveryVerified,
   readyOutcome,
+  REPOSITORY_IN_USE_REASON,
   TOKEN_REJECTED_REASON,
   WEBHOOK_EVENTS_UNSUPPORTED_REASON
 } from './binding-state.js'
@@ -679,12 +680,23 @@ export class GiteaProvisioner {
   }
 
   /** §6 unbind: authority off first, then every managed webhook (recorded ids, then the managed URL), then the rows and the claim; a rejected token parks it. */
-  async disconnect(orgId: string, bindingId: string): Promise<{ removed: boolean; reason?: string }> {
+  async disconnect(
+    orgId: string,
+    bindingId: string,
+    /** `unlessReferenced` refuses, under the claim's lock, while a trigger, workspace or grant still names the repository (§6). */
+    opts: { unlessReferenced?: boolean } = {}
+  ): Promise<{ removed: boolean; reason?: string }> {
     const binding = await this.deps.bindings.get(orgId, bindingId)
     if (!binding) return { removed: false, reason: 'binding_missing' }
-    if (!(await this.deps.bindings.beginCleanup(orgId, bindingId, binding.repoId, new Date(this.deps.clock.now())))) {
-      return { removed: false, reason: 'provisioning_in_progress' }
-    }
+    const entry = await this.deps.bindings.beginCleanup(
+      orgId,
+      bindingId,
+      binding.repoId,
+      new Date(this.deps.clock.now()),
+      opts
+    )
+    if (entry === 'leased') return { removed: false, reason: 'provisioning_in_progress' }
+    if (entry === 'referenced') return { removed: false, reason: REPOSITORY_IN_USE_REASON }
     // The binding just left the servable states: pull its compiled rules off the relay pool now.
     await this.rebroadcast(orgId, binding.repoId)
     const path = splitGiteaRepoPath(binding.repoPath)

--- a/packages/control-plane/src/gitea/references.test.ts
+++ b/packages/control-plane/src/gitea/references.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { OrgId } from '../domain/ids.js'
+import { collectGiteaReferences, describeGiteaReferences } from './references.js'
+
+const REPO = 556677n
+
+describe('describeGiteaReferences', () => {
+  it('names every kind of consumer in the operator’s words', () => {
+    expect(
+      describeGiteaReferences('example-org/example-repo', [
+        { kind: 'workspace', agentName: 'builder' },
+        { kind: 'additional_repository', agentName: 'reviewer' },
+        { kind: 'trigger', hookName: 'example-org/example-repo', agentName: 'reviewer' }
+      ])
+    ).toBe(
+      'example-org/example-repo is still in use — the workspace of agent builder, an additional repository of agent reviewer, trigger “example-org/example-repo” of agent reviewer — remove those first'
+    )
+  })
+
+  it('counts what it does not name past the fourth reference', () => {
+    const references = Array.from({ length: 6 }, (_, i) => ({ kind: 'workspace' as const, agentName: `agent-${i}` }))
+    const text = describeGiteaReferences('example-org/example-repo', references)
+    expect(text).toContain('agent-3')
+    expect(text).not.toContain('agent-4')
+    expect(text).toContain('and 2 more')
+  })
+})
+
+describe('collectGiteaReferences', () => {
+  it('reads workspaces, grants and triggers of the repository only, keyed by the gitea credential', async () => {
+    const agents = [
+      {
+        id: 'a1',
+        name: 'builder',
+        workspaceRepoId: REPO,
+        workspace: { mode: 'git', gitRepo: 'x', credential: { provider: 'gitea', access: 'write' } }
+      },
+      // The same numeric id on another host is a different repository (§8.1).
+      {
+        id: 'a2',
+        name: 'other-host',
+        workspaceRepoId: REPO,
+        workspace: { mode: 'git', gitRepo: 'y', credential: { provider: 'gitlab', access: 'write' } }
+      },
+      { id: 'a3', name: 'scratch', workspace: { mode: 'scratch' } }
+    ]
+    const references = await collectGiteaReferences(
+      {
+        agent: { list: async () => agents as never },
+        agentRepoAuth: { listForRepository: async () => [{ agentId: 'a3', repoId: REPO }] as never },
+        hook: {
+          listForOrgKind: async () =>
+            [
+              { repoId: REPO, agentId: 'a3', name: 'watch' },
+              { repoId: 1n, agentId: 'a3', name: 'elsewhere' },
+              { repoId: REPO, agentId: null, name: 'legacy' }
+            ] as never
+        }
+      },
+      OrgId('org-1'),
+      REPO
+    )
+    expect(references).toEqual([
+      { kind: 'workspace', agentName: 'builder' },
+      { kind: 'additional_repository', agentName: 'scratch' },
+      { kind: 'trigger', hookName: 'watch', agentName: 'scratch' }
+    ])
+  })
+})

--- a/packages/control-plane/src/gitea/references.ts
+++ b/packages/control-plane/src/gitea/references.ts
@@ -1,0 +1,75 @@
+/**
+ * What still points at a managed Gitea repository (gitea-integration.md §6): the triggers, agent
+ * workspaces and additional-repository grants that consume it. A binding is bound on first use but
+ * never unbound on last use, so the operator's Remove is refused while any of these stands — and the
+ * refusal names them, because "in use" alone sends a reader hunting.
+ */
+import type { OrgId } from '../domain/ids.js'
+import type { AgentRecord, AgentRepoAuthorizationRepo, AgentRepo, HookRepo } from '../persistence/ports.js'
+
+export type GiteaBindingReference =
+  | { kind: 'trigger'; hookName: string; agentName: string }
+  | { kind: 'workspace'; agentName: string }
+  | { kind: 'additional_repository'; agentName: string }
+
+/** How many references a refusal names before it counts the rest. */
+const NAMED_REFERENCES = 4
+
+export interface GiteaReferenceReads {
+  hook: Pick<HookRepo, 'listForOrgKind'>
+  agent: Pick<AgentRepo, 'list'>
+  agentRepoAuth: Pick<AgentRepoAuthorizationRepo, 'listForRepository'>
+}
+
+/** Every consumer of one repository in the organization, workspaces first, then grants, then triggers. */
+export async function collectGiteaReferences(
+  repos: GiteaReferenceReads,
+  orgId: OrgId,
+  repoId: bigint
+): Promise<GiteaBindingReference[]> {
+  const [agents, grants, hooks] = await Promise.all([
+    repos.agent.list(orgId),
+    repos.agentRepoAuth.listForRepository(orgId, 'gitea', repoId),
+    repos.hook.listForOrgKind(orgId, 'gitea')
+  ])
+  const nameOf = new Map<string, string>(agents.map((agent): [string, string] => [agent.id, agent.name]))
+  const consumesAsWorkspace = (agent: AgentRecord): boolean =>
+    agent.workspace.mode === 'git' &&
+    agent.workspace.credential?.provider === 'gitea' &&
+    agent.workspaceRepoId === repoId
+  return [
+    ...agents
+      .filter(consumesAsWorkspace)
+      .map((agent): GiteaBindingReference => ({ kind: 'workspace', agentName: agent.name })),
+    ...grants.map((grant): GiteaBindingReference => ({
+      kind: 'additional_repository',
+      agentName: nameOf.get(grant.agentId) ?? grant.agentId
+    })),
+    ...hooks
+      .filter((hook) => hook.repoId === repoId && hook.agentId !== null)
+      .map((hook): GiteaBindingReference => ({
+        kind: 'trigger',
+        hookName: hook.name,
+        agentName: nameOf.get(hook.agentId!) ?? hook.agentId!
+      }))
+  ]
+}
+
+function describeReference(reference: GiteaBindingReference): string {
+  switch (reference.kind) {
+    case 'trigger':
+      return `trigger “${reference.hookName}” of agent ${reference.agentName}`
+    case 'workspace':
+      return `the workspace of agent ${reference.agentName}`
+    case 'additional_repository':
+      return `an additional repository of agent ${reference.agentName}`
+  }
+}
+
+/** The refusal a referenced binding's removal answers; empty references mean nothing to refuse. */
+export function describeGiteaReferences(repoPath: string, references: readonly GiteaBindingReference[]): string {
+  const named = references.slice(0, NAMED_REFERENCES).map(describeReference)
+  const rest = references.length - named.length
+  const list = rest > 0 ? `${named.join(', ')} and ${rest} more` : named.join(', ')
+  return `${repoPath} is still in use — ${list} — remove those first`
+}

--- a/packages/control-plane/src/gitea/references.ts
+++ b/packages/control-plane/src/gitea/references.ts
@@ -66,8 +66,9 @@ function describeReference(reference: GiteaBindingReference): string {
   }
 }
 
-/** The refusal a referenced binding's removal answers; empty references mean nothing to refuse. */
+/** The refusal a referenced binding's removal answers; a reference that left between the refusal and this read is still a refusal. */
 export function describeGiteaReferences(repoPath: string, references: readonly GiteaBindingReference[]): string {
+  if (references.length === 0) return `${repoPath} was still in use when its removal was refused — retry`
   const named = references.slice(0, NAMED_REFERENCES).map(describeReference)
   const rest = references.length - named.length
   const list = rest > 0 ? `${named.join(', ')} and ${rest} more` : named.join(', ')

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -70,6 +70,7 @@ import type { GitlabAccountService } from '../gitlab/account.service.js'
 import type { GitlabProvisioner } from '../gitlab/provisioner.js'
 import type { GiteaConnectionService } from '../gitea/connection.service.js'
 import type { GiteaProvisioner } from '../gitea/provisioner.js'
+import type { GiteaBindingService } from '../gitea/binding.service.js'
 import type { GiteaApiClient } from '../gitea/api.js'
 import type { PullRequestViewService } from '../github/pull-request-view.service.js'
 import type { SessionPullRequestLinkService } from '../github/session-pull-request-link.service.js'
@@ -427,6 +428,8 @@ export interface HttpDeps {
   gitea?: {
     connections: GiteaConnectionService
     provisioner: GiteaProvisioner
+    /** Binding on first use (§6): the one path a trigger, workspace, grant or the card binds a repository through. */
+    bindings: GiteaBindingService
     api: GiteaApiClient
   }
   /** The PR panel's read projection; absent like {@link github} ⇒ the route 404s, hiding the tab. */

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -28,7 +28,7 @@ import {
   type AgentRepoAuthorizationRecord,
   type RepoAccess
 } from '../../persistence/ports.js'
-import { AgentWorkspaceRepoConflict } from '../../persistence/errors.js'
+import { AgentWorkspaceRepoConflict, GiteaBindingUnavailable } from '../../persistence/errors.js'
 import { GithubApiError } from '../../github/api.js'
 import { GiteaApiError } from '../../gitea/api.js'
 import { GiteaConnectDenied } from '../../gitea/connection.service.js'
@@ -265,14 +265,21 @@ export function agentRepoRoutes(deps: HttpDeps) {
           `${binding.repoPath} is already authorized for this agent — upgrade that grant or remove it to lower the tier`
         )
       }
-      const row = await deps.repos.agentRepoAuth.create({
-        agentId: agent.id,
-        provider: 'gitea',
-        repoId,
-        repoFullName: binding.repoPath,
-        access: body.access,
-        ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-      })
+      let row: AgentRepoAuthorizationRecord
+      try {
+        row = await deps.repos.agentRepoAuth.create({
+          agentId: agent.id,
+          provider: 'gitea',
+          repoId,
+          repoFullName: binding.repoPath,
+          access: body.access,
+          ...(req.principal ? { createdByUserId: req.principal.userId } : {})
+        })
+      } catch (e) {
+        // The binding fence (§6): the repository was removed while this grant was in flight.
+        if (e instanceof GiteaBindingUnavailable) return conflict(e.message)
+        throw e
+      }
       void deps.repos.audit
         .append({
           kind: 'agent_repo_change',

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -30,6 +30,8 @@ import {
 } from '../../persistence/ports.js'
 import { AgentWorkspaceRepoConflict } from '../../persistence/errors.js'
 import { GithubApiError } from '../../github/api.js'
+import { GiteaApiError } from '../../gitea/api.js'
+import { GiteaConnectDenied } from '../../gitea/connection.service.js'
 import { gitlabAuthorizationAccessLevel } from '../../gitlab/api.js'
 import { gitlabAccountUnavailableMessage } from '../../gitlab/account.service.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
@@ -218,29 +220,44 @@ export function agentRepoRoutes(deps: HttpDeps) {
       return toDto(row)
     }
 
-    /** The gitea arm of `POST /agents/:agentId/repos` (gitea-integration.md §5): the binding vouches, the tier is a local clamp. */
+    const ERROR_NAMES = {
+      400: 'Bad Request',
+      403: 'Forbidden',
+      404: 'Not Found',
+      409: 'Conflict',
+      429: 'Too Many Requests',
+      502: 'Bad Gateway'
+    } as const
+
+    /** The gitea arm of `POST /agents/:agentId/repos` (gitea-integration.md §5, §6): the binding vouches — bound on first use — and the tier is a local clamp. */
     const authorizeGiteaRepository = async (
       req: FastifyRequest,
       reply: FastifyReply,
       agent: AgentRecord,
       body: { repoId: string; access: RepoAccess }
     ): Promise<AgentRepoAuthDtoT | undefined> => {
-      const conflict = (message: string): undefined => {
-        void reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
+      const refused = (status: 400 | 403 | 404 | 409 | 429 | 502, message: string): undefined => {
+        void reply.code(status).send({ error: ERROR_NAMES[status], statusCode: status, message })
       }
+      const conflict = (message: string): undefined => refused(409, message)
       if (!deps.gitea) return conflict('Gitea is not configured on this deployment')
       const orgId = orgOf(req)
       const repoId = BigInt(body.repoId)
-      const binding = await deps.repos.giteaRepositoryBinding.byRepo(orgId, repoId)
-      if (!binding || binding.state === 'cleanup_pending') {
-        return conflict('the repository is not a managed Gitea repository in this organization')
-      }
       if (
         agent.workspace.mode === 'git' &&
         agent.workspace.credential?.provider === 'gitea' &&
         agent.workspaceRepoId === repoId
       ) {
         return conflict('this is already the agent’s workspace repository')
+      }
+      let binding
+      try {
+        // The grant is the consumer that binds the repository when nothing else has (§6).
+        binding = (await deps.gitea.bindings.ensureBound(orgId, repoId)).binding
+      } catch (e) {
+        if (e instanceof GiteaConnectDenied) return refused(e.status, e.message)
+        if (e instanceof GiteaApiError) return refused(e.code === 'RATE_LIMITED' ? 429 : 502, `gitea: ${e.message}`)
+        throw e
       }
       const held = await deps.repos.agentRepoAuth.listForAgent(agent.id)
       if (held.some((row) => row.provider === 'gitea' && row.repoId === repoId)) {

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -62,7 +62,8 @@ import {
   AGENT_WAKE_FEATURE,
   WorkspaceErrorReason,
   TaskErrorReason,
-  gitRepoLabel
+  gitRepoLabel,
+  isCodeHostHookKind
 } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
@@ -1781,7 +1782,9 @@ export function agentRoutes(deps: HttpDeps) {
         if (ws?.mode === 'git') {
           let derived: DerivedWorkspace
           try {
-            derived = await deriveWorkspaceCredential(deps, orgOf(req), req.principal?.userId, ws.gitRepo, ws.access)
+            derived = await deriveWorkspaceCredential(deps, orgOf(req), req.principal?.userId, ws.gitRepo, ws.access, {
+              write: true
+            })
           } catch (e) {
             if (e instanceof WorkspaceCredentialRefused) return conflict(e.message)
             if (e instanceof UserAuthzDeniedError) {
@@ -2642,7 +2645,8 @@ export function agentRoutes(deps: HttpDeps) {
                 existing.orgId,
                 req.principal?.userId,
                 req.body.gitRepo,
-                req.body.access
+                req.body.access,
+                { write: true }
               )
             } catch (e) {
               if (e instanceof WorkspaceCredentialRefused) return conflict(e.message)
@@ -3208,6 +3212,13 @@ export function agentRoutes(deps: HttpDeps) {
             await removeExternalMemoryFromDaemonIfUnused(current.orgId, current.daemonId, current.memory.connectionId)
           }
           for (const h of removedHooks) deps.hooks.remove(h.id)
+          // A code-host hook that left with the agent no longer wants ingress: its host narrows the managed webhook to what remains.
+          for (const h of removedHooks) {
+            if (!isCodeHostHookKind(h.kind)) continue
+            codeHosts[h.kind].hooks.convergeManagedRepository(deps, current.orgId, h.repoId, (err) =>
+              app.log.warn({ err, hookId: h.id }, `${h.kind} webhook converge after agent delete failed`)
+            )
+          }
           // §19.4: the agent's GitLab accounts retire — memberships removed,
           // PATs revoked, accounts deleted. Best-effort here; an account whose
           // external cleanup fails stays `cleanup_pending` for a repair.

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -131,6 +131,7 @@ import {
   AGENT_WORKSPACE_INTEGRATION_CONFLICT_MESSAGE,
   AgentSetPlacementDenied,
   DaemonPlacementInSet,
+  GiteaBindingUnavailable,
   MemoryConnectionBusy,
   MemoryConnectionMissing
 } from '../../persistence/errors.js'
@@ -2074,6 +2075,8 @@ export function agentRoutes(deps: HttpDeps) {
           if (e instanceof OrganizationEnvironmentAdmissionError) {
             return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: e.message })
           }
+          // The binding fence (gitea-integration.md §6): the repository was removed while this create was in flight.
+          if (e instanceof GiteaBindingUnavailable) return conflict(e.message)
           const refused = placementRefusalMessage(e)
           if (refused) return conflict(refused)
           throw e

--- a/packages/control-plane/src/http/routes/gitea.ts
+++ b/packages/control-plane/src/http/routes/gitea.ts
@@ -22,12 +22,11 @@ import {
   giteaListUserRepositories,
   giteaOrganizationName,
   giteaPageSize,
-  giteaRepositoryById,
   type GiteaRepository
 } from '../../gitea/api.js'
+import { collectGiteaReferences, describeGiteaReferences } from '../../gitea/references.js'
 import { unionGiteaWebhookEvents } from '../../gitea/webhook-events.js'
 import { GITEA_MINIMUM_VERSION_LABEL, parseGiteaVersion } from '../../gitea/version.js'
-import { GiteaRepositoryClaimConflict } from '../../persistence/errors.js'
 import {
   ConnectGiteaBody,
   CreateGiteaRepositoryBody,
@@ -347,9 +346,9 @@ export function giteaRoutes(deps: HttpDeps) {
       {
         schema: {
           tags: [Tag.Gitea],
-          summary: 'Bind a Gitea repository',
+          summary: 'Bind a Gitea repository ahead of use',
           description:
-            'Re-fetches the selected repository by numeric id through the organization’s connection, requires the bot to hold admin on it (§4.4), acquires the deployment-global repository claim, creates the binding in the provisioning state and runs the §6 saga: the managed webhook is installed when an enabled trigger wants ingress, tested, and the binding is ready — with the webhook_unverified warning when the relay never observed the test delivery.',
+            'Optional: a repository is bound on first use when a trigger, an agent workspace or an additional-repository grant names it (§6), and this route binds one ahead of that. It re-fetches the repository by numeric id through the organization’s connection, requires the bot to hold admin on it (§4.4), acquires the deployment-global repository claim, creates the binding and runs the §6 saga: the managed webhook is installed when an enabled trigger wants ingress, tested, and the binding is ready — with the webhook_unverified warning when the relay never observed the test delivery. A repository that is already bound answers 409.',
           operationId: 'createGiteaRepository',
           body: CreateGiteaRepositoryBody,
           response: {
@@ -367,51 +366,23 @@ export function giteaRoutes(deps: HttpDeps) {
         if (denyViewerWrite(req, reply)) return
         const orgId = orgOf(req)
         const repoId = BigInt(req.body.repoId)
-        const err = (status: 400 | 403 | 404 | 409, message: string) =>
-          reply.code(status).send({ error: ERROR_NAMES[status], statusCode: status, message })
-        const connection = await deps.repos.giteaConnection.forOrg(orgId)
-        if (!connection) return err(404, 'this organization has no Gitea connection')
-        if (connection.state !== 'connected') {
-          return err(
-            409,
-            connection.state === 'token_rejected'
-              ? 'the Gitea token was rejected — replace it first'
-              : 'the Gitea connection is being removed'
-          )
-        }
-        if (await deps.repos.giteaRepositoryBinding.byRepo(orgId, repoId)) {
-          return err(409, 'repository is already bound in this organization')
-        }
         try {
-          const token = await gitea.connections.withToken(orgId, connection.id)
-          // The server re-fetches; the client-supplied id is never trusted for facts (§6).
-          const repo = await giteaRepositoryById(token, repoId, gitea.api)
-          if (!repo) return err(400, 'repository is not accessible through this connection')
-          if (repo.permissions?.admin !== true) {
-            return err(
-              403,
-              `the bot ${connection.botUsername} must hold admin on ${repo.full_name} — grant it as a collaborator or through a team first`
-            )
+          const bound = await gitea.bindings.ensureBound(orgId, repoId)
+          if (!bound.created) {
+            return reply.code(409).send({
+              error: ERROR_NAMES[409],
+              statusCode: 409,
+              message: 'repository is already bound in this organization'
+            })
           }
-          const binding = await deps.repos.giteaRepositoryBinding.createWithClaim({
-            orgId,
-            connectionId: connection.id,
-            repoId,
-            repoPath: repo.full_name,
-            ...(repo.default_branch ? { defaultBranch: repo.default_branch } : {}),
-            ...(repo.clone_url ? { cloneUrl: repo.clone_url } : {}),
-            axisBaseUrl: gitea.api.baseUrl
-          })
-          await gitea.provisioner.provision(orgId, binding.id)
-          const converged = await deps.repos.giteaRepositoryBinding.get(orgId, binding.id)
           const wanted = await webhookWanted(orgId)
-          return bindingToDto(converged ?? binding, wanted(binding.repoId))
+          return bindingToDto(bound.binding, wanted(bound.binding.repoId))
         } catch (e) {
-          // The deployment-global claim: one managing organization per repository; never disclose WHICH.
-          if (e instanceof GiteaRepositoryClaimConflict)
-            return err(409, 'repository is already claimed by another organization')
           if (e instanceof GiteaConnectDenied) return denied(reply, e)
-          if (e instanceof GiteaApiError) return upstream(reply, e, orgId, connection.id)
+          if (e instanceof GiteaApiError) {
+            const connection = await deps.repos.giteaConnection.forOrg(orgId)
+            return upstream(reply, e, orgId, connection?.id ?? '')
+          }
           throw e
         }
       }
@@ -474,7 +445,7 @@ export function giteaRoutes(deps: HttpDeps) {
           tags: [Tag.Gitea],
           summary: 'Unbind a managed Gitea repository',
           description:
-            'Disables local authority, deletes the managed webhook by its recorded id and releases the deployment-global claim (§6). A rejected token parks the binding in cleanup_pending until a replacement token or a manual webhook removal clears it.',
+            'Disables local authority, deletes the managed webhook by its recorded id and releases the deployment-global claim (§6). Refused with 409 while a trigger, an agent workspace or an additional-repository grant still references the repository — the binding was bound on first use and is never unbound on last use, so this is the one removal. A rejected token parks the binding in cleanup_pending until a replacement token or a manual webhook removal clears it.',
           operationId: 'deleteGiteaRepository',
           params: IdParam,
           response: {
@@ -484,15 +455,28 @@ export function giteaRoutes(deps: HttpDeps) {
               stateReason: z.string().nullable().optional()
             }),
             403: ErrorDto,
-            404: ErrorDto
+            404: ErrorDto,
+            409: ErrorDto
           }
         }
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const orgId = orgOf(req)
-        if (!(await deps.repos.giteaRepositoryBinding.get(orgId, req.params.id)))
-          return notFound(reply, 'gitea repository')
+        const target = await deps.repos.giteaRepositoryBinding.get(orgId, req.params.id)
+        if (!target) return notFound(reply, 'gitea repository')
+        // A parked cleanup finishes what it started; anything live is refused while something still points at it.
+        if (target.state !== 'cleanup_pending') {
+          const references = await collectGiteaReferences(deps.repos, OrgId(orgId), target.repoId)
+          if (references.length > 0) {
+            return reply.code(409).send({
+              error: ERROR_NAMES[409],
+              statusCode: 409,
+              message: describeGiteaReferences(target.repoPath, references),
+              code: 'repository_in_use'
+            })
+          }
+        }
         const outcome = await gitea.provisioner.disconnect(orgId, req.params.id)
         if (outcome.removed) return { removed: true }
         const binding = await deps.repos.giteaRepositoryBinding.get(orgId, req.params.id)

--- a/packages/control-plane/src/http/routes/gitea.ts
+++ b/packages/control-plane/src/http/routes/gitea.ts
@@ -24,6 +24,7 @@ import {
   giteaPageSize,
   type GiteaRepository
 } from '../../gitea/api.js'
+import { REPOSITORY_IN_USE_REASON } from '../../gitea/binding-state.js'
 import { collectGiteaReferences, describeGiteaReferences } from '../../gitea/references.js'
 import { unionGiteaWebhookEvents } from '../../gitea/webhook-events.js'
 import { GITEA_MINIMUM_VERSION_LABEL, parseGiteaVersion } from '../../gitea/version.js'
@@ -465,19 +466,17 @@ export function giteaRoutes(deps: HttpDeps) {
         const orgId = orgOf(req)
         const target = await deps.repos.giteaRepositoryBinding.get(orgId, req.params.id)
         if (!target) return notFound(reply, 'gitea repository')
-        // A parked cleanup finishes what it started; anything live is refused while something still points at it.
-        if (target.state !== 'cleanup_pending') {
+        // §6: never unbound on last use — refused, under the claim's lock, while a trigger, workspace or grant still names it.
+        const outcome = await gitea.provisioner.disconnect(orgId, req.params.id, { unlessReferenced: true })
+        if (outcome.reason === REPOSITORY_IN_USE_REASON) {
           const references = await collectGiteaReferences(deps.repos, OrgId(orgId), target.repoId)
-          if (references.length > 0) {
-            return reply.code(409).send({
-              error: ERROR_NAMES[409],
-              statusCode: 409,
-              message: describeGiteaReferences(target.repoPath, references),
-              code: 'repository_in_use'
-            })
-          }
+          return reply.code(409).send({
+            error: ERROR_NAMES[409],
+            statusCode: 409,
+            message: describeGiteaReferences(target.repoPath, references),
+            code: REPOSITORY_IN_USE_REASON
+          })
         }
-        const outcome = await gitea.provisioner.disconnect(orgId, req.params.id)
         if (outcome.removed) return { removed: true }
         const binding = await deps.repos.giteaRepositoryBinding.get(orgId, req.params.id)
         return { removed: false, state: binding?.state, stateReason: binding?.stateReason ?? outcome.reason ?? null }

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -495,9 +495,7 @@ export function hookRoutes(deps: HttpDeps) {
       return null
     }
 
-    // gitea (gitea-integration.md §6): a repository is bound on first use, so a trigger names one the
-    // bot administers rather than one already added. The facts come first, for the gates that need
-    // the path; the bind runs AFTER the agent gate, so a refused trigger never binds anything.
+    // gitea (gitea-integration.md §6): the facts first, for the gates that need the path; the bind AFTER the agent gate, so a refused trigger binds nothing.
     type GiteaRepositoryStep<T> =
       ({ ok: true } & T) | { ok: false; status: 400 | 403 | 404 | 409 | 429 | 502; message: string }
     const giteaRefusal = (e: unknown): { ok: false; status: 400 | 403 | 404 | 409 | 429 | 502; message: string } => {
@@ -668,8 +666,7 @@ export function hookRoutes(deps: HttpDeps) {
                 })()
               : req.body.kind === 'gitea'
                 ? await (async () => {
-                    // The repository the bot administers, by the numeric id the server re-reads (§6); bound
-                    // on first use below, AFTER the §8.3 gate — a hook never creates a grant.
+                    // The repository the bot administers, re-read by numeric id (§6); bound below, AFTER the §8.3 gate — a hook never creates a grant.
                     const repoId = BigInt((req.body as { repoId: string }).repoId)
                     const facts = await giteaRepositoryFacts(orgId, repoId)
                     if (!facts.ok) return facts

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -25,6 +25,8 @@ import {
   type UpsertHookInput
 } from '../../persistence/ports.js'
 import { GithubApiError } from '../../github/api.js'
+import { GiteaApiError } from '../../gitea/api.js'
+import { GiteaConnectDenied } from '../../gitea/connection.service.js'
 import { GITLAB_ACCESS_DEVELOPER } from '../../gitlab/api.js'
 import { gitlabAccountUnavailableMessage } from '../../gitlab/account.service.js'
 import { GitCredDeniedError, type ResolvedAgentRepoAuthorization } from '../../github/service.js'
@@ -326,6 +328,8 @@ export function hookRoutes(deps: HttpDeps) {
     }
     const ERROR_NAMES = {
       400: 'Bad Request',
+      403: 'Forbidden',
+      404: 'Not Found',
       409: 'Conflict',
       429: 'Too Many Requests',
       502: 'Bad Gateway'
@@ -491,6 +495,43 @@ export function hookRoutes(deps: HttpDeps) {
       return null
     }
 
+    // gitea (gitea-integration.md §6): a repository is bound on first use, so a trigger names one the
+    // bot administers rather than one already added. The facts come first, for the gates that need
+    // the path; the bind runs AFTER the agent gate, so a refused trigger never binds anything.
+    type GiteaRepositoryStep<T> =
+      ({ ok: true } & T) | { ok: false; status: 400 | 403 | 404 | 409 | 429 | 502; message: string }
+    const giteaRefusal = (e: unknown): { ok: false; status: 400 | 403 | 404 | 409 | 429 | 502; message: string } => {
+      if (e instanceof GiteaConnectDenied) return { ok: false, status: e.status, message: e.message }
+      if (e instanceof GiteaApiError) {
+        return { ok: false, status: e.code === 'RATE_LIMITED' ? 429 : 502, message: `gitea: ${e.message}` }
+      }
+      throw e
+    }
+    const giteaRepositoryFacts = async (
+      orgId: OrgId,
+      repoId: bigint
+    ): Promise<GiteaRepositoryStep<{ repoPath: string }>> => {
+      if (!deps.gitea) return { ok: false, status: 409, message: 'Gitea is not configured on this deployment' }
+      const binding = await deps.repos.giteaRepositoryBinding.byRepo(orgId, repoId)
+      if (binding && binding.state !== 'cleanup_pending') return { ok: true, repoPath: binding.repoPath }
+      try {
+        return { ok: true, repoPath: (await deps.gitea.bindings.administered(orgId, repoId)).repo.full_name }
+      } catch (e) {
+        return giteaRefusal(e)
+      }
+    }
+    const bindGiteaRepository = async (
+      orgId: OrgId,
+      repoId: bigint
+    ): Promise<GiteaRepositoryStep<{ binding: { state: GiteaBindingState; repoPath: string } }>> => {
+      if (!deps.gitea) return { ok: false, status: 409, message: 'Gitea is not configured on this deployment' }
+      try {
+        return { ok: true, binding: (await deps.gitea.bindings.ensureBound(orgId, repoId)).binding }
+      } catch (e) {
+        return giteaRefusal(e)
+      }
+    }
+
     // Validate the optional anchoring target against the hook's agent (the
     // anchor posts through one of THAT agent's integrations — cron semantics).
     const resolveTarget = async (
@@ -521,7 +562,15 @@ export function hookRoutes(deps: HttpDeps) {
             'Create a trigger for one agent. `kind:"webhook"` mints an ingress URL (the response carries it plus — when requested — the one-time HMAC signing secret, never retrievable again). `kind:"github"` subscribes a repository covered by one of the organization’s GitHub App installations to issue, pull-request, push or deployment events. A code-host trigger covers ONE subject `family`, so a repository watched for both pull requests and issues is two triggers, each with its own cadence and mention gate; a second trigger on the same family is a 409. A `deployment_status:<state>` pattern selects on the status state (`success`, `failure`, …).',
           operationId: 'createHook',
           body: CreateHookBody,
-          response: { 200: CreatedHookDto, 400: ErrorDto, 403: ErrorDto, 409: ErrorDto, 429: ErrorDto, 502: ErrorDto }
+          response: {
+            200: CreatedHookDto,
+            400: ErrorDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            429: ErrorDto,
+            502: ErrorDto
+          }
         }
       },
       async (req, reply) => {
@@ -619,31 +668,27 @@ export function hookRoutes(deps: HttpDeps) {
                 })()
               : req.body.kind === 'gitea'
                 ? await (async () => {
-                    // The repository must already be a managed binding (gitea-integration.md §5): a
-                    // hook never creates a binding, and the numeric id is validated against the org's row.
+                    // The repository the bot administers, by the numeric id the server re-reads (§6); bound
+                    // on first use below, AFTER the §8.3 gate — a hook never creates a grant.
                     const repoId = BigInt((req.body as { repoId: string }).repoId)
-                    const binding = deps.gitea ? await deps.repos.giteaRepositoryBinding.byRepo(orgId, repoId) : null
-                    if (!binding || binding.state === 'cleanup_pending') {
-                      return {
-                        ok: false as const,
-                        status: 409 as const,
-                        message: 'the repository is not a managed Gitea binding in this organization'
-                      }
-                    }
-                    const siblingError = await siblingShapeError(agent.id, 'gitea', repoId, binding.repoPath, hookId, {
+                    const facts = await giteaRepositoryFacts(orgId, repoId)
+                    if (!facts.ok) return facts
+                    const siblingError = await siblingShapeError(agent.id, 'gitea', repoId, facts.repoPath, hookId, {
                       targetPlatform: target.targetPlatform,
                       targetChannel: req.body.targetChannel ?? null,
                       targetIntegrationId: target.targetIntegrationId ?? null
                     })
                     if (siblingError) return { ok: false as const, status: 409 as const, message: siblingError }
-                    const authz = await watchRepoAuthorized(agent, 'gitea', repoId, binding.repoPath)
+                    const authz = await watchRepoAuthorized(agent, 'gitea', repoId, facts.repoPath)
                     if (!authz.ok) return authz
-                    const effectError = validateGiteaEffects(binding, effects!)
+                    const bound = await bindGiteaRepository(orgId, repoId)
+                    if (!bound.ok) return bound
+                    const effectError = validateGiteaEffects(bound.binding, effects!)
                     if (effectError) return { ok: false as const, ...effectError }
                     return {
                       sessionMode: 'perThread' as const,
                       repoId,
-                      repoFullName: binding.repoPath,
+                      repoFullName: bound.binding.repoPath,
                       githubSessionKey: `gitea:${repoId}`,
                       hmacSecret: null
                     }
@@ -1061,15 +1106,15 @@ export function hookRoutes(deps: HttpDeps) {
           }
         } else if (req.body.kind === 'gitea') {
           const repoId = BigInt(req.body.repoId)
-          const binding = deps.gitea ? await deps.repos.giteaRepositoryBinding.byRepo(orgId, repoId) : null
-          if (!binding || binding.state === 'cleanup_pending') {
-            return reply.code(409).send({
-              error: ERROR_NAMES[409],
-              statusCode: 409,
-              message: 'the repository is not a managed Gitea binding in this organization'
+          const facts = await giteaRepositoryFacts(orgId, repoId)
+          if (!facts.ok) {
+            return reply.code(facts.status).send({
+              error: ERROR_NAMES[facts.status],
+              statusCode: facts.status,
+              message: facts.message
             })
           }
-          const siblingError = await siblingShapeError(agent.id, 'gitea', repoId, binding.repoPath, existing.id, {
+          const siblingError = await siblingShapeError(agent.id, 'gitea', repoId, facts.repoPath, existing.id, {
             targetPlatform: target.targetPlatform,
             targetChannel: req.body.targetChannel ?? null,
             targetIntegrationId: target.targetIntegrationId ?? null
@@ -1079,7 +1124,7 @@ export function hookRoutes(deps: HttpDeps) {
           }
           // Binding-CHANGING edits go through the gate, exactly as the other two hosts.
           if (repoId !== existing.repoId || agent.id !== existing.agentId) {
-            const authz = await watchRepoAuthorized(agent, 'gitea', repoId, binding.repoPath)
+            const authz = await watchRepoAuthorized(agent, 'gitea', repoId, facts.repoPath)
             if (!authz.ok) {
               return reply.code(authz.status).send({
                 error: ERROR_NAMES[authz.status],
@@ -1088,6 +1133,16 @@ export function hookRoutes(deps: HttpDeps) {
               })
             }
           }
+          // Bound on first use (§6), after the gate.
+          const bound = await bindGiteaRepository(orgId, repoId)
+          if (!bound.ok) {
+            return reply.code(bound.status).send({
+              error: ERROR_NAMES[bound.status],
+              statusCode: bound.status,
+              message: bound.message
+            })
+          }
+          const binding = bound.binding
           const effectConfig = {
             reviewPolicy: req.body.reviewPolicy ?? existing.reviewPolicy,
             reportingMode: req.body.reportingMode ?? existing.reportingMode

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -35,7 +35,7 @@ import { NoConnection } from '../../orchestrator/outbound.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView } from '../../authorization/policy.js'
 import { toDbPlatform, type DbPlatform } from '../../persistence/platform.js'
-import { AgentWorkspaceIntegrationConflict } from '../../persistence/errors.js'
+import { AgentWorkspaceIntegrationConflict, GiteaBindingUnavailable } from '../../persistence/errors.js'
 import { isCanonicalGithubAddress } from '../../domain/git-host.js'
 import { hookFamilyShapeError, hookSiblingShapeError, type HookFamily } from '../../hooks/hook-family.js'
 import { codeHostsOf } from '../../codehost/registry.js'
@@ -210,7 +210,7 @@ export function hookRoutes(deps: HttpDeps) {
     // The repository repeats the workspace-access invariant under its shared
     // transaction fence. Surface a concurrent loser as the same 409 as the
     // route's fast preflight instead of leaking it as a generic 500.
-    type PersistOutcome = HookRecord | AgentWorkspaceIntegrationConflict | DuplicateHookFamily
+    type PersistOutcome = HookRecord | AgentWorkspaceIntegrationConflict | DuplicateHookFamily | GiteaBindingUnavailable
     const persistHook = async (input: UpsertHookInput): Promise<PersistOutcome> => {
       try {
         // §24.1: every gitlab-kind write carries the instance its repoId names,
@@ -224,7 +224,7 @@ export function hookRoutes(deps: HttpDeps) {
               : input
         return await deps.repos.hook.upsert(fenced)
       } catch (err) {
-        if (err instanceof AgentWorkspaceIntegrationConflict) return err
+        if (err instanceof AgentWorkspaceIntegrationConflict || err instanceof GiteaBindingUnavailable) return err
         if (isHookFamilyCollision(err)) return new DuplicateHookFamily()
         throw err
       }
@@ -777,7 +777,7 @@ export function hookRoutes(deps: HttpDeps) {
             .send({ error: ERROR_NAMES[written.status], statusCode: written.status, message: written.message })
         }
         const hook = written.result
-        if (hook instanceof AgentWorkspaceIntegrationConflict) {
+        if (hook instanceof AgentWorkspaceIntegrationConflict || hook instanceof GiteaBindingUnavailable) {
           return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: hook.message })
         }
         if (hook instanceof DuplicateHookFamily) {
@@ -1205,7 +1205,7 @@ export function hookRoutes(deps: HttpDeps) {
             .send({ error: ERROR_NAMES[written.status], statusCode: written.status, message: written.message })
         }
         const hook = written.result
-        if (hook instanceof AgentWorkspaceIntegrationConflict) {
+        if (hook instanceof AgentWorkspaceIntegrationConflict || hook instanceof GiteaBindingUnavailable) {
           return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: hook.message })
         }
         // A retarget carries the row's own family onto the new repository, where

--- a/packages/control-plane/src/http/routes/workspace-credential.ts
+++ b/packages/control-plane/src/http/routes/workspace-credential.ts
@@ -39,7 +39,9 @@ export async function deriveWorkspaceCredential(
   orgId: string,
   actorUserId: string | undefined,
   gitRepo: string,
-  requestedAccess?: 'read' | 'write'
+  requestedAccess?: 'read' | 'write',
+  /** `write` marks the two persisting callers: a host that binds on first use binds only for them (gitea-integration.md §6). */
+  opts: { write?: boolean } = {}
 ): Promise<DerivedWorkspace> {
   // Asked in the registry's own order, which is the order these arms have always
   // run in: the first host that RECOGNIZES the address owns the outcome, refusals
@@ -51,7 +53,8 @@ export async function deriveWorkspaceCredential(
       orgId,
       ...(actorUserId !== undefined ? { actorUserId } : {}),
       gitRepo,
-      ...(requestedAccess !== undefined ? { requestedAccess } : {})
+      ...(requestedAccess !== undefined ? { requestedAccess } : {}),
+      ...(opts.write ? { write: true } : {})
     })
     if (derived) return derived
   }

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -43,7 +43,7 @@ import type {
   IntegrationChannelRepo,
   IntegrationRepo
 } from '../persistence/ports.js'
-import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
+import { AgentWorkspaceIntegrationConflict, GiteaBindingUnavailable } from '../persistence/errors.js'
 import { isCanonicalGithubAddress } from '../domain/git-host.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import {
@@ -428,7 +428,7 @@ export class AgentMoveService {
         const observed = await this.deps.agents.getUnscoped(agent.id).catch(() => null)
         if (observed && !isPlaced(observed) && sameWorkspace(observed, workspace, workspaceRepoId)) {
           converted = observed
-        } else if (err instanceof AgentWorkspaceIntegrationConflict) {
+        } else if (err instanceof AgentWorkspaceIntegrationConflict || err instanceof GiteaBindingUnavailable) {
           throw new AgentMoveConflict(err.message)
         } else {
           throw new AgentMoveFailed('failed to persist the workspace settings', err)
@@ -493,7 +493,10 @@ export class AgentMoveService {
           persistenceError ? 'workspace persistence failed' : 'workspace compare-and-set failed'
         )
         if (persistenceError) {
-          if (persistenceError instanceof AgentWorkspaceIntegrationConflict) {
+          if (
+            persistenceError instanceof AgentWorkspaceIntegrationConflict ||
+            persistenceError instanceof GiteaBindingUnavailable
+          ) {
             throw new AgentMoveConflict(persistenceError.message)
           }
           throw new AgentMoveFailed('failed to persist the workspace settings', persistenceError)

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
@@ -99,6 +99,7 @@ function repoAuthWith(rows: Array<[fullName: string, repoId: bigint]>): AgentRep
         createdBy: null
       })),
     create: unused,
+    listForRepository: unused,
     get: unused,
     updateAccess: unused,
     updateFullName: unused,

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -299,6 +299,17 @@ export class GiteaConnectionExists extends Error {
   }
 }
 
+/** A write would reference a Gitea binding that is gone or parked (gitea-integration.md §6): the removal fence refused it. */
+export class GiteaBindingUnavailable extends Error {
+  readonly code = 'GITEA_BINDING_UNAVAILABLE' as const
+  constructor(readonly repoId: bigint) {
+    super(
+      `gitea repository ${repoId} is no longer a live managed binding in this organization — it was removed while this write was in flight`
+    )
+    this.name = 'GiteaBindingUnavailable'
+  }
+}
+
 /** A numeric repository is already the agent's implicit workspace authority,
  * so persisting a second "additional repository" grant would be redundant and
  * could later make grant deletion look like a real authority revocation. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3957,10 +3957,20 @@ export interface GiteaRepositoryBindingRepo {
   ): Promise<boolean>
   endProviderMutation(orgId: string, bindingId: string, repoId: bigint, owner: string): Promise<void>
   renewProviderLease(orgId: string, bindingId: string, repoId: bigint, owner: string, until: Date): Promise<boolean>
-  /** Cleanup entry, exclusive with a live lease (false while held): flips the attached claim AND the binding to `cleanup_pending` in one transaction. */
-  beginCleanup(orgId: string, bindingId: string, repoId: bigint, now: Date): Promise<boolean>
+  /** Cleanup entry under the claim row held exclusively: `leased` while a live lease holds it, `referenced` when
+   *  `unlessReferenced` and a trigger, workspace or grant still names the repository (§6), else the attached claim
+   *  AND the binding flip to `cleanup_pending` in one transaction. */
+  beginCleanup(
+    orgId: string,
+    bindingId: string,
+    repoId: bigint,
+    now: Date,
+    opts?: { unlessReferenced?: boolean }
+  ): Promise<GiteaCleanupEntry>
   removeWithClaim(orgId: string, bindingId: string, repoId: bigint): Promise<boolean>
 }
+
+export type GiteaCleanupEntry = 'parked' | 'leased' | 'referenced'
 
 /** The managed webhook's sealed signing keys (§7): the current one and, mid-rotation, its successor. */
 export interface GiteaWebhookSigningKeys {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4193,6 +4193,8 @@ export interface AgentRepoAuthorizationRepo {
   get(id: string): Promise<AgentRepoAuthorizationRecord | null>
   /** The agent's grants — the console card AND the mint-gate read (viewer-free). */
   listForAgent(agentId: AgentId): Promise<AgentRepoAuthorizationRecord[]>
+  /** Every grant in the organization over one numeric repository — who still consumes a binding (gitea-integration.md §6). */
+  listForRepository(orgId: OrgId, provider: CodeHostProvider, repoId: bigint): Promise<AgentRepoAuthorizationRecord[]>
   /** Raise a grant's capability tier after the caller's GitHub access is re-checked. */
   updateAccess(id: string, access: RepoAccess): Promise<AgentRepoAuthorizationRecord | null>
   /** Best-effort display refresh when the mint gate detects a rename (repoId match

--- a/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
@@ -22,6 +22,7 @@ import { AgentId, type OrgId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockHookReviewAgentRepoScope } from '../review-projection-lock.js'
 import { AgentWorkspaceRepoConflict } from '../errors.js'
+import { joinGiteaBindingFence } from './gitea-binding-fence.js'
 import { bumpAgentConfigRevisions } from './organization-environment-fence.js'
 
 const withCreator = { createdBy: true } as const
@@ -66,13 +67,15 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
       await lockHookReviewAgentRepoScope(tx, input.agentId, input.repoId)
       const agent = await tx.agent.findUnique({
         where: { id: input.agentId },
-        select: { workspaceRepoId: true, gitCredentialProvider: true }
+        select: { orgId: true, workspaceRepoId: true, gitCredentialProvider: true }
       })
       // The hosts number repositories independently, so the workspace collides only
       // when the grant names ITS provider — `gitCredentialProvider` is that provider.
       if (agent?.workspaceRepoId === input.repoId && agent.gitCredentialProvider === input.provider) {
         throw new AgentWorkspaceRepoConflict(input.repoId)
       }
+      // A gitea grant references a binding (gitea-integration.md §6): it commits only while that binding is live.
+      if (input.provider === 'gitea' && agent) await joinGiteaBindingFence(tx, agent.orgId, input.repoId)
       const row = await tx.agentRepoAuthorization.create({
         data: {
           agentId: input.agentId,

--- a/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
@@ -18,7 +18,7 @@ import { Prisma } from '../../generated/prisma/client.js'
 import type { PrismaLike } from '../prisma.js'
 import type { CodeHostProvider } from '@agentconnect.md/protocol'
 import type { AgentRepoAuthorizationRecord, AgentRepoAuthorizationRepo, RepoAccess } from '../ports.js'
-import { AgentId } from '../../domain/ids.js'
+import { AgentId, type OrgId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
 import { lockHookReviewAgentRepoScope } from '../review-projection-lock.js'
 import { AgentWorkspaceRepoConflict } from '../errors.js'
@@ -97,6 +97,19 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
   async listForAgent(agentId: AgentId): Promise<AgentRepoAuthorizationRecord[]> {
     const rows = await this.db.agentRepoAuthorization.findMany({
       where: { agentId },
+      include: withCreator,
+      orderBy: { createdAt: 'asc' }
+    })
+    return rows.map(toRecord)
+  }
+
+  async listForRepository(
+    orgId: OrgId,
+    provider: CodeHostProvider,
+    repoId: bigint
+  ): Promise<AgentRepoAuthorizationRecord[]> {
+    const rows = await this.db.agentRepoAuthorization.findMany({
+      where: { provider, repoId, agent: { orgId } },
       include: withCreator,
       orderBy: { createdAt: 'asc' }
     })

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -777,6 +777,10 @@ export class PgAgentRepo implements AgentRepo {
           await lockHookReviewAgentRepoScope(tx, agentId, repoId)
         }
         await assertWorkspaceIntegrationCompatible(tx, agentId, affectedRepoIds, workspace, workspaceRepoId)
+        // A rollback onto a gitea workspace is a reference too (§6): it fails closed if the binding went meanwhile.
+        if (workspace.mode === 'git' && workspace.credential?.provider === 'gitea' && workspaceRepoId !== undefined) {
+          await joinGiteaBindingFence(tx, orgId, workspaceRepoId)
+        }
         const a = await tx.agent.update({
           where: {
             id: agentId,

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -53,6 +53,7 @@ import {
 } from '../../agent-memory/home.js'
 import { PgAgentMemoryFileRepo, PgAgentMemoryHistoryRepo } from './agent-memory.repo.js'
 import { PgHookRepo } from './hook.repo.js'
+import { joinGiteaBindingFence } from './gitea-binding-fence.js'
 import { lockAgentPlacement, settlePlacementChange } from './agent-placement.js'
 import { assertAgentMayUseSet, assertDaemonNotInSet } from './member-set.repo.js'
 
@@ -360,6 +361,10 @@ export class PgAgentRepo implements AgentRepo {
       // the two writers in a cycle. Full order for every agent-config writer:
       // skill-source name scopes → org row (create only) → agent rows.
       await lockOrgForConfigWrite(tx, input.orgId)
+      // A gitea workspace references a binding (gitea-integration.md §6): it commits only while that binding is live.
+      if (ws.mode === 'git' && ws.credential?.provider === 'gitea' && input.workspaceRepoId !== undefined) {
+        await joinGiteaBindingFence(tx, input.orgId, input.workspaceRepoId)
+      }
       const bindId = externalConnectionIdOf(input.memory)[0]
       await fenceMemoryConnections(tx, input.orgId, externalConnectionIdOf(input.memory), bindId)
       const orgDefault =
@@ -727,6 +732,10 @@ export class PgAgentRepo implements AgentRepo {
           await lockHookReviewAgentRepoScope(tx, agentId, repoId)
         }
         await assertWorkspaceIntegrationCompatible(tx, agentId, affectedRepoIds, workspace, workspaceRepoId)
+        // A gitea workspace references a binding (gitea-integration.md §6): it commits only while that binding is live.
+        if (workspace.mode === 'git' && workspace.credential?.provider === 'gitea' && workspaceRepoId !== undefined) {
+          await joinGiteaBindingFence(tx, orgId, workspaceRepoId)
+        }
         const a = await tx.agent.update({
           where: { id: agentId, orgId, workspaceMode: expectedMode, lastModifiedAt: expectedLastModifiedAt },
           data: {

--- a/packages/control-plane/src/persistence/repositories/gitea-binding-fence.ts
+++ b/packages/control-plane/src/persistence/repositories/gitea-binding-fence.ts
@@ -1,0 +1,24 @@
+/**
+ * The reference fence of a Gitea binding (gitea-integration.md §6). Every transaction that commits a
+ * reference to a managed repository — a trigger, an agent workspace, an additional-repository grant —
+ * locks the repository's claim SHARED and proves the binding is still live; a removal locks the same
+ * row EXCLUSIVELY while it counts references and parks, so neither can slip past the other.
+ */
+import type { Prisma } from '../../generated/prisma/client.js'
+import { GiteaBindingUnavailable } from '../errors.js'
+
+/** The claim states under which a binding still serves (§5); anything else is gone or parked. */
+const LIVE_CLAIM_STATES: ReadonlySet<string> = new Set(['provisioning', 'active'])
+
+export async function joinGiteaBindingFence(
+  tx: Prisma.TransactionClient,
+  orgId: string,
+  repoId: bigint
+): Promise<void> {
+  const rows = await tx.$queryRaw<{ state: string }[]>`
+    SELECT "state" FROM "code_host_repository_claim"
+     WHERE "provider" = 'gitea' AND "externalId" = ${repoId.toString()}::bigint AND "orgId" = ${orgId}
+       FOR SHARE`
+  const state = rows[0]?.state
+  if (state === undefined || !LIVE_CLAIM_STATES.has(state)) throw new GiteaBindingUnavailable(repoId)
+}

--- a/packages/control-plane/src/persistence/repositories/gitea.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitea.repo.ts
@@ -12,6 +12,7 @@ import type { PrismaLike } from '../prisma.js'
 import { GiteaBotAlreadyBound, GiteaConnectionExists, GiteaRepositoryClaimConflict } from '../errors.js'
 import type {
   GiteaBindingState,
+  GiteaCleanupEntry,
   GiteaConnectionRecord,
   GiteaConnectionRepo,
   GiteaConnectionSecretStore,
@@ -408,32 +409,51 @@ export class PgGiteaRepositoryBindingRepo implements GiteaRepositoryBindingRepo 
     return res.count === 1
   }
 
-  async beginCleanup(orgId: string, bindingId: string, repoId: bigint, now: Date): Promise<boolean> {
+  async beginCleanup(
+    orgId: string,
+    bindingId: string,
+    repoId: bigint,
+    now: Date,
+    opts: { unlessReferenced?: boolean } = {}
+  ): Promise<GiteaCleanupEntry> {
     // The binding leaves the servable states in the SAME transaction as its claim: nothing compiles, issues or authorizes past here.
     const parked = { state: 'cleanup_pending', convergeOwedAt: null }
-    const attached = await this.prisma.codeHostRepositoryClaim.count({
-      where: { provider: 'gitea', externalId: repoId, orgId, bindingRef: bindingId }
-    })
-    if (attached === 0) {
-      await this.prisma.giteaRepositoryBinding.updateMany({ where: { id: bindingId, orgId }, data: parked })
-      return true
-    }
-    // A live lease refuses: cleanup must wait, so there is no window between a fence check and its write.
     return this.prisma.$transaction(async (tx) => {
-      const res = await tx.codeHostRepositoryClaim.updateMany({
-        where: {
-          provider: 'gitea',
-          externalId: repoId,
-          orgId,
-          bindingRef: bindingId,
-          OR: [{ opOwner: null }, { opLeaseUntil: { lt: now } }]
-        },
+      // The claim row is the mutex every reference-committing write shares (FOR SHARE): held exclusively here, nothing lands between the count and the park.
+      const claims = await tx.$queryRaw<{ state: string; opOwner: string | null; opLeaseUntil: Date | null }[]>`
+        SELECT "state", "opOwner", "opLeaseUntil" FROM "code_host_repository_claim"
+         WHERE "provider" = 'gitea' AND "externalId" = ${repoId.toString()}::bigint AND "orgId" = ${orgId}
+           AND "bindingRef" = ${bindingId}::uuid
+           FOR UPDATE`
+      const claim = claims[0]
+      if (claim === undefined) {
+        // An already-tombstoned claim leaves only the binding to park.
+        await tx.giteaRepositoryBinding.updateMany({ where: { id: bindingId, orgId }, data: parked })
+        return 'parked'
+      }
+      // A live lease refuses: cleanup must wait, so there is no window between a fence check and its write.
+      const leaseUntil = claim.opLeaseUntil === null ? null : new Date(claim.opLeaseUntil).getTime()
+      if (claim.opOwner !== null && (leaseUntil === null || leaseUntil >= now.getTime())) return 'leased'
+      // A parked cleanup finishes what it started; a live binding stays while anything still points at it (§6).
+      if (opts.unlessReferenced && claim.state !== 'cleanup_pending' && (await this.referenced(tx, orgId, repoId))) {
+        return 'referenced'
+      }
+      await tx.codeHostRepositoryClaim.updateMany({
+        where: { provider: 'gitea', externalId: repoId, orgId, bindingRef: bindingId },
         data: { state: 'cleanup_pending', opOwner: null, opLeaseUntil: null }
       })
-      if (res.count !== 1) return false
       await tx.giteaRepositoryBinding.updateMany({ where: { id: bindingId, orgId }, data: parked })
-      return true
+      return 'parked'
     })
+  }
+
+  /** Whether a trigger, an agent workspace or an additional-repository grant in the organization still names the repository. */
+  private async referenced(tx: Prisma.TransactionClient, orgId: string, repoId: bigint): Promise<boolean> {
+    if ((await tx.hookDef.count({ where: { orgId, kind: 'gitea', repoId } })) > 0) return true
+    if ((await tx.agent.count({ where: { orgId, gitCredentialProvider: 'gitea', workspaceRepoId: repoId } })) > 0) {
+      return true
+    }
+    return (await tx.agentRepoAuthorization.count({ where: { provider: 'gitea', repoId, agent: { orgId } } })) > 0
   }
 
   async removeWithClaim(orgId: string, bindingId: string, repoId: bigint): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -67,6 +67,7 @@ import { AgentWorkspaceIntegrationConflict, HookMissing } from '../errors.js'
 import { bumpAgentConfigRevisions } from './organization-environment-fence.js'
 import { joinAxisFence } from './gitlab-axis.js'
 import { joinGiteaAxisFence } from './gitea-axis.js'
+import { joinGiteaBindingFence } from './gitea-binding-fence.js'
 
 type HookWithUsers = HookDef & {
   createdBy: User | null
@@ -542,6 +543,8 @@ export class PgHookRepo implements HookRepo {
         if (input.kind === 'gitea') {
           if (!input.axisBaseUrl) throw new Error('gitea hook write is missing its axis base url')
           await joinGiteaAxisFence(tx, input.axisBaseUrl)
+          // §6: the row references a binding, so it commits only while that binding is live.
+          if (input.repoId != null) await joinGiteaBindingFence(tx, input.orgId, input.repoId)
         }
         const lockedAgentIds = await this.lockAgentLifecycleScopes(tx, [
           ownerHint ? AgentId(ownerHint) : null,

--- a/packages/control-plane/test/fakes/gitea-api.ts
+++ b/packages/control-plane/test/fakes/gitea-api.ts
@@ -43,6 +43,8 @@ export interface FakeGiteaOptions {
   onTestDelivery?: (hookId: number) => Promise<void> | void
   /** Fault injection: a Response returned here answers an authenticated request in place of its handler. */
   intercept?: (method: string, route: string) => Response | undefined
+  /** Awaited before an authenticated request is served — a race test's barrier. */
+  gate?: (method: string, route: string) => Promise<void>
 }
 
 export type GiteaScopeCategory = 'user' | 'repository' | 'organization' | 'issue'
@@ -124,7 +126,8 @@ function page<T>(url: string, rows: readonly T[], limitCap: number, withLink = t
 }
 
 export class FakeGitea {
-  readonly opts: Required<Omit<FakeGiteaOptions, 'onTestDelivery' | 'dropEvents' | 'intercept'>> & FakeGiteaOptions
+  readonly opts: Required<Omit<FakeGiteaOptions, 'onTestDelivery' | 'dropEvents' | 'intercept' | 'gate'>> &
+    FakeGiteaOptions
   readonly api: GiteaApiClient
   /** What `GET /version` answers NOW — assign mid-test to downgrade. */
   version: string
@@ -275,6 +278,7 @@ export class FakeGitea {
         return Response.json(this.repoJson(repo))
       }
       if (token !== this.token) return Response.json({ message: 'token is required' }, { status: 401 })
+      await this.opts.gate?.(method, route)
       const injected = this.opts.intercept?.(method, route)
       if (injected) return injected
       // The scope gate precedes every handler, existence checks included (§16).
@@ -290,6 +294,12 @@ export class FakeGitea {
       }
 
       if (route === '/user') return Response.json({ ...this.opts.bot, username: this.opts.bot.login })
+      // The same path read AS THE BOT: every listed repository is one it can see (§6 first-use read).
+      if (publicRepo && method === 'GET') {
+        const repo = this.repositories.find((candidate) => candidate.full_name === `${publicRepo[1]}/${publicRepo[2]}`)
+        if (!repo) return Response.json({ message: "The target couldn't be found." }, { status: 404 })
+        return Response.json(this.repoJson(repo))
+      }
       const userByLogin = /^\/users\/([^/]+)$/.exec(route)
       if (userByLogin) {
         const login = decodeURIComponent(userByLogin[1]!)

--- a/packages/control-plane/test/fakes/gitea-seam.ts
+++ b/packages/control-plane/test/fakes/gitea-seam.ts
@@ -105,8 +105,8 @@ export function buildGiteaSeam(
     track(convergeRepository(orgId, repoId, convergeOpts))
   // The routes also kick a parked cleanup fire-and-forget after a token replacement.
   const disconnect = provisioner.disconnect.bind(provisioner)
-  provisioner.disconnect = (orgId, bindingId) => {
-    const run = disconnect(orgId, bindingId)
+  provisioner.disconnect = (orgId, bindingId, opts) => {
+    const run = disconnect(orgId, bindingId, opts)
     void track(run.then(() => undefined))
     return run
   }

--- a/packages/control-plane/test/fakes/gitea-seam.ts
+++ b/packages/control-plane/test/fakes/gitea-seam.ts
@@ -7,8 +7,10 @@
 import type { PrismaClient } from '../../src/generated/prisma/client.js'
 import type { Clock } from '../../src/domain/clock.js'
 import { OrgId } from '../../src/domain/ids.js'
+import { GiteaBindingService } from '../../src/gitea/binding.service.js'
 import { GiteaConnectionService } from '../../src/gitea/connection.service.js'
 import { GiteaProvisioner } from '../../src/gitea/provisioner.js'
+import type { HttpDeps } from '../../src/http/deps.js'
 import { unionGiteaWebhookEvents } from '../../src/gitea/webhook-events.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
@@ -34,6 +36,10 @@ export interface GiteaSeam {
   fake: FakeGitea
   connections: GiteaConnectionService
   provisioner: GiteaProvisioner
+  /** Binding on first use (§6) over the same stores. */
+  bindingService: GiteaBindingService
+  /** The bundle a suite hands `buildHttpApp` as `depsOverrides.gitea`. */
+  httpDeps: NonNullable<HttpDeps['gitea']>
   api: FakeGitea['api']
   connectionRepo: PgGiteaConnectionRepo
   bindings: PgGiteaRepositoryBindingRepo
@@ -110,5 +116,24 @@ export function buildGiteaSeam(
       await new Promise<void>((resolve) => setImmediate(resolve))
     }
   }
-  return { fake, connections, provisioner, api: fake.api, connectionRepo, bindings, webhookSecrets, broadcast, settled }
+  const bindingService = new GiteaBindingService({
+    connections: connectionRepo,
+    tokens: connections,
+    bindings,
+    provisioner,
+    api: fake.api
+  })
+  return {
+    fake,
+    connections,
+    provisioner,
+    bindingService,
+    httpDeps: { connections, provisioner, bindings: bindingService, api: fake.api },
+    api: fake.api,
+    connectionRepo,
+    bindings,
+    webhookSecrets,
+    broadcast,
+    settled
+  }
 }

--- a/packages/control-plane/test/integration/gitea-connection.route.test.ts
+++ b/packages/control-plane/test/integration/gitea-connection.route.test.ts
@@ -31,7 +31,7 @@ function app(options: GiteaSeamOptions = {}): HttpApp & { seam: GiteaSeam } {
   const built = buildGiteaSeam(prisma, cipher, clock, options)
   seam = built
   running = buildHttpApp(prisma, { PUBLIC_RELAY_URL: 'https://relay.example.test' }, undefined, undefined, {
-    gitea: { connections: built.connections, provisioner: built.provisioner, api: built.api }
+    gitea: built.httpDeps
   })
   built.broadcast.current = (hook) => running!.deps.hooks.broadcast(hook)
   return { ...running, seam: built }

--- a/packages/control-plane/test/integration/gitea-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitea-hooks.route.test.ts
@@ -40,7 +40,7 @@ async function harness() {
   const built = buildGiteaSeam(prisma, cipher, clock)
   seam = built
   running = buildHttpApp(prisma, { PUBLIC_RELAY_URL: RELAY_URL }, undefined, undefined, {
-    gitea: { connections: built.connections, provisioner: built.provisioner, api: built.api }
+    gitea: built.httpDeps
   })
   built.broadcast.current = (hook) => running!.deps.hooks.broadcast(hook)
   // A live relay row so the ingress gate passes.
@@ -166,15 +166,16 @@ describe('gitea hooks — routes, compile, webhook converge (§7)', () => {
     expect(await prisma.giteaWebhookSecret.count()).toBe(0)
   })
 
-  it('refuses a repository that is not a managed binding, an unauthorized agent, and GitLab-only run notes', async () => {
+  it('refuses a repository the bot cannot see, an unauthorized agent, and GitLab-only run notes', async () => {
     const h = await harness()
+    // Binding on first use (§6) reaches only what the bot administers: an unknown id is the bot's 404, answered as such.
     const unbound = await h.a.app.inject({
       method: 'POST',
       url: `${ORG}/hooks`,
       payload: body(h.agentId, { repoId: '999' })
     })
-    expect(unbound.statusCode).toBe(409)
-    expect((unbound.json() as { message: string }).message).toContain('not a managed Gitea binding')
+    expect(unbound.statusCode).toBe(400)
+    expect((unbound.json() as { message: string }).message).toContain('not accessible through this connection')
     // §5: a hook never creates a grant, so the stranger is refused until the repository is authorized.
     const stranger = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: body(h.strangerId) })
     expect(stranger.statusCode).toBe(409)

--- a/packages/control-plane/test/integration/gitea-implicit-binding.test.ts
+++ b/packages/control-plane/test/integration/gitea-implicit-binding.test.ts
@@ -15,6 +15,12 @@ import { makeSecretCipher } from '../../src/secrets/cipher.js'
 import { trackedTestClock } from '../fakes/tracked-clock.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { DaemonLiveness } from '../../src/ports.js'
+import { GiteaBindingUnavailable } from '../../src/persistence/errors.js'
+import { joinGiteaBindingFence } from '../../src/persistence/repositories/gitea-binding-fence.js'
+import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgAgentRepoAuthorizationRepo } from '../../src/persistence/repositories/agent-repo-auth.repo.js'
+import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const REPO = 556677n
@@ -477,5 +483,155 @@ describe('removing a referenced binding (§6)', () => {
     expect(await bindings()).toHaveLength(0)
     expect(await claims()).toBe(0)
     expect(managedHooks(h)).toHaveLength(0)
+  })
+})
+
+describe('the reference fence (§6)', () => {
+  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+  /** Settles to 'blocked' unless `run` finishes first — the probe that a lock is really held against it. */
+  const raced = (run: Promise<unknown>) =>
+    Promise.race([
+      run.then(
+        () => 'finished',
+        () => 'finished'
+      ),
+      sleep(400).then(() => 'blocked')
+    ])
+  const hookRow = (agentId: string) => ({
+    id: randomUUID(),
+    orgId: DEFAULT_ORG_ID,
+    agentId,
+    kind: 'gitea' as const,
+    name: 'late',
+    sessionMode: 'perThread' as const,
+    repoId: REPO,
+    repoFullName: 'example-org/example-repo',
+    family: 'merge_request',
+    events: ['merge_request:*']
+  })
+
+  it('a removal waits for an in-flight reference commit and is then refused by it', async () => {
+    const h = await harness()
+    const { binding } = await h.seam.bindingService.ensureBound(DEFAULT_ORG_ID, REPO)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: h.daemonId, name: 'writer' })
+    // A writer has passed the fence and inserted its trigger, but has not committed yet.
+    let release: () => void = () => undefined
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const writer = prisma.$transaction(
+      async (tx) => {
+        await joinGiteaBindingFence(tx, DEFAULT_ORG_ID, REPO)
+        await tx.hookDef.create({ data: hookRow(agentId) })
+        await held
+      },
+      { timeout: 15_000 }
+    )
+    await sleep(200)
+    // The removal cannot count past the writer's shared lock; once it can, the reference is there.
+    const removal = h.seam.bindings.beginCleanup(DEFAULT_ORG_ID, binding.id, REPO, new Date(clock.now()), {
+      unlessReferenced: true
+    })
+    expect(await raced(removal)).toBe('blocked')
+    release()
+    await writer
+    expect(await removal).toBe('referenced')
+    expect((await h.seam.bindings.get(DEFAULT_ORG_ID, binding.id))!.state).toBe('ready')
+    expect(await claims()).toBe(1)
+  })
+
+  it('a reference write behind a removal waits for it and is refused once the binding is parked', async () => {
+    const h = await harness()
+    await h.seam.bindingService.ensureBound(DEFAULT_ORG_ID, REPO)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: h.daemonId, name: 'late' })
+    // A removal holds the claim exclusively, about to park it.
+    let release: () => void = () => undefined
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const remover = prisma.$transaction(
+      async (tx) => {
+        await tx.$queryRaw`SELECT "id" FROM "code_host_repository_claim" WHERE "provider" = 'gitea' AND "externalId" = ${REPO.toString()}::bigint FOR UPDATE`
+        await held
+        await tx.codeHostRepositoryClaim.updateMany({
+          where: { provider: 'gitea', externalId: REPO },
+          data: { state: 'cleanup_pending' }
+        })
+      },
+      { timeout: 15_000 }
+    )
+    await sleep(200)
+    const grant = new PgAgentRepoAuthorizationRepo(prisma).create({
+      agentId: AgentId(agentId),
+      provider: 'gitea',
+      repoId: REPO,
+      repoFullName: 'example-org/example-repo',
+      access: 'read'
+    })
+    // The grant waits on the exclusive lock, then re-reads a parked binding and refuses.
+    expect(await raced(grant)).toBe('blocked')
+    release()
+    await remover
+    await expect(grant).rejects.toBeInstanceOf(GiteaBindingUnavailable)
+    expect(await prisma.agentRepoAuthorization.count({ where: { provider: 'gitea', repoId: REPO } })).toBe(0)
+  })
+
+  it('the trigger, workspace and grant writes all refuse a parked binding', async () => {
+    const h = await harness()
+    const { binding } = await h.seam.bindingService.ensureBound(DEFAULT_ORG_ID, REPO)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: h.daemonId, name: 'parked-out' })
+    expect(await h.seam.bindings.beginCleanup(DEFAULT_ORG_ID, binding.id, REPO, new Date(clock.now()))).toBe('parked')
+    await expect(
+      new PgHookRepo(prisma).upsert({
+        hookId: HookId(randomUUID()),
+        orgId: OrgId(DEFAULT_ORG_ID),
+        agentId: AgentId(agentId),
+        kind: 'gitea',
+        name: 'late',
+        sessionMode: 'perThread',
+        axisBaseUrl: BASE,
+        repoId: REPO,
+        repoFullName: 'example-org/example-repo',
+        family: 'merge_request',
+        events: ['merge_request:*']
+      })
+    ).rejects.toBeInstanceOf(GiteaBindingUnavailable)
+    const agents = new PgAgentRepo(prisma)
+    const agent = (await agents.get(OrgId(DEFAULT_ORG_ID), AgentId(agentId)))!
+    await expect(
+      agents.setWorkspace(
+        OrgId(DEFAULT_ORG_ID),
+        agent.id,
+        agent.lastModifiedAt,
+        'scratch',
+        {
+          mode: 'git',
+          isolation: 'shared',
+          gitRepo: `${BASE}/example-org/example-repo.git`,
+          credential: { provider: 'gitea', access: 'write' }
+        },
+        REPO
+      )
+    ).rejects.toBeInstanceOf(GiteaBindingUnavailable)
+    await expect(
+      new PgAgentRepoAuthorizationRepo(prisma).create({
+        agentId: AgentId(agentId),
+        provider: 'gitea',
+        repoId: REPO,
+        repoFullName: 'example-org/example-repo',
+        access: 'read'
+      })
+    ).rejects.toBeInstanceOf(GiteaBindingUnavailable)
+    expect(await prisma.hookDef.count({ where: { orgId: DEFAULT_ORG_ID, kind: 'gitea', repoId: REPO } })).toBe(0)
+    // The route answers the same refusal as a 409, not a 500.
+    const viaRoute = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${agentId}/repos`,
+      payload: { provider: 'gitea', repoId: REPO.toString(), access: 'read' }
+    })
+    expect(viaRoute.statusCode).toBe(409)
   })
 })

--- a/packages/control-plane/test/integration/gitea-implicit-binding.test.ts
+++ b/packages/control-plane/test/integration/gitea-implicit-binding.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Binding on first use (gitea-integration.md §6): a trigger, an agent workspace or an
+ * additional-repository grant binds the repository it names as the same write, several agents share
+ * one binding and one webhook whose subscription is the union of their triggers, the binding is never
+ * unbound on last use, and the operator's Remove is refused while anything still references it.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { buildGiteaSeam, type GiteaSeam } from '../fakes/gitea-seam.js'
+import { makeSecretCipher } from '../../src/secrets/cipher.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
+import type { ControlSender } from '../../src/orchestrator/outbound.js'
+import type { DaemonLiveness } from '../../src/ports.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const REPO = 556677n
+const SECOND = 556678n
+const NO_ADMIN = 556690n
+const BASE = 'https://gitea.example.test'
+const RELAY_URL = 'https://relay.example.test'
+const MANAGED_URL = `${RELAY_URL}/webhooks/gitea`
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
+const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
+const CAPS = {
+  platforms: [],
+  runtimes: ['claude'],
+  acp: true,
+  features: ['gitea-v1', 'workspace-git-v1', 'workspace-edit-v2']
+}
+
+let running: HttpApp | undefined
+let seam: GiteaSeam | undefined
+afterEach(async () => {
+  // Own the routes' fire-and-forget convergence: a run outliving its test writes into the next one's swept database.
+  await seam?.settled()
+  await running?.close()
+  running = undefined
+  seam = undefined
+})
+
+/** The one online daemon: the workspace-replace route needs it READY and able to detach/activate; deletes tell it to drop the agent. */
+class ControlSpy {
+  async agentDetach(): Promise<{ ok: true }> {
+    return { ok: true }
+  }
+  async agentActivate(): Promise<{ ok: true }> {
+    return { ok: true }
+  }
+  async agentUpsert(): Promise<void> {}
+  async agentRemove(): Promise<void> {}
+}
+
+async function harness() {
+  const built = buildGiteaSeam(prisma, cipher, clock, {
+    fake: {
+      baseUrl: BASE,
+      repositories: [
+        { id: Number(REPO), full_name: 'example-org/example-repo', admin: true },
+        { id: Number(SECOND), full_name: 'example-org/second-repo', admin: true },
+        { id: Number(NO_ADMIN), full_name: 'example-org/public-unbound', admin: false, private: false }
+      ]
+    }
+  })
+  seam = built
+  const daemonId = randomUUID()
+  const liveness: DaemonLiveness = {
+    get: (id) => (id === daemonId ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
+  }
+  running = buildHttpApp(
+    prisma,
+    { PUBLIC_RELAY_URL: RELAY_URL },
+    liveness,
+    new ControlSpy() as unknown as ControlSender,
+    { gitea: built.httpDeps }
+  )
+  built.broadcast.current = (hook) => running!.deps.hooks.broadcast(hook)
+  // A live relay row so the hook ingress gate passes.
+  await prisma.relay.create({
+    data: {
+      id: randomUUID(),
+      name: `relay-${randomUUID().slice(0, 8)}`,
+      daemonUrl: 'wss://relay-0',
+      lastSeenAt: new Date()
+    }
+  })
+  const connection = await built.connections.connect(DEFAULT_ORG_ID, built.fake.token)
+  // The connect step's own scope probes (§4.1) are not what these suites count.
+  built.fake.requests.length = 0
+  await seedDaemon(prisma, daemonId, { capabilities: CAPS })
+  // NOTHING is bound yet: the writes under test bind.
+  const withWorkspace = async (name: string, repoId = REPO): Promise<string> => {
+    const id = randomUUID()
+    await seedAgent(prisma, id, {
+      daemonId,
+      name,
+      giteaRepoId: repoId,
+      gitRepo: `${BASE}/example-org/example-repo.git`
+    })
+    return id
+  }
+  return { a: running, seam: built, fake: built.fake, connection, daemonId, withWorkspace }
+}
+type Harness = Awaited<ReturnType<typeof harness>>
+
+const trigger = (agentId: string, over: Record<string, unknown> = {}) => ({
+  agentId,
+  kind: 'gitea',
+  name: 'example-org/example-repo',
+  repoId: REPO.toString(),
+  family: 'merge_request',
+  events: ['merge_request:*'],
+  commentFamilies: ['merge_request'],
+  ...over
+})
+const ISSUES_TRIGGER = { family: 'issues', events: ['issues:*'], commentFamilies: ['issues'] }
+const PR_EVENTS = ['pull_request', 'pull_request_sync', 'pull_request_review_request', 'pull_request_comment']
+
+/** Webhook creates the fake saw — the count that must stay at one however many agents subscribe. */
+const webhookCreates = (h: Harness) =>
+  h.fake.requests.filter(
+    (r) => r.method === 'POST' && (r.body as { config?: { url?: string } } | undefined)?.config?.url === MANAGED_URL
+  )
+const managedHooks = (h: Harness) => [...h.fake.hooks.values()].filter((hook) => hook.url === MANAGED_URL)
+const bindings = () => prisma.giteaRepositoryBinding.findMany({ where: { orgId: DEFAULT_ORG_ID } })
+const claims = () => prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitea' } })
+
+/** A barrier over the first-use read: released once `writers` have reached it, failing loudly if they never do. */
+function barrier(h: Harness, repoId: bigint, writers = 2): { arrivals: string[] } {
+  const arrivals: string[] = []
+  let release: () => void = () => undefined
+  const open = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const opened = Promise.race([
+    open,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('the barrier never saw every writer')), 5_000))
+  ])
+  h.fake.opts.gate = async (method, route) => {
+    if (method !== 'GET' || route !== `/repositories/${repoId}`) return
+    arrivals.push(route)
+    if (arrivals.length === writers) release()
+    await opened
+  }
+  return { arrivals }
+}
+
+describe('gitea triggers bind on first use (§6)', () => {
+  it('binds the repository and installs its webhook as the same write; a refused trigger binds nothing', async () => {
+    const h = await harness()
+    // §8.3 still holds: a stranger's trigger is refused BEFORE anything is bound.
+    const strangerId = randomUUID()
+    await seedAgent(prisma, strangerId, { daemonId: h.daemonId, name: 'stranger' })
+    const refused = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(strangerId) })
+    expect(refused.statusCode).toBe(409)
+    expect((refused.json() as { message: string }).message).toContain('not authorized for this agent')
+    expect(await bindings()).toHaveLength(0)
+    expect(await claims()).toBe(0)
+    expect(h.fake.hooks.size).toBe(0)
+
+    const agentId = await h.withWorkspace('builder')
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(agentId) })
+    expect(created.statusCode).toBe(200)
+    expect(created.json()).toMatchObject({
+      kind: 'gitea',
+      repoId: REPO.toString(),
+      repoFullName: 'example-org/example-repo'
+    })
+    await h.seam.settled()
+    const rows = await bindings()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ repoId: REPO, repoPath: 'example-org/example-repo', state: 'ready' })
+    expect(await claims()).toBe(1)
+    // The catalog row the workspace and Git credentials read from carries the provider's clone URL.
+    const catalog = await prisma.codeHostRepository.findFirstOrThrow({
+      where: { provider: 'gitea', externalId: REPO }
+    })
+    expect(catalog.cloneUrl).toBe(`${BASE}/example-org/example-repo.git`)
+    const hooks = managedHooks(h)
+    expect(hooks).toHaveLength(1)
+    for (const event of PR_EVENTS) expect(hooks[0]!.events).toContain(event)
+    expect(hooks[0]!.events).not.toContain('issues')
+    // The card reads the same binding, webhook installed.
+    const listed = await h.a.app.inject({ method: 'GET', url: `${ORG}/gitea/repositories` })
+    expect(listed.json()).toMatchObject({
+      bindings: [{ repoId: REPO.toString(), state: 'ready', webhookState: 'installed' }]
+    })
+  })
+
+  it('a repository the bot does not administer is refused and stays unbound', async () => {
+    const h = await harness()
+    const agentId = await h.withWorkspace('builder', NO_ADMIN)
+    const refused = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: trigger(agentId, { repoId: NO_ADMIN.toString(), name: 'example-org/public-unbound' })
+    })
+    expect(refused.statusCode).toBe(403)
+    expect((refused.json() as { message: string }).message).toContain('must hold admin on example-org/public-unbound')
+    expect(await bindings()).toHaveLength(0)
+    expect(await claims()).toBe(0)
+  })
+})
+
+describe('several agents on one repository (§6, §7)', () => {
+  it('share one binding and one webhook: the union grows by PATCH, narrows as triggers and agents go, and the last reference leaving never unbinds', async () => {
+    const h = await harness()
+    const first = await h.withWorkspace('first')
+    const second = await h.withWorkspace('second')
+
+    // (1) The first trigger binds and installs; the second reuses the binding and installs nothing.
+    const a = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(first) })
+    expect(a.statusCode).toBe(200)
+    await h.seam.settled()
+    expect(webhookCreates(h)).toHaveLength(1)
+    const b = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(second) })
+    expect(b.statusCode).toBe(200)
+    await h.seam.settled()
+    expect(await bindings()).toHaveLength(1)
+    expect(await claims()).toBe(1)
+    expect(managedHooks(h)).toHaveLength(1)
+    expect(webhookCreates(h)).toHaveLength(1)
+
+    // (2) A new family on the second agent widens the union by PATCHing the one webhook, never by creating another.
+    h.fake.requests.length = 0
+    const issues = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: trigger(second, ISSUES_TRIGGER)
+    })
+    expect(issues.statusCode).toBe(200)
+    await h.seam.settled()
+    expect(managedHooks(h)).toHaveLength(1)
+    expect(webhookCreates(h)).toHaveLength(0)
+    expect(h.fake.requests.some((r) => r.method === 'PATCH' && /\/hooks\/\d+$/.test(r.url))).toBe(true)
+    const widened = managedHooks(h)[0]!
+    expect(widened.events).toContain('issues')
+    for (const event of PR_EVENTS) expect(widened.events).toContain(event)
+
+    // (3a) Removing the second agent's issues trigger narrows the union; the binding and webhook stay for the others.
+    const issuesId = (issues.json() as { id: string }).id
+    expect((await h.a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${issuesId}` })).statusCode).toBe(204)
+    await h.seam.settled()
+    expect(await bindings()).toHaveLength(1)
+    expect(managedHooks(h)).toHaveLength(1)
+    expect(managedHooks(h)[0]!.events).not.toContain('issues')
+    for (const event of PR_EVENTS) expect(managedHooks(h)[0]!.events).toContain(event)
+
+    // (3b) The same narrowing when the agent itself goes: its triggers leave with it, the first agent's stays.
+    const again = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: trigger(second, ISSUES_TRIGGER)
+    })
+    expect(again.statusCode).toBe(200)
+    await h.seam.settled()
+    expect(managedHooks(h)[0]!.events).toContain('issues')
+    expect((await h.a.app.inject({ method: 'DELETE', url: `${ORG}/agents/${second}` })).statusCode).toBe(204)
+    await h.seam.settled()
+    expect(await bindings()).toHaveLength(1)
+    expect(managedHooks(h)).toHaveLength(1)
+    expect(managedHooks(h)[0]!.events).not.toContain('issues')
+    for (const event of PR_EVENTS) expect(managedHooks(h)[0]!.events).toContain(event)
+
+    // (4) The last referencing trigger leaving does not unbind: the binding and its claim stay for the operator, and
+    // the webhook follows §7's inverse — no enabled trigger, no ingress — until the card's Remove releases the claim.
+    const firstHookId = (a.json() as { id: string }).id
+    expect((await h.a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${firstHookId}` })).statusCode).toBe(204)
+    await h.seam.settled()
+    const [row] = await bindings()
+    expect(row).toMatchObject({ repoId: REPO, state: 'ready' })
+    expect(await claims()).toBe(1)
+    expect(managedHooks(h)).toHaveLength(0)
+    const listed = await h.a.app.inject({ method: 'GET', url: `${ORG}/gitea/repositories` })
+    expect(listed.json()).toMatchObject({ bindings: [{ id: row!.id, webhookState: 'not_needed' }] })
+    // Still the first agent's workspace: the operator's Remove is refused until that reference is gone too.
+    const held = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/gitea/repositories/${row!.id}` })
+    expect(held.statusCode).toBe(409)
+    expect((held.json() as { message: string }).message).toContain('the workspace of agent first')
+    expect((await h.a.app.inject({ method: 'DELETE', url: `${ORG}/agents/${first}` })).statusCode).toBe(204)
+    await h.seam.settled()
+    expect(await bindings()).toHaveLength(1)
+    const removed = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/gitea/repositories/${row!.id}` })
+    expect(removed.statusCode).toBe(200)
+    expect(removed.json()).toEqual({ removed: true })
+    expect(await bindings()).toHaveLength(0)
+    expect(await claims()).toBe(0)
+  })
+
+  it('two first uses racing resolve on the claim: one binding, one webhook, the loser adopts the winner', async () => {
+    const h = await harness()
+    const first = await h.withWorkspace('first')
+    const second = await h.withWorkspace('second')
+    // The barrier holds every first-use read of the repository until BOTH writers have passed their
+    // "is it bound yet?" check, so the critical section is entered by two writers at once and only
+    // the claim's uniqueness can tell them apart — not the order the requests happened to arrive in.
+    const { arrivals } = barrier(h, REPO)
+    const [a, b] = await Promise.all([
+      h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(first) }),
+      h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(second, ISSUES_TRIGGER) })
+    ])
+    expect(a.statusCode).toBe(200)
+    expect(b.statusCode).toBe(200)
+    // Both were inside the window before either wrote.
+    expect(arrivals.length).toBeGreaterThanOrEqual(2)
+    await h.seam.settled()
+    const rows = await bindings()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.state).toBe('ready')
+    expect(await claims()).toBe(1)
+    expect(managedHooks(h)).toHaveLength(1)
+    expect(webhookCreates(h)).toHaveLength(1)
+    const hook = managedHooks(h)[0]!
+    expect(hook.events).toContain('issues')
+    for (const event of PR_EVENTS) expect(hook.events).toContain(event)
+    expect(await prisma.hookDef.count({ where: { orgId: DEFAULT_ORG_ID, kind: 'gitea', repoId: REPO } })).toBe(2)
+
+    // The same section at the service: exactly one writer creates, both read the same row.
+    barrier(h, SECOND)
+    const outcomes = await Promise.all([
+      h.seam.bindingService.ensureBound(DEFAULT_ORG_ID, SECOND),
+      h.seam.bindingService.ensureBound(DEFAULT_ORG_ID, SECOND)
+    ])
+    expect(outcomes.filter((outcome) => outcome.created)).toHaveLength(1)
+    expect(new Set(outcomes.map((outcome) => outcome.binding.id)).size).toBe(1)
+    expect(await prisma.giteaRepositoryBinding.count({ where: { repoId: SECOND } })).toBe(1)
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitea', externalId: SECOND } })).toBe(1)
+  })
+})
+
+describe('gitea workspaces and grants bind on first use (§6)', () => {
+  it('creating an agent on an unbound repository the bot administers binds it; the resolve preview only says so', async () => {
+    const h = await harness()
+    const address = `${BASE}/example-org/second-repo`
+    const preview = await h.a.app.inject({
+      method: 'GET',
+      url: `${ORG}/git/resolve?gitRepo=${encodeURIComponent(address)}`
+    })
+    expect(preview.statusCode).toBe(200)
+    expect(preview.json()).toMatchObject({ provider: 'gitea', access: 'write', defaultBranch: 'main' })
+    // A preview is a read: nothing was bound.
+    expect(await bindings()).toHaveLength(0)
+
+    const created = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: {
+        name: 'gitea-writer',
+        runtime: 'claude',
+        workspace: { mode: 'git', gitRepo: address, access: 'write' }
+      }
+    })
+    expect(created.statusCode).toBe(201)
+    const dto = created.json() as { workspace: { gitRepo: string; credential?: unknown } }
+    expect(dto.workspace.credential).toEqual({ provider: 'gitea', access: 'write', repoId: SECOND.toString() })
+    // The clone URL is the catalog row's — the provider's own answer, written by the bind.
+    expect(dto.workspace.gitRepo).toBe(`${BASE}/example-org/second-repo.git`)
+    await h.seam.settled()
+    const rows = await bindings()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ repoId: SECOND, repoPath: 'example-org/second-repo', state: 'ready' })
+    // No trigger wants ingress yet, so the bind installed no webhook.
+    expect(h.fake.hooks.size).toBe(0)
+  })
+
+  it('replacing a workspace binds the repository it moves to', async () => {
+    const h = await harness()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: h.daemonId, name: 'mover' })
+    const replaced = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/workspace`,
+      payload: { mode: 'git', gitRepo: `${BASE}/example-org/example-repo`, access: 'write' }
+    })
+    expect(replaced.statusCode).toBe(200)
+    expect(replaced.json()).toMatchObject({
+      workspace: { mode: 'git', credential: { provider: 'gitea', access: 'write', repoId: REPO.toString() } }
+    })
+    await h.seam.settled()
+    const rows = await bindings()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ repoId: REPO, state: 'ready' })
+  })
+
+  it('an additional-repository grant binds the repository it names', async () => {
+    const h = await harness()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: h.daemonId, name: 'granted' })
+    const granted = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${agentId}/repos`,
+      payload: { provider: 'gitea', repoId: SECOND.toString(), access: 'comment' }
+    })
+    expect(granted.statusCode).toBe(200)
+    expect(granted.json()).toMatchObject({
+      provider: 'gitea',
+      repoId: SECOND.toString(),
+      repoFullName: 'example-org/second-repo'
+    })
+    await h.seam.settled()
+    expect((await bindings())[0]).toMatchObject({ repoId: SECOND, state: 'ready' })
+    // Granting it twice is still the grant's own refusal, not a second binding.
+    const twice = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${agentId}/repos`,
+      payload: { provider: 'gitea', repoId: SECOND.toString(), access: 'comment' }
+    })
+    expect(twice.statusCode).toBe(409)
+    expect((twice.json() as { message: string }).message).toContain('already authorized')
+    expect(await bindings()).toHaveLength(1)
+  })
+
+  it('the card’s own Add still binds ahead of use and refuses a second Add', async () => {
+    const h = await harness()
+    const added = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitea/repositories`,
+      payload: { repoId: SECOND.toString() }
+    })
+    expect(added.statusCode).toBe(200)
+    expect(added.json()).toMatchObject({ repoId: SECOND.toString(), state: 'ready', webhookState: 'not_needed' })
+    const again = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitea/repositories`,
+      payload: { repoId: SECOND.toString() }
+    })
+    expect(again.statusCode).toBe(409)
+    expect((again.json() as { message: string }).message).toContain('already bound')
+  })
+})
+
+describe('removing a referenced binding (§6)', () => {
+  it('is refused with 409 naming the workspace, the grant and the trigger, and succeeds once they are gone', async () => {
+    const h = await harness()
+    const owner = await h.withWorkspace('owner')
+    const hook = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: trigger(owner) })
+    expect(hook.statusCode).toBe(200)
+    const reader = randomUUID()
+    await seedAgent(prisma, reader, { daemonId: h.daemonId, name: 'reader' })
+    const grant = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${reader}/repos`,
+      payload: { provider: 'gitea', repoId: REPO.toString(), access: 'read' }
+    })
+    expect(grant.statusCode).toBe(200)
+    await h.seam.settled()
+    const [row] = await bindings()
+
+    const refused = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/gitea/repositories/${row!.id}` })
+    expect(refused.statusCode).toBe(409)
+    const body = refused.json() as { message: string; code: string }
+    expect(body.code).toBe('repository_in_use')
+    expect(body.message).toContain('example-org/example-repo is still in use')
+    expect(body.message).toContain('the workspace of agent owner')
+    expect(body.message).toContain('an additional repository of agent reader')
+    expect(body.message).toContain('trigger “example-org/example-repo” of agent owner')
+    // Nothing was touched: the webhook and the claim stand.
+    expect(managedHooks(h)).toHaveLength(1)
+    expect(await claims()).toBe(1)
+
+    const grantId = (grant.json() as { id: string }).id
+    const hookId = (hook.json() as { id: string }).id
+    expect(
+      (await h.a.app.inject({ method: 'DELETE', url: `${ORG}/agents/${reader}/repos/${grantId}` })).statusCode
+    ).toBe(204)
+    expect((await h.a.app.inject({ method: 'DELETE', url: `${ORG}/hooks/${hookId}` })).statusCode).toBe(204)
+    const ownerGone = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/agents/${owner}` })
+    expect(ownerGone.statusCode, ownerGone.body).toBe(204)
+    await h.seam.settled()
+    const removed = await h.a.app.inject({ method: 'DELETE', url: `${ORG}/gitea/repositories/${row!.id}` })
+    expect(removed.statusCode).toBe(200)
+    expect(removed.json()).toEqual({ removed: true })
+    expect(await bindings()).toHaveLength(0)
+    expect(await claims()).toBe(0)
+    expect(managedHooks(h)).toHaveLength(0)
+  })
+})

--- a/packages/control-plane/test/integration/gitea-implicit-binding.test.ts
+++ b/packages/control-plane/test/integration/gitea-implicit-binding.test.ts
@@ -601,21 +601,28 @@ describe('the reference fence (§6)', () => {
     ).rejects.toBeInstanceOf(GiteaBindingUnavailable)
     const agents = new PgAgentRepo(prisma)
     const agent = (await agents.get(OrgId(DEFAULT_ORG_ID), AgentId(agentId)))!
+    const giteaWorkspace = {
+      mode: 'git' as const,
+      isolation: 'shared' as const,
+      gitRepo: `${BASE}/example-org/example-repo.git`,
+      credential: { provider: 'gitea' as const, access: 'write' as const }
+    }
     await expect(
-      agents.setWorkspace(
+      agents.setWorkspace(OrgId(DEFAULT_ORG_ID), agent.id, agent.lastModifiedAt, 'scratch', giteaWorkspace, REPO)
+    ).rejects.toBeInstanceOf(GiteaBindingUnavailable)
+    // A rollback onto the old gitea workspace is a reference too: it fails closed rather than reviving the binding's authority.
+    await expect(
+      agents.restoreWorkspace(
         OrgId(DEFAULT_ORG_ID),
         agent.id,
         agent.lastModifiedAt,
-        'scratch',
-        {
-          mode: 'git',
-          isolation: 'shared',
-          gitRepo: `${BASE}/example-org/example-repo.git`,
-          credential: { provider: 'gitea', access: 'write' }
-        },
+        agent.workspace,
+        agent.workspaceRepoId,
+        giteaWorkspace,
         REPO
       )
     ).rejects.toBeInstanceOf(GiteaBindingUnavailable)
+    expect((await agents.get(OrgId(DEFAULT_ORG_ID), AgentId(agentId)))!.workspace.mode).toBe('scratch')
     await expect(
       new PgAgentRepoAuthorizationRepo(prisma).create({
         agentId: AgentId(agentId),

--- a/packages/control-plane/test/integration/gitea-provision.test.ts
+++ b/packages/control-plane/test/integration/gitea-provision.test.ts
@@ -531,7 +531,7 @@ describe('GiteaProvisioner (§6) — unbind', () => {
   it('parks the binding with its claim in ONE transaction before any provider call', async () => {
     const h = await harness()
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
-    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, REPO, new Date(clock.now()))).toBe(true)
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, REPO, new Date(clock.now()))).toBe('parked')
     expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('cleanup_pending')
     const claim = await prisma.codeHostRepositoryClaim.findUniqueOrThrow({
       where: { provider_externalId: { provider: 'gitea', externalId: REPO } }
@@ -540,7 +540,7 @@ describe('GiteaProvisioner (§6) — unbind', () => {
     // The same flip without an attached claim (an already-tombstoned one).
     await prisma.codeHostRepositoryClaim.update({ where: { id: claim.id }, data: { bindingRef: null } })
     await h.bindings.update(DEFAULT_ORG_ID, h.binding.id, { state: 'ready' })
-    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, REPO, new Date(clock.now()))).toBe(true)
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, REPO, new Date(clock.now()))).toBe('parked')
     expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('cleanup_pending')
     // A live lease refuses, and the binding is left exactly as it was.
     await h.bindings.update(DEFAULT_ORG_ID, h.binding.id, { state: 'ready' })
@@ -552,7 +552,7 @@ describe('GiteaProvisioner (§6) — unbind', () => {
     expect(
       await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, REPO, 'peer', until, new Date())
     ).toBe(true)
-    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, REPO, new Date(clock.now()))).toBe(false)
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, REPO, new Date(clock.now()))).toBe('leased')
     expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('ready')
   })
 

--- a/packages/control-plane/test/integration/gitea-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitea-workspace.route.test.ts
@@ -51,7 +51,7 @@ async function harness() {
   })
   seam = built
   running = buildHttpApp(prisma, { PUBLIC_RELAY_URL: 'https://relay.example.test' }, undefined, undefined, {
-    gitea: { connections: built.connections, provisioner: built.provisioner, api: built.api }
+    gitea: built.httpDeps
   })
   built.broadcast.current = (hook) => running!.deps.hooks.broadcast(hook)
   const connection = await built.connections.connect(DEFAULT_ORG_ID, built.fake.token)
@@ -142,7 +142,9 @@ describe('gitea workspaces (§5) — the binding vouches', () => {
       }
     })
     expect(write.statusCode).toBe(409)
-    expect((write.json() as { message: string }).message).toContain('managed repository')
+    expect((write.json() as { message: string }).message).toContain('a repository the connected bot administers')
+    // Nothing the bot does not administer was bound along the way (§6).
+    expect(await prisma.giteaRepositoryBinding.count({ where: { repoId: 556690n } })).toBe(0)
   })
 
   it('refuses a workspace on a binding mid-removal', async () => {
@@ -201,12 +203,14 @@ describe('gitea additional-repository grants (§5)', () => {
       payload: { provider: 'gitea', repoId: REPO.toString() }
     })
     expect(workspace.statusCode).toBe(409)
+    // A repository the bot does not administer cannot be bound on first use (§4.4, §6).
     const unbound = await h.a.app.inject({
       method: 'POST',
       url: `${ORG}/agents/${agentId}/repos`,
       payload: { provider: 'gitea', repoId: '556690' }
     })
-    expect(unbound.statusCode).toBe(409)
+    expect(unbound.statusCode).toBe(403)
+    expect((unbound.json() as { message: string }).message).toContain('must hold admin')
   })
 })
 

--- a/packages/web/src/components/console/GiteaCard.tsx
+++ b/packages/web/src/components/console/GiteaCard.tsx
@@ -1,10 +1,11 @@
 // No 'use client' here: rendered only inside a client boundary (IntegrationsView).
 
-// The organization's Gitea connection and the repositories it manages
+// The organization's Gitea connection and the repositories in use under it
 // (gitea-integration.md §4, §6, §12). Unlike the GitLab card the CONNECTION is the only
-// identity — one bot user serves every agent — so the rows under it are repositories, and
-// they are added here: binding one needs the bot to hold Admin on it, which is a fact about
-// the bot rather than about whoever is picking.
+// identity — one bot user serves every agent — so the rows under it are repositories. They
+// arrive by first use: a trigger, a workspace or a grant that names one the bot administers
+// binds it, and "Add repository" here binds one ahead of that. Each row keeps Repair, rotate
+// and Remove; Remove is refused, naming the reference, while anything still points at it.
 // Deployment-config opt-in: with no Gitea instance configured these routes 404 and the card says so.
 // Connections and repositories are org-level infrastructure — visible to all, writable by non-viewers.
 
@@ -107,7 +108,7 @@ function ConnectFields({
           <Icon name="users" size={13} className="mt-[2px] flex-none" />
           <span>
             Use a dedicated bot user with <span className="text-(--text-secondary)">Admin</span>&#32;on each repository
-            you add. Everything an agent writes is attributed to it, and an agent can do anything the bot can.
+            agents will use. Everything an agent writes is attributed to it, and an agent can do anything the bot can.
           </span>
         </span>
       </div>
@@ -576,7 +577,8 @@ export default function GiteaCard({ canWrite }: { canWrite: boolean }) {
 
       {enabled === true && connection !== null && bindings.length === 0 && (
         <div className="px-4 py-5 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-          No repositories yet. Add one here, then point a trigger or an agent workspace at it.
+          No repositories in use yet. Point a trigger or an agent workspace at one the bot administers and it appears
+          here — or add one ahead of time.
         </div>
       )}
 

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -380,21 +380,19 @@ export function GiteaRepositoryField(props: RepositoryPickerProps) {
 }
 
 /** One pickable Gitea repository — already added, or one the organization's bot administers.
- *  Picking an unadded one installs its managed webhook, which is why it says so before the
- *  click. Transient states are listed and disabled, not hidden: a repository that is mid-setup
- *  reads as on its way rather than mysteriously absent. */
+ *  An unadded one is added by the save that follows (gitea-integration.md §6), which is why it
+ *  says so before the click. Transient states are listed and disabled, not hidden: a repository
+ *  that is mid-setup reads as on its way rather than mysteriously absent. */
 export function GiteaRepositoryOption({
   choice,
   selected = false,
-  busy = false,
   onSelect
 }: {
   choice: GiteaRepositoryChoice
   selected?: boolean
-  busy?: boolean
   onSelect: () => void
 }) {
-  const selectable = giteaChoiceSelectable(choice) && !busy
+  const selectable = giteaChoiceSelectable(choice)
   const state = choice.binding ? GITEA_REPOSITORY_STATE[choice.binding.state] : null
   const branch = choice.defaultBranch ? `default branch ${choice.defaultBranch}` : 'no default branch reported'
   return (
@@ -421,7 +419,7 @@ export function GiteaRepositoryOption({
           {choice.repoPath}
         </span>
         <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-          {busy ? 'Installing the repository webhook…' : choice.binding ? branch : `${branch} · sets up on pick`}
+          {choice.binding ? branch : `${branch} · added on save`}
         </span>
       </span>
       {state && state.label !== 'ready' && <span className={`badge flex-none ${state.badge}`}>{state.label}</span>}
@@ -490,7 +488,7 @@ export function GiteaNoRepositoriesNotice({
       ) : (
         <span>
           The connected Gitea bot administers no repository. Give it Admin on one — as a collaborator or through a team
-          — before it can be set up here.
+          — before it can be picked here.
         </span>
       )}
     </div>

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -205,7 +205,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [glAccessOpen, setGlAccessOpen] = useState(false)
   const [glPush, setGlPush] = useState(true)
   // Gitea path: repositories picked by their numeric id. One this organization has not added
-  // yet is set up as part of picking it (gitea-integration.md §6); there is no anonymous arm —
+  // yet is bound by the create itself (gitea-integration.md §6); there is no anonymous arm —
   // a public Gitea repository is the Git URL tile's business.
   const [gtRepo, setGtRepo] = useState('')
   const [gtOpen, setGtOpen] = useState(false)
@@ -445,9 +445,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const gtPicked = gt.choices.find((choice) => choice.repoId === gtRepo)
   const gtMatches = matchGiteaRepositories(gt.choices, gtQ)
 
-  // Picking an unadded repository installs its webhook first; a failed setup picks nothing.
-  const pickGtRepository = async (choice: GiteaRepositoryChoice) => {
-    if (!choice.binding && !(await gt.provision(choice.repoId))) return
+  // An unadded repository is bound by the create itself, so the pick is only a pick.
+  const pickGtRepository = (choice: GiteaRepositoryChoice) => {
     setGtRepo(choice.repoId)
     setGtOpen(false)
     setBranch(choice.defaultBranch ?? '')
@@ -1395,15 +1394,13 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                       }}
                       onClose={() => setGtOpen(false)}
                       onQueryChange={setGtQ}
-                      error={gt.provisionError ? `Couldn’t set up that repository — ${gt.provisionError}` : undefined}
                     >
                       {gtMatches.map((choice) => (
                         <GiteaRepositoryOption
                           key={choice.repoId}
                           choice={choice}
                           selected={gtRepo === choice.repoId}
-                          busy={gt.provisioning === choice.repoId}
-                          onSelect={() => void pickGtRepository(choice)}
+                          onSelect={() => pickGtRepository(choice)}
                         />
                       ))}
                       {gtMatches.length === 0 && (

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.gitea.test.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.gitea.test.tsx
@@ -179,7 +179,7 @@ describe('AddAgentRepoModal, Gitea repositories', () => {
     expect(created).toHaveLength(1)
   })
 
-  it('sets a repository up before the selection lands, then authorizes it', async () => {
+  it('offers a repository that is not added yet and authorizes it — the grant binds it', async () => {
     mocks.fetchGiteaRepositories.mockResolvedValue([])
     connected([
       {
@@ -190,18 +190,18 @@ describe('AddAgentRepoModal, Gitea repositories', () => {
         private: false
       }
     ])
-    mocks.createGiteaRepository.mockResolvedValue(binding({ repoId: '7712', repoPath: 'example-org/example-second' }))
     mocks.createAgentRepo.mockResolvedValue(grant({ repoId: '7712' }))
     await render()
     await act(async () => buttonsNamed('Gitea')[0]?.click())
     await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
-    expect(document.body.textContent).toContain('sets up on pick')
+    expect(document.body.textContent).toContain('added on save')
 
     const option = Array.from(document.querySelectorAll('button')).find((button) =>
       button.textContent?.includes('example-org/example-second')
     )
     await act(async () => option?.click())
-    expect(mocks.createGiteaRepository).toHaveBeenCalledWith({ repoId: '7712' })
+    // Binding on first use (§6): the grant itself binds the repository; the picker sets nothing up.
+    expect(mocks.createGiteaRepository).not.toHaveBeenCalled()
 
     await act(async () => buttonsNamed('Add')[0]?.click())
     expect(mocks.createAgentRepo).toHaveBeenCalledWith('agent-a', {
@@ -209,6 +209,7 @@ describe('AddAgentRepoModal, Gitea repositories', () => {
       repoId: '7712',
       access: 'read'
     })
+    expect(mocks.createGiteaRepository).not.toHaveBeenCalled()
   })
 
   it('says a repository is taken by the workspace or an existing grant instead of offering it', async () => {

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -6,8 +6,8 @@
 // installations, GitLab projects the connection administers, Gitea repositories
 // the organization's bot administers — plus an access choice, preflighted against
 // the per-user identity-assertion gate when the deployment has one. Picking a
-// project or repository that is not set up yet runs its provisioning saga inline
-// before the selection lands, exactly as the workspace and trigger pickers do.
+// GitLab project that is not set up yet runs its provisioning saga inline before
+// the selection lands; a Gitea repository is bound by the grant itself (§6).
 //
 // This renders its own scrim/modal overlay because Edit workspace can expose it
 // as a preserved-state subview while another editor (such as GitHub hook setup)
@@ -273,10 +273,8 @@ export default function AddAgentRepoModal({
     workspaceRepository === repoId ? 'workspace' : authorizedRepositories.has(repoId) ? 'authorized' : null
   const gtNoRepositories = gt.empty || !gt.enabled || !gt.connected
 
-  // Picking a repository that is not set up yet installs its webhook first; a failed setup
-  // selects nothing, so the footer stays inert (gitea-integration.md §6).
-  const selectRepository = async (choice: GiteaRepositoryChoice) => {
-    if (!choice.binding && !(await gt.provision(choice.repoId))) return
+  // A repository that is not added yet is bound by the grant itself (gitea-integration.md §6).
+  const selectRepository = (choice: GiteaRepositoryChoice) => {
     setGtPick(choice.repoId)
     setGtPickOpen(false)
     setErr(null)
@@ -348,7 +346,8 @@ export default function AddAgentRepoModal({
         input: { provider: 'gitlab', projectId: glPick, access }
       },
       gitea: {
-        ready: !!gtPick && gtTakenBy(gtPick) === null && gt.provisioning === null,
+        // Nothing to wait for: an unadded repository is bound by the grant itself (gitea-integration.md §6).
+        ready: !!gtPick && gtTakenBy(gtPick) === null,
         input: { provider: 'gitea', repoId: gtPick, access }
       }
     }
@@ -430,7 +429,6 @@ export default function AddAgentRepoModal({
               }}
               onClose={() => setGtPickOpen(false)}
               onQueryChange={setGtQ}
-              error={gt.provisionError ? `Couldn’t set up that repository — ${gt.provisionError}` : undefined}
             >
               {gtMatches.map((choice) => {
                 const taken = gtTakenBy(choice.repoId)
@@ -449,8 +447,7 @@ export default function AddAgentRepoModal({
                     key={choice.repoId}
                     choice={choice}
                     selected={gtPick === choice.repoId}
-                    busy={gt.provisioning === choice.repoId}
-                    onSelect={() => void selectRepository(choice)}
+                    onSelect={() => selectRepository(choice)}
                   />
                 )
               })}

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitea.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitea.test.tsx
@@ -375,9 +375,9 @@ describe('AddIntegrationModal, Gitea trigger', () => {
     expect(mocks.createGiteaHook).toHaveBeenCalledWith(expect.objectContaining({ family: 'issues' }))
   })
 
-  it('sets up a repository the organization has not added yet, then keys the hook on its id', async () => {
-    // The wizard is where a repository joins the organization (§6): picking an unadded one
-    // installs its webhook first, and the create that follows carries the numeric id.
+  it('offers a repository the organization has not added yet and keys the hook on its id — the create binds it', async () => {
+    // Binding on first use (§6): the wizard never sets a repository up itself; the hook create
+    // carries the numeric id and the Control Plane binds the repository as the same write.
     mocks.fetchGiteaRepositories.mockResolvedValue([])
     mocks.fetchGiteaConnectionRepositories.mockResolvedValue([
       {
@@ -388,17 +388,17 @@ describe('AddIntegrationModal, Gitea trigger', () => {
         private: true
       }
     ])
-    mocks.createGiteaRepository.mockResolvedValue(binding)
     await renderAgent({ id: 'agent-fresh-repo' })
 
     await act(async () => tileNamed('Gitea')?.click())
     expect(mocks.fetchGiteaConnectionRepositories).toHaveBeenCalledWith('conn-1')
     await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
-    expect(document.body.textContent).toContain('sets up on pick')
+    expect(document.body.textContent).toContain('added on save')
     await act(async () => clickText('example-org/example-repo')?.click())
-    expect(mocks.createGiteaRepository).toHaveBeenCalledWith({ repoId: '7711' })
+    expect(mocks.createGiteaRepository).not.toHaveBeenCalled()
 
     await act(async () => clickText('Connect')?.click())
     expect(mocks.createGiteaHook).toHaveBeenCalledWith(expect.objectContaining({ repoId: '7711' }))
+    expect(mocks.createGiteaRepository).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -618,7 +618,7 @@ export default function AddIntegrationModal({
   const [glReportingMode, setGlReportingMode] = useState<HookReportingMode>('check')
 
   // Gitea path: one hook per repository, picked here. A repository the organization has not
-  // added yet is set up as part of picking it (gitea-integration.md §6).
+  // added yet is bound by the create itself (gitea-integration.md §6).
   const [gtRepo, setGtRepo] = useState<string | null>(null)
   const [gtOpen, setGtOpen] = useState(false)
   const [gtQ, setGtQ] = useState('')
@@ -1111,10 +1111,8 @@ export default function AddIntegrationModal({
   const gtPicked = gt.choices.find((choice) => choice.repoId === gtRepo)
   const gtMatches = matchGiteaRepositories(gt.choices, gtQ)
 
-  // Picking an unadded repository installs its webhook first; the pick lands on the binding the
-  // saga produced, so a failed setup selects nothing.
-  const pickGtRepository = async (choice: GiteaRepositoryChoice) => {
-    if (!choice.binding && !(await gt.provision(choice.repoId))) return
+  // An unadded repository is bound by the create below, so the pick is only a pick.
+  const pickGtRepository = (choice: GiteaRepositoryChoice) => {
     setGtRepo(choice.repoId)
     setGtOpen(false)
     setErr(null)
@@ -2051,11 +2049,9 @@ export default function AddIntegrationModal({
                     onClose={() => setGtOpen(false)}
                     onQueryChange={setGtQ}
                     error={
-                      gt.provisionError
-                        ? `Couldn’t set up that repository — ${gt.provisionError}`
-                        : gtAlreadyWatched
-                          ? `This agent already watches ${gtPicked?.repoPath ?? 'this repository'}.`
-                          : undefined
+                      gtAlreadyWatched
+                        ? `This agent already watches ${gtPicked?.repoPath ?? 'this repository'}.`
+                        : undefined
                     }
                   >
                     {gtMatches.map((choice) => (
@@ -2063,8 +2059,7 @@ export default function AddIntegrationModal({
                         key={choice.repoId}
                         choice={choice}
                         selected={gtRepo === choice.repoId}
-                        busy={gt.provisioning === choice.repoId}
-                        onSelect={() => void pickGtRepository(choice)}
+                        onSelect={() => pickGtRepository(choice)}
                       />
                     ))}
                     {gtMatches.length === 0 && <div className="fnohit">No repositories match &ldquo;{gtQ}&rdquo;</div>}

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitea.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitea.test.tsx
@@ -193,7 +193,7 @@ describe('EditWorkspaceModal, Gitea workspace', () => {
     expect(mocks.fetchGiteaConnectionRepositories).not.toHaveBeenCalled()
   })
 
-  it('sets up a repository the organization has not added, then saves it', async () => {
+  it('offers a repository the organization has not added and saves it as its address — the save binds it', async () => {
     mocks.fetchGiteaRepositories.mockResolvedValue([])
     connected([
       {
@@ -204,30 +204,19 @@ describe('EditWorkspaceModal, Gitea workspace', () => {
         private: true
       }
     ])
-    let settle: (value: unknown) => void = () => undefined
-    mocks.createGiteaRepository.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          settle = resolve
-        })
-    )
     await render()
     await act(async () => buttonsNamed('Gitea')[0]?.click())
     expect(mocks.fetchGiteaConnectionRepositories).toHaveBeenCalledWith('conn-1')
 
     await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
-    expect(document.body.textContent).toContain('sets up on pick')
+    expect(document.body.textContent).toContain('added on save')
     const option = Array.from(document.querySelectorAll('button')).find((button) =>
       button.textContent?.includes('example-org/example-repo')
     )
     await act(async () => option?.click())
-    expect(mocks.createGiteaRepository).toHaveBeenCalledWith({ repoId: '7711' })
-    // The saga installs a webhook, which takes a moment — the picker says so instead of looking stuck.
-    expect(document.body.textContent).toContain('Installing the repository webhook')
+    // Binding on first use (§6): the workspace write binds the repository; the picker sets nothing up.
+    expect(mocks.createGiteaRepository).not.toHaveBeenCalled()
 
-    await act(async () => {
-      settle(binding({ repoId: '7711' }))
-    })
     await act(async () => buttonsNamed('Replace workspace')[0]?.click())
     expect(mocks.setAgentWorkspace).toHaveBeenCalledWith('agent-a', {
       mode: 'git',
@@ -236,5 +225,6 @@ describe('EditWorkspaceModal, Gitea workspace', () => {
       gitBranch: 'main',
       access: 'write'
     })
+    expect(mocks.createGiteaRepository).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -251,8 +251,8 @@ export default function EditWorkspaceModal({
   // still add — picking one of those sets it up here (§18.1).
   const gl = useGitlabProjects(repositoryEditor === null && mode === 'gitlab', glQ)
 
-  // The repositories this organization added, plus the ones the bot administers — picking one of
-  // those installs its webhook here (gitea-integration.md §6).
+  // The repositories this organization added, plus the ones the bot administers — saving one of
+  // those as the workspace binds it (gitea-integration.md §6).
   const gt = useGiteaRepositories(repositoryEditor === null && mode === 'gitea')
 
   const openGhInstall = async () => {
@@ -501,9 +501,8 @@ export default function EditWorkspaceModal({
     setErr(null)
   }
 
-  // Picking an unadded repository installs its webhook first; a failed setup picks nothing.
-  const selectRepository = async (choice: GiteaRepositoryChoice) => {
-    if (!choice.binding && !(await gt.provision(choice.repoId))) return
+  // An unadded repository is bound by the save itself, so the pick is only a pick.
+  const selectRepository = (choice: GiteaRepositoryChoice) => {
     setGtPick(choice.repoId)
     setGtPickOpen(false)
     setAccessOpen(false)
@@ -829,15 +828,13 @@ export default function EditWorkspaceModal({
                     }}
                     onClose={() => setGtPickOpen(false)}
                     onQueryChange={setGtQ}
-                    error={gt.provisionError ? `Couldn’t set up that repository — ${gt.provisionError}` : undefined}
                   >
                     {gtMatches.map((choice) => (
                       <GiteaRepositoryOption
                         key={choice.repoId}
                         choice={choice}
                         selected={gtPick === choice.repoId}
-                        busy={gt.provisioning === choice.repoId}
-                        onSelect={() => void selectRepository(choice)}
+                        onSelect={() => selectRepository(choice)}
                       />
                     ))}
                     {gtMatches.length === 0 && <div className="fnohit">No repositories match &ldquo;{gtQ}&rdquo;</div>}

--- a/packages/web/src/lib/gitea-repositories.ts
+++ b/packages/web/src/lib/gitea-repositories.ts
@@ -5,11 +5,11 @@
  *
  * The shape is `gitlab-projects.ts` with Gitea's two differences. The picker
  * offers one list of two kinds of row — a repository this organization already
- * added and one the connection's bot administers — so the flow reads as "pick a
- * repository" rather than "go set one up elsewhere first". And the candidate
- * list is the bot's own `admin` set (§4.4), not a search: a repository the bot
- * only has `write` on is never offered, because binding it could not install the
- * managed webhook.
+ * added and one the connection's bot administers — and picking either is the
+ * whole flow: the write that names an unadded one (the trigger, the workspace,
+ * the grant) binds it on the way (§6). And the candidate list is the bot's own
+ * `admin` set (§4.4), not a search: a repository the bot only has `write` on is
+ * never offered, because binding it could not install the managed webhook.
  *
  * The state vocabulary is the one GitLab uses (gitea-integration.md §12), so a
  * reader who manages both hosts reads one set of badges; the host-specific
@@ -98,7 +98,7 @@ export function giteaStateReasonText(reason: string | null): string | null {
   return GITEA_STATE_REASON[reason] ?? null
 }
 
-/** One pickable repository: `binding` null means picking it sets it up first. */
+/** One pickable repository: `binding` null means the write that picks it binds it (§6). */
 export interface GiteaRepositoryChoice {
   repoId: string
   repoPath: string
@@ -113,7 +113,7 @@ export function giteaRepositorySelectable(state: GiteaRepositoryBindingState): b
   return state === 'ready' || state === 'admin_degraded' || state === 'runtime_degraded'
 }
 
-/** An unadded repository is always selectable — setup is what picking it does. */
+/** An unadded repository is always selectable — the save that follows binds it. */
 export function giteaChoiceSelectable(choice: GiteaRepositoryChoice): boolean {
   return choice.binding === null || giteaRepositorySelectable(choice.binding.state)
 }

--- a/packages/web/src/lib/use-gitea-repositories.ts
+++ b/packages/web/src/lib/use-gitea-repositories.ts
@@ -5,21 +5,22 @@
  * Add-integration wizard's Gitea trigger, the agent-workspace forms, and the
  * additional-repository grant.
  *
- * The shape is `use-gitlab-projects.ts` with Gitea's two differences
+ * The shape is `use-gitlab-projects.ts` with Gitea's three differences
  * (gitea-integration.md §4, §6). Authorization is the organization's ONE bot
  * connection, which is made on the Integrations card — there is no browser
  * authorization to start from a picker, so this hook offers no `connect`: it
- * reports `connected: false` and the caller sends the reader to the card. And
- * the candidates are the bot's whole `admin` set in one listing rather than a
+ * reports `connected: false` and the caller sends the reader to the card. The
+ * candidates are the bot's whole `admin` set in one listing rather than a
  * server-side search, so the query filters locally: the set is bounded by what
  * one bot user administers, and Gitea's repository search cannot express
- * "administered by me".
+ * "administered by me". And there is no `provision`: a repository the
+ * organization has not added is bound by the write that first names it — the
+ * trigger, the workspace, the grant — so picking one is just picking it.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   ApiError,
-  createGiteaRepository,
   fetchGiteaConnectionRepositories,
   fetchGiteaConnections,
   fetchGiteaRepositories,
@@ -63,12 +64,6 @@ export interface GiteaRepositoryPicker {
   reload: () => void
   /** A `reload` is in flight. */
   reloading: boolean
-  /** Repository id whose setup saga is running right now. */
-  provisioning: string | null
-  /** The last failed setup, in Gitea's words. */
-  provisionError: string | null
-  /** Bind an unadded repository. Resolves to null when setup failed. */
-  provision: (repoId: string) => Promise<GiteaRepositoryBindingDto | null>
 }
 
 /** `active` keeps a pane that is not showing from issuing any request at all. */
@@ -79,11 +74,8 @@ export function useGiteaRepositories(active: boolean): GiteaRepositoryPicker {
   const [instanceUrl, setInstanceUrl] = useState(GITEA_DEFAULT_INSTANCE_URL)
   const [candidates, setCandidates] = useState<GiteaRepositoryDto[]>([])
   const [error, setError] = useState<string | null>(null)
-  const [provisioning, setProvisioning] = useState<string | null>(null)
-  const [provisionError, setProvisionError] = useState<string | null>(null)
   const [reloadToken, setReloadToken] = useState(0)
   const [reloading, setReloading] = useState(false)
-  const busy = useRef(false)
 
   // One request per active lifecycle, and no one-shot guard: the guard would survive the
   // cleanup that abandons its own request, so Strict Mode's setup/cleanup/setup — or leaving
@@ -128,29 +120,6 @@ export function useGiteaRepositories(active: boolean): GiteaRepositoryPicker {
     }
   }, [active, connectionId, reloadToken])
 
-  const provision = useCallback(
-    async (repoId: string): Promise<GiteaRepositoryBindingDto | null> => {
-      if (busy.current || !connectionId) return null
-      busy.current = true
-      setProvisioning(repoId)
-      setProvisionError(null)
-      try {
-        // The saga runs server-side and answers with the converged binding, so its outcome
-        // state — ready, or ready with a webhook warning — is what the picker shows.
-        const binding = await createGiteaRepository({ repoId })
-        setBindings((current) => [...(current ?? []).filter((b) => b.id !== binding.id), binding])
-        return binding
-      } catch (e) {
-        setProvisionError(errorText(e))
-        return null
-      } finally {
-        busy.current = false
-        setProvisioning(null)
-      }
-    },
-    [connectionId]
-  )
-
   const reload = useCallback((): void => {
     setReloading(true)
     setReloadToken((token) => token + 1)
@@ -175,9 +144,6 @@ export function useGiteaRepositories(active: boolean): GiteaRepositoryPicker {
     connected: connectionId !== null,
     instanceUrl,
     reload,
-    reloading,
-    provisioning,
-    provisionError,
-    provision
+    reloading
   }
 }


### PR DESCRIPTION
## Summary

A Gitea repository no longer needs a separate "Add repository" step. Creating a Gitea trigger, making a Gitea repository an agent's workspace, or granting it as an additional repository binds the repository as the same write: the Control Plane re-reads it as the bot, requires admin (§4.4), takes the deployment-global claim, creates the binding and catalog row, and converges inline. The card's `POST /gitea/repositories` stays as an optional pre-warm over the same path.

- **Control plane** — new `GiteaBindingService` (`administered`, `administeredByPath`, `ensureBound`) behind `deps.gitea.bindings`; the hook create/update arms, the additional-repository grant arm and the Gitea workspace derivation bind through it. The derivation gains a `write` flag so `GET /git/resolve` reports an administered-but-unbound address as managed without binding it. The §8.3 rule holds: the agent gate runs before the bind, so a refused trigger binds nothing. Two writers racing for one repository resolve on the claim's uniqueness — the loser adopts the winner's binding and joins its convergence. Agent deletion now re-converges the code-host webhooks its hooks left, so a shared webhook's subscription narrows. `DELETE /gitea/repositories/:id` answers 409 `repository_in_use` naming the trigger, workspace or grant that still references the binding; a binding already parked in `cleanup_pending` finishes its cleanup regardless.
- **Reference fence** — the claim row is the mutex both sides share. Every transaction that commits a reference (the hook upsert, the agent create, the workspace replace and its rollback, the grant create) locks the repository's claim `FOR SHARE` and re-reads the binding as live, answering 409 (`GiteaBindingUnavailable`) when it is gone or parked; `beginCleanup` locks the same row `FOR UPDATE`, refuses a live lease, counts references when asked to (`unlessReferenced`, passed only by the per-binding removal) and parks the claim and binding in that one transaction. The connection-level disconnect keeps walking its bindings unconditionally.
- **Web** — the trigger, agent-workspace and additional-repository pickers stop running the binding saga before a pick lands; an unbound row reads "added on save". The Integrations card keeps Repair / rotate / Remove per row and "Add repository" as the optional pre-warm.
- **Design doc** — §6 (implicit binding, shared webhook, never unbound on last use, the refusal and its fence), §12 (card, routes and their refusals), §16 (landed row).

One behavior is deliberately unchanged: when the last enabled trigger on a repository is removed, the webhook follows §7's inverse (no enabled trigger, no ingress) while the binding and its claim stay until the operator removes the row from the card.

## Gates

- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 202 files, incl. the new `gitea/references.test.ts`
- `pnpm --filter @agentconnect.md/control-plane test:int` — full suite against Postgres
- `pnpm --filter @agentconnect.md/relay test`, `pnpm --filter @agentconnect.md/web test`

New integration coverage (`test/integration/gitea-implicit-binding.test.ts`):

- a trigger on an unbound repository the bot administers binds it and installs the webhook as the same write; a stranger's trigger is refused before anything is bound; a repository the bot does not administer is refused (403) and stays unbound
- several agents on one repository: the first trigger binds and installs, the second reuses the binding and installs nothing (one webhook row, one claim); the webhook's events are the union of both agents' triggers, and a new family on the second agent PATCHes the existing webhook rather than creating another; removing one agent's trigger, or the agent itself, leaves the binding and webhook in place and narrows the events back to the remaining agent's families; removing the last referencing trigger does not auto-unbind — the binding and claim stay until the card's Remove releases them
- two first uses racing on one repository: a barrier in the fake holds both writers past their "is it bound yet?" check, so only the claim's uniqueness separates them — one binding, one claim, one webhook create, both triggers persisted; the same section at the service level yields exactly one `created: true`
- a workspace on an unbound administered repository binds it on agent create and on workspace replace, while the resolve preview binds nothing; an additional-repository grant binds; the card's Add still binds ahead of use and refuses a second Add
- removing a referenced binding answers 409 naming the workspace, the grant and the trigger, and succeeds once they are gone
- the reference fence, asserted structurally: a removal is blocked behind a writer's shared lock and then answers `referenced`; a grant behind a removal's exclusive lock is blocked and then refused once the binding is parked; the trigger, workspace, workspace-rollback and grant writes all refuse a parked binding, and the route answers 409

Existing GitHub and GitLab expectations are unchanged; the two Gitea route suites were updated where the refusal for an unbound repository changed shape (400 "not accessible" / 403 "must hold admin" instead of the old 409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
