### PR TITLE
feat(daemon): generalize session startup progress

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -166,20 +166,22 @@ live reply and saved transcript use the same destination.
 
 ## Session startup shows what the turn is waiting for
 
-Before an agent can respond, its turn may need to start a sandbox, prepare a workspace
-(including Git clone and checkout), and start or resume its runtime session. Each real
-wait updates one startup status. Stages that do not run are skipped, including sandbox
-startup when the current session's own sandbox is already bound.
+Before an agent can respond, its turn may need to start a sandbox, prepare a workspace,
+clone a repository, and start or resume its runtime session. Each real wait updates one
+startup notice. Stages that do not run are skipped, including sandbox startup when the
+current session's own sandbox is already bound. Git clone has its own label within
+workspace preparation; checkout and skills installation use the workspace label.
 
-A platform with a pushed status surface shows the phase there. The console replaces
-one live wait notice per agent and turn; other chat platforms post one temporary message
-and edit it as the phase changes. A code-host turn adds no startup comment. Status
-publication is best-effort and never holds up initialization.
+The console replaces one live wait line below the agent's name. Other chat platforms
+edit one message in the existing bootstrap-notice location and retain it in platform
+history. Slack keeps its native working indicator: its lifecycle API accepts a state,
+not phase text. A code-host turn adds no startup comment. Status publication is
+best-effort and never holds up initialization.
 
 Startup notices are not recorded in the AgentConnect transcript. On success or
-cancellation, the console clears the wait and chat platforms remove the temporary
-message. A failed console turn may retain its last phase beside the error. Standing
-notices, such as an unavailable approval, survive startup updates and clearing.
+cancellation, the console clears the wait. A failed console turn may retain its last
+phase beside the error. Standing notices, such as an unavailable approval, survive
+startup updates and clearing.
 
 Each observer belongs to its turn. Turns joining a shared host start see its current
 phase, and a cancelled or displaced turn cannot publish late updates into its successor.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -164,23 +164,25 @@ the known workspaces keep the readable text fallback, with host paths reduced to
 file names. Webchat holds link-bearing text until its logical message is complete so its
 live reply and saved transcript use the same destination.
 
-## A cold sandbox pod is announced, not waited out in silence
+## Session startup shows what the turn is waiting for
 
-A turn whose agent runs in the cluster and has no pod up yet must first claim (or resume) a
-Sandbox, wait for it to become Ready, and bind its shim before the runtime sees the prompt.
-That is up to a minute and a half in which nothing is streaming, and a reader with no signal
-reads it as the agent having ignored them.
+Before an agent can respond, its turn may need to start a sandbox, prepare a workspace
+(including Git clone and checkout), and start or resume its runtime session. Each real
+wait updates one startup status. Stages that do not run are skipped, including sandbox
+startup when the current session's own sandbox is already bound.
 
-So the turn says what it is waiting for, once, before the wait starts. A platform with a pushed
-per-turn status bar carries it there, in place of the generic startup label; every other surface —
-the console playground, the on-demand-status chat platforms — gets a short message of its own.
-Exactly one of the two, never both.
+A platform with a pushed status surface shows the phase there. The console replaces
+one live wait notice per agent and turn; other chat platforms post one temporary message
+and edit it as the phase changes. A code-host turn adds no startup comment. Status
+publication is best-effort and never holds up initialization.
 
-It is live chrome and is never recorded: reloading a conversation rebuilds it from the
-transcript, where a wait that is over has nothing to say. A turn whose pod is already up says
-nothing at all, so the notice always means a real wait — and neither does the wait's label
-outlive it: once the pod is up the status returns to the ordinary working state, so a streamed
-answer is never delivered under a line still claiming a sandbox is being allocated.
+Startup notices are not recorded in the AgentConnect transcript. On success or
+cancellation, the console clears the wait and chat platforms remove the temporary
+message. A failed console turn may retain its last phase beside the error. Standing
+notices, such as an unavailable approval, survive startup updates and clearing.
+
+Each observer belongs to its turn. Turns joining a shared host start see its current
+phase, and a cancelled or displaced turn cannot publish late updates into its successor.
 
 ## A trigger is acknowledged before it is answered
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10652,6 +10652,7 @@ export class Daemon {
    * entries. Pass an `error` for reject/cancel/shutdown; omit it for a clean gate-drop.
    */
   private terminateQueuedSink(entry: QueueEntry, error?: string): void {
+    entry.closeStartup?.()
     if (!entry.webchat || entry.webchat.doneSent) return
     entry.webchat.doneSent = true
     entry.webchat.sink.done({
@@ -11757,12 +11758,14 @@ export class Daemon {
     work: () => Promise<T>
   ): Promise<T> {
     const { plan, entry, replyConn } = run
-    const labels: Record<StartupPhase, [string, string]> = {
-      sandbox: ['is starting a sandbox…', '⏳ Starting sandbox…'],
-      workspace: ['is preparing the workspace…', '⏳ Preparing workspace…'],
-      runtime: ['is starting up…', '⏳ Starting agent…']
+    const labels: Record<StartupPhase, string> = {
+      sandbox: '⏳ Starting sandbox…',
+      workspace: '⏳ Preparing workspace…',
+      clone: '⏳ Cloning repository…',
+      runtime: '⏳ Starting agent…'
     }
     const turnBar = turnChromeFor(plan.platform).statusSurface === 'turn-bar'
+    if (!webchat && (!replyConn || turnBar || originKindOf(plan.platform) !== 'chat')) return await work()
     const notice =
       replyConn && !turnBar && originKindOf(plan.platform) === 'chat'
         ? new StartupNotice(replyConn as StartupNoticeConnection, plan.channel, plan.thread, (error) =>
@@ -11791,26 +11794,35 @@ export class Daemon {
       if (notice) void notice.close().finally(releaseNotice)
     }
     const abort = (): void => {
+      if (closed) return
       close()
       if (last) emit('')
     }
+    entry.closeStartup = abort
     entry.initAbort.signal.addEventListener('abort', abort, { once: true })
     try {
       const result = await observeStartup((phase) => {
-        if (!phase || closed || entry.initAbort.signal.aborted || entry.displacedByNewerTurn || last === phase) return
+        if (
+          !phase ||
+          closed ||
+          entry.cancelledReason ||
+          entry.initAbort.signal.aborted ||
+          entry.displacedByNewerTurn ||
+          last === phase
+        )
+          return
         last = phase
-        const [activity, text] = labels[phase]
-        if (turnBar) this.showActivity(replyConn, plan.channel, plan.statusThread, activity, plan.statusOptions)
+        const text = labels[phase]
         emit(text)
         notice?.update(text)
       }, work)
-      if (last && !closed && !entry.displacedByNewerTurn) {
+      if (last && !closed && !entry.cancelledReason && !entry.displacedByNewerTurn) {
         emit('')
-        this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
       }
       return result
     } finally {
       close()
+      delete entry.closeStartup
       entry.initAbort.signal.removeEventListener('abort', abort)
     }
   }
@@ -13585,6 +13597,7 @@ export class Daemon {
     const activeEntry = this.activeGateEntries.get(key)
     if (activeEntry) {
       activeEntry.cancelledReason ??= reason
+      activeEntry.closeStartup?.()
       // Terminalize before cancellation unwinds so a crash cannot replay the head; superseded hooks retain the reason.
       if (reason === 'superseded' && activeEntry.hookContext) {
         await this.emitHookCompletion(activeEntry.hookContext, 'failed', { reason }, activeEntry)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -674,10 +674,17 @@ import {
   MAX_TURN_CONTEXT_REGENERATION_MS,
   MAX_TURN_CONTEXT_REGENERATIONS,
   PROBE_ROOT_SWEEP_INTERVAL_MS,
-  SANDBOX_BOOTSTRAP_NOTICE,
   SEGMENT_BOUNDARY_UPDATES,
   SESSION_RETENTION_SWEEP_INTERVAL_MS
 } from './daemon/constants.js'
+import {
+  observeStartup,
+  withStartupPhase,
+  shareStartup,
+  awaitStartup,
+  type StartupPhase
+} from './session/startup-progress.js'
+import { StartupNotice, type StartupNoticeConnection } from './platforms/startup-notice.js'
 import type {
   DaemonEvaluationOptions,
   DaemonEvaluationTurnInput,
@@ -4722,11 +4729,13 @@ export class Daemon {
     request?: PrepareSessionWorkspaceRequest,
     allowAgentDrain = false
   ): Promise<string> {
-    return this.enqueueAgentWorkspacePreparation(
-      agent,
-      () => this.runAgentWorkspacePreparation(agent, request),
-      expectedWarmHost,
-      allowAgentDrain
+    return withStartupPhase('workspace', () =>
+      this.enqueueAgentWorkspacePreparation(
+        agent,
+        () => this.runAgentWorkspacePreparation(agent, request),
+        expectedWarmHost,
+        allowAgentDrain
+      )
     )
   }
 
@@ -5351,7 +5360,7 @@ export class Daemon {
       }
       this.hostLaunch.set(hostKey, { agentDir: agent.dir, cwd })
       try {
-        await host.start()
+        await withStartupPhase('runtime', () => host.start())
         return host
       } catch (error) {
         lastError = error
@@ -11559,8 +11568,6 @@ export class Daemon {
       // Read here, not in the planner: the sticky override is live daemon state.
       stickyOutputMode: await this.store.getOutputModeOverride(key),
       hostAlreadyRunning: this.hostStarts.has(this.hostKeyFor(agentId, key)) || this.modelSessions.hasStartedHost(key),
-      // Synchronous and exact: an attached shim session IS the pod being up, so no cluster read.
-      clusterPodBootstrap: this.k8sPlane !== undefined && !this.k8sPlane.runsInSandbox(agentId),
       protectedAddresses: this.compoundMentionAddresses(agentId, msg),
       codexUsageIsPerPrompt: this.isCodexRuntime(agentId),
       features: { turnFinalContextRefresh: this.cfg.features.turnFinalContextRefresh },
@@ -11577,10 +11584,7 @@ export class Daemon {
     // between them, and the turn then holds a lease on a client it never writes to.
     const egressConn = this.platformTurnEgress.get(msg.platform)?.(plan.integrationId)
     const run: TurnRun = { entry, key, plan, agent, replyConn, ...(egressConn ? { egressConn } : {}), evaluation }
-    // Add the streaming fields onto the SAME webchat object held by QueueEntry. Sharing
-    // `doneSent` closes a Pending-vs-gate race where cancel could otherwise terminally signal
-    // each copy once. Seeded HERE, before `openSession`, because the sandbox-bootstrap notice
-    // below emits on this turn's `index` and must not collide with the reply's.
+    // Startup notices and replies share the queue entry's index and terminal fence from before openSession.
     const pendingWebchat = webchat
       ? Object.assign(webchat, {
           index: 0,
@@ -11603,7 +11607,6 @@ export class Daemon {
     })
     this.showActivity(replyConn, msg.channel, plan.statusThread, plan.startupActivityLabel, plan.statusOptions)
     this.acknowledgeTrigger(run)
-    if (plan.clusterPodBootstrap) this.announceSandboxBootstrap(run, pendingWebchat)
     // Two holds, one release. A platform whose output does NOT go through `replyConn` still
     // needs the reconciler to drain before it stops that transport (§7.5): without a lease the
     // prune pass can stop the client mid-turn and the settling activity is simply lost.
@@ -11613,7 +11616,7 @@ export class Daemon {
       releaseReplyTransport()
       releaseEgressTransport()
     }
-    const opened = await this.openSession(run, releaseReplyConn)
+    const opened = await this.observeSessionStartup(run, pendingWebchat, () => this.openSession(run, releaseReplyConn))
     if (opened.kind === 'cancelled') return null
     const { handled, restoreDeliveryBinding } = opened
     const { sessionId, created } = handled
@@ -11747,27 +11750,69 @@ export class Daemon {
     return typeof likely === 'function' && likely.call(conn)
   }
 
-  /** Say that this turn is waiting on a cluster Sandbox pod, before the wait starts.
-   *  Live-only chrome: nothing is recorded, because the wait is not part of the conversation. */
-  private announceSandboxBootstrap(run: TurnRun, webchat: Pending['webchat']): void {
+  // Startup chrome belongs to this turn, including work shared with another turn or aborted before Pending exists.
+  private async observeSessionStartup<T>(
+    run: TurnRun,
+    webchat: Pending['webchat'],
+    work: () => Promise<T>
+  ): Promise<T> {
     const { plan, entry, replyConn } = run
-    if (webchat) {
-      webchat.sink.output({
-        conversationId: webchat.conversationId,
-        turnId: webchat.turnId,
-        index: webchat.index++,
-        event: { kind: 'notice', text: SANDBOX_BOOTSTRAP_NOTICE }
-      })
+    const labels: Record<StartupPhase, [string, string]> = {
+      sandbox: ['is starting a sandbox…', '⏳ Starting sandbox…'],
+      workspace: ['is preparing the workspace…', '⏳ Preparing workspace…'],
+      runtime: ['is starting up…', '⏳ Starting agent…']
     }
-    // Chat origins only: a hook/code-host turn publishes one artifact at the end and must not
-    // grow a second message of its own.
-    if (!replyConn || originKindOf(plan.platform) !== 'chat') return
-    // A pushed status bar carries this turn's `startupActivityLabel` already, so a platform that
-    // shows one never reaches this post — and none that does has chrome metadata to be marked with.
-    if (turnChromeFor(plan.platform).statusSurface === 'turn-bar') return
-    void replyConn
-      .postMessage(plan.channel, SANDBOX_BOOTSTRAP_NOTICE, entry.msg.thread)
-      .catch((err) => this.log.warn(`cluster: sandbox bootstrap notice failed (${formatErr(err)})`))
+    const turnBar = turnChromeFor(plan.platform).statusSurface === 'turn-bar'
+    const notice =
+      replyConn && !turnBar && originKindOf(plan.platform) === 'chat'
+        ? new StartupNotice(replyConn as StartupNoticeConnection, plan.channel, plan.thread, (error) =>
+            this.log.warn(`session: startup notice failed (${formatErr(error)})`)
+          )
+        : undefined
+    let closed = false
+    let last: StartupPhase | undefined
+    const releaseNotice = notice ? this.holdReplyConnection(replyConn) : () => {}
+    const emit = (text: string): void => {
+      try {
+        if (webchat && !webchat.doneSent)
+          webchat.sink.output({
+            conversationId: webchat.conversationId,
+            turnId: webchat.turnId,
+            index: webchat.index++,
+            event: { kind: 'notice', text }
+          })
+      } catch (error) {
+        this.log.warn(`session: startup notice failed (${formatErr(error)})`)
+      }
+    }
+    const close = (): void => {
+      if (closed) return
+      closed = true
+      if (notice) void notice.close().finally(releaseNotice)
+    }
+    const abort = (): void => {
+      close()
+      if (last) emit('')
+    }
+    entry.initAbort.signal.addEventListener('abort', abort, { once: true })
+    try {
+      const result = await observeStartup((phase) => {
+        if (!phase || closed || entry.initAbort.signal.aborted || entry.displacedByNewerTurn || last === phase) return
+        last = phase
+        const [activity, text] = labels[phase]
+        if (turnBar) this.showActivity(replyConn, plan.channel, plan.statusThread, activity, plan.statusOptions)
+        emit(text)
+        notice?.update(text)
+      }, work)
+      if (last && !closed && !entry.displacedByNewerTurn) {
+        emit('')
+        this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
+      }
+      return result
+    } finally {
+      close()
+      entry.initAbort.signal.removeEventListener('abort', abort)
+    }
   }
 
   /** §3.3 source gate: bind this session to the inbound envelope's external audience, then — only
@@ -12508,11 +12553,8 @@ export class Daemon {
         })
       }
     }
-    // The pod wait ENDED inside openSession, so its label must not outlive it: a bootstrap turn
-    // transitions to "is thinking…" here even when its host was already running (a suspended pod
-    // drops its channel while `hostStarts` still holds the agent).
-    const podWaitOver = plan.clusterPodBootstrap
-    if (podWaitOver || !plan.hostAlreadyRunning)
+    // Startup observers have settled; a cold host's initial activity now yields to its ordinary turn.
+    if (!plan.hostAlreadyRunning)
       this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
     // Post/refresh the session status bar up front — with the model now known (session
     // created) plus any usage carried over from prior turns — so it sits at the top of
@@ -15262,7 +15304,9 @@ export class Daemon {
       this.hostStartGeneration.set(key, generation)
       const startAbort = new AbortController()
       this.hostStartAborts.set(key, startAbort)
-      p = this.startHostWithRetry(key, generation, startAbort.signal, opts.allowAgentDrain === true, opts.session)
+      p = shareStartup(() =>
+        this.startHostWithRetry(key, generation, startAbort.signal, opts.allowAgentDrain === true, opts.session)
+      )
       this.hostStarts.set(key, p)
       // A total failure (all attempts exhausted) must NOT poison the cache: without
       // this the rejected promise stays memoized and every later message re-awaits the
@@ -15279,7 +15323,7 @@ export class Daemon {
         }
       )
     }
-    return await p
+    return await awaitStartup(p)
   }
 
   /** Launch an agent's ACP host — spawn + the `initialize` handshake — retrying a
@@ -15323,14 +15367,15 @@ export class Daemon {
         bound && bound.cwd === undefined ? bound.workspace : undefined,
         allowAgentDrain
       )
-      if (!this.usesMicrosandbox(agent)) await this.ensureRuntimeInstalled(agent.runtime, true)
+      if (!this.usesMicrosandbox(agent))
+        await withStartupPhase('runtime', () => this.ensureRuntimeInstalled(agent.runtime, true))
       if (this.hostStartGeneration.get(key) !== generation) {
         throw new Error(`host start superseded for ${label}`)
       }
       // Constructs + memoizes into this.hosts, in the session directory for a session-bound host.
       const host = this.ensureHost(key, this.cfg, bound ? (bound.cwd ?? prepared) : undefined)
       try {
-        await host.start()
+        await withStartupPhase('runtime', () => host.start())
         if (this.hostStartGeneration.get(key) !== generation) {
           throw new Error(`host start superseded for ${label}`)
         }

--- a/packages/daemon/src/daemon/constants.ts
+++ b/packages/daemon/src/daemon/constants.ts
@@ -90,7 +90,3 @@ export const MAX_DRAIN_TEXT_CHARS = 16_000
  *  or the host is reclaimed. 20 is a display depth, not a durability promise — the panel is a
  *  live view, and the retained records are strictly outside the liveness set (see `settled`). */
 export const MAX_SETTLED_TASKS_PER_SESSION = 20
-
-/** Shown while a cluster turn waits for its Sandbox pod to come up and bind — up to
- *  `K8sDriver.podUpTimeoutMs` of silence otherwise, with nothing to read as progress. */
-export const SANDBOX_BOOTSTRAP_NOTICE = '⏳ Allocating a sandbox pod…'

--- a/packages/daemon/src/daemon/turn-plan.ts
+++ b/packages/daemon/src/daemon/turn-plan.ts
@@ -154,7 +154,7 @@ export function buildTurnPlan(input: TurnPlanInput): TurnPlan {
       turnSurfaces.exact(msg.platform)?.elicitCards !== undefined
     ),
     suppressReplyConn,
-    // Actual startup phases replace this initial activity as the turn reaches each wait.
+    // Keep the ordinary cold/warm working indicator; startup notices use their own surface.
     startupActivityLabel: input.hostAlreadyRunning ? 'is thinking…' : 'is starting up…',
     hostAlreadyRunning: input.hostAlreadyRunning,
     turnSurface,

--- a/packages/daemon/src/daemon/turn-plan.ts
+++ b/packages/daemon/src/daemon/turn-plan.ts
@@ -38,9 +38,6 @@ export interface TurnPlanInput {
   stickyOutputMode: OutputMode | undefined
   /** `hostStarts.has(agentId) || modelSessions.hasStartedHost(key)`, read cold. */
   hostAlreadyRunning: boolean
-  /** `!k8sPlane.runsInSandbox(agentId)` on a cluster daemon: this turn must first bring a
-   *  Sandbox pod up and bind its shim, which is up to a minute and a half of silence. */
-  clusterPodBootstrap: boolean
   /** `daemon.compoundMentionAddresses(agentId, msg)`. */
   protectedAddresses: readonly string[]
   /** Pre-computed `isCodexRuntime(agentId)` — it reads the runtime command config, not just the name. */
@@ -74,10 +71,8 @@ export interface TurnPlan {
 
   /** True when this turn takes the null-connection seam: headless, non-continuation webchat, or `none`. */
   readonly suppressReplyConn: boolean
-  readonly startupActivityLabel: 'is thinking…' | 'is starting up…' | 'is allocating a sandbox pod…'
+  readonly startupActivityLabel: 'is thinking…' | 'is starting up…'
   readonly hostAlreadyRunning: boolean
-  /** This turn waits on a cluster sandbox pod — see {@link TurnPlanInput.clusterPodBootstrap}. */
-  readonly clusterPodBootstrap: boolean
 
   readonly turnSurface: DaemonTurnOutputSurface
   readonly turnCtx: TurnOutputContext<NormalizedMessage>
@@ -159,15 +154,9 @@ export function buildTurnPlan(input: TurnPlanInput): TurnPlan {
       turnSurfaces.exact(msg.platform)?.elicitCards !== undefined
     ),
     suppressReplyConn,
-    // Cold/warm is captured BEFORE sessions.handle(), which boots the host via hostFor().
-    // A pod that is not up yet outranks both: it is the wait the user is actually about to sit through.
-    startupActivityLabel: input.clusterPodBootstrap
-      ? 'is allocating a sandbox pod…'
-      : input.hostAlreadyRunning
-        ? 'is thinking…'
-        : 'is starting up…',
+    // Actual startup phases replace this initial activity as the turn reaches each wait.
+    startupActivityLabel: input.hostAlreadyRunning ? 'is thinking…' : 'is starting up…',
     hostAlreadyRunning: input.hostAlreadyRunning,
-    clusterPodBootstrap: input.clusterPodBootstrap,
     turnSurface,
     turnCtx,
     statusOptions: slackStatusOptions(msg.platform, agentName, iconUrl, input.sessionKey),

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -265,6 +265,8 @@ export interface QueueEntry {
   /** Cancels the entire cold SessionManager initialization path after the bounded
    *  host-stop backstop, including non-host awaits such as workspace/history I/O. */
   initAbort: AbortController
+  // Stop startup chrome immediately while uncancellable initialization retains its cleanup fence.
+  closeStartup?: () => void
   integrationId?: string
   webchat?: WebchatTurnContext
   callMeta?: CallMeta

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -742,22 +742,6 @@ export class DiscordConnection implements PlatformConnection {
     })
   }
 
-  // Remove transient chrome from the same native channel or thread where it was posted.
-  async deleteMessage(channel: string, messageId: string, threadTs?: string): Promise<boolean> {
-    const target = this.replyTarget(channel, threadTs)
-    return this.queue.enqueue(async () => {
-      try {
-        const ch = await this.sendableChannel(target)
-        if (!ch?.messages) return false
-        await (await ch.messages.fetch(messageId)).delete()
-        return true
-      } catch (err) {
-        this.deps.log?.debug(`discord: delete chrome failed (${(err as Error).message})`)
-        return false
-      }
-    })
-  }
-
   /** Best-effort transient "typing…" indicator (Discord's analog of a status bar).
    *  Not queued — a fire-and-forget hint that expires on its own (~10s). */
   async sendChatAction(channel: string, threadTs?: string): Promise<void> {

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -742,6 +742,22 @@ export class DiscordConnection implements PlatformConnection {
     })
   }
 
+  // Remove transient chrome from the same native channel or thread where it was posted.
+  async deleteMessage(channel: string, messageId: string, threadTs?: string): Promise<boolean> {
+    const target = this.replyTarget(channel, threadTs)
+    return this.queue.enqueue(async () => {
+      try {
+        const ch = await this.sendableChannel(target)
+        if (!ch?.messages) return false
+        await (await ch.messages.fetch(messageId)).delete()
+        return true
+      } catch (err) {
+        this.deps.log?.debug(`discord: delete chrome failed (${(err as Error).message})`)
+        return false
+      }
+    })
+  }
+
   /** Best-effort transient "typing…" indicator (Discord's analog of a status bar).
    *  Not queued — a fire-and-forget hint that expires on its own (~10s). */
   async sendChatAction(channel: string, threadTs?: string): Promise<void> {

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -1232,20 +1232,6 @@ export class FeishuConnection implements PlatformConnection {
     })
   }
 
-  // Remove a startup notice after its wait ends, including a post that completed after cancellation.
-  async deleteMessage(channel: string, messageId: string): Promise<boolean> {
-    return this.queue.enqueue(async () => {
-      try {
-        await this.handle.api.deleteMessage(messageId)
-        return true
-      } catch (err) {
-        this.rememberPermissionIssue(err, channel)
-        this.deps.log?.debug(`feishu: delete chrome failed (${(err as Error).message})`)
-        return false
-      }
-    })
-  }
-
   /** No-op — Feishu has no typing / chat-action API. Present for applier parity. */
   async sendChatAction(_channel: string): Promise<void> {
     // intentionally empty

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -1232,6 +1232,20 @@ export class FeishuConnection implements PlatformConnection {
     })
   }
 
+  // Remove a startup notice after its wait ends, including a post that completed after cancellation.
+  async deleteMessage(channel: string, messageId: string): Promise<boolean> {
+    return this.queue.enqueue(async () => {
+      try {
+        await this.handle.api.deleteMessage(messageId)
+        return true
+      } catch (err) {
+        this.rememberPermissionIssue(err, channel)
+        this.deps.log?.debug(`feishu: delete chrome failed (${(err as Error).message})`)
+        return false
+      }
+    })
+  }
+
   /** No-op — Feishu has no typing / chat-action API. Present for applier parity. */
   async sendChatAction(_channel: string): Promise<void> {
     // intentionally empty

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -11,6 +11,7 @@ import { isSandboxReady, type OperatingMode, type SandboxClaim, type SandboxApi 
 import { SandboxLease } from './sandbox-lease.js'
 import { LaunchRegistry, type Launch, type LaunchGenerations } from './launch-registry.js'
 import { ChannelBinder } from './channel-binder.js'
+import { withStartupPhase } from '../session/startup-progress.js'
 import { awaitBoundSandbox, awaitReady, readIfPresent, type SandboxWaitDeps } from './sandbox-waits.js'
 import {
   AC_ANNOTATION_ADMITTED,
@@ -123,6 +124,11 @@ export class K8sDriver implements SpawnDriver {
   // bypass warm-pool adoption; the same labels ride the claim's own metadata so a member can list an
   // agent's session claims without knowing their sessions.
   async ensureSandbox(subject: SandboxSubject, timer?: LaunchTimer): Promise<Launch> {
+    const ensure = () => this.ensureSandboxInner(subject, timer)
+    return this.sessionFor(subject)?.isAttached() ? await ensure() : await withStartupPhase('sandbox', ensure)
+  }
+
+  private async ensureSandboxInner(subject: SandboxSubject, timer?: LaunchTimer): Promise<Launch> {
     const suspending = this.lease.suspensionOf(subject)
     if (suspending) await suspending
     const adopting = this.registry.adoptInFlight(subject)
@@ -465,7 +471,8 @@ export class K8sDriver implements SpawnDriver {
     grants?: ShimCapability[]
   ): Promise<ShimConnection> {
     const launch = await this.ensureSandbox(subject, timer)
-    return await this.binder.bindChannel(subject, launch, timer, grants ?? this.grantsFor(subject))
+    const bind = () => this.binder.bindChannel(subject, launch, timer, grants ?? this.grantsFor(subject))
+    return this.sessionFor(subject)?.isAttached() ? await bind() : await withStartupPhase('sandbox', bind)
   }
 
   /** What this subject's channel may do — decided per agent. */

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -5,6 +5,7 @@ import type { RuntimeDef } from '../config/config-schema.js'
 import { formatErr } from '../daemon/text.js'
 import type { ModelSessionHost, SelectedTurnHost } from '../daemon/turn-types.js'
 import type { Logger } from '../log.js'
+import { shareStartup, awaitStartup } from '../session/startup-progress.js'
 import {
   modelProviderTarget,
   type ModelCredential,
@@ -284,16 +285,18 @@ export class ModelSessionHostPool {
     if (!host) {
       // Publish the start before awaiting it: a concurrent release joins this promise instead
       // of seeing an entry with no host, stopping nothing, and leaking the process it misses.
-      const starting: Promise<AcpHost> = (owner.starting ??= this.host
-        .startRuntime(agent, owner)
-        .then((started) => {
-          owner.host = started
-          return started
-        })
-        .finally(() => {
-          if (owner.starting === starting) owner.starting = undefined
-        }))
-      host = await starting
+      const starting: Promise<AcpHost> = (owner.starting ??= shareStartup(() =>
+        this.host
+          .startRuntime(agent, owner)
+          .then((started) => {
+            owner.host = started
+            return started
+          })
+          .finally(() => {
+            if (owner.starting === starting) owner.starting = undefined
+          })
+      ))
+      host = await awaitStartup(starting)
       if (owner.released || this.entries.get(sessionKey) !== owner) {
         await this.stopRuntime(owner, host).catch(() => {})
         throw new Error(`model session host for ${sessionKey} was released during startup`)

--- a/packages/daemon/src/microsandbox/driver.ts
+++ b/packages/daemon/src/microsandbox/driver.ts
@@ -9,6 +9,7 @@ import type { SpawnDriver, SpawnedRuntime, SpawnRequest } from '../acp/spawn-dri
 import type { SandboxMount } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
 import { formatErr } from '../daemon/text.js'
+import { shareStartup, awaitStartup, withStartupPhase } from '../session/startup-progress.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import { canonicalPath, contains } from '../runtimes/read-roots.js'
 import { SinkRelPathSchema } from '../shim/file-sink.js'
@@ -171,7 +172,7 @@ export class MicrosandboxManager {
     })
     state.pending.add(pending)
     try {
-      await state.sandbox
+      await awaitStartup(state.sandbox)
     } finally {
       state.pending.delete(pending)
       release()
@@ -196,8 +197,8 @@ export class MicrosandboxManager {
     })
     state.pending.add(pending)
     try {
+      const sandbox = await awaitStartup(state.sandbox)
       state.shim ??= (async () => {
-        const sandbox = await state.sandbox
         if (!this.options.nextShimGeneration) throw new Error('microsandbox shim generation allocator is unavailable')
         return startMicrosandboxShim({
           sdk: this.options.sdk,
@@ -963,7 +964,12 @@ export class MicrosandboxManager {
       state = {
         environment,
         spec,
-        sandbox: stopping ? stopping.then(() => this.open(environment)) : this.open(environment),
+        sandbox: shareStartup(() =>
+          withStartupPhase('sandbox', async () => {
+            if (stopping) await stopping
+            return await this.open(environment)
+          })
+        ),
         active: 0,
         processes: new Set(),
         pending: new Set(),
@@ -1009,7 +1015,7 @@ export class MicrosandboxManager {
     })
     state.pending.add(pending)
     try {
-      const sandbox = await state.sandbox
+      const sandbox = await awaitStartup(state.sandbox)
       if (this.closed) throw new Error('microsandbox manager is shutting down')
       options.abort?.throwIfAborted()
       if (!this.bridges.has(environment.id))

--- a/packages/daemon/src/platforms/startup-notice.ts
+++ b/packages/daemon/src/platforms/startup-notice.ts
@@ -1,0 +1,51 @@
+export interface StartupNoticeConnection {
+  postMessage(channel: string, text: string, thread?: string): Promise<string | undefined>
+  updateMessage(channel: string, id: string, text: string, options?: { threadTs?: string }): Promise<void>
+  deleteMessage(channel: string, id: string, thread?: string): Promise<unknown>
+}
+
+// One transient message, with serialized edits and removal even when the initial post finishes late.
+export class StartupNotice {
+  private closed = false
+  private attempted = false
+  private id?: string
+  private text?: string
+  private sent?: string
+  private writes = Promise.resolve()
+
+  constructor(
+    private readonly conn: StartupNoticeConnection,
+    private readonly channel: string,
+    private readonly thread: string | undefined,
+    private readonly failed: (error: unknown) => void
+  ) {}
+
+  update(text: string): void {
+    if (this.closed || this.text === text) return
+    this.text = text
+    this.writes = this.writes
+      .then(async () => {
+        if (this.closed || this.sent === this.text) return
+        const text = this.text!
+        if (!this.attempted) {
+          this.attempted = true
+          this.id = await this.conn.postMessage(this.channel, text, this.thread)
+        } else if (this.id) {
+          await this.conn.updateMessage(this.channel, this.id, text, { threadTs: this.thread })
+        }
+        this.sent = text
+      })
+      .catch(this.failed)
+  }
+
+  close(): Promise<void> {
+    if (this.closed) return this.writes
+    this.closed = true
+    this.writes = this.writes
+      .then(async () => {
+        if (this.id) await this.conn.deleteMessage(this.channel, this.id, this.thread)
+      })
+      .catch(this.failed)
+    return this.writes
+  }
+}

--- a/packages/daemon/src/platforms/startup-notice.ts
+++ b/packages/daemon/src/platforms/startup-notice.ts
@@ -1,10 +1,9 @@
 export interface StartupNoticeConnection {
   postMessage(channel: string, text: string, thread?: string): Promise<string | undefined>
   updateMessage(channel: string, id: string, text: string, options?: { threadTs?: string }): Promise<void>
-  deleteMessage(channel: string, id: string, thread?: string): Promise<unknown>
 }
 
-// One transient message, with serialized edits and removal even when the initial post finishes late.
+// One message, with serialized edits that stop when its turn leaves startup.
 export class StartupNotice {
   private closed = false
   private attempted = false
@@ -39,13 +38,7 @@ export class StartupNotice {
   }
 
   close(): Promise<void> {
-    if (this.closed) return this.writes
     this.closed = true
-    this.writes = this.writes
-      .then(async () => {
-        if (this.id) await this.conn.deleteMessage(this.channel, this.id, this.thread)
-      })
-      .catch(this.failed)
     return this.writes
   }
 }

--- a/packages/daemon/src/session/startup-progress.ts
+++ b/packages/daemon/src/session/startup-progress.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-export type StartupPhase = 'sandbox' | 'workspace' | 'runtime'
+export type StartupPhase = 'sandbox' | 'workspace' | 'clone' | 'runtime'
 type Report = (phase: StartupPhase | undefined) => void
 const context = new AsyncLocalStorage<{ report: Report; phase?: StartupPhase }>()
 const shared = new WeakMap<Promise<unknown>, { phase?: StartupPhase; listeners: Set<Report> }>()
@@ -16,13 +16,14 @@ export async function observeStartup<T>(report: Report, work: () => Promise<T>):
 }
 
 // A nested wait restores its enclosing phase, such as workspace preparation after a sandbox binds.
-export async function withStartupPhase<T>(phase: StartupPhase, work: () => Promise<T>): Promise<T> {
+export function withStartupPhase<T>(phase: StartupPhase, work: () => Promise<T>): Promise<T> {
   const parent = context.getStore()
-  if (!parent) return await work()
+  if (!parent) return work()
   parent.report(phase)
-  const result = await context.run({ report: parent.report, phase }, work)
-  parent.report(parent.phase)
-  return result
+  return context.run({ report: parent.report, phase }, work).then((result) => {
+    parent.report(parent.phase)
+    return result
+  })
 }
 
 // Shared host starts broadcast to their current waiters, including a turn joining an existing start.

--- a/packages/daemon/src/session/startup-progress.ts
+++ b/packages/daemon/src/session/startup-progress.ts
@@ -1,0 +1,57 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export type StartupPhase = 'sandbox' | 'workspace' | 'runtime'
+type Report = (phase: StartupPhase | undefined) => void
+const context = new AsyncLocalStorage<{ report: Report; phase?: StartupPhase }>()
+const shared = new WeakMap<Promise<unknown>, { phase?: StartupPhase; listeners: Set<Report> }>()
+
+// Observers belong to one turn; work that outlives it cannot publish through its closed observer.
+export async function observeStartup<T>(report: Report, work: () => Promise<T>): Promise<T> {
+  let active = true
+  try {
+    return await context.run({ report: (phase) => active && report(phase) }, work)
+  } finally {
+    active = false
+  }
+}
+
+// A nested wait restores its enclosing phase, such as workspace preparation after a sandbox binds.
+export async function withStartupPhase<T>(phase: StartupPhase, work: () => Promise<T>): Promise<T> {
+  const parent = context.getStore()
+  if (!parent) return await work()
+  parent.report(phase)
+  const result = await context.run({ report: parent.report, phase }, work)
+  parent.report(parent.phase)
+  return result
+}
+
+// Shared host starts broadcast to their current waiters, including a turn joining an existing start.
+export function shareStartup<T>(work: () => Promise<T>): Promise<T> {
+  const state: { phase?: StartupPhase; listeners: Set<Report> } = { listeners: new Set() }
+  const promise = context.run(
+    {
+      report: (phase) => {
+        state.phase = phase
+        for (const report of state.listeners) report(phase)
+      }
+    },
+    work
+  )
+  shared.set(promise, state)
+  return promise
+}
+
+export async function awaitStartup<T>(promise: Promise<T>): Promise<T> {
+  const observer = context.getStore()
+  const state = shared.get(promise)
+  if (!observer || !state) return await promise
+  state.listeners.add(observer.report)
+  observer.report(state.phase)
+  try {
+    const result = await promise
+    observer.report(observer.phase)
+    return result
+  } finally {
+    state.listeners.delete(observer.report)
+  }
+}

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@agentclientprotocol/sdk'
 import type { AcpHost } from '../../acp/acp-host.js'
 import type { Agent } from '../../agents/agent-schema.js'
 import type { LocalStore, SessionRecord } from '../../store/local-store.js'
+import { withStartupPhase } from '../startup-progress.js'
 
 /** The store writes the opener owns — the session row plus the ingress-supplied title. */
 type OpenerStore = Pick<LocalStore, 'setSessionState' | 'upsertSession' | 'setSessionTitle'>
@@ -126,7 +127,10 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
       const selected = await sessionStartEffort()
       const create = (servers: McpServer[]) =>
         abortable(
-          () => host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories, bindOutward),
+          () =>
+            withStartupPhase('runtime', () =>
+              host.newSession(cwd, servers, selected.value, systemAppend, additionalDirectories, bindOutward)
+            ),
           signal
         )
       const sessionId = await withAdditionalMcpFallback(
@@ -148,7 +152,10 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
     const additionalDirectories = await input.workspaceDirectories(cwd)
     const load = (servers: McpServer[]) =>
       abortable(
-        () => host.loadSession(sessionId, cwd, servers, selected.value, systemAppend, additionalDirectories),
+        () =>
+          withStartupPhase('runtime', () =>
+            host.loadSession(sessionId, cwd, servers, selected.value, systemAppend, additionalDirectories)
+          ),
         signal
       )
     await withAdditionalMcpFallback(

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -32,6 +32,7 @@ import {
 } from '../codehost/credentials.js'
 import { formatErr } from '../daemon/text.js'
 import { makeLogger } from '../log.js'
+import { withStartupPhase } from '../session/startup-progress.js'
 import { installSkills, type LocalSkillSource } from '../skills/install-skills.js'
 import { acceptedDreamSkillSources } from '../skills/dream-skills.js'
 import { bundlePathsFromCheckoutRoot, excludeManagedSkillBundles } from './git-exclude.js'
@@ -935,7 +936,7 @@ export class WorkspaceManager {
 
   async convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
     const clone = this.cloneInFlight.get(this.cloneKey(agent.id, cwd))
-    if (clone) await clone
+    if (clone) await withStartupPhase('clone', () => clone)
     if (!existsSync(join(cwd, '.git'))) return
     await this.convergeOriginInPlace(agent, cwd)
   }
@@ -2170,13 +2171,9 @@ export class WorkspaceManager {
     if (root.githubApp) await preWarmGitCred(agentId, 'clone')
     // Run in the target's parent, which names the pod that owns it: a runner with no cwd is the agent pod's.
     const git = this.runnerFor(agentId, dirname(cwd)).withEnv(this.sessionCloneGitEnv(agentId, root))
-    await git.clone(root.cloneUrl, cwd, [
-      '--filter=blob:none',
-      '--no-checkout',
-      '--branch',
-      root.branch,
-      '--single-branch'
-    ])
+    await withStartupPhase('clone', () =>
+      git.clone(root.cloneUrl, cwd, ['--filter=blob:none', '--no-checkout', '--branch', root.branch, '--single-branch'])
+    )
     if (root.githubApp) await writeRepoHelperConfig(this.runnerFor(agentId, cwd), agentId, root.managed)
   }
 
@@ -2570,7 +2567,7 @@ export class WorkspaceManager {
     // reattachment would then re-await that dead promise until the daemon restarted.
     const key = this.cloneKey(agent.id, checkout)
     const inflight = this.cloneInFlight.get(key)
-    if (inflight) return await inflight
+    if (inflight) return await withStartupPhase('clone', () => inflight)
     const started = this.cloneInSandbox(agent, root, repository, checkout).finally(() => {
       this.cloneInFlight.delete(key)
     })
@@ -2585,9 +2582,11 @@ export class WorkspaceManager {
       ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository, this.managedScopeOf(agent)) }
       : { ...workspaceGitEnvBase(repository), GIT_TERMINAL_PROMPT: '0' }
     try {
-      await this.runnerFor(agent.id, root)
-        .withEnv(env)
-        .clone(repository, SANDBOX_CHECKOUT_DIR, ['--branch', agent.workspace.gitBranch, '--single-branch'])
+      await withStartupPhase('clone', () =>
+        this.runnerFor(agent.id, root)
+          .withEnv(env)
+          .clone(repository, SANDBOX_CHECKOUT_DIR, ['--branch', agent.workspace.gitBranch, '--single-branch'])
+      )
     } catch (err) {
       // A partial checkout would fail the probe above forever after, since git refuses to clone into
       // a non-empty directory. Emptying it is the pod's own job — there is no rmSync to reach it.
@@ -2915,7 +2914,7 @@ export class WorkspaceManager {
   async cloneRootAt(agentId: string, root: WorkspaceRoot, cwd: string): Promise<void> {
     const key = this.cloneKey(agentId, cwd)
     const inflight = this.cloneInFlight.get(key)
-    if (inflight) return inflight
+    if (inflight) return withStartupPhase('clone', () => inflight)
 
     const { cloneUrl, branch, githubApp, managed } = root
 
@@ -2930,7 +2929,7 @@ export class WorkspaceManager {
           })
         : this.runnerFor(agentId).withEnv({ ...workspaceGitEnvBase(cloneUrl), GIT_TERMINAL_PROMPT: '0' })
       try {
-        await git.clone(cloneUrl, cwd, ['--branch', branch, '--single-branch'])
+        await withStartupPhase('clone', () => git.clone(cloneUrl, cwd, ['--branch', branch, '--single-branch']))
       } catch (e) {
         // A failed clone leaves a half-written dir whose stray `.git` would make
         // every later attempt think the checkout exists — clean before rethrowing.

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1209,6 +1209,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       start: vi.fn(async () => {}),
       newSession: vi.fn(async () => {
         await sessionGate
+        await withStartupPhase('clone', async () => {})
         return 'acp-wc-cold'
       }),
       modelOptions: vi.fn(() => null),
@@ -1220,6 +1221,8 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
     await daemon.start()
     const cp = fakeCpClient()
+    const output = vi.spyOn(cp.sink, 'output')
+    const done = vi.spyOn(cp.sink, 'done')
 
     const ack = await (daemon as any).webchatTransport.dispatchWebchatTurn(
       AGENT_ID,
@@ -1231,15 +1234,20 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     expect(ack.accepted).toBe(true)
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
     expect((daemon as any).pending.size).toBe(0)
+    expect(cp.outputs.at(-1)?.event).toEqual({ kind: 'notice', text: '⏳ Starting agent…' })
 
     await (daemon as any).webchatTransport.handleWebchatCancel(CONV)
+    expect(cp.outputs.at(-1)?.event).toEqual({ kind: 'notice', text: '' })
+    expect(output.mock.invocationCallOrder.at(-1)).toBeLessThan(done.mock.invocationCallOrder[0]!)
     expect(cp.dones).toEqual([expect.objectContaining({ turnId: ack.turnId, error: 'cancel' })])
     expect(host.cancel).not.toHaveBeenCalled()
+    const outputsAfterCancel = cp.outputs.length
 
     releaseSession()
     await vi.waitFor(() => expect((daemon as any).inflight.size).toBe(0), WAIT)
     expect(host.prompt).not.toHaveBeenCalled()
     expect(cp.dones).toHaveLength(1)
+    expect(cp.outputs).toHaveLength(outputsAfterCancel)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1,3 +1,4 @@
+import { withStartupPhase } from '../src/session/startup-progress.js'
 import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -143,7 +144,7 @@ function fakeK8sPlane(bound: boolean) {
   return {
     runsInSandbox: () => bound,
     withSandbox: (_id: string, work: () => Promise<unknown>) => work(),
-    ensureChannel: async () => {},
+    ensureChannel: () => (bound ? Promise.resolve() : withStartupPhase('sandbox', async () => {})),
     workspaceRootFor: () => undefined,
     gitRunnerFor: () => undefined,
     workspaceFsFor: () => undefined,
@@ -288,8 +289,8 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
     // Every chunk carries the conversation + turn and a per-turn monotonic index.
     expect(cp.outputs.every((o) => o.conversationId === CONV && o.turnId === turnId)).toBe(true)
-    expect(cp.outputs.map((o) => o.index)).toEqual([0, 1, 2, 3, 4])
-    expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
+    expect(cp.outputs.map((o) => o.index)).toEqual([...cp.outputs.keys()])
+    expect(cp.outputs.filter((o) => o.event && o.event.kind !== 'notice').map((o) => o.event)).toEqual([
       { kind: 'thinking', text: 'let me think' },
       { kind: 'tool_call', toolCallId: 't1', title: 'Read file.ts', status: 'pending' },
       { kind: 'tool_update', toolCallId: 't1', status: 'completed' },
@@ -387,14 +388,18 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     // The notice leads the stream, and the reply's indices continue from it rather than
     // restarting at 0 — a duplicate index is silently dropped by the browser's cursor.
     expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
-      { kind: 'notice', text: '\u23f3 Allocating a sandbox pod\u2026' },
+      { kind: 'notice', text: '⏳ Preparing workspace…' },
+      { kind: 'notice', text: '⏳ Starting sandbox…' },
+      { kind: 'notice', text: '⏳ Preparing workspace…' },
+      { kind: 'notice', text: '⏳ Starting agent…' },
+      { kind: 'notice', text: '' },
       { kind: 'message', text: 'here is the answer' }
     ])
     expect(cp.outputs.map((o) => o.index)).toEqual([...cp.outputs.keys()])
     await daemon.stop()
   })
 
-  it('leaves the webchat stream alone when the agent already has a bound sandbox', async () => {
+  it('skips the sandbox phase when the pod is bound but still reports workspace and runtime preparation', async () => {
     const { factory } = streamingHost([text('here is the answer')])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
@@ -417,7 +422,11 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     }
     await (daemon as any).dispatch(AGENT_ID, msg, undefined, { conversationId: CONV, turnId, sink: cp.sink })
 
-    expect(cp.outputs.some((o) => o.event?.kind === 'notice')).toBe(false)
+    expect(cp.outputs.flatMap((o) => (o.event?.kind === 'notice' ? [o.event.text] : []))).toEqual([
+      '⏳ Preparing workspace…',
+      '⏳ Starting agent…',
+      ''
+    ])
     await daemon.stop()
   })
 
@@ -456,7 +465,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await (daemon as any).dispatch(AGENT_ID, msg, undefined, { conversationId: CONV, turnId, sink: cp.sink })
 
     // The reply + interstitial events stream regardless of `none` …
-    expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
+    expect(cp.outputs.filter((o) => o.event && o.event.kind !== 'notice').map((o) => o.event)).toEqual([
       { kind: 'thinking', text: 'thinking' },
       { kind: 'tool_call', toolCallId: 't1', title: 'Read file.ts', status: 'pending' },
       { kind: 'message', text: 'here is the answer' }
@@ -507,7 +516,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await (daemon as any).dispatch(AGENT_ID, msg, undefined, { conversationId: CONV, turnId, sink: cp.sink })
 
     // Only the non-empty title reaches the live client; the reply follows.
-    expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
+    expect(cp.outputs.filter((o) => o.event && o.event.kind !== 'notice').map((o) => o.event)).toEqual([
       { kind: 'session_info', title: 'Roll back the deploy' },
       { kind: 'message', text: 'done' }
     ])
@@ -583,7 +592,9 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       { conversationId: CONV, turnId, sink: cp.sink }
     )
 
-    expect(cp.outputs.filter((output) => output.event).map((output) => output.event)).toEqual([
+    expect(
+      cp.outputs.filter((output) => output.event && output.event.kind !== 'notice').map((output) => output.event)
+    ).toEqual([
       { kind: 'session_info', title: 'Inspect startup state' },
       { kind: 'message', text: 'done' }
     ])
@@ -1366,7 +1377,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
     expect(attempt).toBe(2) // one failed start, one that stuck
     // Clean completion — the reply streamed and the turn closed with NO error field.
-    expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
+    expect(cp.outputs.filter((o) => o.event && o.event.kind !== 'notice').map((o) => o.event)).toEqual([
       { kind: 'message', text: 'recovered reply' }
     ])
     expect(cp.dones).toEqual([{ conversationId: CONV, turnId, stopReason: 'end_turn' }])

--- a/packages/daemon/test/k8s-driver.test.ts
+++ b/packages/daemon/test/k8s-driver.test.ts
@@ -4,7 +4,8 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { K8sDriver } from '../src/k8s/driver.js'
-import { AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/sandbox-identity.js'
+import { AC_LABEL_AGENT, AC_LABEL_ORG, sessionSandboxSubject } from '../src/k8s/sandbox-identity.js'
+import { observeStartup } from '../src/session/startup-progress.js'
 import { LocalStore } from '../src/store/local-store.js'
 import { fakeGenerations } from './fake-generations.js'
 import { GuardedResumeRejectedError, OperatingModeRejectedError } from '../src/k8s/sandbox-api.js'
@@ -157,6 +158,19 @@ function driver(api: ReturnType<typeof fakeApi>['api'], overrides: Record<string
 }
 
 describe('cluster spawn driver', () => {
+  it('announces a new session pod even when the agent pod is already bound, and skips a warm bind', async () => {
+    const { api } = fakeApi()
+    const { instance } = driver(api)
+    await instance.ensureBoundChannel('agent-a')
+    const report = vi.fn()
+    const subject = sessionSandboxSubject('agent-a', 'session-1')
+    await observeStartup(report, () => instance.ensureBoundChannel(subject))
+    expect(report).toHaveBeenCalledWith('sandbox')
+    report.mockClear()
+    await observeStartup(report, () => instance.ensureBoundChannel(subject))
+    expect(report).not.toHaveBeenCalled()
+  })
+
   it('creates a claim that carries the pool and labels but no per-agent env', async () => {
     const { api, state } = fakeApi()
     const { instance } = driver(api)

--- a/packages/daemon/test/sandbox-bootstrap-notice.test.ts
+++ b/packages/daemon/test/sandbox-bootstrap-notice.test.ts
@@ -3,21 +3,12 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
-import { SANDBOX_BOOTSTRAP_NOTICE } from '../src/daemon/constants.js'
+import { withStartupPhase } from '../src/session/startup-progress.js'
 import { LocalMemoryFs } from '../src/memory/fs.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
 
-/**
- * The sandbox-bootstrap notice (#1475), on the legacy (non-streaming) pipeline. A cluster turn
- * whose agent has no attached shim session must bring a pod up first — up to a minute and a half
- * of silence with nothing to read as progress — and the daemon says so before the wait. On a
- * turn-bar platform (Slack) the wait rides the per-turn status bar and posts NO extra message; on
- * an on-demand chat platform it is a message of its own. Either label then retires to
- * "is thinking…" once the wait is over — even on a warm host, because a suspended pod drops its
- * channel while `hostStarts` still holds the agent. The webchat `notice` event is covered in
- * daemon-webchat.test.ts.
- */
+// Startup phases use one transient surface per turn.
 
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-sandbox-notice-'))
@@ -46,12 +37,12 @@ function scaffold(): string {
   return root
 }
 
-/** A cluster daemon whose agent has no bound pod: the one plane fact the notice is decided on. */
+// Simulate the resource wait reported by the cluster driver.
 function coldSandbox(daemon: Daemon): void {
   ;(daemon as unknown as { k8sPlane: unknown }).k8sPlane = {
     runsInSandbox: () => false,
     withSandbox: (_id: string, work: () => Promise<unknown>) => work(),
-    ensureChannel: async () => {},
+    ensureChannel: () => withStartupPhase('sandbox', async () => {}),
     workspaceRootFor: () => undefined,
     gitRunnerFor: () => undefined,
     workspaceFsFor: () => undefined,
@@ -93,7 +84,7 @@ function chatMsg(platform: 'slack' | 'telegram', id: string): NormalizedMessage 
 
 type Dispatchable = { dispatch: (agentId: string, msg: NormalizedMessage) => Promise<unknown> }
 
-describe('sandbox-bootstrap notice on the legacy pipeline', () => {
+describe('session startup notices', () => {
   it("narrates a cold sandbox on Slack's status bar and posts no message for it", async () => {
     const daemon = bootDaemon(scaffold())
     await daemon.start()
@@ -107,17 +98,16 @@ describe('sandbox-bootstrap notice on the legacy pipeline', () => {
 
     await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('slack', '1'))
 
-    expect(statuses).toContain('is allocating a sandbox pod…')
+    expect(statuses).toContain('is starting a sandbox…')
     // Slack is turn-bar: the label rides the status bar, so no second message says the same thing.
-    expect(conn.postMessage).not.toHaveBeenCalledWith('C1', SANDBOX_BOOTSTRAP_NOTICE, expect.anything())
+    expect(conn.postMessage).not.toHaveBeenCalledWith('C1', '⏳ Starting sandbox…', expect.anything())
     // The label does not outlive the wait it names — the row retires to "is thinking…".
     expect(statuses.filter((text) => text !== '').at(-1)).toBe('is thinking…')
     await daemon.stop()
   })
 
-  it('retires the bootstrap label to "is thinking…" on a warm-host turn that still has no pod', async () => {
-    // The transition must not depend on the host being cold: a suspended pod drops its channel
-    // while `hostStarts` still holds the agent, which is a bootstrap turn with a warm host.
+  it('does not announce sandbox preparation when a warm turn does no preparation', async () => {
+    // A fake plane reports no pod, but this warm turn never asks it to prepare one.
     const daemon = bootDaemon(scaffold())
     await daemon.start()
     coldSandbox(daemon)
@@ -132,7 +122,7 @@ describe('sandbox-bootstrap notice on the legacy pipeline', () => {
     statuses.length = 0
     await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('slack', '2')) // warm host, still no pod
 
-    expect(statuses).toContain('is allocating a sandbox pod…')
+    expect(statuses).not.toContain('is starting a sandbox…')
     expect(statuses.filter((text) => text !== '').at(-1)).toBe('is thinking…')
     await daemon.stop()
   })
@@ -144,13 +134,17 @@ describe('sandbox-bootstrap notice on the legacy pipeline', () => {
     // Telegram is on-demand, not turn-bar, so the wait cannot ride a pushed status bar.
     const conn = {
       sendChatAction: vi.fn(async () => {}),
-      postMessage: vi.fn(async () => 'm1')
+      postMessage: vi.fn(async () => 'm1'),
+      updateMessage: vi.fn(async () => {}),
+      deleteMessage: vi.fn(async () => true)
     }
     vi.spyOn(daemon as never as { replyConnFor: () => unknown }, 'replyConnFor').mockReturnValue(conn)
 
     await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('telegram', '1'))
 
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', SANDBOX_BOOTSTRAP_NOTICE, 'T1')
+    expect(conn.postMessage).toHaveBeenCalledTimes(1)
+    expect(conn.updateMessage).toHaveBeenCalledWith('C1', 'm1', '⏳ Starting agent…', { threadTs: 'T1' })
+    expect(conn.deleteMessage).toHaveBeenCalledWith('C1', 'm1', 'T1')
     await daemon.stop()
   })
 })

--- a/packages/daemon/test/sandbox-bootstrap-notice.test.ts
+++ b/packages/daemon/test/sandbox-bootstrap-notice.test.ts
@@ -8,7 +8,7 @@ import { LocalMemoryFs } from '../src/memory/fs.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
 
-// Startup phases use one transient surface per turn.
+// Startup phases update the existing notice without adding messages to Slack.
 
 function scaffold(): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-sandbox-notice-'))
@@ -85,7 +85,7 @@ function chatMsg(platform: 'slack' | 'telegram', id: string): NormalizedMessage 
 type Dispatchable = { dispatch: (agentId: string, msg: NormalizedMessage) => Promise<unknown> }
 
 describe('session startup notices', () => {
-  it("narrates a cold sandbox on Slack's status bar and posts no message for it", async () => {
+  it('keeps Slack on its existing working indicator without posting phase messages', async () => {
     const daemon = bootDaemon(scaffold())
     await daemon.start()
     coldSandbox(daemon)
@@ -98,10 +98,9 @@ describe('session startup notices', () => {
 
     await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('slack', '1'))
 
-    expect(statuses).toContain('is starting a sandbox…')
-    // Slack is turn-bar: the label rides the status bar, so no second message says the same thing.
+    expect(statuses.slice(0, 2)).toEqual(['is starting up…', 'is thinking…'])
+    // Slack consumes only the lifecycle state; phase text is not supported there.
     expect(conn.postMessage).not.toHaveBeenCalledWith('C1', '⏳ Starting sandbox…', expect.anything())
-    // The label does not outlive the wait it names — the row retires to "is thinking…".
     expect(statuses.filter((text) => text !== '').at(-1)).toBe('is thinking…')
     await daemon.stop()
   })
@@ -144,7 +143,7 @@ describe('session startup notices', () => {
 
     expect(conn.postMessage).toHaveBeenCalledTimes(1)
     expect(conn.updateMessage).toHaveBeenCalledWith('C1', 'm1', '⏳ Starting agent…', { threadTs: 'T1' })
-    expect(conn.deleteMessage).toHaveBeenCalledWith('C1', 'm1', 'T1')
+    expect(conn.deleteMessage).not.toHaveBeenCalled()
     await daemon.stop()
   })
 })

--- a/packages/daemon/test/startup-progress.test.ts
+++ b/packages/daemon/test/startup-progress.test.ts
@@ -48,7 +48,7 @@ describe('startup progress lifetime', () => {
     expect(second).toHaveBeenCalledWith('runtime')
   })
 
-  it('does not send queued updates after cancellation and removes a late post', async () => {
+  it('stops queued edits on cancellation and retains a post already sent', async () => {
     const posted = deferred<string>()
     const conn = {
       postMessage: vi.fn(() => posted.promise),
@@ -62,10 +62,11 @@ describe('startup progress lifetime', () => {
     await Promise.resolve()
     expect(conn.postMessage).toHaveBeenCalledOnce()
     notice.update('Starting agent…')
-    notice.close()
+    const closed = notice.close()
     notice.update('late update')
     posted.resolve('notice-id')
-    await vi.waitFor(() => expect(conn.deleteMessage).toHaveBeenCalledWith('channel', 'notice-id', 'thread'))
+    await closed
+    expect(conn.deleteMessage).not.toHaveBeenCalled()
     expect(conn.updateMessage).not.toHaveBeenCalled()
   })
 })

--- a/packages/daemon/test/startup-progress.test.ts
+++ b/packages/daemon/test/startup-progress.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import { observeStartup, withStartupPhase, shareStartup, awaitStartup } from '../src/session/startup-progress.js'
+import { StartupNotice } from '../src/platforms/startup-notice.js'
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('startup progress lifetime', () => {
+  it('keeps the failed nested phase and propagates the startup error', async () => {
+    const report = vi.fn()
+    const operation = shareStartup(() =>
+      withStartupPhase('sandbox', async () => {
+        throw new Error('sandbox failed')
+      })
+    )
+    await expect(
+      observeStartup(report, () => withStartupPhase('workspace', () => awaitStartup(operation)))
+    ).rejects.toThrow('sandbox failed')
+    expect(report).toHaveBeenLastCalledWith('sandbox')
+  })
+
+  it('keeps a shared start visible to its later waiter after the first turn leaves', async () => {
+    const workspace = deferred()
+    const cancelled = deferred()
+    const first = vi.fn()
+    const second = vi.fn()
+    const operation = shareStartup(() =>
+      withStartupPhase('workspace', async () => {
+        await workspace.promise
+        await withStartupPhase('runtime', async () => {})
+      })
+    )
+    const a = observeStartup(first, () => Promise.race([awaitStartup(operation), cancelled.promise]))
+    const b = observeStartup(second, () => awaitStartup(operation))
+    expect(first).toHaveBeenCalledWith('workspace')
+    expect(second).toHaveBeenCalledWith('workspace')
+    cancelled.resolve()
+    await a
+    first.mockClear()
+    workspace.resolve()
+    await b
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledWith('runtime')
+  })
+
+  it('does not send queued updates after cancellation and removes a late post', async () => {
+    const posted = deferred<string>()
+    const conn = {
+      postMessage: vi.fn(() => posted.promise),
+      updateMessage: vi.fn(async () => {}),
+      deleteMessage: vi.fn(async () => true)
+    }
+    const notice = new StartupNotice(conn, 'channel', 'thread', (error) => {
+      throw error
+    })
+    notice.update('Preparing workspace…')
+    await Promise.resolve()
+    expect(conn.postMessage).toHaveBeenCalledOnce()
+    notice.update('Starting agent…')
+    notice.close()
+    notice.update('late update')
+    posted.resolve('notice-id')
+    await vi.waitFor(() => expect(conn.deleteMessage).toHaveBeenCalledWith('channel', 'notice-id', 'thread'))
+    expect(conn.updateMessage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/test/turn-plan.test.ts
+++ b/packages/daemon/test/turn-plan.test.ts
@@ -62,7 +62,6 @@ const planFor = (over: Partial<TurnPlanInput> = {}) =>
     evaluationTurnId: 'turn-1',
     stickyOutputMode: undefined,
     hostAlreadyRunning: true,
-    clusterPodBootstrap: false,
     protectedAddresses: [],
     codexUsageIsPerPrompt: false,
     features: { turnFinalContextRefresh: true },
@@ -113,15 +112,6 @@ describe('buildTurnPlan', () => {
   it('labels startup activity by whether the host is already running', () => {
     expect(planFor({ hostAlreadyRunning: true }).startupActivityLabel).toBe('is thinking…')
     expect(planFor({ hostAlreadyRunning: false }).startupActivityLabel).toBe('is starting up…')
-  })
-
-  it('lets a sandbox pod that is not up yet outrank both startup labels', () => {
-    for (const hostAlreadyRunning of [true, false]) {
-      const plan = planFor({ hostAlreadyRunning, clusterPodBootstrap: true })
-      expect(plan.startupActivityLabel).toBe('is allocating a sandbox pod…')
-      expect(plan.clusterPodBootstrap).toBe(true)
-    }
-    expect(planFor({ clusterPodBootstrap: false }).clusterPodBootstrap).toBe(false)
   })
 
   it('routes the final context refresh to exactly one of stageAnswer / webchatRefresh', () => {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -17,6 +17,7 @@ import { GitTransportError } from '../src/workspace/git-runner.js'
 import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
 import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
+import { observeStartup } from '../src/session/startup-progress.js'
 
 const { rename: realRename } = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
 const renameMock = vi.fn(realRename)
@@ -182,7 +183,7 @@ describe('prepareWorkspace', () => {
     configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
   })
 
-  it('single-flights concurrent clones into the same cwd (dedupe)', async () => {
+  it('shares one clone and reports the wait to both callers', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     let resolveClone!: () => void
     cloneImpl = vi.fn().mockImplementation(
@@ -192,11 +193,17 @@ describe('prepareWorkspace', () => {
         })
     )
     const agent = gitRepoAgent(path)
-    const p1 = workspaces.prepareWorkspace(agent)
-    const p2 = workspaces.prepareWorkspace(agent) // arrives while p1's clone is in flight
+    const first = vi.fn()
+    const second = vi.fn()
+    const p1 = observeStartup(first, () => workspaces.prepareWorkspace(agent))
+    const p2 = observeStartup(second, () => workspaces.prepareWorkspace(agent))
+    expect(first).toHaveBeenLastCalledWith('clone')
+    expect(second).toHaveBeenLastCalledWith('clone')
     resolveClone()
     await Promise.all([p1, p2])
     expect(cloneImpl).toHaveBeenCalledTimes(1)
+    expect(first).toHaveBeenLastCalledWith(undefined)
+    expect(second).toHaveBeenLastCalledWith(undefined)
   })
 
   it('THROWS on clone failure (no on-disk fallback)', async () => {

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -406,8 +406,7 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // terminal frame: the turn still ends with exactly one `done`, so replay,
   // busy-state, and older browsers (which ignore unknown kinds) stay coherent.
   z.object({ kind: z.literal('superseded'), generation: z.number().int() }),
-  // Live-only chrome for a wait the user cannot otherwise see (a cluster sandbox pod coming up).
-  // Never persisted — a refresh rebuilds from the transcript, which does not record it.
+  // Live-only startup progress: replace this turn's wait notice; empty text clears it. Never persisted.
   // `standing` ⇒ the line is not a wait but something the reader has to keep: an ask this surface
   // could not show, or an answer it would not take (#1794). A wait notice retires the moment
   // output resumes, which would delete exactly those lines; a standing one stays put. An added

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -791,14 +791,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           return steps
         }
         if (ev.kind === 'notice') {
-          // Daemon chrome for a wait with nothing else to show (a sandbox pod coming up).
-          // Its own lane, not the work lane: it is not something the agent thought or did,
-          // so it must not be counted or hidden as a reasoning step. `boundary` keeps the
-          // reply chunks that follow from accumulating into it. A `standing` one is not a wait —
-          // it is what the reader was told about an ask this surface could not show, or an answer
-          // it would not take — so it is marked and never retired when output resumes.
+          // One current wait per turn; standing notices survive updates, and empty text clears only the wait.
+          const next = ev.standing ? steps : dropWaitNotices(steps, agentId, turnId)
+          if (!ev.text) return next
           return [
-            ...steps,
+            ...next,
             lane({ kind: 'notice', text: ev.text, ...(ev.standing ? { standing: true } : {}), boundary: true })
           ]
         }

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -397,6 +397,43 @@ describe('stream text delta batching', () => {
     ])
   })
 
+  it('replaces and clears only the current turn wait while keeping standing notices and other participants', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+    act(() => {
+      for (const output of [
+        { agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Starting sandbox…' } },
+        { agentId: 'agent-2', index: 0, event: { kind: 'notice', text: 'Starting sandbox…' } },
+        { agentId: 'agent-1', index: 1, event: { kind: 'notice', text: 'An approval is unavailable', standing: true } },
+        { agentId: 'agent-1', index: 2, event: { kind: 'notice', text: 'Preparing workspace…' } }
+      ])
+        socket.onmessage?.({ data: JSON.stringify({ type: 'output', output: { turnId, ...output } }) })
+    })
+    act(runFrame)
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'notice', text: 'An approval is unavailable', standing: true },
+      { kind: 'notice', text: 'Preparing workspace…' }
+    ])
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: {
+            turnId,
+            agentId: 'agent-1',
+            index: 3,
+            event: { kind: 'notice', text: '' }
+          }
+        })
+      })
+    })
+    act(runFrame)
+    expect(getLiveSteps('s1').filter((step) => step.kind === 'notice')).toMatchObject([
+      { agentId: 'agent-2', text: 'Starting sandbox…' },
+      { agentId: 'agent-1', text: 'An approval is unavailable', standing: true }
+    ])
+  })
+
   it('retires the notice as soon as the turn streams, so it never stands above the answer', async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()


### PR DESCRIPTION
Session startup now reuses the existing bootstrap notice for sandbox startup, workspace preparation, Git clone, and runtime initialization. The current session's actual operations update the notice, so an already running agent pod no longer hides a new session's sandbox wait. Git clone has its own label and returns to workspace preparation when it finishes.

The Console replaces its live wait line below the agent's name. Other chat platforms edit one notice and retain the message in platform history. Slack keeps its existing native working indicator, whose lifecycle API does not display custom phase text. Code-host turns add no startup comment.

Startup notices stay out of AgentConnect transcripts. Cancellation closes the observer and clears the Console wait before the terminal frame, while underlying workspace work retains its cleanup fence. Shared host starts report to their waiting turns, and standing notices remain visible.

Closes #2038.

Validation: daemon startup, cancellation, lifecycle, smoke, workspace, and real Git session-clone suites (357 tests); Kubernetes, microsandbox, shared-host, model-key, and turn-plan suites; Console Playground suite; daemon typecheck; repository lint and format check; publication guard.

Created by Codex . GPT-6
