### PR TITLE
fix(daemon): author an OpenCode read-only agent for the dream host

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -121,7 +121,13 @@ side effects. The executor therefore separates two independent gates:
   if the runtime advertises none or the switch is rejected, the dream fails
   rather than running with write access. This is what keeps the executor safe
   on runtimes without a trusted system-prompt channel (Codex has read-only
-  mode), and it is stricter than "staging contains everything."
+  mode), and it is stricter than "staging contains everything." On OpenCode
+  the daemon authors that mode itself: the native `plan` denies only edits
+  (shell stays allowed) and injects a plan-mode reminder that a compliant
+  model honours by never calling `writeMemory`, so the dream host defines a
+  `read-only` agent through `OPENCODE_CONFIG_CONTENT` — an allow-list of read
+  tools plus the daemon's bridge tools — which the gate prefers over `plan`
+  (`runtime-defs/opencode-runtime.ts`).
 - **Trusted system-prompt channel — OBSERVED.** When the runtime carries the system
   prompt via `_meta.systemPrompt` the dream policy rides it; otherwise the
   policy is prepended to the user prompt. Auto-accept is the user's explicit

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5064,7 +5064,10 @@ export class Daemon {
         ...(excludeAgentToolCredentials ? {} : { configFileDir: agent.dir }),
         finalizeLaunchEnv: (launchEnv) => {
           // A dream host on OpenCode carries the daemon-authored `read-only` agent, which the extraction gate prefers over `plan`.
-          if (excludeAgentToolCredentials) applyOpenCodeReadOnlyMode(target, launchEnv)
+          // Every launch but a pod inherits this daemon's environment beneath the explicit env, so overlay that value too.
+          if (excludeAgentToolCredentials) {
+            applyOpenCodeReadOnlyMode(target, launchEnv, this.k8s ? undefined : process.env.OPENCODE_CONFIG_CONTENT)
+          }
           if (!this.k8s || !target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
           else {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -206,6 +206,7 @@ import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
 import { DREAM_TOPIC_RE } from './dream/dreamer.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
 import { CLAUDE_HEADLESS_DISALLOWED_TOOLS } from './runtime-defs/claude-runtime.js'
+import { applyOpenCodeReadOnlyMode } from './runtime-defs/opencode-runtime.js'
 import {
   DREAM_MODEL_READABLE_CREDENTIALS_REASON,
   DreamRunner,
@@ -5062,6 +5063,8 @@ export class Daemon {
         // A dream host materializes nothing: it has no cleanup path and needs none of these secrets.
         ...(excludeAgentToolCredentials ? {} : { configFileDir: agent.dir }),
         finalizeLaunchEnv: (launchEnv) => {
+          // A dream host on OpenCode carries the daemon-authored `read-only` agent, which the extraction gate prefers over `plan`.
+          if (excludeAgentToolCredentials) applyOpenCodeReadOnlyMode(target, launchEnv)
           if (!this.k8s || !target) return
           if (opts.modelCredential) applyModelCredential(target, launchEnv, opts.modelCredential.credential)
           else {

--- a/packages/daemon/src/runtime-defs/opencode-runtime.ts
+++ b/packages/daemon/src/runtime-defs/opencode-runtime.ts
@@ -19,10 +19,13 @@ export const OPENCODE_READ_ONLY_PERMISSION = {
 /** Merge the read-only agent into `OPENCODE_CONFIG_CONTENT`, keeping what the provider layer already wrote there. */
 export function applyOpenCodeReadOnlyMode(
   target: Pick<ModelProviderTarget, 'runtime'> | undefined,
-  env: Record<string, string>
+  env: Record<string, string>,
+  // The daemon's own OPENCODE_CONFIG_CONTENT, which a non-pod launch inherits under its explicit env.
+  inherited?: string
 ): void {
   if (target?.runtime !== 'opencode') return
-  const config = objectFromJson(env.OPENCODE_CONFIG_CONTENT, 'OPENCODE_CONFIG_CONTENT')
+  // Overlay the value the child would otherwise see: an explicit entry wins, else the inherited one.
+  const config = objectFromJson(env.OPENCODE_CONFIG_CONTENT ?? inherited, 'OPENCODE_CONFIG_CONTENT')
   const agents = record(config.agent, 'OPENCODE_CONFIG_CONTENT.agent')
   // The daemon's definition replaces a same-named operator agent: on this host the name is a contract.
   env.OPENCODE_CONFIG_CONTENT = JSON.stringify({

--- a/packages/daemon/src/runtime-defs/opencode-runtime.ts
+++ b/packages/daemon/src/runtime-defs/opencode-runtime.ts
@@ -1,0 +1,40 @@
+import { RESERVED_MCP_SERVER_NAME } from '../mcp/resolve-servers.js'
+import { objectFromJson, record } from '../runtimes/codex-config.js'
+import type { ModelProviderTarget } from '../runtimes/model-provider-config.js'
+
+/** The OpenCode agent the daemon authors for its own extraction passes, advertised as the ACP `read-only` mode. */
+export const OPENCODE_READ_ONLY_MODE = 'read-only'
+
+// OpenCode's `plan` keeps bash allowed and tells the model to change nothing, so `writeMemory` is never called under it.
+// An allow-list instead, in precedence order (last match wins): future tools are denied, the daemon's bridge tools stay callable.
+export const OPENCODE_READ_ONLY_PERMISSION = {
+  '*': 'deny',
+  read: 'allow',
+  glob: 'allow',
+  grep: 'allow',
+  list: 'allow',
+  [`${RESERVED_MCP_SERVER_NAME}_*`]: 'allow'
+} as const
+
+/** Merge the read-only agent into `OPENCODE_CONFIG_CONTENT`, keeping what the provider layer already wrote there. */
+export function applyOpenCodeReadOnlyMode(
+  target: Pick<ModelProviderTarget, 'runtime'> | undefined,
+  env: Record<string, string>
+): void {
+  if (target?.runtime !== 'opencode') return
+  const config = objectFromJson(env.OPENCODE_CONFIG_CONTENT, 'OPENCODE_CONFIG_CONTENT')
+  const agents = record(config.agent, 'OPENCODE_CONFIG_CONTENT.agent')
+  // The daemon's definition replaces a same-named operator agent: on this host the name is a contract.
+  env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+    ...config,
+    agent: {
+      ...agents,
+      [OPENCODE_READ_ONLY_MODE]: {
+        mode: 'primary',
+        description:
+          'AgentConnect memory extraction: reads its working directory and calls the AgentConnect tools only.',
+        permission: OPENCODE_READ_ONLY_PERMISSION
+      }
+    }
+  })
+}

--- a/packages/daemon/test/opencode-runtime.test.ts
+++ b/packages/daemon/test/opencode-runtime.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { agentHostKey } from '../src/acp/host-key.js'
+import { Daemon } from '../src/daemon.js'
+import { readOnlyExtractionMode } from '../src/memory/distill.js'
+import {
+  applyOpenCodeReadOnlyMode,
+  OPENCODE_READ_ONLY_MODE,
+  OPENCODE_READ_ONLY_PERMISSION
+} from '../src/runtime-defs/opencode-runtime.js'
+
+const opencode = { runtime: 'opencode' as const }
+
+describe('applyOpenCodeReadOnlyMode', () => {
+  it('authors a primary read-only agent whose ACP mode the extraction gate prefers over plan', () => {
+    const env: Record<string, string> = {}
+    applyOpenCodeReadOnlyMode(opencode, env)
+    const agent = JSON.parse(env.OPENCODE_CONFIG_CONTENT!).agent[OPENCODE_READ_ONLY_MODE]
+    expect(agent.mode).toBe('primary')
+    expect(agent.permission).toEqual(OPENCODE_READ_ONLY_PERMISSION)
+    // OpenCode advertises every visible primary agent as a mode; the gate's own preference then selects it.
+    expect(readOnlyExtractionMode(['build', 'plan', OPENCODE_READ_ONLY_MODE])).toBe(OPENCODE_READ_ONLY_MODE)
+  })
+
+  it('is an allow-list: deny first, then reads and the daemon bridge tools (key order is precedence)', () => {
+    const keys = Object.keys(OPENCODE_READ_ONLY_PERMISSION)
+    expect(keys[0]).toBe('*')
+    expect(OPENCODE_READ_ONLY_PERMISSION['*']).toBe('deny')
+    expect(keys.slice(1)).toEqual(['read', 'glob', 'grep', 'list', 'agentconnect_*'])
+    for (const key of keys.slice(1))
+      expect(OPENCODE_READ_ONLY_PERMISSION[key as keyof typeof OPENCODE_READ_ONLY_PERMISSION]).toBe('allow')
+    // Nothing native and mutating is ever re-allowed.
+    expect(keys).not.toContain('bash')
+    expect(keys).not.toContain('edit')
+    expect(keys).not.toContain('webfetch')
+  })
+
+  it('preserves the provider config already in OPENCODE_CONFIG_CONTENT and other agents, replacing a same-named one', () => {
+    const env: Record<string, string> = {
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        provider: { openai: { options: { apiKey: '{env:MODEL_TOKEN}', baseURL: 'https://api.example.test/v1' } } },
+        agent: { reviewer: { mode: 'subagent' }, [OPENCODE_READ_ONLY_MODE]: { permission: { bash: 'allow' } } }
+      }),
+      MODEL_TOKEN: 'token'
+    }
+    applyOpenCodeReadOnlyMode(opencode, env)
+    const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT!)
+    expect(config.provider.openai.options).toEqual({
+      apiKey: '{env:MODEL_TOKEN}',
+      baseURL: 'https://api.example.test/v1'
+    })
+    expect(config.agent.reviewer).toEqual({ mode: 'subagent' })
+    expect(config.agent[OPENCODE_READ_ONLY_MODE].permission).toEqual(OPENCODE_READ_ONLY_PERMISSION)
+    expect(env.MODEL_TOKEN).toBe('token')
+  })
+
+  it('leaves every other runtime alone', () => {
+    for (const target of [undefined, { runtime: 'claude' as const }, { runtime: 'codex' as const }]) {
+      const env: Record<string, string> = { KEEP: '1' }
+      applyOpenCodeReadOnlyMode(target, env)
+      expect(env).toEqual({ KEEP: '1' })
+    }
+  })
+
+  it('refuses a malformed OPENCODE_CONFIG_CONTENT rather than silently replacing it', () => {
+    const env: Record<string, string> = { OPENCODE_CONFIG_CONTENT: '[not an object]' }
+    expect(() => applyOpenCodeReadOnlyMode(opencode, env)).toThrow(/OPENCODE_CONFIG_CONTENT/)
+  })
+})
+
+describe('dream host launch (daemon)', () => {
+  function scaffold(runtime: string): string {
+    const root = mkdtempSync(join(tmpdir(), 'ac-opencode-dream-'))
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { [runtime]: { command: 'node', args: ['unused'], env: [{ name: 'RUNTIME_VALUE', value: 'r' }] } }
+      })
+    )
+    const adir = join(root, 'agents', 'bot-a')
+    mkdirSync(adir, { recursive: true })
+    writeFileSync(
+      join(adir, 'agent.json'),
+      JSON.stringify({
+        id: 'bot-a',
+        name: 'bot-a',
+        runtime,
+        workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+        memory: { provider: 'managed' }
+      })
+    )
+    return root
+  }
+
+  async function launchEnv(runtime: string, excludeAgentToolCredentials: boolean): Promise<Record<string, string>> {
+    const root = scaffold(runtime)
+    const daemon = new Daemon({ root, probeRuntimes: async () => [] })
+    try {
+      await daemon.start()
+      const inner = daemon as any
+      const agent = inner.agents.get('bot-a')
+      return inner.buildAcpHost(agent, inner.cfg, {
+        hostKey: agentHostKey(agent.id),
+        runInSandbox: false,
+        cwd: join(root, 'in'),
+        excludeAgentToolCredentials
+      }).host.opts.env
+    } finally {
+      await daemon.stop()
+    }
+  }
+
+  it('authors the read-only agent on an OpenCode dream host only, keeping the runtime env', async () => {
+    const dream = await launchEnv('opencode', true)
+    expect(JSON.parse(dream.OPENCODE_CONFIG_CONTENT!).agent[OPENCODE_READ_ONLY_MODE].permission).toEqual(
+      OPENCODE_READ_ONLY_PERMISSION
+    )
+    expect(dream.RUNTIME_VALUE).toBe('r')
+    // The warm host is untouched: its mode list stays the runtime's own, and the console never sees the agent.
+    expect((await launchEnv('opencode', false)).OPENCODE_CONFIG_CONTENT).toBeUndefined()
+    expect((await launchEnv('claude', true)).OPENCODE_CONFIG_CONTENT).toBeUndefined()
+  })
+})

--- a/packages/daemon/test/opencode-runtime.test.ts
+++ b/packages/daemon/test/opencode-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -54,6 +54,23 @@ describe('applyOpenCodeReadOnlyMode', () => {
     expect(config.agent.reviewer).toEqual({ mode: 'subagent' })
     expect(config.agent[OPENCODE_READ_ONLY_MODE].permission).toEqual(OPENCODE_READ_ONLY_PERMISSION)
     expect(env.MODEL_TOKEN).toBe('token')
+  })
+
+  it('overlays the inherited daemon config when the launch sets none, and lets an explicit entry win over it', () => {
+    const inherited = JSON.stringify({ provider: { custom: { options: { baseURL: 'https://llm.example.test/v1' } } } })
+    const env: Record<string, string> = {}
+    applyOpenCodeReadOnlyMode(opencode, env, inherited)
+    const overlaid = JSON.parse(env.OPENCODE_CONFIG_CONTENT!)
+    expect(overlaid.provider.custom.options.baseURL).toBe('https://llm.example.test/v1')
+    expect(overlaid.agent[OPENCODE_READ_ONLY_MODE].mode).toBe('primary')
+
+    const explicit: Record<string, string> = {
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({ provider: { openai: { options: { apiKey: '{env:MODEL_TOKEN}' } } } })
+    }
+    applyOpenCodeReadOnlyMode(opencode, explicit, inherited)
+    const config = JSON.parse(explicit.OPENCODE_CONFIG_CONTENT!)
+    expect(config.provider).toEqual({ openai: { options: { apiKey: '{env:MODEL_TOKEN}' } } })
+    expect(config.agent[OPENCODE_READ_ONLY_MODE].permission).toEqual(OPENCODE_READ_ONLY_PERMISSION)
   })
 
   it('leaves every other runtime alone', () => {
@@ -123,5 +140,20 @@ describe('dream host launch (daemon)', () => {
     // The warm host is untouched: its mode list stays the runtime's own, and the console never sees the agent.
     expect((await launchEnv('opencode', false)).OPENCODE_CONFIG_CONTENT).toBeUndefined()
     expect((await launchEnv('claude', true)).OPENCODE_CONFIG_CONTENT).toBeUndefined()
+  })
+
+  it('keeps the providers a self-hosted daemon supplies through its own OPENCODE_CONFIG_CONTENT', async () => {
+    // An unsandboxed launch inherits the daemon environment beneath the explicit env; the overlay must not shadow it.
+    vi.stubEnv(
+      'OPENCODE_CONFIG_CONTENT',
+      JSON.stringify({ provider: { custom: { options: { baseURL: 'https://llm.example.test/v1' } } } })
+    )
+    try {
+      const config = JSON.parse((await launchEnv('opencode', true)).OPENCODE_CONFIG_CONTENT!)
+      expect(config.provider.custom.options.baseURL).toBe('https://llm.example.test/v1')
+      expect(config.agent[OPENCODE_READ_ONLY_MODE].permission).toEqual(OPENCODE_READ_ONLY_PERMISSION)
+    } finally {
+      vi.unstubAllEnvs()
+    }
   })
 })


### PR DESCRIPTION
## What broke

A scheduled memory dream on an OpenCode runtime failed with `empty_proposal` ("the dream wrote no memory files; refusing a rebuild that would delete N existing topic(s)"). The model had done the full consolidation and then wrote, in its reply, that plan mode was active so it had not staged anything and was waiting for approval. A cron-driven dream has no approver, so the staged store stayed empty and the safety check correctly refused the rebuild.

Root cause is a three-way mismatch, not model capability:

1. `runDreamExtractionSession` hard-gates on a non-mutating mode and, for OpenCode (modes `build` / `plan`), picks `plan`.
2. OpenCode injects its plan-mode reminder ("you MUST NOT make any edits, run any non-readonly tools … This supersedes any other instructions") whenever the session's agent is `plan`.
3. A compliant model obeys that reminder and never calls `writeMemory`.

Worse, OpenCode's `plan` was never the gate the design assumes: its permission block denies only `edit` (with a plan-file carve-out) — `bash` inherits `allow`. So on OpenCode the "verified non-mutating mode" restricted nothing at the tool level; it only told the model not to write.

## The fix

The dream host (the `excludeAgentToolCredentials` launch) now merges a daemon-authored `read-only` agent into `OPENCODE_CONFIG_CONTENT` (`runtime-defs/opencode-runtime.ts`):

```json
{ "agent": { "read-only": { "mode": "primary", "permission": {
  "*": "deny", "read": "allow", "glob": "allow", "grep": "allow", "list": "allow", "agentconnect_*": "allow" } } } }
```

- OpenCode lists every visible primary agent as an ACP mode, so the runtime now advertises `build` / `plan` / `read-only`, and the existing gate (`read-only` preferred over `plan`) selects it — no change to the gate.
- No plan-mode reminder is injected (OpenCode adds it only for the agent named `plan`).
- The allow-list removes `bash`, `edit`/`write`/`apply_patch`, `webfetch`, `websearch`, `task`, `skill`, `todowrite` from the model's tool set; the daemon's own bridge tools stay callable. Key order is precedence, so future tools are denied by default.
- Scoped to the dream host only: the warm host's mode list (and the console's permission-mode picker) is unchanged. Existing provider config in `OPENCODE_CONFIG_CONTENT` is preserved.

Design doc §2 records why OpenCode needs its own mode.

## Verification

- New `test/opencode-runtime.test.ts`: allow-list shape and precedence, config merge, other runtimes untouched, and a daemon-level launch check that the agent lands only on an OpenCode dream host.
- Against the real `opencode` 1.18.27 binary with the exact daemon-authored config: `agent list` shows `read-only (primary)`; `debug agent read-only` resolves `bash/edit/write/apply_patch/webfetch/websearch/task/skill/todowrite` to false and `read/glob/grep` to true (for comparison, `debug agent plan` resolves `bash`, `edit`, `write` to true); an ACP `session/new` advertises mode values `["build","plan","read-only"]` and `session/set_config_option` to `read-only` is accepted while a bogus value is rejected.
- Not run here: a live model turn (needs provider credentials). The behavioural claim rests on the reminder being keyed on the agent name in OpenCode's `session/reminders.ts`.
- `pnpm --filter @agentconnect.md/daemon typecheck` clean; dream/host-launch/distiller/runner suites green.

## Follow-ups (not in this PR)

- Per-turn distillation on OpenCode runs on the warm host under the same `plan` gate and has the same shape; its failure is silent because "write nothing" is a valid distillation outcome.
- The prompt-level override proposed in the incident write-up is deliberately not taken: it would fight OpenCode's "supersedes any other instructions" reminder and widen the blast radius to Claude/Codex dreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
