### PR TITLE
docs(readme): list Gitea alongside the other code hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <a href="https://www.larksuite.com"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/lark.svg" width="16" height="16" alt="Lark and Feishu" title="Lark / Feishu" /></a>&nbsp;&nbsp;
   <a href="https://github.com"><img src="https://cdn.simpleicons.org/github/181717/e6edf3" width="16" height="16" alt="GitHub" title="GitHub" /></a>&nbsp;&nbsp;
   <a href="https://gitlab.com"><img src="https://api.iconify.design/logos/gitlab-icon.svg" width="16" height="16" alt="GitLab" title="GitLab" /></a>&nbsp;&nbsp;
+  <a href="https://about.gitea.com"><img src="https://cdn.simpleicons.org/gitea" width="16" height="16" alt="Gitea" title="Gitea" /></a>&nbsp;&nbsp;
   <a href="https://linear.app"><img src="https://cdn.simpleicons.org/linear" width="16" height="16" alt="Linear" title="Linear" /></a>&nbsp;&nbsp;
   <a href="https://en.wikipedia.org/wiki/Webhook"><img src="https://api.iconify.design/logos/webhooks.svg" width="16" height="16" alt="Webhook" title="Webhook" /></a>
   &nbsp;&nbsp;&nbsp;&nbsp;
@@ -56,9 +57,10 @@
 </p>
 
 AgentConnect is an open-source platform where teams and multiple AI agents work
-together across Slack, Telegram, Discord, Lark, GitHub, GitLab, and Linear.
-Bring Claude Code, Codex, Grok Build, DeepSeek, Pi, or any ACP-compatible agent
-into the conversations and workflows your team already has open.
+together across Slack, Telegram, Discord, Lark, GitHub, GitLab, Gitea, and
+Linear. Bring Claude Code, Codex, Grok Build, DeepSeek, Pi, or any
+ACP-compatible agent into the conversations and workflows your team already has
+open.
 
 Give each agent a role, then let people and agents collaborate in shared
 conversations. Agents can call one another and remember what they learn, and
@@ -114,7 +116,7 @@ Teams use it to:
   rebuild the workflow around it.
 - **Keep work where it happens.** Link agents to bots in Slack, Telegram,
   Discord, and Lark, or to repositories, issues, and workflows on GitHub,
-  GitLab, and Linear.
+  GitLab, Gitea, and Linear.
 - **Choose the right agent for every job.** Configure each agent's runtime,
   model, workspace, tools, and machine independently.
 - **Carry context forward.** Give each agent its own memory and skills, and


### PR DESCRIPTION
Gitea ingress, triggers and reviews have shipped, but the README still
described the code hosts as GitHub, GitLab and Linear. A reader landing on the
repository could not tell that Gitea is supported.

## What changed

- **Header `FROM` row** — added a Gitea mark between GitLab and Linear.
- **Opening paragraph** — `Slack, Telegram, Discord, Lark, GitHub, GitLab, Gitea, and Linear`.
- **Features, "Keep work where it happens"** — `repositories, issues, and workflows on GitHub, GitLab, Gitea, and Linear`.

## Notes for the reviewer

The mark is served from `https://cdn.simpleicons.org/gitea`, the same source and
treatment already used for Telegram, Discord and Linear in that row: a single
brand-green glyph that stays legible on both the light and the dark README
theme. The colourful upstream logo was the other candidate and was rejected —
it carries a `fill:#fff` cut-out that washes out at 16px on the light theme.

The four "Ask <assistant>" badges near the bottom carry an abbreviated product
description in their query strings that already omits Lark and Linear, so it
was left untouched rather than half-extended.

Prose reflow in the opening paragraph is line-wrapping only; `prettier --check`
passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
